### PR TITLE
Optimize Gale lexer codegen: first-char dispatch and token priority fix

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -23,7 +23,7 @@ Prerequisites: `cc`, `rustc`, `zig`, `node` (managed by `mise install`).
 
 ## Results
 
-Environment: Wado 2026-04-09, wasmtime 42.0.1, gcc 13.3.0, rustc 1.94.1, Zig 0.15.2, Node.js v24.14.1, Linux x86_64.
+Environment: Wado 2026-04-10, wasmtime 42.0.1, gcc 13.3.0, rustc 1.94.1, Zig 0.15.2, Node.js v24.14.1, Linux x86_64.
 
 ### Compute
 
@@ -53,15 +53,15 @@ Environment: Wado 2026-04-09, wasmtime 42.0.1, gcc 13.3.0, rustc 1.94.1, Zig 0.1
 
 | Benchmark        | Baseline (native)   | Baseline (ms) | Wado (ms) | Relative |
 | ---------------- | ------------------- | ------------- | --------- | -------- |
-| SQLite parse     | sqlparser-rs (Rust) | 187           | 3,001     | 16.05x   |
-| Syntax highlight | tree-sitter (Rust)  | 451           | 9,058     | 20.08x   |
+| SQLite parse     | sqlparser-rs (Rust) | 178           | 2,952     | 16.58x   |
+| Syntax highlight | tree-sitter (Rust)  | 519           | 10,158    | 19.57x   |
 
 Syntax highlight Wasm-to-Wasm comparison (both on wasmtime):
 
 | Runtime                        | Time (ms) | Relative |
 | ------------------------------ | --------- | -------- |
-| tree-sitter (Wasm/wasmtime)    | 587       | 1.00x    |
-| **Wado** (Gale, Wasm/wasmtime) | 9,058     | 15.43x   |
+| tree-sitter (Wasm/wasmtime)    | 650       | 1.00x    |
+| **Wado** (Gale, Wasm/wasmtime) | 10,158    | 15.63x   |
 
 ## Profiling
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -53,7 +53,7 @@ Environment: Wado 2026-04-09, wasmtime 42.0.1, gcc 13.3.0, rustc 1.94.1, Zig 0.1
 
 | Benchmark        | Baseline (native)   | Baseline (ms) | Wado (ms) | Relative |
 | ---------------- | ------------------- | ------------- | --------- | -------- |
-| SQLite parse     | sqlparser-rs (Rust) | 164           | 2,800     | 17.07x   |
+| SQLite parse     | sqlparser-rs (Rust) | 187           | 3,001     | 16.05x   |
 | Syntax highlight | tree-sitter (Rust)  | 451           | 9,058     | 20.08x   |
 
 Syntax highlight Wasm-to-Wasm comparison (both on wasmtime):

--- a/docs/cheatsheet-stdlib-core.md
+++ b/docs/cheatsheet-stdlib-core.md
@@ -2362,22 +2362,23 @@ RFC 1950 (zlib format) is supported except for preset dictionaries (FDICT);
 streams with FDICT set will return `ZlibError::PresetDictionaryNotSupported`.
 
 Features:
-  - Adler-32 and CRC-32 checksums (with combine operations)
-  - DEFLATE inflate (decompression) with dynamic/fixed Huffman and stored blocks
-  - DEFLATE deflate (compression) with fixed and dynamic Huffman codes + LZ77
-  - Compression levels 0-9 with strategy selection
-  - zlib and gzip format support
-  - Streaming deflate/inflate API
+
+- Adler-32 and CRC-32 checksums (with combine operations)
+- DEFLATE inflate (decompression) with dynamic/fixed Huffman and stored blocks
+- DEFLATE deflate (compression) with fixed and dynamic Huffman codes + LZ77
+- Compression levels 0-9 with strategy selection
+- zlib and gzip format support
+- Streaming deflate/inflate API
 
 Usage - Compression:
-  let input: Array<u8> = [...];
-  let compressed = zlib_compress(&input);
-  let compressed_fast = compress2(&input, Z_BEST_SPEED);
-  let compressed_best = compress2(&input, Z_BEST_COMPRESSION);
+let input: Array<u8> = [...];
+let compressed = zlib_compress(&input);
+let compressed_fast = compress2(&input, Z_BEST_SPEED);
+let compressed_best = compress2(&input, Z_BEST_COMPRESSION);
 
 Usage - Decompression:
-  let decompressed = inflate_zlib(&compressed);
-  let decompressed_gz = inflate_gzip(&gzipped_data);
+let decompressed = inflate_zlib(&compressed);
+let decompressed_gz = inflate_gzip(&gzipped_data);
 
 ### Globals
 

--- a/docs/cheatsheet-stdlib-core.md
+++ b/docs/cheatsheet-stdlib-core.md
@@ -880,6 +880,7 @@ impl String {
     pub fn to_ascii_lowercase(&self) -> String;
     pub fn to_ascii_uppercase(&self) -> String;
     pub fn eq_ignore_ascii_case(&self, other: String) -> bool;
+    pub fn substr_bytes(&self, start: i32, end: i32) -> String;
     pub fn contains(&self, pat: String) -> bool;
     pub fn starts_with(&self, pat: String) -> bool;
     pub fn ends_with(&self, pat: String) -> bool;
@@ -2361,23 +2362,22 @@ RFC 1950 (zlib format) is supported except for preset dictionaries (FDICT);
 streams with FDICT set will return `ZlibError::PresetDictionaryNotSupported`.
 
 Features:
-
-- Adler-32 and CRC-32 checksums (with combine operations)
-- DEFLATE inflate (decompression) with dynamic/fixed Huffman and stored blocks
-- DEFLATE deflate (compression) with fixed and dynamic Huffman codes + LZ77
-- Compression levels 0-9 with strategy selection
-- zlib and gzip format support
-- Streaming deflate/inflate API
+  - Adler-32 and CRC-32 checksums (with combine operations)
+  - DEFLATE inflate (decompression) with dynamic/fixed Huffman and stored blocks
+  - DEFLATE deflate (compression) with fixed and dynamic Huffman codes + LZ77
+  - Compression levels 0-9 with strategy selection
+  - zlib and gzip format support
+  - Streaming deflate/inflate API
 
 Usage - Compression:
-let input: Array<u8> = [...];
-let compressed = zlib_compress(&input);
-let compressed_fast = compress2(&input, Z_BEST_SPEED);
-let compressed_best = compress2(&input, Z_BEST_COMPRESSION);
+  let input: Array<u8> = [...];
+  let compressed = zlib_compress(&input);
+  let compressed_fast = compress2(&input, Z_BEST_SPEED);
+  let compressed_best = compress2(&input, Z_BEST_COMPRESSION);
 
 Usage - Decompression:
-let decompressed = inflate_zlib(&compressed);
-let decompressed_gz = inflate_gzip(&gzipped_data);
+  let decompressed = inflate_zlib(&compressed);
+  let decompressed_gz = inflate_gzip(&gzipped_data);
 
 ### Globals
 

--- a/docs/stdlib-core.md
+++ b/docs/stdlib-core.md
@@ -1701,6 +1701,10 @@ Non-ASCII bytes are left unchanged.
 Checks that two strings are an ASCII case-insensitive match.
 Non-ASCII bytes are compared exactly.
 
+##### `pub fn substr_bytes(&self, start: i32, end: i32) -> String`
+
+Extract a substring by byte range [start, end).
+
 ##### `pub fn contains(&self, pat: String) -> bool`
 
 Returns true if this string contains the given substring.

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -724,6 +724,7 @@ struct TryCall {
     extra: String,
     first_chars: Array<[char, char]>,
     is_wildcard: bool,
+    is_catch_all: bool,
     match_length: i32,
 }
 
@@ -742,7 +743,11 @@ fn compute_first_chars(rule: &LexerRule, all_rules: &Array<LexerRule>) -> TryCal
     }
     let mut chars: Array<[char, char]> = [];
     let is_wc = compute_elem_first_chars(&rule.body, all_rules, &mut chars);
-    return TryCall { fn_name, token_kind, extra, first_chars: chars, is_wildcard: is_wc, match_length: -1 };
+    // A catch-all rule (e.g., UNEXPECTED_CHAR: .) matches any single character.
+    // It's only useful in the wildcard fallback, never in specific dispatch branches
+    // where another rule already matches at least 1 character.
+    let catch_all = is_wc && rule.body.len() == 1 && rule.body[0].elements.len() == 1 && rule.body[0].elements[0] matches { AnyChar };
+    return TryCall { fn_name, token_kind, extra, first_chars: chars, is_wildcard: is_wc, is_catch_all: catch_all, match_length: -1 };
 }
 
 /// Analyze first elements of rule body alternatives to find first-char set.
@@ -839,10 +844,11 @@ fn build_dispatch_groups(calls: &Array<TryCall>) -> Array<DispatchGroup> {
 
     let mut groups: Array<DispatchGroup> = [];
 
-    // For each unique single char, find all matching calls
+    // For each unique single char, find all matching calls (excluding catch-all rules)
     for let c of &all_chars {
         let mut matching: Array<i32> = [];
         for let mut i = 0; i < calls.len(); i += 1 {
+            if calls[i].is_catch_all { continue; }
             if calls[i].is_wildcard || char_matches_ranges(*c, &calls[i].first_chars) {
                 matching.push(i);
             }
@@ -902,9 +908,9 @@ fn build_dispatch_groups(calls: &Array<TryCall>) -> Array<DispatchGroup> {
                 if !found_group {
                     let mut cs: Array<i32> = [];
                     cs.push(i);
-                    // Also add wildcards
+                    // Also add non-catch-all wildcards
                     for let mut j = 0; j < calls.len(); j += 1 {
-                        if calls[j].is_wildcard { cs.push(j); }
+                        if calls[j].is_wildcard && !calls[j].is_catch_all { cs.push(j); }
                     }
                     groups.push(DispatchGroup { guard, calls: cs });
                 }
@@ -912,12 +918,32 @@ fn build_dispatch_groups(calls: &Array<TryCall>) -> Array<DispatchGroup> {
         }
     }
 
-    // Wildcard fallback: all calls
+    // Wildcard fallback: only include wildcard calls, range-based calls,
+    // and calls whose first_chars include characters not covered by specific groups.
+    // Single-char-only calls are fully covered by their specific dispatch branches.
     let mut wildcard_calls: Array<i32> = [];
     for let mut i = 0; i < calls.len(); i += 1 {
-        wildcard_calls.push(i);
+        if calls[i].is_wildcard {
+            wildcard_calls.push(i);
+            continue;
+        }
+        let mut has_range = false;
+        for let r of &calls[i].first_chars {
+            if r[0] != r[1] { has_range = true; }
+        }
+        if has_range { wildcard_calls.push(i); }
     }
-    groups.push(DispatchGroup { guard: String::from("true"), calls: wildcard_calls });
+    if !wildcard_calls.is_empty() {
+        groups.push(DispatchGroup { guard: String::from("true"), calls: wildcard_calls });
+    }
+
+    // Sort each group's calls by original index to preserve grammar priority order.
+    // When wildcards and range-based calls are mixed in a group, the insertion order
+    // may not match grammar order — sorting restores it so that same-length matches
+    // respect ANTLR4-style "first rule in grammar wins" priority.
+    for let g of &mut groups {
+        g.calls.sort();
+    }
 
     return groups;
 }
@@ -1072,6 +1098,7 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
                 extra: String::from(""),
                 first_chars: fc,
                 is_wildcard: false,
+                is_catch_all: false,
                 match_length: mlen,
             });
         }
@@ -1084,38 +1111,10 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
         emit_dispatch_groups(w, &all_calls, &groups, false);
     }
 
-    // Keyword reclassification: after matching a non-keyword token,
-    // check if the matched text is actually a keyword.
-    // Guard: only call classify_keyword when the first char could start a keyword.
+    // Keyword reclassification: check if the matched text is actually a keyword.
+    // classify_keyword does length-based dispatch internally, so no first-char guard needed.
     if !keywords.is_empty() {
-        // Collect unique first chars of all keywords (lowercase)
-        let mut first_chars: Array<char> = [];
-        for let kw of keywords {
-            let fc = kw.lowercase_text.chars().next().unwrap();
-            let mut found = false;
-            for let existing of &first_chars {
-                if *existing == fc { found = true; }
-            }
-            if !found { first_chars.push(fc); }
-        }
-        // Build the guard condition
-        let mut guard = String::with_capacity(128);
-        guard.push_str("if best_end > start");
-        // Check both lower and upper case of each first char
-        guard.push_str(" && (");
-        let mut first = true;
-        for let fc of &first_chars {
-            if !first { guard.push_str(" || "); }
-            first = false;
-            let uc = fc.to_ascii_uppercase();
-            if *fc == uc {
-                guard.push_str(`first_char == {escape_char(*fc)}`);
-            } else {
-                guard.push_str(`first_char == {escape_char(*fc)} || first_char == {escape_char(uc)}`);
-            }
-        }
-        guard.push(')');
-        w.begin(&guard);
+        w.begin("if best_end > start");
         w.line("let kw_kind = classify_keyword(&lexer.chars, start, best_end);");
         w.line("if kw_kind >= 0 { best_kind = kw_kind; }");
         w.end();

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -724,6 +724,7 @@ struct TryCall {
     extra: String,
     first_chars: Array<[char, char]>,
     is_wildcard: bool,
+    match_length: i32,
 }
 
 /// Compute the first-char set for a lexer rule body's first element.
@@ -741,7 +742,7 @@ fn compute_first_chars(rule: &LexerRule, all_rules: &Array<LexerRule>) -> TryCal
     }
     let mut chars: Array<[char, char]> = [];
     let is_wc = compute_elem_first_chars(&rule.body, all_rules, &mut chars);
-    return TryCall { fn_name, token_kind, extra, first_chars: chars, is_wildcard: is_wc };
+    return TryCall { fn_name, token_kind, extra, first_chars: chars, is_wildcard: is_wc, match_length: -1 };
 }
 
 /// Analyze first elements of rule body alternatives to find first-char set.
@@ -851,13 +852,13 @@ fn build_dispatch_groups(calls: &Array<TryCall>) -> Array<DispatchGroup> {
         for let g of &mut groups {
             if arrays_equal(&g.calls, &matching) {
                 // Add char to existing group's guard
-                g.guard.push_str(` || lexer.chars[start] == {escape_char(*c)}`);
+                g.guard.push_str(` || first_char == {escape_char(*c)}`);
                 merged = true;
             }
         }
         if !merged {
             groups.push(DispatchGroup {
-                guard: `lexer.chars[start] == {escape_char(*c)}`,
+                guard: `first_char == {escape_char(*c)}`,
                 calls: matching,
             });
         }
@@ -885,7 +886,7 @@ fn build_dispatch_groups(calls: &Array<TryCall>) -> Array<DispatchGroup> {
         for let r of &calls[i].first_chars {
             if r[0] != r[1] {
                 // Build range guard
-                let guard = `{escape_char(r[0])} <= lexer.chars[start] <= {escape_char(r[1])}`;
+                let guard = `{escape_char(r[0])} <= first_char <= {escape_char(r[1])}`;
                 // Find or create group
                 let mut found_group = false;
                 for let g of &mut groups {
@@ -924,14 +925,15 @@ fn build_dispatch_groups(calls: &Array<TryCall>) -> Array<DispatchGroup> {
 fn emit_dispatch_groups(w: &mut CodeWriter, calls: &Array<TryCall>, groups: &Array<DispatchGroup>, use_modes: bool) {
     // If only a wildcard group exists, emit calls directly without dispatch
     if groups.len() == 1 && groups[0].guard == "true" {
-        emit_group_calls(w, calls, &groups[0].calls, use_modes);
+        emit_group_calls(w, calls, &groups[0].calls, use_modes, true);
         return;
     }
     let mut first_group = true;
     for let g of groups {
-        if g.guard == "true" {
+        let is_wc = g.guard == "true";
+        if is_wc {
             if first_group {
-                emit_group_calls(w, calls, &g.calls, use_modes);
+                emit_group_calls(w, calls, &g.calls, use_modes, true);
                 continue;
             }
             w.else_begin("else");
@@ -941,16 +943,31 @@ fn emit_dispatch_groups(w: &mut CodeWriter, calls: &Array<TryCall>, groups: &Arr
             w.else_begin(`else if {g.guard}`);
         }
         first_group = false;
-        emit_group_calls(w, calls, &g.calls, use_modes);
+        emit_group_calls(w, calls, &g.calls, use_modes, is_wc);
     }
     if !first_group {
         w.end();
     }
 }
 
-fn emit_group_calls(w: &mut CodeWriter, calls: &Array<TryCall>, indices: &Array<i32>, use_modes: bool) {
+fn emit_group_calls(w: &mut CodeWriter, calls: &Array<TryCall>, indices: &Array<i32>, use_modes: bool, is_wildcard_group: bool) {
     for let ci of indices {
         let call = &calls[*ci];
+        // In specific dispatch branches, single-char literals are guaranteed to match
+        // (the dispatch already confirmed the character). Inline the result
+        // instead of calling the try_* function.
+        if !is_wildcard_group && call.match_length == 1 {
+            if use_modes {
+                let mut extra = String::from(call.extra);
+                if extra.is_empty() {
+                    extra = String::from(" best_push_mode = -1; best_pop_mode = false;");
+                }
+                w.line(`if start + 1 > best_end \{ best_end = start + 1; best_kind = {call.token_kind};{extra} \}`);
+            } else {
+                w.line(`if start + 1 > best_end \{ best_end = start + 1; best_kind = {call.token_kind}; \}`);
+            }
+            continue;
+        }
         w.line(`end = {call.fn_name}(&lexer.chars, start);`);
         if use_modes {
             let mut extra = String::from(call.extra);
@@ -994,6 +1011,7 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
     w.line("let mut best_end: i32 = -1;");
     w.line("let mut best_kind: i32 = TK_ERROR;");
     w.line("let mut end: i32 = -1;");
+    w.line("let first_char = lexer.chars[start];");
 
     if use_modes {
         w.line("let mut best_push_mode: i32 = -1;");
@@ -1047,12 +1065,14 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
             let mut fc: Array<[char, char]> = [];
             fc.push([c, c]);
             let tk = lit.const_name;
+            let mlen = lit.text.chars().count();
             all_calls.push(TryCall {
                 fn_name,
                 token_kind: tk,
                 extra: String::from(""),
                 first_chars: fc,
                 is_wildcard: false,
+                match_length: mlen,
             });
         }
         for let rule of lexer_rules {
@@ -1089,9 +1109,9 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
             first = false;
             let uc = fc.to_ascii_uppercase();
             if *fc == uc {
-                guard.push_str(`lexer.chars[start] == {escape_char(*fc)}`);
+                guard.push_str(`first_char == {escape_char(*fc)}`);
             } else {
-                guard.push_str(`lexer.chars[start] == {escape_char(*fc)} || lexer.chars[start] == {escape_char(uc)}`);
+                guard.push_str(`first_char == {escape_char(*fc)} || first_char == {escape_char(uc)}`);
             }
         }
         guard.push(')');

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -25,7 +25,7 @@ pub struct LitToken {
 pub struct KeywordInfo {
     pub rule_name: String,
     pub lowercase_text: String,
-    pub case_insensitive: bool,
+    pub char_ci: Array<bool>,
 }
 
 fn seen_contains(seen: &Array<String>, text: &String) -> bool {
@@ -101,7 +101,7 @@ pub fn gen_token_constants(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, l
 pub fn gen_lexer(w: &mut CodeWriter, grammar: &Grammar, lit_tokens: &Array<LitToken>) {
     let keywords = collect_keyword_rules(&grammar.lexer_rules);
     gen_lexer_struct(w);
-    gen_lexer_match_fns(w, &grammar.lexer_rules, &keywords);
+    gen_lexer_match_fns(w, &grammar.lexer_rules, &keywords, lit_tokens);
     gen_literal_match_fns(w, lit_tokens);
     gen_keyword_classifier_fn(w, &keywords);
     gen_tokenize_fn(w, &grammar.lexer_rules, lit_tokens, &grammar.mode_names, &keywords);
@@ -150,12 +150,12 @@ fn gen_lexer_struct(w: &mut CodeWriter) {
     w.blank();
 }
 
-fn gen_lexer_match_fns(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, keywords: &Array<KeywordInfo>) {
+fn gen_lexer_match_fns(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, keywords: &Array<KeywordInfo>, lit_tokens: &Array<LitToken>) {
     for let rule of lexer_rules {
         if rule.body.is_empty() {
             // Virtual token (from `tokens { }` block): no match function needed
         } else if !rule.is_fragment {
-            if !is_keyword_rule_name(&rule.name, keywords) {
+            if !is_keyword_rule_name(&rule.name, keywords) && !is_literal_duplicate(rule, lit_tokens) {
                 gen_lexer_match_fn(w, rule, lexer_rules);
             }
         } else if fragment_is_recursive(rule, lexer_rules) {
@@ -502,23 +502,26 @@ fn try_extract_keyword_info(rule: &LexerRule, all_rules: &Array<LexerRule>) -> O
     let alt = &rule.body[0];
     if alt.elements.is_empty() { return null; }
     let mut text = String::with_capacity(alt.elements.len());
-    let mut all_ci = true;
+    let mut char_ci: Array<bool> = [];
     for let elem of &alt.elements {
         if let Some(pair) = try_extract_keyword_char(elem, all_rules) {
             text.push(pair.0);
-            if !pair.1 { all_ci = false; }
+            char_ci.push(pair.1);
         } else {
             return null;
         }
     }
-    // Only optimize pure ASCII-letter keywords
+    // Only treat identifier-like patterns as keywords (letters, digits, underscores).
+    // `text` is already lowercased by try_extract_keyword_char.
     for let c of text.chars() {
-        if !c.is_ascii_lowercase() { return null; }
+        if !c.is_ascii_lowercase() && c != '_' && !(c >= '0' && c <= '9') {
+            return null;
+        }
     }
     return Option::<KeywordInfo>::Some(KeywordInfo {
         rule_name: rule.name,
         lowercase_text: text,
-        case_insensitive: all_ci,
+        char_ci,
     });
 }
 
@@ -538,6 +541,32 @@ pub fn collect_keyword_rules(lexer_rules: &Array<LexerRule>) -> Array<KeywordInf
 fn is_keyword_rule_name(name: &String, keywords: &Array<KeywordInfo>) -> bool {
     for let kw of keywords {
         if kw.rule_name == *name { return true; }
+    }
+    return false;
+}
+
+/// Extracts the fixed literal text from a lexer rule, if it's a pure literal sequence.
+fn try_extract_fixed_text(rule: &LexerRule) -> Option<String> {
+    if rule.is_fragment || rule.body.len() != 1 { return null; }
+    let alt = &rule.body[0];
+    let mut text = String::with_capacity(alt.elements.len());
+    for let elem of &alt.elements {
+        if let Literal(s) = elem {
+            text.push_str(*s);
+        } else {
+            return null;
+        }
+    }
+    return Option::<String>::Some(text);
+}
+
+/// Check if a lexer rule has the same fixed text as any literal token.
+fn is_literal_duplicate(rule: &LexerRule, lit_tokens: &Array<LitToken>) -> bool {
+    let text = try_extract_fixed_text(rule);
+    if let Some(t) = &text {
+        for let lit of lit_tokens {
+            if lit.text == *t { return true; }
+        }
     }
     return false;
 }
@@ -579,23 +608,45 @@ fn gen_keyword_classifier_fn(w: &mut CodeWriter, keywords: &Array<KeywordInfo>) 
             w.else_begin(`else if len == {target_len}`);
         }
 
-        // Generate checks for each keyword of this length
+        // Group keywords of this length by first character for dispatch
+        let mut len_keywords: Array<&KeywordInfo> = [];
         for let kw of keywords {
-            let kw_chars: Array<char> = kw.lowercase_text.chars().collect();
-            if kw_chars.len() != target_len { continue; }
-
-            w.write("if ");
-            for let mut ci = 0; ci < kw_chars.len(); ci += 1 {
-                if ci > 0 { w.write(" && "); }
-                let lower = kw_chars[ci];
-                let upper = kw_chars[ci].to_ascii_uppercase();
-                if kw.case_insensitive {
-                    w.write(`(chars[start + {ci}] == {escape_char(lower)} || chars[start + {ci}] == {escape_char(upper)})`);
+            if kw.lowercase_text.len() == target_len {
+                len_keywords.push(kw);
+            }
+        }
+        // Collect unique first chars
+        let mut first_chars: Array<char> = [];
+        for let kw of &len_keywords {
+            let fc = kw.lowercase_text.chars().next().unwrap();
+            let mut found = false;
+            for let existing of &first_chars {
+                if *existing == fc { found = true; }
+            }
+            if !found { first_chars.push(fc); }
+        }
+        first_chars.sort();
+        // Emit first-char dispatch within this length group if >1 first char
+        if first_chars.len() > 1 {
+            let mut first_fc = true;
+            for let fc of &first_chars {
+                let guard = gen_char_guard("chars[start]", *fc, true);
+                if first_fc {
+                    w.begin(`if {guard}`);
+                    first_fc = false;
                 } else {
-                    w.write(`chars[start + {ci}] == {escape_char(lower)}`);
+                    w.else_begin(`else if {guard}`);
+                }
+                for let kw of &len_keywords {
+                    if kw.lowercase_text.chars().next().unwrap() != *fc { continue; }
+                    emit_keyword_check(w, *kw);
                 }
             }
-            w.write(` \{ return TK_{kw.rule_name}; \}\n`);
+            w.end();
+        } else {
+            for let kw of &len_keywords {
+                emit_keyword_check(w, *kw);
+            }
         }
     }
     if !first_len {
@@ -605,6 +656,30 @@ fn gen_keyword_classifier_fn(w: &mut CodeWriter, keywords: &Array<KeywordInfo>) 
     w.line("return -1;");
     w.end();
     w.blank();
+}
+
+fn gen_char_guard(access: &String, lower: char, ci: bool) -> String {
+    let upper = lower.to_ascii_uppercase();
+    if ci && lower != upper {
+        return `({access} == {escape_char(lower)} || {access} == {escape_char(upper)})`;
+    }
+    return `{access} == {escape_char(lower)}`;
+}
+
+fn emit_keyword_check(w: &mut CodeWriter, kw: &KeywordInfo) {
+    let kw_chars: Array<char> = kw.lowercase_text.chars().collect();
+    w.write("if ");
+    for let mut ci = 0; ci < kw_chars.len(); ci += 1 {
+        if ci > 0 { w.write(" && "); }
+        let lower = kw_chars[ci];
+        let upper = kw_chars[ci].to_ascii_uppercase();
+        if kw.char_ci[ci] {
+            w.write(`(chars[start + {ci}] == {escape_char(lower)} || chars[start + {ci}] == {escape_char(upper)})`);
+        } else {
+            w.write(`chars[start + {ci}] == {escape_char(lower)}`);
+        }
+    }
+    w.write(` \{ return TK_{kw.rule_name}; \}\n`);
 }
 
 fn gen_literal_match_fns(w: &mut CodeWriter, lit_tokens: &Array<LitToken>) {
@@ -639,6 +714,262 @@ fn lit_try_fn_name(const_name: &String) -> String {
 
 fn has_modes(mode_names: &Array<String>) -> bool {
     return mode_names.len() > 1;
+}
+
+// --- First-character dispatch ---
+
+struct TryCall {
+    fn_name: String,
+    token_kind: String,
+    extra: String,
+    first_chars: Array<[char, char]>,
+    is_wildcard: bool,
+}
+
+/// Compute the first-char set for a lexer rule body's first element.
+fn compute_first_chars(rule: &LexerRule, all_rules: &Array<LexerRule>) -> TryCall {
+    let fn_name = `try_{to_lower(&rule.name)}`;
+    let token_kind = `TK_{rule.name}`;
+    let mut extra = String::with_capacity(64);
+    if rule.push_mode >= 0 {
+        extra.push_str(` best_push_mode = {rule.push_mode};`);
+    } else if rule.push_mode == -1 {
+        // only add if modes are used (caller will check)
+    }
+    if rule.pop_mode {
+        extra.push_str(" best_pop_mode = true;");
+    }
+    let mut chars: Array<[char, char]> = [];
+    let is_wc = compute_elem_first_chars(&rule.body, all_rules, &mut chars);
+    return TryCall { fn_name, token_kind, extra, first_chars: chars, is_wildcard: is_wc };
+}
+
+/// Analyze first elements of rule body alternatives to find first-char set.
+/// Returns true if it's a wildcard (any char could match).
+fn compute_elem_first_chars(body: &Array<LexerAlt>, all_rules: &Array<LexerRule>, out: &mut Array<[char, char]>) -> bool {
+    for let alt of body {
+        if alt.elements.is_empty() { return true; }
+        let elem = &alt.elements[0];
+        if compute_single_elem_first(elem, all_rules, out) {
+            return true;
+        }
+    }
+    return false;
+}
+
+fn compute_single_elem_first(elem: &LexerElement, all_rules: &Array<LexerRule>, out: &mut Array<[char, char]>) -> bool {
+    match *elem {
+        Literal(text) => {
+            let c = text.chars().next().unwrap();
+            add_range(out, c, c);
+            return false;
+        },
+        CharRange(pair) => {
+            add_range(out, pair.0, pair.1);
+            return false;
+        },
+        CharClass(cc) => {
+            if cc.negated { return true; }
+            for let r of &cc.ranges {
+                add_range(out, r.start, r.end);
+            }
+            return false;
+        },
+        RuleRef(name) => {
+            for let rule of all_rules {
+                if rule.name == name && rule.is_fragment {
+                    return compute_elem_first_chars(&rule.body, all_rules, out);
+                }
+            }
+            return true;
+        },
+        Repeat(rep) => {
+            let is_wc = compute_single_elem_first(&rep.element, all_rules, out);
+            if is_wc { return true; }
+            if rep.kind matches { Star } || rep.kind matches { Optional } {
+                return true;
+            }
+            return false;
+        },
+        Group(alts) => {
+            return compute_elem_first_chars(&alts, all_rules, out);
+        },
+        _ => { return true; },
+    }
+}
+
+fn add_range(out: &mut Array<[char, char]>, start: char, end: char) {
+    for let r of out {
+        if r[0] == start && r[1] == end { return; }
+    }
+    out.push([start, end]);
+}
+
+/// Check if a char matches any of the ranges in first_chars.
+fn char_matches_ranges(c: char, ranges: &Array<[char, char]>) -> bool {
+    for let r of ranges {
+        if c >= r[0] && c <= r[1] { return true; }
+    }
+    return false;
+}
+
+/// Build dispatch groups: for each unique first char, which try calls apply?
+struct DispatchGroup {
+    guard: String,
+    calls: Array<i32>,
+}
+
+fn build_dispatch_groups(calls: &Array<TryCall>) -> Array<DispatchGroup> {
+    // Collect all unique single chars from first_chars
+    let mut all_chars: Array<char> = [];
+    for let call of calls {
+        if call.is_wildcard { continue; }
+        for let r of &call.first_chars {
+            if r[0] == r[1] {
+                let mut found = false;
+                for let existing of &all_chars {
+                    if *existing == r[0] { found = true; }
+                }
+                if !found { all_chars.push(r[0]); }
+            }
+        }
+    }
+    all_chars.sort();
+
+    let mut groups: Array<DispatchGroup> = [];
+
+    // For each unique single char, find all matching calls
+    for let c of &all_chars {
+        let mut matching: Array<i32> = [];
+        for let mut i = 0; i < calls.len(); i += 1 {
+            if calls[i].is_wildcard || char_matches_ranges(*c, &calls[i].first_chars) {
+                matching.push(i);
+            }
+        }
+        // Check if this group already exists
+        let mut merged = false;
+        for let g of &mut groups {
+            if arrays_equal(&g.calls, &matching) {
+                // Add char to existing group's guard
+                g.guard.push_str(` || lexer.chars[start] == {escape_char(*c)}`);
+                merged = true;
+            }
+        }
+        if !merged {
+            groups.push(DispatchGroup {
+                guard: `lexer.chars[start] == {escape_char(*c)}`,
+                calls: matching,
+            });
+        }
+    }
+
+    // Collect all ranged entries (ranges where start != end)
+    let mut range_calls: Array<i32> = [];
+    for let mut i = 0; i < calls.len(); i += 1 {
+        if calls[i].is_wildcard { continue; }
+        for let r of &calls[i].first_chars {
+            if r[0] != r[1] {
+                let mut found = false;
+                for let existing of &range_calls {
+                    if *existing == i { found = true; }
+                }
+                if !found { range_calls.push(i); }
+            }
+        }
+    }
+
+    // Merge range-based calls into groups or add them to wildcard fallback
+    // For simplicity, add range-based calls to a "range group" with their guard
+    for let mut i = 0; i < calls.len(); i += 1 {
+        if calls[i].is_wildcard { continue; }
+        for let r of &calls[i].first_chars {
+            if r[0] != r[1] {
+                // Build range guard
+                let guard = `{escape_char(r[0])} <= lexer.chars[start] <= {escape_char(r[1])}`;
+                // Find or create group
+                let mut found_group = false;
+                for let g of &mut groups {
+                    if g.guard == guard {
+                        let mut already = false;
+                        for let ci of &g.calls {
+                            if *ci == i { already = true; }
+                        }
+                        if !already { g.calls.push(i); }
+                        found_group = true;
+                    }
+                }
+                if !found_group {
+                    let mut cs: Array<i32> = [];
+                    cs.push(i);
+                    // Also add wildcards
+                    for let mut j = 0; j < calls.len(); j += 1 {
+                        if calls[j].is_wildcard { cs.push(j); }
+                    }
+                    groups.push(DispatchGroup { guard, calls: cs });
+                }
+            }
+        }
+    }
+
+    // Wildcard fallback: all calls
+    let mut wildcard_calls: Array<i32> = [];
+    for let mut i = 0; i < calls.len(); i += 1 {
+        wildcard_calls.push(i);
+    }
+    groups.push(DispatchGroup { guard: String::from("true"), calls: wildcard_calls });
+
+    return groups;
+}
+
+fn emit_dispatch_groups(w: &mut CodeWriter, calls: &Array<TryCall>, groups: &Array<DispatchGroup>, use_modes: bool) {
+    // If only a wildcard group exists, emit calls directly without dispatch
+    if groups.len() == 1 && groups[0].guard == "true" {
+        emit_group_calls(w, calls, &groups[0].calls, use_modes);
+        return;
+    }
+    let mut first_group = true;
+    for let g of groups {
+        if g.guard == "true" {
+            if first_group {
+                emit_group_calls(w, calls, &g.calls, use_modes);
+                continue;
+            }
+            w.else_begin("else");
+        } else if first_group {
+            w.begin(`if {g.guard}`);
+        } else {
+            w.else_begin(`else if {g.guard}`);
+        }
+        first_group = false;
+        emit_group_calls(w, calls, &g.calls, use_modes);
+    }
+    if !first_group {
+        w.end();
+    }
+}
+
+fn emit_group_calls(w: &mut CodeWriter, calls: &Array<TryCall>, indices: &Array<i32>, use_modes: bool) {
+    for let ci of indices {
+        let call = &calls[*ci];
+        w.line(`end = {call.fn_name}(&lexer.chars, start);`);
+        if use_modes {
+            let mut extra = String::from(call.extra);
+            if extra.is_empty() {
+                extra = String::from(" best_push_mode = -1; best_pop_mode = false;");
+            }
+            w.line(`if end > best_end \{ best_end = end; best_kind = {call.token_kind};{extra} \}`);
+        } else {
+            w.line(`if end > best_end \{ best_end = end; best_kind = {call.token_kind}; \}`);
+        }
+    }
+}
+
+fn arrays_equal(a: &Array<i32>, b: &Array<i32>) -> bool {
+    if a.len() != b.len() { return false; }
+    for let mut i = 0; i < a.len(); i += 1 {
+        if a[i] != b[i] { return false; }
+    }
+    return true;
 }
 
 fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_tokens: &Array<LitToken>, mode_names: &Array<String>, keywords: &Array<KeywordInfo>) {
@@ -688,7 +1019,7 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
                 }
             }
             for let rule of lexer_rules {
-                if !rule.is_fragment && !rule.body.is_empty() && rule.mode == mi && !is_keyword_rule_name(&rule.name, keywords) {
+                if !rule.is_fragment && !rule.body.is_empty() && rule.mode == mi && !is_keyword_rule_name(&rule.name, keywords) && !is_literal_duplicate(rule, lit_tokens) {
                     let fn_name = `try_{to_lower(&rule.name)}`;
                     w.line(`end = {fn_name}(&lexer.chars, start);`);
                     let mut extra = String::with_capacity(64);
@@ -708,25 +1039,63 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
         }
         w.end();  // mode dispatch
     } else {
-        // No modes — simple dispatch
+        // No modes — first-character dispatch
+        let mut all_calls: Array<TryCall> = [];
         for let lit of lit_tokens {
             let fn_name = lit_try_fn_name(&lit.const_name);
-            w.line(`end = {fn_name}(&lexer.chars, start);`);
-            w.line(`if end > best_end \{ best_end = end; best_kind = {lit.const_name}; \}`);
+            let c = lit.text.chars().next().unwrap();
+            let mut fc: Array<[char, char]> = [];
+            fc.push([c, c]);
+            let tk = lit.const_name;
+            all_calls.push(TryCall {
+                fn_name,
+                token_kind: tk,
+                extra: String::from(""),
+                first_chars: fc,
+                is_wildcard: false,
+            });
         }
         for let rule of lexer_rules {
-            if !rule.is_fragment && !rule.body.is_empty() && !is_keyword_rule_name(&rule.name, keywords) {
-                let fn_name = `try_{to_lower(&rule.name)}`;
-                w.line(`end = {fn_name}(&lexer.chars, start);`);
-                w.line(`if end > best_end \{ best_end = end; best_kind = TK_{rule.name}; \}`);
+            if !rule.is_fragment && !rule.body.is_empty() && !is_keyword_rule_name(&rule.name, keywords) && !is_literal_duplicate(rule, lit_tokens) {
+                all_calls.push(compute_first_chars(rule, lexer_rules));
             }
         }
+        let groups = build_dispatch_groups(&all_calls);
+        emit_dispatch_groups(w, &all_calls, &groups, false);
     }
 
     // Keyword reclassification: after matching a non-keyword token,
     // check if the matched text is actually a keyword.
+    // Guard: only call classify_keyword when the first char could start a keyword.
     if !keywords.is_empty() {
-        w.begin("if best_end > start");
+        // Collect unique first chars of all keywords (lowercase)
+        let mut first_chars: Array<char> = [];
+        for let kw of keywords {
+            let fc = kw.lowercase_text.chars().next().unwrap();
+            let mut found = false;
+            for let existing of &first_chars {
+                if *existing == fc { found = true; }
+            }
+            if !found { first_chars.push(fc); }
+        }
+        // Build the guard condition
+        let mut guard = String::with_capacity(128);
+        guard.push_str("if best_end > start");
+        // Check both lower and upper case of each first char
+        guard.push_str(" && (");
+        let mut first = true;
+        for let fc of &first_chars {
+            if !first { guard.push_str(" || "); }
+            first = false;
+            let uc = fc.to_ascii_uppercase();
+            if *fc == uc {
+                guard.push_str(`lexer.chars[start] == {escape_char(*fc)}`);
+            } else {
+                guard.push_str(`lexer.chars[start] == {escape_char(*fc)} || lexer.chars[start] == {escape_char(uc)}`);
+            }
+        }
+        guard.push(')');
+        w.begin(&guard);
         w.line("let kw_kind = classify_keyword(&lexer.chars, start, best_end);");
         w.line("if kw_kind >= 0 { best_kind = kw_kind; }");
         w.end();

--- a/package-gale/tests/driver_calculator_test.wado
+++ b/package-gale/tests/driver_calculator_test.wado
@@ -52,3 +52,155 @@ test "tree: multiplication" {
             (multiplyingExpression (powExpression (signedAtom (atom (scientific 6)))))))
     ");
 }
+
+test "tree: division" {
+    assert_tree(&"10 / 2 = 5", &"
+        (equation
+          (expression
+            (multiplyingExpression
+              (powExpression (signedAtom (atom (scientific 10))))
+              / (powExpression (signedAtom (atom (scientific 2))))))
+          (relop =)
+          (expression
+            (multiplyingExpression (powExpression (signedAtom (atom (scientific 5)))))))
+    ");
+}
+
+test "tree: power" {
+    assert_tree(&"2 ^ 3 = 8", &"
+        (equation
+          (expression
+            (multiplyingExpression
+              (powExpression
+                (signedAtom (atom (scientific 2)))
+                ^ (signedAtom (atom (scientific 3))))))
+          (relop =)
+          (expression
+            (multiplyingExpression (powExpression (signedAtom (atom (scientific 8)))))))
+    ");
+}
+
+test "tree: unary minus" {
+    assert_tree(&"-1 = -1", &"
+        (equation
+          (expression
+            (multiplyingExpression
+              (powExpression (signedAtom - (signedAtom (atom (scientific 1)))))))
+          (relop =)
+          (expression
+            (multiplyingExpression
+              (powExpression (signedAtom - (signedAtom (atom (scientific 1))))))))
+    ");
+}
+
+test "tree: parenthesized expression" {
+    assert_tree(&"(1 + 2) * 3 = 9", &"
+        (equation
+          (expression
+            (multiplyingExpression
+              (powExpression
+                (signedAtom
+                  (atom (
+                    (expression
+                      (multiplyingExpression (powExpression (signedAtom (atom (scientific 1)))))
+                      + (multiplyingExpression (powExpression (signedAtom (atom (scientific 2))))))
+                    ))))
+              * (powExpression (signedAtom (atom (scientific 3))))))
+          (relop =)
+          (expression
+            (multiplyingExpression (powExpression (signedAtom (atom (scientific 9)))))))
+    ");
+}
+
+test "tree: function call sin" {
+    assert_tree(&"sin(0) = 0", &"
+        (equation
+          (expression
+            (multiplyingExpression
+              (powExpression
+                (signedAtom
+                  (func_ (funcname sin) ( (expression (multiplyingExpression (powExpression (signedAtom (atom (scientific 0)))))) ))))))
+          (relop =)
+          (expression
+            (multiplyingExpression (powExpression (signedAtom (atom (scientific 0)))))))
+    ");
+}
+
+test "tree: function call with multiple args" {
+    assert_tree(&"log(10, 2) > 3", &"
+        (equation
+          (expression
+            (multiplyingExpression
+              (powExpression
+                (signedAtom
+                  (func_ (funcname log) (
+                    (expression (multiplyingExpression (powExpression (signedAtom (atom (scientific 10))))))
+                    , (expression (multiplyingExpression (powExpression (signedAtom (atom (scientific 2))))))
+                  ))))))
+          (relop >)
+          (expression
+            (multiplyingExpression (powExpression (signedAtom (atom (scientific 3)))))))
+    ");
+}
+
+test "tree: constant pi" {
+    assert_tree(&"pi > 3", &"
+        (equation
+          (expression
+            (multiplyingExpression
+              (powExpression (signedAtom (atom (constant pi))))))
+          (relop >)
+          (expression
+            (multiplyingExpression (powExpression (signedAtom (atom (scientific 3)))))))
+    ");
+}
+
+test "tree: variable" {
+    assert_tree(&"x = 1", &"
+        (equation
+          (expression
+            (multiplyingExpression
+              (powExpression (signedAtom (atom (variable x))))))
+          (relop =)
+          (expression
+            (multiplyingExpression (powExpression (signedAtom (atom (scientific 1)))))))
+    ");
+}
+
+test "tree: scientific notation" {
+    assert_tree(&"1.5E2 = 150", &"
+        (equation
+          (expression
+            (multiplyingExpression
+              (powExpression (signedAtom (atom (scientific 1.5E2))))))
+          (relop =)
+          (expression
+            (multiplyingExpression (powExpression (signedAtom (atom (scientific 150)))))))
+    ");
+}
+
+test "tree: complex nested" {
+    assert_tree(&"2 * x + 1 = 3", &"
+        (equation
+          (expression
+            (multiplyingExpression
+              (powExpression (signedAtom (atom (scientific 2))))
+              * (powExpression (signedAtom (atom (variable x)))))
+            + (multiplyingExpression (powExpression (signedAtom (atom (scientific 1))))))
+          (relop =)
+          (expression
+            (multiplyingExpression (powExpression (signedAtom (atom (scientific 3)))))))
+    ");
+}
+
+test "tree: relop less than" {
+    assert_tree(&"x < 10", &"
+        (equation
+          (expression
+            (multiplyingExpression
+              (powExpression (signedAtom (atom (variable x))))))
+          (relop <)
+          (expression
+            (multiplyingExpression (powExpression (signedAtom (atom (scientific 10)))))))
+    ");
+}

--- a/package-gale/tests/driver_sexpression_test.wado
+++ b/package-gale/tests/driver_sexpression_test.wado
@@ -58,3 +58,98 @@ test "tree: nested lists" {
             ))))
     ");
 }
+
+test "tree: number atom" {
+    assert_tree(&"42", &"(sexpr (item (atom 42)))");
+}
+
+test "tree: negative number" {
+    assert_tree(&"-3.14", &"(sexpr (item (atom -3.14)))");
+}
+
+test "tree: string atom" {
+    assert_tree(&"\"hello world\"", &"
+        (sexpr (item (atom \"hello world\")))
+    ");
+}
+
+test "tree: dot atom" {
+    assert_tree(&".", &"(sexpr (item (atom .)))");
+}
+
+test "tree: dotted pair" {
+    assert_tree(&"(a . b)", &"
+        (sexpr
+          (item
+            (list_ ( (item (atom a)) (item (atom .)) (item (atom b)) ))))
+    ");
+}
+
+test "tree: empty list" {
+    assert_tree(&"()", &"
+        (sexpr (item (list_ ( ))))
+    ");
+}
+
+test "tree: multiple top-level items" {
+    assert_tree(&"a b c", &"
+        (sexpr
+          (item (atom a))
+          (item (atom b))
+          (item (atom c)))
+    ");
+}
+
+test "tree: deeply nested" {
+    assert_tree(&"(((x)))", &"
+        (sexpr
+          (item
+            (list_ (
+              (item
+                (list_ (
+                  (item
+                    (list_ ( (item (atom x)) )))
+                )))
+            ))))
+    ");
+}
+
+test "tree: mixed atoms in list" {
+    assert_tree(&"(hello 42 \"world\")", &"
+        (sexpr
+          (item
+            (list_ (
+              (item (atom hello))
+              (item (atom 42))
+              (item (atom \"world\"))
+            ))))
+    ");
+}
+
+test "tree: lambda expression" {
+    assert_tree(&"(lambda (x y) (+ x y))", &"
+        (sexpr
+          (item
+            (list_ (
+              (item (atom lambda))
+              (item (list_ ( (item (atom x)) (item (atom y)) )))
+              (item (list_ ( (item (atom +)) (item (atom x)) (item (atom y)) )))
+            ))))
+    ");
+}
+
+test "tree: let expression" {
+    assert_tree(&"(let ((x 1) (y 2)) (+ x y))", &"
+        (sexpr
+          (item
+            (list_ (
+              (item (atom let))
+              (item
+                (list_ (
+                  (item (list_ ( (item (atom x)) (item (atom 1)) )))
+                  (item (list_ ( (item (atom y)) (item (atom 2)) )))
+                )))
+              (item (list_ ( (item (atom +)) (item (atom x)) (item (atom y)) )))
+            ))))
+    ");
+}

--- a/package-gale/tests/golden/antlr4.wado
+++ b/package-gale/tests/golden/antlr4.wado
@@ -3377,6 +3377,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
         let mut best_push_mode: i32 = -1;
         let mut best_pop_mode = false;
         if current_mode == 0 {

--- a/package-gale/tests/golden/calculator.wado
+++ b/package-gale/tests/golden/calculator.wado
@@ -1204,58 +1204,12 @@ pub fn tokenize(input: &String) -> Array<Token> {
             end = try_scientific_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SCIENTIFIC_NUMBER; }
         } else {
-            end = try_cos(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_COS; }
-            end = try_sin(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SIN; }
-            end = try_tan(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TAN; }
-            end = try_acos(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ACOS; }
-            end = try_asin(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ASIN; }
-            end = try_atan(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ATAN; }
-            end = try_ln(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LN; }
-            end = try_log(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LOG; }
-            end = try_sqrt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SQRT; }
-            end = try_lparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LPAREN; }
-            end = try_rparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RPAREN; }
-            end = try_plus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PLUS; }
-            end = try_minus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MINUS; }
-            end = try_times(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TIMES; }
-            end = try_div(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DIV; }
-            end = try_gt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_GT; }
-            end = try_lt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LT; }
-            end = try_eq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_EQ; }
-            end = try_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_COMMA; }
-            end = try_point(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_POINT; }
-            end = try_pow(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_POW; }
-            end = try_pi(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PI; }
             end = try_variable(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
             end = try_scientific_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SCIENTIFIC_NUMBER; }
-            end = try_ws(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_WS; }
         }
-        if best_end > start && (first_char == 'e' || first_char == 'E' || first_char == 'i' || first_char == 'I') {
+        if best_end > start {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
             if kw_kind >= 0 { best_kind = kw_kind; }
         }

--- a/package-gale/tests/golden/calculator.wado
+++ b/package-gale/tests/golden/calculator.wado
@@ -1113,49 +1113,50 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        if lexer.chars[start] == '\t' || lexer.chars[start] == '\n' || lexer.chars[start] == '\r' || lexer.chars[start] == ' ' {
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
             end = try_ws(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_WS; }
-        } else if lexer.chars[start] == '(' {
+        } else if first_char == '(' {
             end = try_lparen(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LPAREN; }
-        } else if lexer.chars[start] == ')' {
+        } else if first_char == ')' {
             end = try_rparen(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_RPAREN; }
-        } else if lexer.chars[start] == '*' {
+        } else if first_char == '*' {
             end = try_times(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_TIMES; }
-        } else if lexer.chars[start] == '+' {
+        } else if first_char == '+' {
             end = try_plus(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_PLUS; }
-        } else if lexer.chars[start] == ',' {
+        } else if first_char == ',' {
             end = try_comma(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_COMMA; }
-        } else if lexer.chars[start] == '-' {
+        } else if first_char == '-' {
             end = try_minus(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_MINUS; }
-        } else if lexer.chars[start] == '.' {
+        } else if first_char == '.' {
             end = try_point(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_POINT; }
-        } else if lexer.chars[start] == '/' {
+        } else if first_char == '/' {
             end = try_div(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_DIV; }
-        } else if lexer.chars[start] == '<' {
+        } else if first_char == '<' {
             end = try_lt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LT; }
-        } else if lexer.chars[start] == '=' {
+        } else if first_char == '=' {
             end = try_eq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_EQ; }
-        } else if lexer.chars[start] == '>' {
+        } else if first_char == '>' {
             end = try_gt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_GT; }
-        } else if lexer.chars[start] == '^' {
+        } else if first_char == '^' {
             end = try_pow(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_POW; }
-        } else if lexer.chars[start] == '_' {
+        } else if first_char == '_' {
             end = try_variable(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
-        } else if lexer.chars[start] == 'a' {
+        } else if first_char == 'a' {
             end = try_acos(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_ACOS; }
             end = try_asin(&lexer.chars, start);
@@ -1164,42 +1165,42 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_ATAN; }
             end = try_variable(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
-        } else if lexer.chars[start] == 'c' {
+        } else if first_char == 'c' {
             end = try_cos(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_COS; }
             end = try_variable(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
-        } else if lexer.chars[start] == 'l' {
+        } else if first_char == 'l' {
             end = try_ln(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LN; }
             end = try_log(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LOG; }
             end = try_variable(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
-        } else if lexer.chars[start] == 'p' {
+        } else if first_char == 'p' {
             end = try_pi(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_PI; }
             end = try_variable(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
-        } else if lexer.chars[start] == 's' {
+        } else if first_char == 's' {
             end = try_sin(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SIN; }
             end = try_sqrt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SQRT; }
             end = try_variable(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
-        } else if lexer.chars[start] == 't' {
+        } else if first_char == 't' {
             end = try_tan(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_TAN; }
             end = try_variable(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
-        } else if 'a' <= lexer.chars[start] <= 'z' {
+        } else if 'a' <= first_char <= 'z' {
             end = try_variable(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
-        } else if 'A' <= lexer.chars[start] <= 'Z' {
+        } else if 'A' <= first_char <= 'Z' {
             end = try_variable(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
-        } else if '0' <= lexer.chars[start] <= '9' {
+        } else if '0' <= first_char <= '9' {
             end = try_scientific_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SCIENTIFIC_NUMBER; }
         } else {
@@ -1254,7 +1255,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             end = try_ws(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_WS; }
         }
-        if best_end > start && (lexer.chars[start] == 'e' || lexer.chars[start] == 'E' || lexer.chars[start] == 'i' || lexer.chars[start] == 'I') {
+        if best_end > start && (first_char == 'e' || first_char == 'E' || first_char == 'i' || first_char == 'I') {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
             if kw_kind >= 0 { best_kind = kw_kind; }
         }

--- a/package-gale/tests/golden/calculator.wado
+++ b/package-gale/tests/golden/calculator.wado
@@ -1095,8 +1095,11 @@ fn try_ws(chars: &Array<char>, start: i32) -> i32 {
 fn classify_keyword(chars: &Array<char>, start: i32, end: i32) -> i32 {
     let len = end - start;
     if len == 1 {
-        if chars[start + 0] == 'e' { return TK_EULER; }
-        if chars[start + 0] == 'i' { return TK_I; }
+        if (chars[start] == 'e' || chars[start] == 'E') {
+            if chars[start + 0] == 'e' { return TK_EULER; }
+        } else if (chars[start] == 'i' || chars[start] == 'I') {
+            if chars[start + 0] == 'i' { return TK_I; }
+        }
     }
     return -1;
 }
@@ -1110,57 +1113,148 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        end = try_cos(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_COS; }
-        end = try_sin(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SIN; }
-        end = try_tan(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_TAN; }
-        end = try_acos(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_ACOS; }
-        end = try_asin(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_ASIN; }
-        end = try_atan(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_ATAN; }
-        end = try_ln(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LN; }
-        end = try_log(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LOG; }
-        end = try_sqrt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SQRT; }
-        end = try_lparen(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LPAREN; }
-        end = try_rparen(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_RPAREN; }
-        end = try_plus(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PLUS; }
-        end = try_minus(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_MINUS; }
-        end = try_times(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_TIMES; }
-        end = try_div(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_DIV; }
-        end = try_gt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_GT; }
-        end = try_lt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LT; }
-        end = try_eq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_EQ; }
-        end = try_comma(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_COMMA; }
-        end = try_point(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_POINT; }
-        end = try_pow(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_POW; }
-        end = try_pi(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PI; }
-        end = try_variable(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
-        end = try_scientific_number(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SCIENTIFIC_NUMBER; }
-        end = try_ws(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_WS; }
-        if best_end > start {
+        if lexer.chars[start] == '\t' || lexer.chars[start] == '\n' || lexer.chars[start] == '\r' || lexer.chars[start] == ' ' {
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if lexer.chars[start] == '(' {
+            end = try_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LPAREN; }
+        } else if lexer.chars[start] == ')' {
+            end = try_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RPAREN; }
+        } else if lexer.chars[start] == '*' {
+            end = try_times(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_TIMES; }
+        } else if lexer.chars[start] == '+' {
+            end = try_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PLUS; }
+        } else if lexer.chars[start] == ',' {
+            end = try_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_COMMA; }
+        } else if lexer.chars[start] == '-' {
+            end = try_minus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MINUS; }
+        } else if lexer.chars[start] == '.' {
+            end = try_point(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_POINT; }
+        } else if lexer.chars[start] == '/' {
+            end = try_div(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DIV; }
+        } else if lexer.chars[start] == '<' {
+            end = try_lt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LT; }
+        } else if lexer.chars[start] == '=' {
+            end = try_eq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_EQ; }
+        } else if lexer.chars[start] == '>' {
+            end = try_gt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_GT; }
+        } else if lexer.chars[start] == '^' {
+            end = try_pow(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_POW; }
+        } else if lexer.chars[start] == '_' {
+            end = try_variable(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
+        } else if lexer.chars[start] == 'a' {
+            end = try_acos(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ACOS; }
+            end = try_asin(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ASIN; }
+            end = try_atan(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ATAN; }
+            end = try_variable(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
+        } else if lexer.chars[start] == 'c' {
+            end = try_cos(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_COS; }
+            end = try_variable(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
+        } else if lexer.chars[start] == 'l' {
+            end = try_ln(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LN; }
+            end = try_log(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LOG; }
+            end = try_variable(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
+        } else if lexer.chars[start] == 'p' {
+            end = try_pi(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PI; }
+            end = try_variable(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
+        } else if lexer.chars[start] == 's' {
+            end = try_sin(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SIN; }
+            end = try_sqrt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SQRT; }
+            end = try_variable(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
+        } else if lexer.chars[start] == 't' {
+            end = try_tan(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_TAN; }
+            end = try_variable(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
+        } else if 'a' <= lexer.chars[start] <= 'z' {
+            end = try_variable(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
+        } else if 'A' <= lexer.chars[start] <= 'Z' {
+            end = try_variable(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
+        } else if '0' <= lexer.chars[start] <= '9' {
+            end = try_scientific_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SCIENTIFIC_NUMBER; }
+        } else {
+            end = try_cos(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_COS; }
+            end = try_sin(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SIN; }
+            end = try_tan(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_TAN; }
+            end = try_acos(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ACOS; }
+            end = try_asin(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ASIN; }
+            end = try_atan(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ATAN; }
+            end = try_ln(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LN; }
+            end = try_log(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LOG; }
+            end = try_sqrt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SQRT; }
+            end = try_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LPAREN; }
+            end = try_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RPAREN; }
+            end = try_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PLUS; }
+            end = try_minus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MINUS; }
+            end = try_times(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_TIMES; }
+            end = try_div(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DIV; }
+            end = try_gt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_GT; }
+            end = try_lt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LT; }
+            end = try_eq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_EQ; }
+            end = try_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_COMMA; }
+            end = try_point(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_POINT; }
+            end = try_pow(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_POW; }
+            end = try_pi(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PI; }
+            end = try_variable(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_VARIABLE; }
+            end = try_scientific_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SCIENTIFIC_NUMBER; }
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        }
+        if best_end > start && (lexer.chars[start] == 'e' || lexer.chars[start] == 'E' || lexer.chars[start] == 'i' || lexer.chars[start] == 'I') {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
             if kw_kind >= 0 { best_kind = kw_kind; }
         }

--- a/package-gale/tests/golden/css3.wado
+++ b/package-gale/tests/golden/css3.wado
@@ -2263,104 +2263,6 @@ impl Lexer {
     }
 }
 
-fn try_openbracket(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '[' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_closebracket(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != ']' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_openparen(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '(' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_closeparen(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != ')' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_openbrace(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '{' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_closebrace(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '}' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_semicolon(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != ';' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_equal(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_colon(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != ':' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_dot(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '.' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_multiply(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '*' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_divide(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '/' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_pipe(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '|' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_underscore(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '_' { return -1; }
-    pos += 1;
-    return pos;
-}
-
 fn try_comment(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
     if pos >= chars.len() || chars[pos] != '/' { return -1; }
@@ -28479,6 +28381,14 @@ fn try_lit__(chars: &Array<char>, start: i32) -> i32 {
     return pos + 1;
 }
 
+fn classify_keyword(chars: &Array<char>, start: i32, end: i32) -> i32 {
+    let len = end - start;
+    if len == 1 {
+        if chars[start + 0] == '_' { return TK_Underscore; }
+    }
+    return -1;
+}
+
 pub fn tokenize(input: &String) -> Array<Token> {
     let mut lexer = Lexer::new(input);
     let mut tokens: Array<Token> = [];
@@ -28488,162 +28398,863 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        end = try_lit_semi(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
-        end = try_lit_lparen(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
-        end = try_lit_colon(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
-        end = try_lit_rparen(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
-        end = try_lit_lbrace(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
-        end = try_lit_rbrace(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
-        end = try_lit_star(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
-        end = try_lit_pipe(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
-        end = try_lit_dot(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
-        end = try_lit_lbracket(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
-        end = try_lit_eq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
-        end = try_lit_rbracket(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
-        end = try_lit_slash(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
-        end = try_lit__(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT__; }
-        end = try_openbracket(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_OpenBracket; }
-        end = try_closebracket(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_CloseBracket; }
-        end = try_openparen(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_OpenParen; }
-        end = try_closeparen(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_CloseParen; }
-        end = try_openbrace(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_OpenBrace; }
-        end = try_closebrace(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_CloseBrace; }
-        end = try_semicolon(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SemiColon; }
-        end = try_equal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Equal; }
-        end = try_colon(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Colon; }
-        end = try_dot(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Dot; }
-        end = try_multiply(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Multiply; }
-        end = try_divide(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Divide; }
-        end = try_pipe(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Pipe; }
-        end = try_underscore(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Underscore; }
-        end = try_comment(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Comment; }
-        end = try_url(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Url; }
-        end = try_space(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Space; }
-        end = try_cdo(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Cdo; }
-        end = try_cdc(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Cdc; }
-        end = try_includes(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Includes; }
-        end = try_dashmatch(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_DashMatch; }
-        end = try_hash(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Hash; }
-        end = try_import(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Import; }
-        end = try_page(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Page; }
-        end = try_media(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Media; }
-        end = try_namespace(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Namespace; }
-        end = try_charset(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Charset; }
-        end = try_important(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Important; }
-        end = try_percentage(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Percentage; }
-        end = try_url_(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Url_; }
-        end = try_unicoderange(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_UnicodeRange; }
-        end = try_mediaonly(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_MediaOnly; }
-        end = try_not(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Not; }
-        end = try_and(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_And; }
-        end = try_dimension(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Dimension; }
-        end = try_unknowndimension(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
-        end = try_plus(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Plus; }
-        end = try_minus(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Minus; }
-        end = try_greater(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Greater; }
-        end = try_comma(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Comma; }
-        end = try_tilde(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Tilde; }
-        end = try_pseudonot(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PseudoNot; }
-        end = try_number(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Number; }
-        end = try_string_(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_String_; }
-        end = try_prefixmatch(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PrefixMatch; }
-        end = try_suffixmatch(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SuffixMatch; }
-        end = try_substringmatch(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SubstringMatch; }
-        end = try_fontface(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_FontFace; }
-        end = try_supports(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Supports; }
-        end = try_or(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Or; }
-        end = try_keyframes(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Keyframes; }
-        end = try_from(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_From; }
-        end = try_to(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_To; }
-        end = try_calc(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Calc; }
-        end = try_viewport(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Viewport; }
-        end = try_counterstyle(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_CounterStyle; }
-        end = try_fontfeaturevalues(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_FontFeatureValues; }
-        end = try_dximagetransform(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_DxImageTransform; }
-        end = try_atkeyword(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_AtKeyword; }
-        end = try_variable(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Variable; }
-        end = try_var(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Var; }
-        end = try_ident(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Ident; }
-        end = try_function_(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_Function_; }
-        end = try_unexpectedcharacter(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        if lexer.chars[start] == '\t' || lexer.chars[start] == '\n' || lexer.chars[start] == '\r' || lexer.chars[start] == ' ' {
+            end = try_space(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Space; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '!' {
+            end = try_important(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Important; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '"' || lexer.chars[start] == '\'' {
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_string_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_String_; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '#' {
+            end = try_hash(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Hash; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '$' {
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_suffixmatch(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SuffixMatch; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '(' {
+            end = try_lit_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == ')' {
+            end = try_lit_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '*' {
+            end = try_lit_star(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_substringmatch(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SubstringMatch; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '+' {
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Plus; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == ',' {
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Comma; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '-' {
+            end = try_cdc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Cdc; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_minus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Minus; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_variable(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Variable; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '.' {
+            end = try_lit_dot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '/' {
+            end = try_lit_slash(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
+            end = try_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Comment; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == ':' {
+            end = try_lit_colon(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_pseudonot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PseudoNot; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == ';' {
+            end = try_lit_semi(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '<' {
+            end = try_cdo(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Cdo; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '=' {
+            end = try_lit_eq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '>' {
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_greater(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Greater; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '@' {
+            end = try_import(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Import; }
+            end = try_page(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Page; }
+            end = try_media(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Media; }
+            end = try_namespace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Namespace; }
+            end = try_charset(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Charset; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_fontface(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FontFace; }
+            end = try_supports(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Supports; }
+            end = try_keyframes(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Keyframes; }
+            end = try_viewport(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Viewport; }
+            end = try_counterstyle(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_CounterStyle; }
+            end = try_fontfeaturevalues(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FontFeatureValues; }
+            end = try_atkeyword(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_AtKeyword; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == 'A' || lexer.chars[start] == 'a' {
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_and(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_And; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == 'F' {
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_from(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_From; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == 'N' || lexer.chars[start] == 'n' {
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_not(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Not; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == 'O' || lexer.chars[start] == 'o' {
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_mediaonly(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MediaOnly; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_or(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Or; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == 'T' || lexer.chars[start] == 't' {
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_to(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_To; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == 'U' {
+            end = try_url(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Url; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_unicoderange(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnicodeRange; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '[' {
+            end = try_lit_lbracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '\\' {
+            end = try_url(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Url; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_mediaonly(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MediaOnly; }
+            end = try_not(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Not; }
+            end = try_and(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_And; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_or(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Or; }
+            end = try_from(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_From; }
+            end = try_to(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_To; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == ']' {
+            end = try_lit_rbracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '^' {
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_prefixmatch(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PrefixMatch; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '_' {
+            end = try_lit__(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT__; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == 'c' {
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_calc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Calc; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == 'f' {
+            end = try_space(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Space; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_from(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_From; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == 'p' {
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_dximagetransform(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DxImageTransform; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == 'u' {
+            end = try_url(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Url; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_url_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Url_; }
+            end = try_unicoderange(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnicodeRange; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == 'v' {
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_var(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Var; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '{' {
+            end = try_lit_lbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '|' {
+            end = try_lit_pipe(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
+            end = try_dashmatch(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DashMatch; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_unicoderange(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnicodeRange; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '}' {
+            end = try_lit_rbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else if lexer.chars[start] == '~' {
+            end = try_includes(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Includes; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_tilde(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Tilde; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        } else {
+            end = try_lit_semi(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
+            end = try_lit_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+            end = try_lit_colon(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
+            end = try_lit_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+            end = try_lit_lbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
+            end = try_lit_rbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
+            end = try_lit_star(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+            end = try_lit_pipe(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
+            end = try_lit_dot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
+            end = try_lit_lbracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
+            end = try_lit_eq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
+            end = try_lit_rbracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
+            end = try_lit_slash(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
+            end = try_lit__(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT__; }
+            end = try_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Comment; }
+            end = try_url(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Url; }
+            end = try_space(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Space; }
+            end = try_cdo(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Cdo; }
+            end = try_cdc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Cdc; }
+            end = try_includes(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Includes; }
+            end = try_dashmatch(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DashMatch; }
+            end = try_hash(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Hash; }
+            end = try_import(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Import; }
+            end = try_page(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Page; }
+            end = try_media(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Media; }
+            end = try_namespace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Namespace; }
+            end = try_charset(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Charset; }
+            end = try_important(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Important; }
+            end = try_percentage(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            end = try_url_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Url_; }
+            end = try_unicoderange(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnicodeRange; }
+            end = try_mediaonly(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MediaOnly; }
+            end = try_not(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Not; }
+            end = try_and(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_And; }
+            end = try_dimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            end = try_unknowndimension(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            end = try_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Plus; }
+            end = try_minus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Minus; }
+            end = try_greater(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Greater; }
+            end = try_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Comma; }
+            end = try_tilde(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Tilde; }
+            end = try_pseudonot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PseudoNot; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Number; }
+            end = try_string_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_String_; }
+            end = try_prefixmatch(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PrefixMatch; }
+            end = try_suffixmatch(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SuffixMatch; }
+            end = try_substringmatch(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SubstringMatch; }
+            end = try_fontface(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FontFace; }
+            end = try_supports(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Supports; }
+            end = try_or(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Or; }
+            end = try_keyframes(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Keyframes; }
+            end = try_from(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_From; }
+            end = try_to(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_To; }
+            end = try_calc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Calc; }
+            end = try_viewport(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Viewport; }
+            end = try_counterstyle(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_CounterStyle; }
+            end = try_fontfeaturevalues(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FontFeatureValues; }
+            end = try_dximagetransform(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DxImageTransform; }
+            end = try_atkeyword(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_AtKeyword; }
+            end = try_variable(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Variable; }
+            end = try_var(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Var; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            end = try_function_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            end = try_unexpectedcharacter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+        }
+        if best_end > start && (lexer.chars[start] == '_') {
+            let kw_kind = classify_keyword(&lexer.chars, start, best_end);
+            if kw_kind >= 0 { best_kind = kw_kind; }
+        }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
             tokens.push(tok);

--- a/package-gale/tests/golden/css3.wado
+++ b/package-gale/tests/golden/css3.wado
@@ -28398,7 +28398,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        if lexer.chars[start] == '\t' || lexer.chars[start] == '\n' || lexer.chars[start] == '\r' || lexer.chars[start] == ' ' {
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
             end = try_space(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Space; }
             end = try_percentage(&lexer.chars, start);
@@ -28415,7 +28416,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '!' {
+        } else if first_char == '!' {
             end = try_important(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Important; }
             end = try_percentage(&lexer.chars, start);
@@ -28432,7 +28433,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '"' || lexer.chars[start] == '\'' {
+        } else if first_char == '"' || first_char == '\'' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28449,7 +28450,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '#' {
+        } else if first_char == '#' {
             end = try_hash(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Hash; }
             end = try_percentage(&lexer.chars, start);
@@ -28466,7 +28467,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '$' {
+        } else if first_char == '$' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28483,9 +28484,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '(' {
-            end = try_lit_lparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+        } else if first_char == '(' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LPAREN; }
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28500,9 +28500,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == ')' {
-            end = try_lit_rparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+        } else if first_char == ')' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RPAREN; }
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28517,9 +28516,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '*' {
-            end = try_lit_star(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+        } else if first_char == '*' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; }
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28536,7 +28534,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '+' {
+        } else if first_char == '+' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28553,7 +28551,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == ',' {
+        } else if first_char == ',' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28570,7 +28568,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '-' {
+        } else if first_char == '-' {
             end = try_cdc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Cdc; }
             end = try_percentage(&lexer.chars, start);
@@ -28591,9 +28589,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '.' {
-            end = try_lit_dot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
+        } else if first_char == '.' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_DOT; }
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28608,9 +28605,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '/' {
-            end = try_lit_slash(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
+        } else if first_char == '/' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SLASH; }
             end = try_comment(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Comment; }
             end = try_percentage(&lexer.chars, start);
@@ -28627,9 +28623,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == ':' {
-            end = try_lit_colon(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
+        } else if first_char == ':' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COLON; }
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28646,9 +28641,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == ';' {
-            end = try_lit_semi(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
+        } else if first_char == ';' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SEMI; }
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28663,7 +28657,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '<' {
+        } else if first_char == '<' {
             end = try_cdo(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Cdo; }
             end = try_percentage(&lexer.chars, start);
@@ -28680,9 +28674,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '=' {
-            end = try_lit_eq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
+        } else if first_char == '=' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_EQ; }
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28697,7 +28690,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '>' {
+        } else if first_char == '>' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28714,7 +28707,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '@' {
+        } else if first_char == '@' {
             end = try_import(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Import; }
             end = try_page(&lexer.chars, start);
@@ -28753,7 +28746,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == 'A' || lexer.chars[start] == 'a' {
+        } else if first_char == 'A' || first_char == 'a' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_and(&lexer.chars, start);
@@ -28770,7 +28763,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == 'F' {
+        } else if first_char == 'F' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28787,7 +28780,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == 'N' || lexer.chars[start] == 'n' {
+        } else if first_char == 'N' || first_char == 'n' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_not(&lexer.chars, start);
@@ -28804,7 +28797,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == 'O' || lexer.chars[start] == 'o' {
+        } else if first_char == 'O' || first_char == 'o' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_mediaonly(&lexer.chars, start);
@@ -28823,7 +28816,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == 'T' || lexer.chars[start] == 't' {
+        } else if first_char == 'T' || first_char == 't' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28840,7 +28833,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == 'U' {
+        } else if first_char == 'U' {
             end = try_url(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Url; }
             end = try_percentage(&lexer.chars, start);
@@ -28859,9 +28852,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '[' {
-            end = try_lit_lbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
+        } else if first_char == '[' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LBRACKET; }
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28876,7 +28868,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '\\' {
+        } else if first_char == '\\' {
             end = try_url(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Url; }
             end = try_percentage(&lexer.chars, start);
@@ -28905,9 +28897,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == ']' {
-            end = try_lit_rbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
+        } else if first_char == ']' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RBRACKET; }
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28922,7 +28913,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '^' {
+        } else if first_char == '^' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28939,9 +28930,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '_' {
-            end = try_lit__(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT__; }
+        } else if first_char == '_' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT__; }
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28956,7 +28946,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == 'c' {
+        } else if first_char == 'c' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -28973,7 +28963,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == 'f' {
+        } else if first_char == 'f' {
             end = try_space(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Space; }
             end = try_percentage(&lexer.chars, start);
@@ -28992,7 +28982,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == 'p' {
+        } else if first_char == 'p' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -29009,7 +28999,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == 'u' {
+        } else if first_char == 'u' {
             end = try_url(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Url; }
             end = try_percentage(&lexer.chars, start);
@@ -29030,7 +29020,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == 'v' {
+        } else if first_char == 'v' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -29047,9 +29037,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '{' {
-            end = try_lit_lbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
+        } else if first_char == '{' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LBRACE; }
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -29064,9 +29053,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '|' {
-            end = try_lit_pipe(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
+        } else if first_char == '|' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PIPE; }
             end = try_dashmatch(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_DashMatch; }
             end = try_percentage(&lexer.chars, start);
@@ -29085,9 +29073,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '}' {
-            end = try_lit_rbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
+        } else if first_char == '}' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RBRACE; }
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
             end = try_dimension(&lexer.chars, start);
@@ -29102,7 +29089,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Function_; }
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
-        } else if lexer.chars[start] == '~' {
+        } else if first_char == '~' {
             end = try_includes(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Includes; }
             end = try_percentage(&lexer.chars, start);
@@ -29251,7 +29238,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         }
-        if best_end > start && (lexer.chars[start] == '_') {
+        if best_end > start && (first_char == '_') {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
             if kw_kind >= 0 { best_kind = kw_kind; }
         }

--- a/package-gale/tests/golden/css3.wado
+++ b/package-gale/tests/golden/css3.wado
@@ -28414,8 +28414,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '!' {
             end = try_important(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Important; }
@@ -28431,8 +28429,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '"' || first_char == '\'' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
@@ -28448,8 +28444,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '#' {
             end = try_hash(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Hash; }
@@ -28465,8 +28459,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '$' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
@@ -28482,8 +28474,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '(' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LPAREN; }
             end = try_percentage(&lexer.chars, start);
@@ -28498,8 +28488,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == ')' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RPAREN; }
             end = try_percentage(&lexer.chars, start);
@@ -28514,8 +28502,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '*' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; }
             end = try_percentage(&lexer.chars, start);
@@ -28532,8 +28518,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '+' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
@@ -28549,8 +28533,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == ',' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
@@ -28566,8 +28548,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '-' {
             end = try_cdc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Cdc; }
@@ -28587,8 +28567,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '.' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_DOT; }
             end = try_percentage(&lexer.chars, start);
@@ -28603,8 +28581,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '/' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SLASH; }
             end = try_comment(&lexer.chars, start);
@@ -28621,8 +28597,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == ':' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COLON; }
             end = try_percentage(&lexer.chars, start);
@@ -28639,8 +28613,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == ';' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SEMI; }
             end = try_percentage(&lexer.chars, start);
@@ -28655,8 +28627,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '<' {
             end = try_cdo(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Cdo; }
@@ -28672,8 +28642,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '=' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_EQ; }
             end = try_percentage(&lexer.chars, start);
@@ -28688,8 +28656,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '>' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
@@ -28705,8 +28671,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '@' {
             end = try_import(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Import; }
@@ -28744,8 +28708,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == 'A' || first_char == 'a' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
@@ -28761,8 +28723,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == 'F' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
@@ -28778,8 +28738,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == 'N' || first_char == 'n' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
@@ -28795,8 +28753,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == 'O' || first_char == 'o' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
@@ -28814,8 +28770,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == 'T' || first_char == 't' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
@@ -28831,8 +28785,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == 'U' {
             end = try_url(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Url; }
@@ -28850,8 +28802,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '[' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LBRACKET; }
             end = try_percentage(&lexer.chars, start);
@@ -28866,8 +28816,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '\\' {
             end = try_url(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Url; }
@@ -28895,8 +28843,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == ']' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RBRACKET; }
             end = try_percentage(&lexer.chars, start);
@@ -28911,8 +28857,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '^' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
@@ -28928,8 +28872,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '_' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT__; }
             end = try_percentage(&lexer.chars, start);
@@ -28944,8 +28886,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == 'c' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
@@ -28961,8 +28901,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == 'f' {
             end = try_space(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Space; }
@@ -28980,8 +28918,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == 'p' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
@@ -28997,8 +28933,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == 'u' {
             end = try_url(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Url; }
@@ -29018,8 +28952,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == 'v' {
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
@@ -29035,8 +28967,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '{' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LBRACE; }
             end = try_percentage(&lexer.chars, start);
@@ -29051,8 +28981,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '|' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PIPE; }
             end = try_dashmatch(&lexer.chars, start);
@@ -29071,8 +28999,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '}' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RBRACE; }
             end = try_percentage(&lexer.chars, start);
@@ -29087,8 +29013,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else if first_char == '~' {
             end = try_includes(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Includes; }
@@ -29106,131 +29030,15 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Function_; }
-            end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         } else {
-            end = try_lit_semi(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
-            end = try_lit_lparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
-            end = try_lit_colon(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
-            end = try_lit_rparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
-            end = try_lit_lbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
-            end = try_lit_rbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
-            end = try_lit_star(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
-            end = try_lit_pipe(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
-            end = try_lit_dot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
-            end = try_lit_lbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
-            end = try_lit_eq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
-            end = try_lit_rbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
-            end = try_lit_slash(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
-            end = try_lit__(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT__; }
-            end = try_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Comment; }
-            end = try_url(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Url; }
-            end = try_space(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Space; }
-            end = try_cdo(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Cdo; }
-            end = try_cdc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Cdc; }
-            end = try_includes(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Includes; }
-            end = try_dashmatch(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DashMatch; }
-            end = try_hash(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Hash; }
-            end = try_import(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Import; }
-            end = try_page(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Page; }
-            end = try_media(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Media; }
-            end = try_namespace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Namespace; }
-            end = try_charset(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Charset; }
-            end = try_important(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Important; }
             end = try_percentage(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Percentage; }
-            end = try_url_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Url_; }
-            end = try_unicoderange(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnicodeRange; }
-            end = try_mediaonly(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MediaOnly; }
-            end = try_not(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Not; }
-            end = try_and(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_And; }
             end = try_dimension(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Dimension; }
             end = try_unknowndimension(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
-            end = try_plus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Plus; }
-            end = try_minus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Minus; }
-            end = try_greater(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Greater; }
-            end = try_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Comma; }
-            end = try_tilde(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Tilde; }
-            end = try_pseudonot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PseudoNot; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Number; }
-            end = try_string_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_String_; }
-            end = try_prefixmatch(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PrefixMatch; }
-            end = try_suffixmatch(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SuffixMatch; }
-            end = try_substringmatch(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SubstringMatch; }
-            end = try_fontface(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FontFace; }
-            end = try_supports(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Supports; }
-            end = try_or(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Or; }
-            end = try_keyframes(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Keyframes; }
-            end = try_from(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_From; }
-            end = try_to(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_To; }
-            end = try_calc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Calc; }
-            end = try_viewport(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Viewport; }
-            end = try_counterstyle(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CounterStyle; }
-            end = try_fontfeaturevalues(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FontFeatureValues; }
-            end = try_dximagetransform(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DxImageTransform; }
-            end = try_atkeyword(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_AtKeyword; }
-            end = try_variable(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Variable; }
-            end = try_var(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Var; }
             end = try_ident(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Ident; }
             end = try_function_(&lexer.chars, start);
@@ -29238,7 +29046,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             end = try_unexpectedcharacter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
         }
-        if best_end > start && (first_char == '_') {
+        if best_end > start {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
             if kw_kind >= 0 { best_kind = kw_kind; }
         }

--- a/package-gale/tests/golden/html.wado
+++ b/package-gale/tests/golden/html.wado
@@ -1713,6 +1713,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
         let mut best_push_mode: i32 = -1;
         let mut best_pop_mode = false;
         if current_mode == 0 {

--- a/package-gale/tests/golden/json.wado
+++ b/package-gale/tests/golden/json.wado
@@ -780,59 +780,54 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        if lexer.chars[start] == '\t' || lexer.chars[start] == '\n' || lexer.chars[start] == '\r' || lexer.chars[start] == ' ' {
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
             end = try_ws(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_WS; }
-        } else if lexer.chars[start] == '"' {
+        } else if first_char == '"' {
             end = try_string(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_STRING; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == ',' {
-            end = try_lit_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
+        } else if first_char == ',' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COMMA; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == ':' {
-            end = try_lit_colon(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
+        } else if first_char == ':' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COLON; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == '[' {
-            end = try_lit_lbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
+        } else if first_char == '[' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LBRACKET; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == ']' {
-            end = try_lit_rbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
+        } else if first_char == ']' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RBRACKET; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == 'f' {
+        } else if first_char == 'f' {
             end = try_lit_false(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_FALSE; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == 'n' {
+        } else if first_char == 'n' {
             end = try_lit_null(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_NULL; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == 't' {
+        } else if first_char == 't' {
             end = try_lit_true(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_TRUE; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == '{' {
-            end = try_lit_lbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
+        } else if first_char == '{' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LBRACE; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == '}' {
-            end = try_lit_rbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
+        } else if first_char == '}' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RBRACE; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
         } else {

--- a/package-gale/tests/golden/json.wado
+++ b/package-gale/tests/golden/json.wado
@@ -780,30 +780,87 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        end = try_lit_lbrace(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
-        end = try_lit_comma(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
-        end = try_lit_rbrace(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
-        end = try_lit_colon(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
-        end = try_lit_lbracket(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
-        end = try_lit_rbracket(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
-        end = try_lit_true(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_TRUE; }
-        end = try_lit_false(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_FALSE; }
-        end = try_lit_null(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_NULL; }
-        end = try_string(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_STRING; }
-        end = try_number(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        end = try_ws(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_WS; }
+        if lexer.chars[start] == '\t' || lexer.chars[start] == '\n' || lexer.chars[start] == '\r' || lexer.chars[start] == ' ' {
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if lexer.chars[start] == '"' {
+            end = try_string(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STRING; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == ',' {
+            end = try_lit_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == ':' {
+            end = try_lit_colon(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == '[' {
+            end = try_lit_lbracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == ']' {
+            end = try_lit_rbracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == 'f' {
+            end = try_lit_false(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_FALSE; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == 'n' {
+            end = try_lit_null(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_NULL; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == 't' {
+            end = try_lit_true(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_TRUE; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == '{' {
+            end = try_lit_lbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == '}' {
+            end = try_lit_rbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else {
+            end = try_lit_lbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
+            end = try_lit_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
+            end = try_lit_rbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
+            end = try_lit_colon(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
+            end = try_lit_lbracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
+            end = try_lit_rbracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
+            end = try_lit_true(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_TRUE; }
+            end = try_lit_false(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_FALSE; }
+            end = try_lit_null(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_NULL; }
+            end = try_string(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STRING; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
             tokens.push(tok);

--- a/package-gale/tests/golden/json.wado
+++ b/package-gale/tests/golden/json.wado
@@ -831,30 +831,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
         } else {
-            end = try_lit_lbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
-            end = try_lit_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
-            end = try_lit_rbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
-            end = try_lit_colon(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
-            end = try_lit_lbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
-            end = try_lit_rbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
-            end = try_lit_true(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_TRUE; }
-            end = try_lit_false(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_FALSE; }
-            end = try_lit_null(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_NULL; }
-            end = try_string(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STRING; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-            end = try_ws(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_WS; }
         }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);

--- a/package-gale/tests/golden/json_highlight.wado
+++ b/package-gale/tests/golden/json_highlight.wado
@@ -780,59 +780,54 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        if lexer.chars[start] == '\t' || lexer.chars[start] == '\n' || lexer.chars[start] == '\r' || lexer.chars[start] == ' ' {
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
             end = try_ws(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_WS; }
-        } else if lexer.chars[start] == '"' {
+        } else if first_char == '"' {
             end = try_string(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_STRING; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == ',' {
-            end = try_lit_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
+        } else if first_char == ',' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COMMA; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == ':' {
-            end = try_lit_colon(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
+        } else if first_char == ':' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COLON; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == '[' {
-            end = try_lit_lbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
+        } else if first_char == '[' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LBRACKET; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == ']' {
-            end = try_lit_rbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
+        } else if first_char == ']' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RBRACKET; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == 'f' {
+        } else if first_char == 'f' {
             end = try_lit_false(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_FALSE; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == 'n' {
+        } else if first_char == 'n' {
             end = try_lit_null(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_NULL; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == 't' {
+        } else if first_char == 't' {
             end = try_lit_true(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_TRUE; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == '{' {
-            end = try_lit_lbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
+        } else if first_char == '{' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LBRACE; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == '}' {
-            end = try_lit_rbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
+        } else if first_char == '}' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RBRACE; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
         } else {

--- a/package-gale/tests/golden/json_highlight.wado
+++ b/package-gale/tests/golden/json_highlight.wado
@@ -780,30 +780,87 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        end = try_lit_lbrace(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
-        end = try_lit_comma(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
-        end = try_lit_rbrace(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
-        end = try_lit_colon(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
-        end = try_lit_lbracket(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
-        end = try_lit_rbracket(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
-        end = try_lit_true(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_TRUE; }
-        end = try_lit_false(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_FALSE; }
-        end = try_lit_null(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_NULL; }
-        end = try_string(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_STRING; }
-        end = try_number(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        end = try_ws(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_WS; }
+        if lexer.chars[start] == '\t' || lexer.chars[start] == '\n' || lexer.chars[start] == '\r' || lexer.chars[start] == ' ' {
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if lexer.chars[start] == '"' {
+            end = try_string(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STRING; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == ',' {
+            end = try_lit_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == ':' {
+            end = try_lit_colon(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == '[' {
+            end = try_lit_lbracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == ']' {
+            end = try_lit_rbracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == 'f' {
+            end = try_lit_false(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_FALSE; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == 'n' {
+            end = try_lit_null(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_NULL; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == 't' {
+            end = try_lit_true(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_TRUE; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == '{' {
+            end = try_lit_lbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == '}' {
+            end = try_lit_rbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else {
+            end = try_lit_lbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
+            end = try_lit_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
+            end = try_lit_rbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
+            end = try_lit_colon(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
+            end = try_lit_lbracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
+            end = try_lit_rbracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
+            end = try_lit_true(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_TRUE; }
+            end = try_lit_false(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_FALSE; }
+            end = try_lit_null(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_NULL; }
+            end = try_string(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STRING; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
             tokens.push(tok);

--- a/package-gale/tests/golden/json_highlight.wado
+++ b/package-gale/tests/golden/json_highlight.wado
@@ -831,30 +831,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
         } else {
-            end = try_lit_lbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; }
-            end = try_lit_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
-            end = try_lit_rbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; }
-            end = try_lit_colon(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COLON; }
-            end = try_lit_lbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; }
-            end = try_lit_rbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; }
-            end = try_lit_true(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_TRUE; }
-            end = try_lit_false(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_FALSE; }
-            end = try_lit_null(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_NULL; }
-            end = try_string(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STRING; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-            end = try_ws(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_WS; }
         }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);

--- a/package-gale/tests/golden/rust.wado
+++ b/package-gale/tests/golden/rust.wado
@@ -8602,288 +8602,44 @@ pub fn tokenize(input: &String) -> Array<Token> {
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
         } else if '\u{2000}' <= first_char <= '\u{200a}' {
-            end = try_whitespace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_whitespace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
             end = try_integer_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
         } else if '0' <= first_char <= '9' {
-            end = try_dec_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DEC_LITERAL; }
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
             end = try_integer_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_dec_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DEC_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
         } else {
-            end = try_kw_as(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_AS; }
-            end = try_kw_break(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_BREAK; }
-            end = try_kw_const(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_CONST; }
-            end = try_kw_continue(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_CONTINUE; }
-            end = try_kw_crate(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_CRATE; }
-            end = try_kw_else(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_ELSE; }
-            end = try_kw_enum(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_ENUM; }
-            end = try_kw_extern(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_EXTERN; }
-            end = try_kw_false(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_FALSE; }
-            end = try_kw_fn(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_FN; }
-            end = try_kw_for(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_FOR; }
-            end = try_kw_if(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_IF; }
-            end = try_kw_impl(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_IMPL; }
-            end = try_kw_in(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_IN; }
-            end = try_kw_let(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_LET; }
-            end = try_kw_loop(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_LOOP; }
-            end = try_kw_match(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_MATCH; }
-            end = try_kw_mod(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_MOD; }
-            end = try_kw_move(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_MOVE; }
-            end = try_kw_mut(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_MUT; }
-            end = try_kw_pub(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_PUB; }
-            end = try_kw_ref(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_REF; }
-            end = try_kw_return(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_RETURN; }
-            end = try_kw_selfvalue(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_SELFVALUE; }
-            end = try_kw_selftype(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_SELFTYPE; }
-            end = try_kw_static(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_STATIC; }
-            end = try_kw_struct(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_STRUCT; }
-            end = try_kw_super(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_SUPER; }
-            end = try_kw_trait(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_TRAIT; }
-            end = try_kw_true(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_TRUE; }
-            end = try_kw_type(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_TYPE; }
-            end = try_kw_unsafe(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_UNSAFE; }
-            end = try_kw_use(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_USE; }
-            end = try_kw_where(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_WHERE; }
-            end = try_kw_while(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_WHILE; }
-            end = try_kw_async(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_ASYNC; }
-            end = try_kw_await(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_AWAIT; }
-            end = try_kw_dyn(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_DYN; }
-            end = try_kw_abstract(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_ABSTRACT; }
-            end = try_kw_become(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_BECOME; }
-            end = try_kw_box(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_BOX; }
-            end = try_kw_do(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_DO; }
-            end = try_kw_final(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_FINAL; }
-            end = try_kw_macro(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_MACRO; }
-            end = try_kw_override(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_OVERRIDE; }
-            end = try_kw_priv(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_PRIV; }
-            end = try_kw_typeof(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_TYPEOF; }
-            end = try_kw_unsized(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_UNSIZED; }
-            end = try_kw_virtual(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_VIRTUAL; }
-            end = try_kw_yield(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_YIELD; }
-            end = try_kw_try(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_TRY; }
-            end = try_kw_union(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_UNION; }
-            end = try_kw_staticlifetime(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_STATICLIFETIME; }
-            end = try_kw_macrorules(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_MACRORULES; }
-            end = try_kw_underlinelifetime(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_UNDERLINELIFETIME; }
-            end = try_kw_dollarcrate(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_DOLLARCRATE; }
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
-            end = try_raw_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RAW_IDENTIFIER; }
-            end = try_line_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LINE_COMMENT; }
-            end = try_block_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT; }
-            end = try_inner_line_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INNER_LINE_DOC; }
-            end = try_inner_block_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INNER_BLOCK_DOC; }
-            end = try_outer_line_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OUTER_LINE_DOC; }
-            end = try_outer_block_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OUTER_BLOCK_DOC; }
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
             end = try_whitespace(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
-            end = try_newline(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NEWLINE; }
-            end = try_char_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CHAR_LITERAL; }
-            end = try_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
-            end = try_raw_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RAW_STRING_LITERAL; }
-            end = try_byte_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BYTE_LITERAL; }
-            end = try_byte_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BYTE_STRING_LITERAL; }
-            end = try_raw_byte_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RAW_BYTE_STRING_LITERAL; }
             end = try_integer_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_dec_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_DEC_LITERAL; }
-            end = try_hex_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_HEX_LITERAL; }
-            end = try_oct_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OCT_LITERAL; }
-            end = try_bin_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BIN_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-            end = try_lifetime_or_label(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIFETIME_OR_LABEL; }
-            end = try_plus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PLUS; }
-            end = try_minus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MINUS; }
-            end = try_star(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STAR; }
-            end = try_slash(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SLASH; }
-            end = try_percent(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PERCENT; }
-            end = try_caret(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CARET; }
-            end = try_not(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NOT; }
-            end = try_and(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_AND; }
-            end = try_or(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OR; }
-            end = try_andand(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ANDAND; }
-            end = try_oror(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OROR; }
-            end = try_pluseq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PLUSEQ; }
-            end = try_minuseq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MINUSEQ; }
-            end = try_stareq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STAREQ; }
-            end = try_slasheq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SLASHEQ; }
-            end = try_percenteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PERCENTEQ; }
-            end = try_careteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CARETEQ; }
-            end = try_andeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ANDEQ; }
-            end = try_oreq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OREQ; }
-            end = try_shleq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHLEQ; }
-            end = try_shreq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHREQ; }
-            end = try_eq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_EQ; }
-            end = try_eqeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_EQEQ; }
-            end = try_ne(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NE; }
-            end = try_gt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_GT; }
-            end = try_lt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LT; }
-            end = try_ge(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_GE; }
-            end = try_le(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LE; }
-            end = try_at(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_AT; }
-            end = try_dot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DOT; }
-            end = try_dotdot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DOTDOT; }
-            end = try_dotdotdot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DOTDOTDOT; }
-            end = try_dotdoteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DOTDOTEQ; }
-            end = try_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_COMMA; }
-            end = try_semi(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SEMI; }
-            end = try_colon(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_COLON; }
-            end = try_pathsep(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PATHSEP; }
-            end = try_rarrow(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RARROW; }
-            end = try_fatarrow(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FATARROW; }
-            end = try_pound(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_POUND; }
-            end = try_dollar(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DOLLAR; }
-            end = try_question(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_QUESTION; }
-            end = try_lcurlybrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LCURLYBRACE; }
-            end = try_rcurlybrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RCURLYBRACE; }
-            end = try_lsquarebracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LSQUAREBRACKET; }
-            end = try_rsquarebracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RSQUAREBRACKET; }
-            end = try_lparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LPAREN; }
-            end = try_rparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RPAREN; }
         }
-        if best_end > start && (first_char == '_') {
+        if best_end > start {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
             if kw_kind >= 0 { best_kind = kw_kind; }
         }

--- a/package-gale/tests/golden/rust.wado
+++ b/package-gale/tests/golden/rust.wado
@@ -7489,13 +7489,6 @@ fn try_at(chars: &Array<char>, start: i32) -> i32 {
     return pos;
 }
 
-fn try_underscore(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '_' { return -1; }
-    pos += 1;
-    return pos;
-}
-
 fn try_dot(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
     if pos >= chars.len() || chars[pos] != '.' { return -1; }
@@ -7645,6 +7638,14 @@ fn try_rparen(chars: &Array<char>, start: i32) -> i32 {
     return pos;
 }
 
+fn classify_keyword(chars: &Array<char>, start: i32, end: i32) -> i32 {
+    let len = end - start;
+    if len == 1 {
+        if chars[start + 0] == '_' { return TK_UNDERSCORE; }
+    }
+    return -1;
+}
+
 pub fn tokenize(input: &String) -> Array<Token> {
     let mut lexer = Lexer::new(input);
     let mut tokens: Array<Token> = [];
@@ -7654,266 +7655,1237 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        end = try_kw_as(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_AS; }
-        end = try_kw_break(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_BREAK; }
-        end = try_kw_const(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_CONST; }
-        end = try_kw_continue(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_CONTINUE; }
-        end = try_kw_crate(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_CRATE; }
-        end = try_kw_else(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_ELSE; }
-        end = try_kw_enum(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_ENUM; }
-        end = try_kw_extern(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_EXTERN; }
-        end = try_kw_false(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_FALSE; }
-        end = try_kw_fn(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_FN; }
-        end = try_kw_for(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_FOR; }
-        end = try_kw_if(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_IF; }
-        end = try_kw_impl(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_IMPL; }
-        end = try_kw_in(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_IN; }
-        end = try_kw_let(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_LET; }
-        end = try_kw_loop(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_LOOP; }
-        end = try_kw_match(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_MATCH; }
-        end = try_kw_mod(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_MOD; }
-        end = try_kw_move(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_MOVE; }
-        end = try_kw_mut(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_MUT; }
-        end = try_kw_pub(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_PUB; }
-        end = try_kw_ref(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_REF; }
-        end = try_kw_return(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_RETURN; }
-        end = try_kw_selfvalue(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_SELFVALUE; }
-        end = try_kw_selftype(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_SELFTYPE; }
-        end = try_kw_static(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_STATIC; }
-        end = try_kw_struct(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_STRUCT; }
-        end = try_kw_super(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_SUPER; }
-        end = try_kw_trait(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_TRAIT; }
-        end = try_kw_true(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_TRUE; }
-        end = try_kw_type(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_TYPE; }
-        end = try_kw_unsafe(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_UNSAFE; }
-        end = try_kw_use(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_USE; }
-        end = try_kw_where(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_WHERE; }
-        end = try_kw_while(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_WHILE; }
-        end = try_kw_async(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_ASYNC; }
-        end = try_kw_await(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_AWAIT; }
-        end = try_kw_dyn(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_DYN; }
-        end = try_kw_abstract(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_ABSTRACT; }
-        end = try_kw_become(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_BECOME; }
-        end = try_kw_box(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_BOX; }
-        end = try_kw_do(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_DO; }
-        end = try_kw_final(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_FINAL; }
-        end = try_kw_macro(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_MACRO; }
-        end = try_kw_override(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_OVERRIDE; }
-        end = try_kw_priv(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_PRIV; }
-        end = try_kw_typeof(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_TYPEOF; }
-        end = try_kw_unsized(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_UNSIZED; }
-        end = try_kw_virtual(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_VIRTUAL; }
-        end = try_kw_yield(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_YIELD; }
-        end = try_kw_try(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_TRY; }
-        end = try_kw_union(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_UNION; }
-        end = try_kw_staticlifetime(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_STATICLIFETIME; }
-        end = try_kw_macrorules(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_MACRORULES; }
-        end = try_kw_underlinelifetime(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_UNDERLINELIFETIME; }
-        end = try_kw_dollarcrate(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_KW_DOLLARCRATE; }
-        end = try_non_keyword_identifier(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
-        end = try_raw_identifier(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_RAW_IDENTIFIER; }
-        end = try_line_comment(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LINE_COMMENT; }
-        end = try_block_comment(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT; }
-        end = try_inner_line_doc(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_INNER_LINE_DOC; }
-        end = try_inner_block_doc(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_INNER_BLOCK_DOC; }
-        end = try_outer_line_doc(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_OUTER_LINE_DOC; }
-        end = try_outer_block_doc(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_OUTER_BLOCK_DOC; }
-        end = try_block_comment_or_doc(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
-        end = try_shebang(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
-        end = try_whitespace(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
-        end = try_newline(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_NEWLINE; }
-        end = try_char_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_CHAR_LITERAL; }
-        end = try_string_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
-        end = try_raw_string_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_RAW_STRING_LITERAL; }
-        end = try_byte_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_BYTE_LITERAL; }
-        end = try_byte_string_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_BYTE_STRING_LITERAL; }
-        end = try_raw_byte_string_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_RAW_BYTE_STRING_LITERAL; }
-        end = try_integer_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
-        end = try_dec_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_DEC_LITERAL; }
-        end = try_hex_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_HEX_LITERAL; }
-        end = try_oct_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_OCT_LITERAL; }
-        end = try_bin_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_BIN_LITERAL; }
-        end = try_float_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        end = try_lifetime_or_label(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIFETIME_OR_LABEL; }
-        end = try_plus(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PLUS; }
-        end = try_minus(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_MINUS; }
-        end = try_star(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_STAR; }
-        end = try_slash(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SLASH; }
-        end = try_percent(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PERCENT; }
-        end = try_caret(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_CARET; }
-        end = try_not(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_NOT; }
-        end = try_and(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_AND; }
-        end = try_or(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_OR; }
-        end = try_andand(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_ANDAND; }
-        end = try_oror(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_OROR; }
-        end = try_pluseq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PLUSEQ; }
-        end = try_minuseq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_MINUSEQ; }
-        end = try_stareq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_STAREQ; }
-        end = try_slasheq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SLASHEQ; }
-        end = try_percenteq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PERCENTEQ; }
-        end = try_careteq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_CARETEQ; }
-        end = try_andeq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_ANDEQ; }
-        end = try_oreq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_OREQ; }
-        end = try_shleq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SHLEQ; }
-        end = try_shreq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SHREQ; }
-        end = try_eq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_EQ; }
-        end = try_eqeq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_EQEQ; }
-        end = try_ne(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_NE; }
-        end = try_gt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_GT; }
-        end = try_lt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LT; }
-        end = try_ge(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_GE; }
-        end = try_le(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LE; }
-        end = try_at(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_AT; }
-        end = try_underscore(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_UNDERSCORE; }
-        end = try_dot(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_DOT; }
-        end = try_dotdot(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_DOTDOT; }
-        end = try_dotdotdot(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_DOTDOTDOT; }
-        end = try_dotdoteq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_DOTDOTEQ; }
-        end = try_comma(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_COMMA; }
-        end = try_semi(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SEMI; }
-        end = try_colon(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_COLON; }
-        end = try_pathsep(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PATHSEP; }
-        end = try_rarrow(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_RARROW; }
-        end = try_fatarrow(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_FATARROW; }
-        end = try_pound(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_POUND; }
-        end = try_dollar(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_DOLLAR; }
-        end = try_question(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_QUESTION; }
-        end = try_lcurlybrace(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LCURLYBRACE; }
-        end = try_rcurlybrace(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_RCURLYBRACE; }
-        end = try_lsquarebracket(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LSQUAREBRACKET; }
-        end = try_rsquarebracket(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_RSQUAREBRACKET; }
-        end = try_lparen(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LPAREN; }
-        end = try_rparen(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_RPAREN; }
+        if lexer.chars[start] == '\n' || lexer.chars[start] == '\r' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_newline(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NEWLINE; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == ' ' || lexer.chars[start] == '\u{a0}' || lexer.chars[start] == '\u{1680}' || lexer.chars[start] == '\u{202f}' || lexer.chars[start] == '\u{205f}' || lexer.chars[start] == '\u{3000}' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_whitespace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == '!' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_not(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NOT; }
+            end = try_ne(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NE; }
+        } else if lexer.chars[start] == '"' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_string_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == '#' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_pound(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_POUND; }
+        } else if lexer.chars[start] == '$' {
+            end = try_kw_dollarcrate(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_DOLLARCRATE; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_dollar(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DOLLAR; }
+        } else if lexer.chars[start] == '%' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_percent(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PERCENT; }
+            end = try_percenteq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PERCENTEQ; }
+        } else if lexer.chars[start] == '&' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_and(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_AND; }
+            end = try_andand(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ANDAND; }
+            end = try_andeq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ANDEQ; }
+        } else if lexer.chars[start] == '\'' {
+            end = try_kw_staticlifetime(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_STATICLIFETIME; }
+            end = try_kw_underlinelifetime(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_UNDERLINELIFETIME; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_char_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_CHAR_LITERAL; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_lifetime_or_label(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIFETIME_OR_LABEL; }
+        } else if lexer.chars[start] == '(' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LPAREN; }
+        } else if lexer.chars[start] == ')' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RPAREN; }
+        } else if lexer.chars[start] == '*' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_star(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STAR; }
+            end = try_stareq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STAREQ; }
+        } else if lexer.chars[start] == '+' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PLUS; }
+            end = try_pluseq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PLUSEQ; }
+        } else if lexer.chars[start] == ',' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_COMMA; }
+        } else if lexer.chars[start] == '-' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_minus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MINUS; }
+            end = try_minuseq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MINUSEQ; }
+            end = try_rarrow(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RARROW; }
+        } else if lexer.chars[start] == '.' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_dot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DOT; }
+            end = try_dotdot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DOTDOT; }
+            end = try_dotdotdot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DOTDOTDOT; }
+            end = try_dotdoteq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DOTDOTEQ; }
+        } else if lexer.chars[start] == '/' {
+            end = try_line_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LINE_COMMENT; }
+            end = try_block_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT; }
+            end = try_inner_line_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INNER_LINE_DOC; }
+            end = try_inner_block_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INNER_BLOCK_DOC; }
+            end = try_outer_line_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OUTER_LINE_DOC; }
+            end = try_outer_block_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OUTER_BLOCK_DOC; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_slash(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SLASH; }
+            end = try_slasheq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SLASHEQ; }
+        } else if lexer.chars[start] == '0' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_dec_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DEC_LITERAL; }
+            end = try_hex_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_HEX_LITERAL; }
+            end = try_oct_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OCT_LITERAL; }
+            end = try_bin_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BIN_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == ':' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_colon(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_COLON; }
+            end = try_pathsep(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PATHSEP; }
+        } else if lexer.chars[start] == ';' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_semi(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SEMI; }
+        } else if lexer.chars[start] == '<' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_shleq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHLEQ; }
+            end = try_lt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LT; }
+            end = try_le(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LE; }
+        } else if lexer.chars[start] == '=' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_eq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_EQ; }
+            end = try_eqeq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_EQEQ; }
+            end = try_fatarrow(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FATARROW; }
+        } else if lexer.chars[start] == '>' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_shreq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHREQ; }
+            end = try_gt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_GT; }
+            end = try_ge(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_GE; }
+        } else if lexer.chars[start] == '?' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_question(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_QUESTION; }
+        } else if lexer.chars[start] == '@' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_at(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_AT; }
+        } else if lexer.chars[start] == 'S' {
+            end = try_kw_selftype(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_SELFTYPE; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == '[' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_lsquarebracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LSQUAREBRACKET; }
+        } else if lexer.chars[start] == ']' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_rsquarebracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RSQUAREBRACKET; }
+        } else if lexer.chars[start] == '^' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_caret(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_CARET; }
+            end = try_careteq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_CARETEQ; }
+        } else if lexer.chars[start] == '_' || lexer.chars[start] == '\u{2118}' || lexer.chars[start] == '\u{212e}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'a' {
+            end = try_kw_as(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_AS; }
+            end = try_kw_async(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_ASYNC; }
+            end = try_kw_await(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_AWAIT; }
+            end = try_kw_abstract(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_ABSTRACT; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'b' {
+            end = try_kw_break(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_BREAK; }
+            end = try_kw_become(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_BECOME; }
+            end = try_kw_box(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_BOX; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_byte_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BYTE_LITERAL; }
+            end = try_byte_string_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BYTE_STRING_LITERAL; }
+            end = try_raw_byte_string_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RAW_BYTE_STRING_LITERAL; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'c' {
+            end = try_kw_const(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_CONST; }
+            end = try_kw_continue(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_CONTINUE; }
+            end = try_kw_crate(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_CRATE; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'd' {
+            end = try_kw_dyn(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_DYN; }
+            end = try_kw_do(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_DO; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'e' {
+            end = try_kw_else(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_ELSE; }
+            end = try_kw_enum(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_ENUM; }
+            end = try_kw_extern(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_EXTERN; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'f' {
+            end = try_kw_false(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_FALSE; }
+            end = try_kw_fn(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_FN; }
+            end = try_kw_for(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_FOR; }
+            end = try_kw_final(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_FINAL; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'i' {
+            end = try_kw_if(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_IF; }
+            end = try_kw_impl(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_IMPL; }
+            end = try_kw_in(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_IN; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'l' {
+            end = try_kw_let(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_LET; }
+            end = try_kw_loop(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_LOOP; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'm' {
+            end = try_kw_match(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_MATCH; }
+            end = try_kw_mod(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_MOD; }
+            end = try_kw_move(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_MOVE; }
+            end = try_kw_mut(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_MUT; }
+            end = try_kw_macro(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_MACRO; }
+            end = try_kw_macrorules(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_MACRORULES; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'o' {
+            end = try_kw_override(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_OVERRIDE; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'p' {
+            end = try_kw_pub(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_PUB; }
+            end = try_kw_priv(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_PRIV; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'r' {
+            end = try_kw_ref(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_REF; }
+            end = try_kw_return(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_RETURN; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_raw_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RAW_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_raw_string_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RAW_STRING_LITERAL; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 's' {
+            end = try_kw_selfvalue(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_SELFVALUE; }
+            end = try_kw_static(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_STATIC; }
+            end = try_kw_struct(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_STRUCT; }
+            end = try_kw_super(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_SUPER; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 't' {
+            end = try_kw_trait(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_TRAIT; }
+            end = try_kw_true(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_TRUE; }
+            end = try_kw_type(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_TYPE; }
+            end = try_kw_typeof(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_TYPEOF; }
+            end = try_kw_try(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_TRY; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'u' {
+            end = try_kw_unsafe(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_UNSAFE; }
+            end = try_kw_use(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_USE; }
+            end = try_kw_unsized(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_UNSIZED; }
+            end = try_kw_union(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_UNION; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'v' {
+            end = try_kw_virtual(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_VIRTUAL; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'w' {
+            end = try_kw_where(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_WHERE; }
+            end = try_kw_while(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_WHILE; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == 'y' {
+            end = try_kw_yield(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_YIELD; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if lexer.chars[start] == '{' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_lcurlybrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LCURLYBRACE; }
+        } else if lexer.chars[start] == '|' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_or(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OR; }
+            end = try_oror(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OROR; }
+            end = try_oreq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OREQ; }
+        } else if lexer.chars[start] == '}' {
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_rcurlybrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RCURLYBRACE; }
+        } else if 'A' <= lexer.chars[start] <= 'Z' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if 'a' <= lexer.chars[start] <= 'z' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{c0}' <= lexer.chars[start] <= '\u{d6}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{d8}' <= lexer.chars[start] <= '\u{f6}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{f8}' <= lexer.chars[start] <= '\u{ff}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{100}' <= lexer.chars[start] <= '\u{24f}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{370}' <= lexer.chars[start] <= '\u{3ff}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{400}' <= lexer.chars[start] <= '\u{4ff}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{600}' <= lexer.chars[start] <= '\u{6ff}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{900}' <= lexer.chars[start] <= '\u{97f}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{4e00}' <= lexer.chars[start] <= '\u{9fff}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{3040}' <= lexer.chars[start] <= '\u{309f}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{30a0}' <= lexer.chars[start] <= '\u{30ff}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{ac00}' <= lexer.chars[start] <= '\u{d7af}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{2160}' <= lexer.chars[start] <= '\u{2188}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{16ee}' <= lexer.chars[start] <= '\u{16f0}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{1885}' <= lexer.chars[start] <= '\u{1886}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{309b}' <= lexer.chars[start] <= '\u{309c}' {
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '\u{2000}' <= lexer.chars[start] <= '\u{200a}' {
+            end = try_whitespace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else if '0' <= lexer.chars[start] <= '9' {
+            end = try_dec_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DEC_LITERAL; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+        } else {
+            end = try_kw_as(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_AS; }
+            end = try_kw_break(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_BREAK; }
+            end = try_kw_const(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_CONST; }
+            end = try_kw_continue(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_CONTINUE; }
+            end = try_kw_crate(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_CRATE; }
+            end = try_kw_else(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_ELSE; }
+            end = try_kw_enum(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_ENUM; }
+            end = try_kw_extern(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_EXTERN; }
+            end = try_kw_false(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_FALSE; }
+            end = try_kw_fn(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_FN; }
+            end = try_kw_for(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_FOR; }
+            end = try_kw_if(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_IF; }
+            end = try_kw_impl(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_IMPL; }
+            end = try_kw_in(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_IN; }
+            end = try_kw_let(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_LET; }
+            end = try_kw_loop(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_LOOP; }
+            end = try_kw_match(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_MATCH; }
+            end = try_kw_mod(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_MOD; }
+            end = try_kw_move(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_MOVE; }
+            end = try_kw_mut(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_MUT; }
+            end = try_kw_pub(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_PUB; }
+            end = try_kw_ref(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_REF; }
+            end = try_kw_return(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_RETURN; }
+            end = try_kw_selfvalue(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_SELFVALUE; }
+            end = try_kw_selftype(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_SELFTYPE; }
+            end = try_kw_static(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_STATIC; }
+            end = try_kw_struct(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_STRUCT; }
+            end = try_kw_super(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_SUPER; }
+            end = try_kw_trait(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_TRAIT; }
+            end = try_kw_true(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_TRUE; }
+            end = try_kw_type(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_TYPE; }
+            end = try_kw_unsafe(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_UNSAFE; }
+            end = try_kw_use(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_USE; }
+            end = try_kw_where(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_WHERE; }
+            end = try_kw_while(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_WHILE; }
+            end = try_kw_async(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_ASYNC; }
+            end = try_kw_await(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_AWAIT; }
+            end = try_kw_dyn(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_DYN; }
+            end = try_kw_abstract(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_ABSTRACT; }
+            end = try_kw_become(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_BECOME; }
+            end = try_kw_box(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_BOX; }
+            end = try_kw_do(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_DO; }
+            end = try_kw_final(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_FINAL; }
+            end = try_kw_macro(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_MACRO; }
+            end = try_kw_override(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_OVERRIDE; }
+            end = try_kw_priv(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_PRIV; }
+            end = try_kw_typeof(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_TYPEOF; }
+            end = try_kw_unsized(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_UNSIZED; }
+            end = try_kw_virtual(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_VIRTUAL; }
+            end = try_kw_yield(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_YIELD; }
+            end = try_kw_try(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_TRY; }
+            end = try_kw_union(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_UNION; }
+            end = try_kw_staticlifetime(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_STATICLIFETIME; }
+            end = try_kw_macrorules(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_MACRORULES; }
+            end = try_kw_underlinelifetime(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_UNDERLINELIFETIME; }
+            end = try_kw_dollarcrate(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KW_DOLLARCRATE; }
+            end = try_non_keyword_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            end = try_raw_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RAW_IDENTIFIER; }
+            end = try_line_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LINE_COMMENT; }
+            end = try_block_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT; }
+            end = try_inner_line_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INNER_LINE_DOC; }
+            end = try_inner_block_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INNER_BLOCK_DOC; }
+            end = try_outer_line_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OUTER_LINE_DOC; }
+            end = try_outer_block_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OUTER_BLOCK_DOC; }
+            end = try_block_comment_or_doc(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            end = try_shebang(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            end = try_whitespace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
+            end = try_newline(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NEWLINE; }
+            end = try_char_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_CHAR_LITERAL; }
+            end = try_string_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
+            end = try_raw_string_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RAW_STRING_LITERAL; }
+            end = try_byte_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BYTE_LITERAL; }
+            end = try_byte_string_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BYTE_STRING_LITERAL; }
+            end = try_raw_byte_string_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RAW_BYTE_STRING_LITERAL; }
+            end = try_integer_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            end = try_dec_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DEC_LITERAL; }
+            end = try_hex_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_HEX_LITERAL; }
+            end = try_oct_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OCT_LITERAL; }
+            end = try_bin_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BIN_LITERAL; }
+            end = try_float_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            end = try_lifetime_or_label(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIFETIME_OR_LABEL; }
+            end = try_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PLUS; }
+            end = try_minus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MINUS; }
+            end = try_star(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STAR; }
+            end = try_slash(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SLASH; }
+            end = try_percent(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PERCENT; }
+            end = try_caret(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_CARET; }
+            end = try_not(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NOT; }
+            end = try_and(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_AND; }
+            end = try_or(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OR; }
+            end = try_andand(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ANDAND; }
+            end = try_oror(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OROR; }
+            end = try_pluseq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PLUSEQ; }
+            end = try_minuseq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MINUSEQ; }
+            end = try_stareq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STAREQ; }
+            end = try_slasheq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SLASHEQ; }
+            end = try_percenteq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PERCENTEQ; }
+            end = try_careteq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_CARETEQ; }
+            end = try_andeq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ANDEQ; }
+            end = try_oreq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OREQ; }
+            end = try_shleq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHLEQ; }
+            end = try_shreq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SHREQ; }
+            end = try_eq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_EQ; }
+            end = try_eqeq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_EQEQ; }
+            end = try_ne(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NE; }
+            end = try_gt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_GT; }
+            end = try_lt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LT; }
+            end = try_ge(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_GE; }
+            end = try_le(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LE; }
+            end = try_at(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_AT; }
+            end = try_dot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DOT; }
+            end = try_dotdot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DOTDOT; }
+            end = try_dotdotdot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DOTDOTDOT; }
+            end = try_dotdoteq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DOTDOTEQ; }
+            end = try_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_COMMA; }
+            end = try_semi(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SEMI; }
+            end = try_colon(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_COLON; }
+            end = try_pathsep(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PATHSEP; }
+            end = try_rarrow(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RARROW; }
+            end = try_fatarrow(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FATARROW; }
+            end = try_pound(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_POUND; }
+            end = try_dollar(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DOLLAR; }
+            end = try_question(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_QUESTION; }
+            end = try_lcurlybrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LCURLYBRACE; }
+            end = try_rcurlybrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RCURLYBRACE; }
+            end = try_lsquarebracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LSQUAREBRACKET; }
+            end = try_rsquarebracket(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RSQUAREBRACKET; }
+            end = try_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LPAREN; }
+            end = try_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RPAREN; }
+        }
+        if best_end > start && (lexer.chars[start] == '_') {
+            let kw_kind = classify_keyword(&lexer.chars, start, best_end);
+            if kw_kind >= 0 { best_kind = kw_kind; }
+        }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
             tokens.push(tok);

--- a/package-gale/tests/golden/rust.wado
+++ b/package-gale/tests/golden/rust.wado
@@ -7655,7 +7655,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        if lexer.chars[start] == '\n' || lexer.chars[start] == '\r' {
+        let first_char = lexer.chars[start];
+        if first_char == '\n' || first_char == '\r' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7666,7 +7667,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == ' ' || lexer.chars[start] == '\u{a0}' || lexer.chars[start] == '\u{1680}' || lexer.chars[start] == '\u{202f}' || lexer.chars[start] == '\u{205f}' || lexer.chars[start] == '\u{3000}' {
+        } else if first_char == ' ' || first_char == '\u{a0}' || first_char == '\u{1680}' || first_char == '\u{202f}' || first_char == '\u{205f}' || first_char == '\u{3000}' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7677,7 +7678,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == '!' {
+        } else if first_char == '!' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7690,7 +7691,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_NOT; }
             end = try_ne(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NE; }
-        } else if lexer.chars[start] == '"' {
+        } else if first_char == '"' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7701,7 +7702,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == '#' {
+        } else if first_char == '#' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7712,7 +7713,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
             end = try_pound(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_POUND; }
-        } else if lexer.chars[start] == '$' {
+        } else if first_char == '$' {
             end = try_kw_dollarcrate(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_DOLLARCRATE; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -7725,7 +7726,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
             end = try_dollar(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_DOLLAR; }
-        } else if lexer.chars[start] == '%' {
+        } else if first_char == '%' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7738,7 +7739,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_PERCENT; }
             end = try_percenteq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_PERCENTEQ; }
-        } else if lexer.chars[start] == '&' {
+        } else if first_char == '&' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7753,7 +7754,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_ANDAND; }
             end = try_andeq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_ANDEQ; }
-        } else if lexer.chars[start] == '\'' {
+        } else if first_char == '\'' {
             end = try_kw_staticlifetime(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_STATICLIFETIME; }
             end = try_kw_underlinelifetime(&lexer.chars, start);
@@ -7770,7 +7771,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
             end = try_lifetime_or_label(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIFETIME_OR_LABEL; }
-        } else if lexer.chars[start] == '(' {
+        } else if first_char == '(' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7781,7 +7782,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
             end = try_lparen(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LPAREN; }
-        } else if lexer.chars[start] == ')' {
+        } else if first_char == ')' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7792,7 +7793,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
             end = try_rparen(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_RPAREN; }
-        } else if lexer.chars[start] == '*' {
+        } else if first_char == '*' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7805,7 +7806,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_STAR; }
             end = try_stareq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_STAREQ; }
-        } else if lexer.chars[start] == '+' {
+        } else if first_char == '+' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7818,7 +7819,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_PLUS; }
             end = try_pluseq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_PLUSEQ; }
-        } else if lexer.chars[start] == ',' {
+        } else if first_char == ',' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7829,7 +7830,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
             end = try_comma(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_COMMA; }
-        } else if lexer.chars[start] == '-' {
+        } else if first_char == '-' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7844,7 +7845,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_MINUSEQ; }
             end = try_rarrow(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_RARROW; }
-        } else if lexer.chars[start] == '.' {
+        } else if first_char == '.' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7861,7 +7862,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_DOTDOTDOT; }
             end = try_dotdoteq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_DOTDOTEQ; }
-        } else if lexer.chars[start] == '/' {
+        } else if first_char == '/' {
             end = try_line_comment(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LINE_COMMENT; }
             end = try_block_comment(&lexer.chars, start);
@@ -7886,7 +7887,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_SLASH; }
             end = try_slasheq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SLASHEQ; }
-        } else if lexer.chars[start] == '0' {
+        } else if first_char == '0' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7903,7 +7904,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_BIN_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == ':' {
+        } else if first_char == ':' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7916,7 +7917,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_COLON; }
             end = try_pathsep(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_PATHSEP; }
-        } else if lexer.chars[start] == ';' {
+        } else if first_char == ';' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7927,7 +7928,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
             end = try_semi(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SEMI; }
-        } else if lexer.chars[start] == '<' {
+        } else if first_char == '<' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7942,7 +7943,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_LT; }
             end = try_le(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LE; }
-        } else if lexer.chars[start] == '=' {
+        } else if first_char == '=' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7957,7 +7958,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_EQEQ; }
             end = try_fatarrow(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FATARROW; }
-        } else if lexer.chars[start] == '>' {
+        } else if first_char == '>' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7972,7 +7973,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_GT; }
             end = try_ge(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_GE; }
-        } else if lexer.chars[start] == '?' {
+        } else if first_char == '?' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7983,7 +7984,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
             end = try_question(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_QUESTION; }
-        } else if lexer.chars[start] == '@' {
+        } else if first_char == '@' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -7994,7 +7995,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
             end = try_at(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_AT; }
-        } else if lexer.chars[start] == 'S' {
+        } else if first_char == 'S' {
             end = try_kw_selftype(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_SELFTYPE; }
             end = try_non_keyword_identifier(&lexer.chars, start);
@@ -8007,7 +8008,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == '[' {
+        } else if first_char == '[' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -8018,7 +8019,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
             end = try_lsquarebracket(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LSQUAREBRACKET; }
-        } else if lexer.chars[start] == ']' {
+        } else if first_char == ']' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -8029,7 +8030,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
             end = try_rsquarebracket(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_RSQUAREBRACKET; }
-        } else if lexer.chars[start] == '^' {
+        } else if first_char == '^' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -8042,7 +8043,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_CARET; }
             end = try_careteq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_CARETEQ; }
-        } else if lexer.chars[start] == '_' || lexer.chars[start] == '\u{2118}' || lexer.chars[start] == '\u{212e}' {
+        } else if first_char == '_' || first_char == '\u{2118}' || first_char == '\u{212e}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8053,7 +8054,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'a' {
+        } else if first_char == 'a' {
             end = try_kw_as(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_AS; }
             end = try_kw_async(&lexer.chars, start);
@@ -8072,7 +8073,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'b' {
+        } else if first_char == 'b' {
             end = try_kw_break(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_BREAK; }
             end = try_kw_become(&lexer.chars, start);
@@ -8095,7 +8096,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'c' {
+        } else if first_char == 'c' {
             end = try_kw_const(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_CONST; }
             end = try_kw_continue(&lexer.chars, start);
@@ -8112,7 +8113,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'd' {
+        } else if first_char == 'd' {
             end = try_kw_dyn(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_DYN; }
             end = try_kw_do(&lexer.chars, start);
@@ -8127,7 +8128,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'e' {
+        } else if first_char == 'e' {
             end = try_kw_else(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_ELSE; }
             end = try_kw_enum(&lexer.chars, start);
@@ -8144,7 +8145,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'f' {
+        } else if first_char == 'f' {
             end = try_kw_false(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_FALSE; }
             end = try_kw_fn(&lexer.chars, start);
@@ -8163,7 +8164,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'i' {
+        } else if first_char == 'i' {
             end = try_kw_if(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_IF; }
             end = try_kw_impl(&lexer.chars, start);
@@ -8180,7 +8181,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'l' {
+        } else if first_char == 'l' {
             end = try_kw_let(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_LET; }
             end = try_kw_loop(&lexer.chars, start);
@@ -8195,7 +8196,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'm' {
+        } else if first_char == 'm' {
             end = try_kw_match(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_MATCH; }
             end = try_kw_mod(&lexer.chars, start);
@@ -8218,7 +8219,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'o' {
+        } else if first_char == 'o' {
             end = try_kw_override(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_OVERRIDE; }
             end = try_non_keyword_identifier(&lexer.chars, start);
@@ -8231,7 +8232,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'p' {
+        } else if first_char == 'p' {
             end = try_kw_pub(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_PUB; }
             end = try_kw_priv(&lexer.chars, start);
@@ -8246,7 +8247,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'r' {
+        } else if first_char == 'r' {
             end = try_kw_ref(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_REF; }
             end = try_kw_return(&lexer.chars, start);
@@ -8265,7 +8266,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 's' {
+        } else if first_char == 's' {
             end = try_kw_selfvalue(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_SELFVALUE; }
             end = try_kw_static(&lexer.chars, start);
@@ -8284,7 +8285,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 't' {
+        } else if first_char == 't' {
             end = try_kw_trait(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_TRAIT; }
             end = try_kw_true(&lexer.chars, start);
@@ -8305,7 +8306,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'u' {
+        } else if first_char == 'u' {
             end = try_kw_unsafe(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_UNSAFE; }
             end = try_kw_use(&lexer.chars, start);
@@ -8324,7 +8325,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'v' {
+        } else if first_char == 'v' {
             end = try_kw_virtual(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_VIRTUAL; }
             end = try_non_keyword_identifier(&lexer.chars, start);
@@ -8337,7 +8338,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'w' {
+        } else if first_char == 'w' {
             end = try_kw_where(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_WHERE; }
             end = try_kw_while(&lexer.chars, start);
@@ -8352,7 +8353,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == 'y' {
+        } else if first_char == 'y' {
             end = try_kw_yield(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KW_YIELD; }
             end = try_non_keyword_identifier(&lexer.chars, start);
@@ -8365,7 +8366,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if lexer.chars[start] == '{' {
+        } else if first_char == '{' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -8376,7 +8377,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
             end = try_lcurlybrace(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LCURLYBRACE; }
-        } else if lexer.chars[start] == '|' {
+        } else if first_char == '|' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -8391,7 +8392,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_OROR; }
             end = try_oreq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_OREQ; }
-        } else if lexer.chars[start] == '}' {
+        } else if first_char == '}' {
             end = try_block_comment_or_doc(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
             end = try_shebang(&lexer.chars, start);
@@ -8402,7 +8403,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
             end = try_rcurlybrace(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_RCURLYBRACE; }
-        } else if 'A' <= lexer.chars[start] <= 'Z' {
+        } else if 'A' <= first_char <= 'Z' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8413,7 +8414,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if 'a' <= lexer.chars[start] <= 'z' {
+        } else if 'a' <= first_char <= 'z' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8424,7 +8425,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{c0}' <= lexer.chars[start] <= '\u{d6}' {
+        } else if '\u{c0}' <= first_char <= '\u{d6}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8435,7 +8436,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{d8}' <= lexer.chars[start] <= '\u{f6}' {
+        } else if '\u{d8}' <= first_char <= '\u{f6}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8446,7 +8447,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{f8}' <= lexer.chars[start] <= '\u{ff}' {
+        } else if '\u{f8}' <= first_char <= '\u{ff}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8457,7 +8458,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{100}' <= lexer.chars[start] <= '\u{24f}' {
+        } else if '\u{100}' <= first_char <= '\u{24f}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8468,7 +8469,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{370}' <= lexer.chars[start] <= '\u{3ff}' {
+        } else if '\u{370}' <= first_char <= '\u{3ff}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8479,7 +8480,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{400}' <= lexer.chars[start] <= '\u{4ff}' {
+        } else if '\u{400}' <= first_char <= '\u{4ff}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8490,7 +8491,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{600}' <= lexer.chars[start] <= '\u{6ff}' {
+        } else if '\u{600}' <= first_char <= '\u{6ff}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8501,7 +8502,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{900}' <= lexer.chars[start] <= '\u{97f}' {
+        } else if '\u{900}' <= first_char <= '\u{97f}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8512,7 +8513,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{4e00}' <= lexer.chars[start] <= '\u{9fff}' {
+        } else if '\u{4e00}' <= first_char <= '\u{9fff}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8523,7 +8524,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{3040}' <= lexer.chars[start] <= '\u{309f}' {
+        } else if '\u{3040}' <= first_char <= '\u{309f}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8534,7 +8535,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{30a0}' <= lexer.chars[start] <= '\u{30ff}' {
+        } else if '\u{30a0}' <= first_char <= '\u{30ff}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8545,7 +8546,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{ac00}' <= lexer.chars[start] <= '\u{d7af}' {
+        } else if '\u{ac00}' <= first_char <= '\u{d7af}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8556,7 +8557,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{2160}' <= lexer.chars[start] <= '\u{2188}' {
+        } else if '\u{2160}' <= first_char <= '\u{2188}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8567,7 +8568,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{16ee}' <= lexer.chars[start] <= '\u{16f0}' {
+        } else if '\u{16ee}' <= first_char <= '\u{16f0}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8578,7 +8579,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{1885}' <= lexer.chars[start] <= '\u{1886}' {
+        } else if '\u{1885}' <= first_char <= '\u{1886}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8589,7 +8590,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{309b}' <= lexer.chars[start] <= '\u{309c}' {
+        } else if '\u{309b}' <= first_char <= '\u{309c}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8600,7 +8601,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '\u{2000}' <= lexer.chars[start] <= '\u{200a}' {
+        } else if '\u{2000}' <= first_char <= '\u{200a}' {
             end = try_whitespace(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8611,7 +8612,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
             end = try_float_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
-        } else if '0' <= lexer.chars[start] <= '9' {
+        } else if '0' <= first_char <= '9' {
             end = try_dec_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_DEC_LITERAL; }
             end = try_block_comment_or_doc(&lexer.chars, start);
@@ -8882,7 +8883,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             end = try_rparen(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_RPAREN; }
         }
-        if best_end > start && (lexer.chars[start] == '_') {
+        if best_end > start && (first_char == '_') {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
             if kw_kind >= 0 { best_kind = kw_kind; }
         }

--- a/package-gale/tests/golden/sexpression.wado
+++ b/package-gale/tests/golden/sexpression.wado
@@ -856,44 +856,45 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        if lexer.chars[start] == '\t' || lexer.chars[start] == '\n' || lexer.chars[start] == '\r' || lexer.chars[start] == ' ' {
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
             end = try_whitespace(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == '"' {
+        } else if first_char == '"' {
             end = try_string(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_STRING; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if lexer.chars[start] == '(' {
+        } else if first_char == '(' {
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
             end = try_lparen(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LPAREN; }
-        } else if lexer.chars[start] == ')' {
+        } else if first_char == ')' {
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
             end = try_rparen(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_RPAREN; }
-        } else if lexer.chars[start] == '*' || lexer.chars[start] == '+' || lexer.chars[start] == '-' || lexer.chars[start] == '/' {
+        } else if first_char == '*' || first_char == '+' || first_char == '-' || first_char == '/' {
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
             end = try_symbol(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
-        } else if lexer.chars[start] == '.' {
+        } else if first_char == '.' {
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
             end = try_symbol(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
             end = try_dot(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_DOT; }
-        } else if 'a' <= lexer.chars[start] <= 'z' {
+        } else if 'a' <= first_char <= 'z' {
             end = try_symbol(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        } else if 'A' <= lexer.chars[start] <= 'Z' {
+        } else if 'A' <= first_char <= 'Z' {
             end = try_symbol(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
             end = try_number(&lexer.chars, start);

--- a/package-gale/tests/golden/sexpression.wado
+++ b/package-gale/tests/golden/sexpression.wado
@@ -890,30 +890,20 @@ pub fn tokenize(input: &String) -> Array<Token> {
             end = try_dot(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_DOT; }
         } else if 'a' <= first_char <= 'z' {
-            end = try_symbol(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+            end = try_symbol(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
         } else if 'A' <= first_char <= 'Z' {
-            end = try_symbol(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+            end = try_symbol(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
         } else {
-            end = try_string(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STRING; }
-            end = try_whitespace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
             end = try_number(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMBER; }
             end = try_symbol(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
-            end = try_lparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LPAREN; }
-            end = try_rparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RPAREN; }
-            end = try_dot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DOT; }
         }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);

--- a/package-gale/tests/golden/sexpression.wado
+++ b/package-gale/tests/golden/sexpression.wado
@@ -856,20 +856,64 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        end = try_string(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_STRING; }
-        end = try_whitespace(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
-        end = try_number(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_NUMBER; }
-        end = try_symbol(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
-        end = try_lparen(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LPAREN; }
-        end = try_rparen(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_RPAREN; }
-        end = try_dot(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_DOT; }
+        if lexer.chars[start] == '\t' || lexer.chars[start] == '\n' || lexer.chars[start] == '\r' || lexer.chars[start] == ' ' {
+            end = try_whitespace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == '"' {
+            end = try_string(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STRING; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if lexer.chars[start] == '(' {
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+            end = try_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LPAREN; }
+        } else if lexer.chars[start] == ')' {
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+            end = try_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RPAREN; }
+        } else if lexer.chars[start] == '*' || lexer.chars[start] == '+' || lexer.chars[start] == '-' || lexer.chars[start] == '/' {
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+            end = try_symbol(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
+        } else if lexer.chars[start] == '.' {
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+            end = try_symbol(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
+            end = try_dot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DOT; }
+        } else if 'a' <= lexer.chars[start] <= 'z' {
+            end = try_symbol(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else if 'A' <= lexer.chars[start] <= 'Z' {
+            end = try_symbol(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+        } else {
+            end = try_string(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STRING; }
+            end = try_whitespace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
+            end = try_symbol(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SYMBOL; }
+            end = try_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LPAREN; }
+            end = try_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_RPAREN; }
+            end = try_dot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_DOT; }
+        }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
             tokens.push(tok);

--- a/package-gale/tests/golden/sqlite.wado
+++ b/package-gale/tests/golden/sqlite.wado
@@ -4362,78 +4362,46 @@ pub fn tokenize(input: &String) -> Array<Token> {
         if first_char == '\t' || first_char == '\n' || first_char == '\u{b}' || first_char == '\r' || first_char == ' ' {
             end = try_spaces(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SPACES; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '!' {
             end = try_lit_bangeq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '"' || first_char == '[' || first_char == '_' || first_char == '`' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '$' || first_char == ':' || first_char == '?' || first_char == '@' {
             end = try_bind_parameter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '%' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PERCENT; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '&' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_AMP; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '\'' {
             end = try_string_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '(' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LPAREN; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == ')' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RPAREN; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '*' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '+' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PLUS; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == ',' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COMMA; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '-' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_MINUS; }
             end = try_single_line_comment(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '.' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_DOT; }
             end = try_numeric_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '/' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SLASH; }
             end = try_multiline_comment(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == ';' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SEMI; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '<' {
             end = try_lit_ltlt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; }
@@ -4442,123 +4410,45 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; }
             end = try_lit_ltgt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '=' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_EQ; }
             end = try_lit_eqeq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '>' {
             end = try_lit_gtgt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_GT; }
             end = try_lit_gteq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == 'X' || first_char == 'x' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
             end = try_blob_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '|' {
             end = try_lit_pipepipe(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; }
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PIPE; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '~' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_TILDE; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if 'a' <= first_char <= 'z' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if 'A' <= first_char <= 'Z' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if '0' <= first_char <= '9' {
             end = try_numeric_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else {
-            end = try_lit_semi(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
-            end = try_lit_dot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
-            end = try_lit_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
-            end = try_lit_lparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
-            end = try_lit_rparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
-            end = try_lit_eq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
-            end = try_lit_pipepipe(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; }
-            end = try_lit_star(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
-            end = try_lit_slash(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
-            end = try_lit_percent(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PERCENT; }
-            end = try_lit_plus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
-            end = try_lit_minus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_MINUS; }
-            end = try_lit_ltlt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; }
-            end = try_lit_gtgt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
-            end = try_lit_amp(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_AMP; }
-            end = try_lit_pipe(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
-            end = try_lit_lt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LT; }
-            end = try_lit_lteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; }
-            end = try_lit_gt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GT; }
-            end = try_lit_gteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; }
-            end = try_lit_eqeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; }
-            end = try_lit_bangeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; }
-            end = try_lit_ltgt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; }
-            end = try_lit_tilde(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_TILDE; }
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
             end = try_numeric_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
-            end = try_bind_parameter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; }
-            end = try_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
-            end = try_blob_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; }
-            end = try_single_line_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; }
-            end = try_multiline_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; }
-            end = try_spaces(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SPACES; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         }
-        if best_end > start && (first_char == 'a' || first_char == 'A' || first_char == 'b' || first_char == 'B' || first_char == 'c' || first_char == 'C' || first_char == 'd' || first_char == 'D' || first_char == 'e' || first_char == 'E' || first_char == 'f' || first_char == 'F' || first_char == 'g' || first_char == 'G' || first_char == 'h' || first_char == 'H' || first_char == 'i' || first_char == 'I' || first_char == 'j' || first_char == 'J' || first_char == 'k' || first_char == 'K' || first_char == 'l' || first_char == 'L' || first_char == 'm' || first_char == 'M' || first_char == 'n' || first_char == 'N' || first_char == 'o' || first_char == 'O' || first_char == 'p' || first_char == 'P' || first_char == 'q' || first_char == 'Q' || first_char == 'r' || first_char == 'R' || first_char == 's' || first_char == 'S' || first_char == 't' || first_char == 'T' || first_char == 'u' || first_char == 'U' || first_char == 'v' || first_char == 'V' || first_char == 'w' || first_char == 'W') {
+        if best_end > start {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
             if kw_kind >= 0 { best_kind = kw_kind; }
         }

--- a/package-gale/tests/golden/sqlite.wado
+++ b/package-gale/tests/golden/sqlite.wado
@@ -4358,149 +4358,134 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        if lexer.chars[start] == '\t' || lexer.chars[start] == '\n' || lexer.chars[start] == '\u{b}' || lexer.chars[start] == '\r' || lexer.chars[start] == ' ' {
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == '\u{b}' || first_char == '\r' || first_char == ' ' {
             end = try_spaces(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SPACES; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '!' {
+        } else if first_char == '!' {
             end = try_lit_bangeq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '"' || lexer.chars[start] == '[' || lexer.chars[start] == '_' || lexer.chars[start] == '`' {
+        } else if first_char == '"' || first_char == '[' || first_char == '_' || first_char == '`' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '$' || lexer.chars[start] == ':' || lexer.chars[start] == '?' || lexer.chars[start] == '@' {
+        } else if first_char == '$' || first_char == ':' || first_char == '?' || first_char == '@' {
             end = try_bind_parameter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '%' {
-            end = try_lit_percent(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PERCENT; }
+        } else if first_char == '%' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PERCENT; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '&' {
-            end = try_lit_amp(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_AMP; }
+        } else if first_char == '&' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_AMP; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '\'' {
+        } else if first_char == '\'' {
             end = try_string_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '(' {
-            end = try_lit_lparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+        } else if first_char == '(' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LPAREN; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == ')' {
-            end = try_lit_rparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+        } else if first_char == ')' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RPAREN; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '*' {
-            end = try_lit_star(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+        } else if first_char == '*' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '+' {
-            end = try_lit_plus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+        } else if first_char == '+' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PLUS; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == ',' {
-            end = try_lit_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
+        } else if first_char == ',' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COMMA; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '-' {
-            end = try_lit_minus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_MINUS; }
+        } else if first_char == '-' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_MINUS; }
             end = try_single_line_comment(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '.' {
-            end = try_lit_dot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
+        } else if first_char == '.' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_DOT; }
             end = try_numeric_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '/' {
-            end = try_lit_slash(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
+        } else if first_char == '/' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SLASH; }
             end = try_multiline_comment(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == ';' {
-            end = try_lit_semi(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
+        } else if first_char == ';' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SEMI; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '<' {
+        } else if first_char == '<' {
             end = try_lit_ltlt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; }
-            end = try_lit_lt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LT; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LT; }
             end = try_lit_lteq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; }
             end = try_lit_ltgt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '=' {
-            end = try_lit_eq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
+        } else if first_char == '=' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_EQ; }
             end = try_lit_eqeq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '>' {
+        } else if first_char == '>' {
             end = try_lit_gtgt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
-            end = try_lit_gt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GT; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_GT; }
             end = try_lit_gteq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == 'X' || lexer.chars[start] == 'x' {
+        } else if first_char == 'X' || first_char == 'x' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
             end = try_blob_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '|' {
+        } else if first_char == '|' {
             end = try_lit_pipepipe(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; }
-            end = try_lit_pipe(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PIPE; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '~' {
-            end = try_lit_tilde(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_TILDE; }
+        } else if first_char == '~' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_TILDE; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if 'a' <= lexer.chars[start] <= 'z' {
+        } else if 'a' <= first_char <= 'z' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if 'A' <= lexer.chars[start] <= 'Z' {
+        } else if 'A' <= first_char <= 'Z' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if '0' <= lexer.chars[start] <= '9' {
+        } else if '0' <= first_char <= '9' {
             end = try_numeric_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
             end = try_unexpected_char(&lexer.chars, start);
@@ -4573,7 +4558,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         }
-        if best_end > start && (lexer.chars[start] == 'a' || lexer.chars[start] == 'A' || lexer.chars[start] == 'b' || lexer.chars[start] == 'B' || lexer.chars[start] == 'c' || lexer.chars[start] == 'C' || lexer.chars[start] == 'd' || lexer.chars[start] == 'D' || lexer.chars[start] == 'e' || lexer.chars[start] == 'E' || lexer.chars[start] == 'f' || lexer.chars[start] == 'F' || lexer.chars[start] == 'g' || lexer.chars[start] == 'G' || lexer.chars[start] == 'h' || lexer.chars[start] == 'H' || lexer.chars[start] == 'i' || lexer.chars[start] == 'I' || lexer.chars[start] == 'j' || lexer.chars[start] == 'J' || lexer.chars[start] == 'k' || lexer.chars[start] == 'K' || lexer.chars[start] == 'l' || lexer.chars[start] == 'L' || lexer.chars[start] == 'm' || lexer.chars[start] == 'M' || lexer.chars[start] == 'n' || lexer.chars[start] == 'N' || lexer.chars[start] == 'o' || lexer.chars[start] == 'O' || lexer.chars[start] == 'p' || lexer.chars[start] == 'P' || lexer.chars[start] == 'q' || lexer.chars[start] == 'Q' || lexer.chars[start] == 'r' || lexer.chars[start] == 'R' || lexer.chars[start] == 's' || lexer.chars[start] == 'S' || lexer.chars[start] == 't' || lexer.chars[start] == 'T' || lexer.chars[start] == 'u' || lexer.chars[start] == 'U' || lexer.chars[start] == 'v' || lexer.chars[start] == 'V' || lexer.chars[start] == 'w' || lexer.chars[start] == 'W') {
+        if best_end > start && (first_char == 'a' || first_char == 'A' || first_char == 'b' || first_char == 'B' || first_char == 'c' || first_char == 'C' || first_char == 'd' || first_char == 'D' || first_char == 'e' || first_char == 'E' || first_char == 'f' || first_char == 'F' || first_char == 'g' || first_char == 'G' || first_char == 'h' || first_char == 'H' || first_char == 'i' || first_char == 'I' || first_char == 'j' || first_char == 'J' || first_char == 'k' || first_char == 'K' || first_char == 'l' || first_char == 'L' || first_char == 'm' || first_char == 'M' || first_char == 'n' || first_char == 'N' || first_char == 'o' || first_char == 'O' || first_char == 'p' || first_char == 'P' || first_char == 'q' || first_char == 'Q' || first_char == 'r' || first_char == 'R' || first_char == 's' || first_char == 'S' || first_char == 't' || first_char == 'T' || first_char == 'u' || first_char == 'U' || first_char == 'v' || first_char == 'V' || first_char == 'w' || first_char == 'W') {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
             if kw_kind >= 0 { best_kind = kw_kind; }
         }

--- a/package-gale/tests/golden/sqlite.wado
+++ b/package-gale/tests/golden/sqlite.wado
@@ -3525,325 +3525,6 @@ impl Lexer {
     }
 }
 
-fn try_scol(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != ';' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_dot(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '.' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_open_par(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '(' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_close_par(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != ')' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_comma(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != ',' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_assign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_star(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '*' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_plus(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '+' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_minus(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '-' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_tilde(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '~' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_pipe2(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '|' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '|' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_div(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '/' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_mod(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '%' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_lt2(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_gt2(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_amp(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '&' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_pipe(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '|' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_lt(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_lt_eq(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_gt(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_gt_eq(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_eq(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_not_eq1(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '!' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_not_eq2(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_k_current_date(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'c' || chars[pos] == 'C') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'u' || chars[pos] == 'U') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'r' || chars[pos] == 'R') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'r' || chars[pos] == 'R') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'e' || chars[pos] == 'E') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'n' || chars[pos] == 'N') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 't' || chars[pos] == 'T') { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '_' { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'd' || chars[pos] == 'D') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'a' || chars[pos] == 'A') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 't' || chars[pos] == 'T') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'e' || chars[pos] == 'E') { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_k_current_time(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'c' || chars[pos] == 'C') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'u' || chars[pos] == 'U') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'r' || chars[pos] == 'R') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'r' || chars[pos] == 'R') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'e' || chars[pos] == 'E') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'n' || chars[pos] == 'N') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 't' || chars[pos] == 'T') { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '_' { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 't' || chars[pos] == 'T') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'i' || chars[pos] == 'I') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'm' || chars[pos] == 'M') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'e' || chars[pos] == 'E') { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_k_current_timestamp(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'c' || chars[pos] == 'C') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'u' || chars[pos] == 'U') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'r' || chars[pos] == 'R') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'r' || chars[pos] == 'R') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'e' || chars[pos] == 'E') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'n' || chars[pos] == 'N') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 't' || chars[pos] == 'T') { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '_' { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 't' || chars[pos] == 'T') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'i' || chars[pos] == 'I') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'm' || chars[pos] == 'M') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'e' || chars[pos] == 'E') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 's' || chars[pos] == 'S') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 't' || chars[pos] == 'T') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'a' || chars[pos] == 'A') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'm' || chars[pos] == 'M') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'p' || chars[pos] == 'P') { return -1; }
-    pos += 1;
-    return pos;
-}
-
 fn try_identifier(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
     let alts_saved_0 = pos;
@@ -4443,137 +4124,227 @@ fn try_lit_tilde(chars: &Array<char>, start: i32) -> i32 {
 fn classify_keyword(chars: &Array<char>, start: i32, end: i32) -> i32 {
     let len = end - start;
     if len == 2 {
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 's' || chars[start + 1] == 'S') { return TK_K_AS; }
-        if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'y' || chars[start + 1] == 'Y') { return TK_K_BY; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') { return TK_K_IF; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') { return TK_K_IN; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 's' || chars[start + 1] == 'S') { return TK_K_IS; }
-        if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') { return TK_K_NO; }
-        if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') { return TK_K_OF; }
-        if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') { return TK_K_ON; }
-        if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') { return TK_K_OR; }
-        if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') { return TK_K_TO; }
+        if (chars[start] == 'a' || chars[start] == 'A') {
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 's' || chars[start + 1] == 'S') { return TK_K_AS; }
+        } else if (chars[start] == 'b' || chars[start] == 'B') {
+            if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'y' || chars[start + 1] == 'Y') { return TK_K_BY; }
+        } else if (chars[start] == 'i' || chars[start] == 'I') {
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') { return TK_K_IF; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') { return TK_K_IN; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 's' || chars[start + 1] == 'S') { return TK_K_IS; }
+        } else if (chars[start] == 'n' || chars[start] == 'N') {
+            if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') { return TK_K_NO; }
+        } else if (chars[start] == 'o' || chars[start] == 'O') {
+            if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') { return TK_K_OF; }
+            if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') { return TK_K_ON; }
+            if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') { return TK_K_OR; }
+        } else if (chars[start] == 't' || chars[start] == 'T') {
+            if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') { return TK_K_TO; }
+        }
     } else if len == 3 {
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'd' || chars[start + 1] == 'D') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') { return TK_K_ADD; }
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') { return TK_K_ALL; }
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') { return TK_K_AND; }
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') { return TK_K_ASC; }
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') { return TK_K_END; }
-        if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') { return TK_K_FOR; }
-        if (chars[start + 0] == 'k' || chars[start + 0] == 'K') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'y' || chars[start + 2] == 'Y') { return TK_K_KEY; }
-        if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 't' || chars[start + 2] == 'T') { return TK_K_NOT; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'w' || chars[start + 2] == 'W') { return TK_K_ROW; }
-        if (chars[start + 0] == 's' || chars[start + 0] == 'S') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 't' || chars[start + 2] == 'T') { return TK_K_SET; }
+        if (chars[start] == 'a' || chars[start] == 'A') {
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'd' || chars[start + 1] == 'D') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') { return TK_K_ADD; }
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') { return TK_K_ALL; }
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') { return TK_K_AND; }
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') { return TK_K_ASC; }
+        } else if (chars[start] == 'e' || chars[start] == 'E') {
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') { return TK_K_END; }
+        } else if (chars[start] == 'f' || chars[start] == 'F') {
+            if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') { return TK_K_FOR; }
+        } else if (chars[start] == 'k' || chars[start] == 'K') {
+            if (chars[start + 0] == 'k' || chars[start + 0] == 'K') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'y' || chars[start + 2] == 'Y') { return TK_K_KEY; }
+        } else if (chars[start] == 'n' || chars[start] == 'N') {
+            if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 't' || chars[start + 2] == 'T') { return TK_K_NOT; }
+        } else if (chars[start] == 'r' || chars[start] == 'R') {
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'w' || chars[start + 2] == 'W') { return TK_K_ROW; }
+        } else if (chars[start] == 's' || chars[start] == 'S') {
+            if (chars[start + 0] == 's' || chars[start + 0] == 'S') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 't' || chars[start + 2] == 'T') { return TK_K_SET; }
+        }
     } else if len == 4 {
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') { return TK_K_CASE; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') { return TK_K_CAST; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') { return TK_K_DESC; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'p' || chars[start + 3] == 'P') { return TK_K_DROP; }
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') { return TK_K_EACH; }
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') { return TK_K_ELSE; }
-        if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') { return TK_K_FAIL; }
-        if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'm' || chars[start + 3] == 'M') { return TK_K_FROM; }
-        if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') { return TK_K_FULL; }
-        if (chars[start + 0] == 'g' || chars[start + 0] == 'G') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'b' || chars[start + 3] == 'B') { return TK_K_GLOB; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') { return TK_K_INTO; }
-        if (chars[start + 0] == 'j' || chars[start + 0] == 'J') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_JOIN; }
-        if (chars[start + 0] == 'l' || chars[start + 0] == 'L') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 't' || chars[start + 3] == 'T') { return TK_K_LEFT; }
-        if (chars[start + 0] == 'l' || chars[start + 0] == 'L') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'k' || chars[start + 2] == 'K') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') { return TK_K_LIKE; }
-        if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') { return TK_K_NULL; }
-        if (chars[start + 0] == 'p' || chars[start + 0] == 'P') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 'a' || chars[start + 2] == 'A') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_PLAN; }
-        if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'p' || chars[start + 3] == 'P') { return TK_K_TEMP; }
-        if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_THEN; }
-        if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'w' || chars[start + 3] == 'W') { return TK_K_VIEW; }
-        if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_WHEN; }
-        if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') { return TK_K_WITH; }
+        if (chars[start] == 'c' || chars[start] == 'C') {
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') { return TK_K_CASE; }
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') { return TK_K_CAST; }
+        } else if (chars[start] == 'd' || chars[start] == 'D') {
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') { return TK_K_DESC; }
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'p' || chars[start + 3] == 'P') { return TK_K_DROP; }
+        } else if (chars[start] == 'e' || chars[start] == 'E') {
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') { return TK_K_EACH; }
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') { return TK_K_ELSE; }
+        } else if (chars[start] == 'f' || chars[start] == 'F') {
+            if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') { return TK_K_FAIL; }
+            if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'm' || chars[start + 3] == 'M') { return TK_K_FROM; }
+            if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') { return TK_K_FULL; }
+        } else if (chars[start] == 'g' || chars[start] == 'G') {
+            if (chars[start + 0] == 'g' || chars[start + 0] == 'G') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'b' || chars[start + 3] == 'B') { return TK_K_GLOB; }
+        } else if (chars[start] == 'i' || chars[start] == 'I') {
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') { return TK_K_INTO; }
+        } else if (chars[start] == 'j' || chars[start] == 'J') {
+            if (chars[start + 0] == 'j' || chars[start + 0] == 'J') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_JOIN; }
+        } else if (chars[start] == 'l' || chars[start] == 'L') {
+            if (chars[start + 0] == 'l' || chars[start + 0] == 'L') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 't' || chars[start + 3] == 'T') { return TK_K_LEFT; }
+            if (chars[start + 0] == 'l' || chars[start + 0] == 'L') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'k' || chars[start + 2] == 'K') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') { return TK_K_LIKE; }
+        } else if (chars[start] == 'n' || chars[start] == 'N') {
+            if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') { return TK_K_NULL; }
+        } else if (chars[start] == 'p' || chars[start] == 'P') {
+            if (chars[start + 0] == 'p' || chars[start + 0] == 'P') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 'a' || chars[start + 2] == 'A') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_PLAN; }
+        } else if (chars[start] == 't' || chars[start] == 'T') {
+            if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'p' || chars[start + 3] == 'P') { return TK_K_TEMP; }
+            if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_THEN; }
+        } else if (chars[start] == 'v' || chars[start] == 'V') {
+            if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'w' || chars[start + 3] == 'W') { return TK_K_VIEW; }
+        } else if (chars[start] == 'w' || chars[start] == 'W') {
+            if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_WHEN; }
+            if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') { return TK_K_WITH; }
+        }
     } else if len == 5 {
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'b' || chars[start + 1] == 'B') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 't' || chars[start + 4] == 'T') { return TK_K_ABORT; }
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_AFTER; }
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_ALTER; }
-        if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'g' || chars[start + 2] == 'G') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 'n' || chars[start + 4] == 'N') { return TK_K_BEGIN; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') && (chars[start + 4] == 'k' || chars[start + 4] == 'K') { return TK_K_CHECK; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 's' || chars[start + 4] == 'S') { return TK_K_CROSS; }
-        if (chars[start + 0] == 'g' || chars[start + 0] == 'G') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') { return TK_K_GROUP; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'x' || chars[start + 4] == 'X') { return TK_K_INDEX; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_INNER; }
-        if (chars[start + 0] == 'l' || chars[start + 0] == 'L') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 't' || chars[start + 4] == 'T') { return TK_K_LIMIT; }
-        if (chars[start + 0] == 'm' || chars[start + 0] == 'M') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') && (chars[start + 4] == 'h' || chars[start + 4] == 'H') { return TK_K_MATCH; }
-        if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_ORDER; }
-        if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_OUTER; }
-        if (chars[start + 0] == 'q' || chars[start + 0] == 'Q') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 'y' || chars[start + 4] == 'Y') { return TK_K_QUERY; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') { return TK_K_RAISE; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'g' || chars[start + 2] == 'G') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') && (chars[start + 4] == 't' || chars[start + 4] == 'T') { return TK_K_RIGHT; }
-        if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'b' || chars[start + 2] == 'B') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') { return TK_K_TABLE; }
-        if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') && (chars[start + 4] == 'n' || chars[start + 4] == 'N') { return TK_K_UNION; }
-        if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') && (chars[start + 4] == 'g' || chars[start + 4] == 'G') { return TK_K_USING; }
-        if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') { return TK_K_WHERE; }
+        if (chars[start] == 'a' || chars[start] == 'A') {
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'b' || chars[start + 1] == 'B') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 't' || chars[start + 4] == 'T') { return TK_K_ABORT; }
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_AFTER; }
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_ALTER; }
+        } else if (chars[start] == 'b' || chars[start] == 'B') {
+            if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'g' || chars[start + 2] == 'G') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 'n' || chars[start + 4] == 'N') { return TK_K_BEGIN; }
+        } else if (chars[start] == 'c' || chars[start] == 'C') {
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') && (chars[start + 4] == 'k' || chars[start + 4] == 'K') { return TK_K_CHECK; }
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 's' || chars[start + 4] == 'S') { return TK_K_CROSS; }
+        } else if (chars[start] == 'g' || chars[start] == 'G') {
+            if (chars[start + 0] == 'g' || chars[start + 0] == 'G') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') { return TK_K_GROUP; }
+        } else if (chars[start] == 'i' || chars[start] == 'I') {
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'x' || chars[start + 4] == 'X') { return TK_K_INDEX; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_INNER; }
+        } else if (chars[start] == 'l' || chars[start] == 'L') {
+            if (chars[start + 0] == 'l' || chars[start + 0] == 'L') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 't' || chars[start + 4] == 'T') { return TK_K_LIMIT; }
+        } else if (chars[start] == 'm' || chars[start] == 'M') {
+            if (chars[start + 0] == 'm' || chars[start + 0] == 'M') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') && (chars[start + 4] == 'h' || chars[start + 4] == 'H') { return TK_K_MATCH; }
+        } else if (chars[start] == 'o' || chars[start] == 'O') {
+            if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_ORDER; }
+            if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_OUTER; }
+        } else if (chars[start] == 'q' || chars[start] == 'Q') {
+            if (chars[start + 0] == 'q' || chars[start + 0] == 'Q') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 'y' || chars[start + 4] == 'Y') { return TK_K_QUERY; }
+        } else if (chars[start] == 'r' || chars[start] == 'R') {
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') { return TK_K_RAISE; }
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'g' || chars[start + 2] == 'G') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') && (chars[start + 4] == 't' || chars[start + 4] == 'T') { return TK_K_RIGHT; }
+        } else if (chars[start] == 't' || chars[start] == 'T') {
+            if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'b' || chars[start + 2] == 'B') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') { return TK_K_TABLE; }
+        } else if (chars[start] == 'u' || chars[start] == 'U') {
+            if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') && (chars[start + 4] == 'n' || chars[start + 4] == 'N') { return TK_K_UNION; }
+            if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') && (chars[start + 4] == 'g' || chars[start + 4] == 'G') { return TK_K_USING; }
+        } else if (chars[start] == 'w' || chars[start] == 'W') {
+            if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') { return TK_K_WHERE; }
+        }
     } else if len == 6 {
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'c' || chars[start + 1] == 'C') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 'o' || chars[start + 4] == 'O') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') { return TK_K_ACTION; }
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 't' || chars[start + 1] == 'T') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'c' || chars[start + 4] == 'C') && (chars[start + 5] == 'h' || chars[start + 5] == 'H') { return TK_K_ATTACH; }
-        if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_BEFORE; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'm' || chars[start + 4] == 'M') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') { return TK_K_COLUMN; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'm' || chars[start + 3] == 'M') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_COMMIT; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_CREATE; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_DELETE; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'c' || chars[start + 4] == 'C') && (chars[start + 5] == 'h' || chars[start + 5] == 'H') { return TK_K_DETACH; }
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_ESCAPE; }
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_EXCEPT; }
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 's' || chars[start + 5] == 'S') { return TK_K_EXISTS; }
-        if (chars[start + 0] == 'h' || chars[start + 0] == 'H') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'v' || chars[start + 2] == 'V') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 'n' || chars[start + 4] == 'N') && (chars[start + 5] == 'g' || chars[start + 5] == 'G') { return TK_K_HAVING; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'g' || chars[start + 1] == 'G') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_IGNORE; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_INSERT; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'l' || chars[start + 4] == 'L') && (chars[start + 5] == 'l' || chars[start + 5] == 'L') { return TK_K_ISNULL; }
-        if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_OFFSET; }
-        if (chars[start + 0] == 'p' || chars[start + 0] == 'P') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'a' || chars[start + 2] == 'A') && (chars[start + 3] == 'g' || chars[start + 3] == 'G') && (chars[start + 4] == 'm' || chars[start + 4] == 'M') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') { return TK_K_PRAGMA; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'g' || chars[start + 2] == 'G') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'x' || chars[start + 4] == 'X') && (chars[start + 5] == 'p' || chars[start + 5] == 'P') { return TK_K_REGEXP; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'm' || chars[start + 4] == 'M') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_RENAME; }
-        if (chars[start + 0] == 's' || chars[start + 0] == 'S') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'c' || chars[start + 4] == 'C') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_SELECT; }
-        if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'q' || chars[start + 3] == 'Q') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_UNIQUE; }
-        if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 'p' || chars[start + 1] == 'P') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_UPDATE; }
-        if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'm' || chars[start + 5] == 'M') { return TK_K_VACUUM; }
-        if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 's' || chars[start + 5] == 'S') { return TK_K_VALUES; }
+        if (chars[start] == 'a' || chars[start] == 'A') {
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'c' || chars[start + 1] == 'C') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 'o' || chars[start + 4] == 'O') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') { return TK_K_ACTION; }
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 't' || chars[start + 1] == 'T') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'c' || chars[start + 4] == 'C') && (chars[start + 5] == 'h' || chars[start + 5] == 'H') { return TK_K_ATTACH; }
+        } else if (chars[start] == 'b' || chars[start] == 'B') {
+            if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_BEFORE; }
+        } else if (chars[start] == 'c' || chars[start] == 'C') {
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'm' || chars[start + 4] == 'M') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') { return TK_K_COLUMN; }
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'm' || chars[start + 3] == 'M') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_COMMIT; }
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_CREATE; }
+        } else if (chars[start] == 'd' || chars[start] == 'D') {
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_DELETE; }
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'c' || chars[start + 4] == 'C') && (chars[start + 5] == 'h' || chars[start + 5] == 'H') { return TK_K_DETACH; }
+        } else if (chars[start] == 'e' || chars[start] == 'E') {
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_ESCAPE; }
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_EXCEPT; }
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 's' || chars[start + 5] == 'S') { return TK_K_EXISTS; }
+        } else if (chars[start] == 'h' || chars[start] == 'H') {
+            if (chars[start + 0] == 'h' || chars[start + 0] == 'H') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'v' || chars[start + 2] == 'V') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 'n' || chars[start + 4] == 'N') && (chars[start + 5] == 'g' || chars[start + 5] == 'G') { return TK_K_HAVING; }
+        } else if (chars[start] == 'i' || chars[start] == 'I') {
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'g' || chars[start + 1] == 'G') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_IGNORE; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_INSERT; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'l' || chars[start + 4] == 'L') && (chars[start + 5] == 'l' || chars[start + 5] == 'L') { return TK_K_ISNULL; }
+        } else if (chars[start] == 'o' || chars[start] == 'O') {
+            if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_OFFSET; }
+        } else if (chars[start] == 'p' || chars[start] == 'P') {
+            if (chars[start + 0] == 'p' || chars[start + 0] == 'P') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'a' || chars[start + 2] == 'A') && (chars[start + 3] == 'g' || chars[start + 3] == 'G') && (chars[start + 4] == 'm' || chars[start + 4] == 'M') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') { return TK_K_PRAGMA; }
+        } else if (chars[start] == 'r' || chars[start] == 'R') {
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'g' || chars[start + 2] == 'G') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'x' || chars[start + 4] == 'X') && (chars[start + 5] == 'p' || chars[start + 5] == 'P') { return TK_K_REGEXP; }
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'm' || chars[start + 4] == 'M') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_RENAME; }
+        } else if (chars[start] == 's' || chars[start] == 'S') {
+            if (chars[start + 0] == 's' || chars[start + 0] == 'S') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'c' || chars[start + 4] == 'C') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_SELECT; }
+        } else if (chars[start] == 'u' || chars[start] == 'U') {
+            if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'q' || chars[start + 3] == 'Q') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_UNIQUE; }
+            if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 'p' || chars[start + 1] == 'P') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_UPDATE; }
+        } else if (chars[start] == 'v' || chars[start] == 'V') {
+            if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'm' || chars[start + 5] == 'M') { return TK_K_VACUUM; }
+            if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 's' || chars[start + 5] == 'S') { return TK_K_VALUES; }
+        }
     } else if len == 7 {
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'a' || chars[start + 2] == 'A') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'y' || chars[start + 4] == 'Y') && (chars[start + 5] == 'z' || chars[start + 5] == 'Z') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_ANALYZE; }
-        if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'w' || chars[start + 3] == 'W') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') { return TK_K_BETWEEN; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'd' || chars[start + 5] == 'D') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_CASCADE; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 't' || chars[start + 5] == 'T') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_COLLATE; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'l' || chars[start + 5] == 'L') && (chars[start + 6] == 't' || chars[start + 6] == 'T') { return TK_K_DEFAULT; }
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'p' || chars[start + 2] == 'P') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') { return TK_K_EXPLAIN; }
-        if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 'g' || chars[start + 5] == 'G') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') { return TK_K_FOREIGN; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'x' || chars[start + 4] == 'X') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'd' || chars[start + 6] == 'D') { return TK_K_INDEXED; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'd' || chars[start + 6] == 'D') { return TK_K_INSTEAD; }
-        if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') { return TK_K_NATURAL; }
-        if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'l' || chars[start + 5] == 'L') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') { return TK_K_NOTNULL; }
-        if (chars[start + 0] == 'p' || chars[start + 0] == 'P') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'm' || chars[start + 3] == 'M') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'y' || chars[start + 6] == 'Y') { return TK_K_PRIMARY; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') && (chars[start + 4] == 'd' || chars[start + 4] == 'D') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'x' || chars[start + 6] == 'X') { return TK_K_REINDEX; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_RELEASE; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'p' || chars[start + 2] == 'P') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'c' || chars[start + 5] == 'C') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_REPLACE; }
-        if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'g' || chars[start + 3] == 'G') && (chars[start + 4] == 'g' || chars[start + 4] == 'G') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'r' || chars[start + 6] == 'R') { return TK_K_TRIGGER; }
-        if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') { return TK_K_VIRTUAL; }
-        if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') && (chars[start + 4] == 'o' || chars[start + 4] == 'O') && (chars[start + 5] == 'u' || chars[start + 5] == 'U') && (chars[start + 6] == 't' || chars[start + 6] == 'T') { return TK_K_WITHOUT; }
+        if (chars[start] == 'a' || chars[start] == 'A') {
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'a' || chars[start + 2] == 'A') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'y' || chars[start + 4] == 'Y') && (chars[start + 5] == 'z' || chars[start + 5] == 'Z') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_ANALYZE; }
+        } else if (chars[start] == 'b' || chars[start] == 'B') {
+            if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'w' || chars[start + 3] == 'W') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') { return TK_K_BETWEEN; }
+        } else if (chars[start] == 'c' || chars[start] == 'C') {
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'd' || chars[start + 5] == 'D') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_CASCADE; }
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 't' || chars[start + 5] == 'T') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_COLLATE; }
+        } else if (chars[start] == 'd' || chars[start] == 'D') {
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'l' || chars[start + 5] == 'L') && (chars[start + 6] == 't' || chars[start + 6] == 'T') { return TK_K_DEFAULT; }
+        } else if (chars[start] == 'e' || chars[start] == 'E') {
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'p' || chars[start + 2] == 'P') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') { return TK_K_EXPLAIN; }
+        } else if (chars[start] == 'f' || chars[start] == 'F') {
+            if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 'g' || chars[start + 5] == 'G') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') { return TK_K_FOREIGN; }
+        } else if (chars[start] == 'i' || chars[start] == 'I') {
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'x' || chars[start + 4] == 'X') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'd' || chars[start + 6] == 'D') { return TK_K_INDEXED; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'd' || chars[start + 6] == 'D') { return TK_K_INSTEAD; }
+        } else if (chars[start] == 'n' || chars[start] == 'N') {
+            if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') { return TK_K_NATURAL; }
+            if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'l' || chars[start + 5] == 'L') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') { return TK_K_NOTNULL; }
+        } else if (chars[start] == 'p' || chars[start] == 'P') {
+            if (chars[start + 0] == 'p' || chars[start + 0] == 'P') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'm' || chars[start + 3] == 'M') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'y' || chars[start + 6] == 'Y') { return TK_K_PRIMARY; }
+        } else if (chars[start] == 'r' || chars[start] == 'R') {
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') && (chars[start + 4] == 'd' || chars[start + 4] == 'D') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'x' || chars[start + 6] == 'X') { return TK_K_REINDEX; }
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_RELEASE; }
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'p' || chars[start + 2] == 'P') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'c' || chars[start + 5] == 'C') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_REPLACE; }
+        } else if (chars[start] == 't' || chars[start] == 'T') {
+            if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'g' || chars[start + 3] == 'G') && (chars[start + 4] == 'g' || chars[start + 4] == 'G') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'r' || chars[start + 6] == 'R') { return TK_K_TRIGGER; }
+        } else if (chars[start] == 'v' || chars[start] == 'V') {
+            if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') { return TK_K_VIRTUAL; }
+        } else if (chars[start] == 'w' || chars[start] == 'W') {
+            if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') && (chars[start + 4] == 'o' || chars[start + 4] == 'O') && (chars[start + 5] == 'u' || chars[start + 5] == 'U') && (chars[start + 6] == 't' || chars[start + 6] == 'T') { return TK_K_WITHOUT; }
+        }
     } else if len == 8 {
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'f' || chars[start + 3] == 'F') && (chars[start + 4] == 'l' || chars[start + 4] == 'L') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 't' || chars[start + 7] == 'T') { return TK_K_CONFLICT; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'b' || chars[start + 4] == 'B') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 's' || chars[start + 6] == 'S') && (chars[start + 7] == 'e' || chars[start + 7] == 'E') { return TK_K_DATABASE; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') && (chars[start + 7] == 'd' || chars[start + 7] == 'D') { return TK_K_DEFERRED; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 't' || chars[start + 7] == 'T') { return TK_K_DISTINCT; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 't' || chars[start + 7] == 'T') { return TK_K_RESTRICT; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'b' || chars[start + 4] == 'B') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 'k' || chars[start + 7] == 'K') { return TK_K_ROLLBACK; }
+        if (chars[start] == 'c' || chars[start] == 'C') {
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'f' || chars[start + 3] == 'F') && (chars[start + 4] == 'l' || chars[start + 4] == 'L') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 't' || chars[start + 7] == 'T') { return TK_K_CONFLICT; }
+        } else if (chars[start] == 'd' || chars[start] == 'D') {
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'b' || chars[start + 4] == 'B') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 's' || chars[start + 6] == 'S') && (chars[start + 7] == 'e' || chars[start + 7] == 'E') { return TK_K_DATABASE; }
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') && (chars[start + 7] == 'd' || chars[start + 7] == 'D') { return TK_K_DEFERRED; }
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 't' || chars[start + 7] == 'T') { return TK_K_DISTINCT; }
+        } else if (chars[start] == 'r' || chars[start] == 'R') {
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 't' || chars[start + 7] == 'T') { return TK_K_RESTRICT; }
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'b' || chars[start + 4] == 'B') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 'k' || chars[start + 7] == 'K') { return TK_K_ROLLBACK; }
+        }
     } else if len == 9 {
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'i' || chars[start + 6] == 'I') && (chars[start + 7] == 'v' || chars[start + 7] == 'V') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') { return TK_K_EXCLUSIVE; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'm' || chars[start + 1] == 'M') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'd' || chars[start + 4] == 'D') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 't' || chars[start + 7] == 'T') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') { return TK_K_IMMEDIATE; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') && (chars[start + 7] == 'l' || chars[start + 7] == 'L') && (chars[start + 8] == 'y' || chars[start + 8] == 'Y') { return TK_K_INITIALLY; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') && (chars[start + 7] == 'c' || chars[start + 7] == 'C') && (chars[start + 8] == 't' || chars[start + 8] == 'T') { return TK_K_INTERSECT; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'i' || chars[start + 6] == 'I') && (chars[start + 7] == 'v' || chars[start + 7] == 'V') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') { return TK_K_RECURSIVE; }
-        if (chars[start + 0] == 's' || chars[start + 0] == 'S') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'v' || chars[start + 2] == 'V') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') && (chars[start + 5] == 'o' || chars[start + 5] == 'O') && (chars[start + 6] == 'i' || chars[start + 6] == 'I') && (chars[start + 7] == 'n' || chars[start + 7] == 'N') && (chars[start + 8] == 't' || chars[start + 8] == 'T') { return TK_K_SAVEPOINT; }
-        if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'p' || chars[start + 3] == 'P') && (chars[start + 4] == 'o' || chars[start + 4] == 'O') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 'r' || chars[start + 7] == 'R') && (chars[start + 8] == 'y' || chars[start + 8] == 'Y') { return TK_K_TEMPORARY; }
+        if (chars[start] == 'e' || chars[start] == 'E') {
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'i' || chars[start + 6] == 'I') && (chars[start + 7] == 'v' || chars[start + 7] == 'V') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') { return TK_K_EXCLUSIVE; }
+        } else if (chars[start] == 'i' || chars[start] == 'I') {
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'm' || chars[start + 1] == 'M') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'd' || chars[start + 4] == 'D') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 't' || chars[start + 7] == 'T') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') { return TK_K_IMMEDIATE; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') && (chars[start + 7] == 'l' || chars[start + 7] == 'L') && (chars[start + 8] == 'y' || chars[start + 8] == 'Y') { return TK_K_INITIALLY; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') && (chars[start + 7] == 'c' || chars[start + 7] == 'C') && (chars[start + 8] == 't' || chars[start + 8] == 'T') { return TK_K_INTERSECT; }
+        } else if (chars[start] == 'r' || chars[start] == 'R') {
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'i' || chars[start + 6] == 'I') && (chars[start + 7] == 'v' || chars[start + 7] == 'V') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') { return TK_K_RECURSIVE; }
+        } else if (chars[start] == 's' || chars[start] == 'S') {
+            if (chars[start + 0] == 's' || chars[start + 0] == 'S') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'v' || chars[start + 2] == 'V') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') && (chars[start + 5] == 'o' || chars[start + 5] == 'O') && (chars[start + 6] == 'i' || chars[start + 6] == 'I') && (chars[start + 7] == 'n' || chars[start + 7] == 'N') && (chars[start + 8] == 't' || chars[start + 8] == 'T') { return TK_K_SAVEPOINT; }
+        } else if (chars[start] == 't' || chars[start] == 'T') {
+            if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'p' || chars[start + 3] == 'P') && (chars[start + 4] == 'o' || chars[start + 4] == 'O') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 'r' || chars[start + 7] == 'R') && (chars[start + 8] == 'y' || chars[start + 8] == 'Y') { return TK_K_TEMPORARY; }
+        }
     } else if len == 10 {
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 'i' || chars[start + 7] == 'I') && (chars[start + 8] == 'n' || chars[start + 8] == 'N') && (chars[start + 9] == 't' || chars[start + 9] == 'T') { return TK_K_CONSTRAINT; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 'b' || chars[start + 7] == 'B') && (chars[start + 8] == 'l' || chars[start + 8] == 'L') && (chars[start + 9] == 'e' || chars[start + 9] == 'E') { return TK_K_DEFERRABLE; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') && (chars[start + 7] == 'c' || chars[start + 7] == 'C') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') && (chars[start + 9] == 's' || chars[start + 9] == 'S') { return TK_K_REFERENCES; }
+        if (chars[start] == 'c' || chars[start] == 'C') {
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 'i' || chars[start + 7] == 'I') && (chars[start + 8] == 'n' || chars[start + 8] == 'N') && (chars[start + 9] == 't' || chars[start + 9] == 'T') { return TK_K_CONSTRAINT; }
+        } else if (chars[start] == 'd' || chars[start] == 'D') {
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 'b' || chars[start + 7] == 'B') && (chars[start + 8] == 'l' || chars[start + 8] == 'L') && (chars[start + 9] == 'e' || chars[start + 9] == 'E') { return TK_K_DEFERRABLE; }
+        } else if (chars[start] == 'r' || chars[start] == 'R') {
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') && (chars[start + 7] == 'c' || chars[start + 7] == 'C') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') && (chars[start + 9] == 's' || chars[start + 9] == 'S') { return TK_K_REFERENCES; }
+        }
     } else if len == 11 {
         if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'a' || chars[start + 2] == 'A') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') && (chars[start + 4] == 's' || chars[start + 4] == 'S') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 't' || chars[start + 7] == 'T') && (chars[start + 8] == 'i' || chars[start + 8] == 'I') && (chars[start + 9] == 'o' || chars[start + 9] == 'O') && (chars[start + 10] == 'n' || chars[start + 10] == 'N') { return TK_K_TRANSACTION; }
+    } else if len == 12 {
+        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') && (chars[start + 6] == 't' || chars[start + 6] == 'T') && chars[start + 7] == '_' && (chars[start + 8] == 'd' || chars[start + 8] == 'D') && (chars[start + 9] == 'a' || chars[start + 9] == 'A') && (chars[start + 10] == 't' || chars[start + 10] == 'T') && (chars[start + 11] == 'e' || chars[start + 11] == 'E') { return TK_K_CURRENT_DATE; }
+        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') && (chars[start + 6] == 't' || chars[start + 6] == 'T') && chars[start + 7] == '_' && (chars[start + 8] == 't' || chars[start + 8] == 'T') && (chars[start + 9] == 'i' || chars[start + 9] == 'I') && (chars[start + 10] == 'm' || chars[start + 10] == 'M') && (chars[start + 11] == 'e' || chars[start + 11] == 'E') { return TK_K_CURRENT_TIME; }
     } else if len == 13 {
         if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 'r' || chars[start + 7] == 'R') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') && (chars[start + 9] == 'm' || chars[start + 9] == 'M') && (chars[start + 10] == 'e' || chars[start + 10] == 'E') && (chars[start + 11] == 'n' || chars[start + 11] == 'N') && (chars[start + 12] == 't' || chars[start + 12] == 'T') { return TK_K_AUTOINCREMENT; }
+    } else if len == 17 {
+        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') && (chars[start + 6] == 't' || chars[start + 6] == 'T') && chars[start + 7] == '_' && (chars[start + 8] == 't' || chars[start + 8] == 'T') && (chars[start + 9] == 'i' || chars[start + 9] == 'I') && (chars[start + 10] == 'm' || chars[start + 10] == 'M') && (chars[start + 11] == 'e' || chars[start + 11] == 'E') && (chars[start + 12] == 's' || chars[start + 12] == 'S') && (chars[start + 13] == 't' || chars[start + 13] == 'T') && (chars[start + 14] == 'a' || chars[start + 14] == 'A') && (chars[start + 15] == 'm' || chars[start + 15] == 'M') && (chars[start + 16] == 'p' || chars[start + 16] == 'P') { return TK_K_CURRENT_TIMESTAMP; }
     }
     return -1;
 }
@@ -4587,127 +4358,222 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        end = try_lit_semi(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
-        end = try_lit_dot(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
-        end = try_lit_comma(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
-        end = try_lit_lparen(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
-        end = try_lit_rparen(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
-        end = try_lit_eq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
-        end = try_lit_pipepipe(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; }
-        end = try_lit_star(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
-        end = try_lit_slash(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
-        end = try_lit_percent(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_PERCENT; }
-        end = try_lit_plus(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
-        end = try_lit_minus(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_MINUS; }
-        end = try_lit_ltlt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; }
-        end = try_lit_gtgt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
-        end = try_lit_amp(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_AMP; }
-        end = try_lit_pipe(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
-        end = try_lit_lt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LT; }
-        end = try_lit_lteq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; }
-        end = try_lit_gt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_GT; }
-        end = try_lit_gteq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; }
-        end = try_lit_eqeq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; }
-        end = try_lit_bangeq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; }
-        end = try_lit_ltgt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; }
-        end = try_lit_tilde(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_TILDE; }
-        end = try_scol(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SCOL; }
-        end = try_dot(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_DOT; }
-        end = try_open_par(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_OPEN_PAR; }
-        end = try_close_par(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_CLOSE_PAR; }
-        end = try_comma(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_COMMA; }
-        end = try_assign(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_ASSIGN; }
-        end = try_star(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_STAR; }
-        end = try_plus(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PLUS; }
-        end = try_minus(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_MINUS; }
-        end = try_tilde(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_TILDE; }
-        end = try_pipe2(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PIPE2; }
-        end = try_div(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_DIV; }
-        end = try_mod(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_MOD; }
-        end = try_lt2(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LT2; }
-        end = try_gt2(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_GT2; }
-        end = try_amp(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_AMP; }
-        end = try_pipe(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PIPE; }
-        end = try_lt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LT; }
-        end = try_lt_eq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LT_EQ; }
-        end = try_gt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_GT; }
-        end = try_gt_eq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_GT_EQ; }
-        end = try_eq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_EQ; }
-        end = try_not_eq1(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_NOT_EQ1; }
-        end = try_not_eq2(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_NOT_EQ2; }
-        end = try_k_current_date(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_K_CURRENT_DATE; }
-        end = try_k_current_time(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_K_CURRENT_TIME; }
-        end = try_k_current_timestamp(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_K_CURRENT_TIMESTAMP; }
-        end = try_identifier(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
-        end = try_numeric_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
-        end = try_bind_parameter(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; }
-        end = try_string_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
-        end = try_blob_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; }
-        end = try_single_line_comment(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; }
-        end = try_multiline_comment(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; }
-        end = try_spaces(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SPACES; }
-        end = try_unexpected_char(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        if best_end > start {
+        if lexer.chars[start] == '\t' || lexer.chars[start] == '\n' || lexer.chars[start] == '\u{b}' || lexer.chars[start] == '\r' || lexer.chars[start] == ' ' {
+            end = try_spaces(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SPACES; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '!' {
+            end = try_lit_bangeq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '"' || lexer.chars[start] == '[' || lexer.chars[start] == '_' || lexer.chars[start] == '`' {
+            end = try_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '$' || lexer.chars[start] == ':' || lexer.chars[start] == '?' || lexer.chars[start] == '@' {
+            end = try_bind_parameter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '%' {
+            end = try_lit_percent(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PERCENT; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '&' {
+            end = try_lit_amp(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_AMP; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '\'' {
+            end = try_string_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '(' {
+            end = try_lit_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == ')' {
+            end = try_lit_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '*' {
+            end = try_lit_star(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '+' {
+            end = try_lit_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == ',' {
+            end = try_lit_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '-' {
+            end = try_lit_minus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_MINUS; }
+            end = try_single_line_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '.' {
+            end = try_lit_dot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
+            end = try_numeric_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '/' {
+            end = try_lit_slash(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
+            end = try_multiline_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == ';' {
+            end = try_lit_semi(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '<' {
+            end = try_lit_ltlt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; }
+            end = try_lit_lt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LT; }
+            end = try_lit_lteq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; }
+            end = try_lit_ltgt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '=' {
+            end = try_lit_eq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
+            end = try_lit_eqeq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '>' {
+            end = try_lit_gtgt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
+            end = try_lit_gt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GT; }
+            end = try_lit_gteq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == 'X' || lexer.chars[start] == 'x' {
+            end = try_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            end = try_blob_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '|' {
+            end = try_lit_pipepipe(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; }
+            end = try_lit_pipe(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '~' {
+            end = try_lit_tilde(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_TILDE; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if 'a' <= lexer.chars[start] <= 'z' {
+            end = try_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if 'A' <= lexer.chars[start] <= 'Z' {
+            end = try_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if '0' <= lexer.chars[start] <= '9' {
+            end = try_numeric_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else {
+            end = try_lit_semi(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
+            end = try_lit_dot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
+            end = try_lit_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
+            end = try_lit_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+            end = try_lit_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+            end = try_lit_eq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
+            end = try_lit_pipepipe(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; }
+            end = try_lit_star(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+            end = try_lit_slash(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
+            end = try_lit_percent(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PERCENT; }
+            end = try_lit_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+            end = try_lit_minus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_MINUS; }
+            end = try_lit_ltlt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; }
+            end = try_lit_gtgt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
+            end = try_lit_amp(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_AMP; }
+            end = try_lit_pipe(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
+            end = try_lit_lt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LT; }
+            end = try_lit_lteq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; }
+            end = try_lit_gt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GT; }
+            end = try_lit_gteq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; }
+            end = try_lit_eqeq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; }
+            end = try_lit_bangeq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; }
+            end = try_lit_ltgt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; }
+            end = try_lit_tilde(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_TILDE; }
+            end = try_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            end = try_numeric_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
+            end = try_bind_parameter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; }
+            end = try_string_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
+            end = try_blob_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; }
+            end = try_single_line_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; }
+            end = try_multiline_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; }
+            end = try_spaces(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SPACES; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        }
+        if best_end > start && (lexer.chars[start] == 'a' || lexer.chars[start] == 'A' || lexer.chars[start] == 'b' || lexer.chars[start] == 'B' || lexer.chars[start] == 'c' || lexer.chars[start] == 'C' || lexer.chars[start] == 'd' || lexer.chars[start] == 'D' || lexer.chars[start] == 'e' || lexer.chars[start] == 'E' || lexer.chars[start] == 'f' || lexer.chars[start] == 'F' || lexer.chars[start] == 'g' || lexer.chars[start] == 'G' || lexer.chars[start] == 'h' || lexer.chars[start] == 'H' || lexer.chars[start] == 'i' || lexer.chars[start] == 'I' || lexer.chars[start] == 'j' || lexer.chars[start] == 'J' || lexer.chars[start] == 'k' || lexer.chars[start] == 'K' || lexer.chars[start] == 'l' || lexer.chars[start] == 'L' || lexer.chars[start] == 'm' || lexer.chars[start] == 'M' || lexer.chars[start] == 'n' || lexer.chars[start] == 'N' || lexer.chars[start] == 'o' || lexer.chars[start] == 'O' || lexer.chars[start] == 'p' || lexer.chars[start] == 'P' || lexer.chars[start] == 'q' || lexer.chars[start] == 'Q' || lexer.chars[start] == 'r' || lexer.chars[start] == 'R' || lexer.chars[start] == 's' || lexer.chars[start] == 'S' || lexer.chars[start] == 't' || lexer.chars[start] == 'T' || lexer.chars[start] == 'u' || lexer.chars[start] == 'U' || lexer.chars[start] == 'v' || lexer.chars[start] == 'V' || lexer.chars[start] == 'w' || lexer.chars[start] == 'W') {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
             if kw_kind >= 0 { best_kind = kw_kind; }
         }

--- a/package-gale/tests/golden/sqlite_highlight.wado
+++ b/package-gale/tests/golden/sqlite_highlight.wado
@@ -4362,78 +4362,46 @@ pub fn tokenize(input: &String) -> Array<Token> {
         if first_char == '\t' || first_char == '\n' || first_char == '\u{b}' || first_char == '\r' || first_char == ' ' {
             end = try_spaces(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SPACES; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '!' {
             end = try_lit_bangeq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '"' || first_char == '[' || first_char == '_' || first_char == '`' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '$' || first_char == ':' || first_char == '?' || first_char == '@' {
             end = try_bind_parameter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '%' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PERCENT; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '&' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_AMP; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '\'' {
             end = try_string_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '(' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LPAREN; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == ')' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RPAREN; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '*' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '+' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PLUS; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == ',' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COMMA; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '-' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_MINUS; }
             end = try_single_line_comment(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '.' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_DOT; }
             end = try_numeric_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '/' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SLASH; }
             end = try_multiline_comment(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == ';' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SEMI; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '<' {
             end = try_lit_ltlt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; }
@@ -4442,123 +4410,45 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; }
             end = try_lit_ltgt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '=' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_EQ; }
             end = try_lit_eqeq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '>' {
             end = try_lit_gtgt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_GT; }
             end = try_lit_gteq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == 'X' || first_char == 'x' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
             end = try_blob_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '|' {
             end = try_lit_pipepipe(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; }
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PIPE; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if first_char == '~' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_TILDE; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if 'a' <= first_char <= 'z' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if 'A' <= first_char <= 'Z' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else if '0' <= first_char <= '9' {
             end = try_numeric_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
-            end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         } else {
-            end = try_lit_semi(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
-            end = try_lit_dot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
-            end = try_lit_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
-            end = try_lit_lparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
-            end = try_lit_rparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
-            end = try_lit_eq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
-            end = try_lit_pipepipe(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; }
-            end = try_lit_star(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
-            end = try_lit_slash(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
-            end = try_lit_percent(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PERCENT; }
-            end = try_lit_plus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
-            end = try_lit_minus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_MINUS; }
-            end = try_lit_ltlt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; }
-            end = try_lit_gtgt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
-            end = try_lit_amp(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_AMP; }
-            end = try_lit_pipe(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
-            end = try_lit_lt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LT; }
-            end = try_lit_lteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; }
-            end = try_lit_gt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GT; }
-            end = try_lit_gteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; }
-            end = try_lit_eqeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; }
-            end = try_lit_bangeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; }
-            end = try_lit_ltgt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; }
-            end = try_lit_tilde(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_TILDE; }
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
             end = try_numeric_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
-            end = try_bind_parameter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; }
-            end = try_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
-            end = try_blob_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; }
-            end = try_single_line_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; }
-            end = try_multiline_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; }
-            end = try_spaces(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SPACES; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         }
-        if best_end > start && (first_char == 'a' || first_char == 'A' || first_char == 'b' || first_char == 'B' || first_char == 'c' || first_char == 'C' || first_char == 'd' || first_char == 'D' || first_char == 'e' || first_char == 'E' || first_char == 'f' || first_char == 'F' || first_char == 'g' || first_char == 'G' || first_char == 'h' || first_char == 'H' || first_char == 'i' || first_char == 'I' || first_char == 'j' || first_char == 'J' || first_char == 'k' || first_char == 'K' || first_char == 'l' || first_char == 'L' || first_char == 'm' || first_char == 'M' || first_char == 'n' || first_char == 'N' || first_char == 'o' || first_char == 'O' || first_char == 'p' || first_char == 'P' || first_char == 'q' || first_char == 'Q' || first_char == 'r' || first_char == 'R' || first_char == 's' || first_char == 'S' || first_char == 't' || first_char == 'T' || first_char == 'u' || first_char == 'U' || first_char == 'v' || first_char == 'V' || first_char == 'w' || first_char == 'W') {
+        if best_end > start {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
             if kw_kind >= 0 { best_kind = kw_kind; }
         }

--- a/package-gale/tests/golden/sqlite_highlight.wado
+++ b/package-gale/tests/golden/sqlite_highlight.wado
@@ -4358,149 +4358,134 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        if lexer.chars[start] == '\t' || lexer.chars[start] == '\n' || lexer.chars[start] == '\u{b}' || lexer.chars[start] == '\r' || lexer.chars[start] == ' ' {
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == '\u{b}' || first_char == '\r' || first_char == ' ' {
             end = try_spaces(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SPACES; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '!' {
+        } else if first_char == '!' {
             end = try_lit_bangeq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '"' || lexer.chars[start] == '[' || lexer.chars[start] == '_' || lexer.chars[start] == '`' {
+        } else if first_char == '"' || first_char == '[' || first_char == '_' || first_char == '`' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '$' || lexer.chars[start] == ':' || lexer.chars[start] == '?' || lexer.chars[start] == '@' {
+        } else if first_char == '$' || first_char == ':' || first_char == '?' || first_char == '@' {
             end = try_bind_parameter(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '%' {
-            end = try_lit_percent(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PERCENT; }
+        } else if first_char == '%' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PERCENT; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '&' {
-            end = try_lit_amp(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_AMP; }
+        } else if first_char == '&' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_AMP; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '\'' {
+        } else if first_char == '\'' {
             end = try_string_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '(' {
-            end = try_lit_lparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+        } else if first_char == '(' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LPAREN; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == ')' {
-            end = try_lit_rparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+        } else if first_char == ')' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RPAREN; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '*' {
-            end = try_lit_star(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+        } else if first_char == '*' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '+' {
-            end = try_lit_plus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+        } else if first_char == '+' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PLUS; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == ',' {
-            end = try_lit_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
+        } else if first_char == ',' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COMMA; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '-' {
-            end = try_lit_minus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_MINUS; }
+        } else if first_char == '-' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_MINUS; }
             end = try_single_line_comment(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '.' {
-            end = try_lit_dot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
+        } else if first_char == '.' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_DOT; }
             end = try_numeric_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '/' {
-            end = try_lit_slash(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
+        } else if first_char == '/' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SLASH; }
             end = try_multiline_comment(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == ';' {
-            end = try_lit_semi(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
+        } else if first_char == ';' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SEMI; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '<' {
+        } else if first_char == '<' {
             end = try_lit_ltlt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; }
-            end = try_lit_lt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LT; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LT; }
             end = try_lit_lteq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; }
             end = try_lit_ltgt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '=' {
-            end = try_lit_eq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
+        } else if first_char == '=' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_EQ; }
             end = try_lit_eqeq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '>' {
+        } else if first_char == '>' {
             end = try_lit_gtgt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
-            end = try_lit_gt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GT; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_GT; }
             end = try_lit_gteq(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == 'X' || lexer.chars[start] == 'x' {
+        } else if first_char == 'X' || first_char == 'x' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
             end = try_blob_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '|' {
+        } else if first_char == '|' {
             end = try_lit_pipepipe(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; }
-            end = try_lit_pipe(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PIPE; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if lexer.chars[start] == '~' {
-            end = try_lit_tilde(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_TILDE; }
+        } else if first_char == '~' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_TILDE; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if 'a' <= lexer.chars[start] <= 'z' {
+        } else if 'a' <= first_char <= 'z' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if 'A' <= lexer.chars[start] <= 'Z' {
+        } else if 'A' <= first_char <= 'Z' {
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        } else if '0' <= lexer.chars[start] <= '9' {
+        } else if '0' <= first_char <= '9' {
             end = try_numeric_literal(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
             end = try_unexpected_char(&lexer.chars, start);
@@ -4573,7 +4558,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
             end = try_unexpected_char(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
         }
-        if best_end > start && (lexer.chars[start] == 'a' || lexer.chars[start] == 'A' || lexer.chars[start] == 'b' || lexer.chars[start] == 'B' || lexer.chars[start] == 'c' || lexer.chars[start] == 'C' || lexer.chars[start] == 'd' || lexer.chars[start] == 'D' || lexer.chars[start] == 'e' || lexer.chars[start] == 'E' || lexer.chars[start] == 'f' || lexer.chars[start] == 'F' || lexer.chars[start] == 'g' || lexer.chars[start] == 'G' || lexer.chars[start] == 'h' || lexer.chars[start] == 'H' || lexer.chars[start] == 'i' || lexer.chars[start] == 'I' || lexer.chars[start] == 'j' || lexer.chars[start] == 'J' || lexer.chars[start] == 'k' || lexer.chars[start] == 'K' || lexer.chars[start] == 'l' || lexer.chars[start] == 'L' || lexer.chars[start] == 'm' || lexer.chars[start] == 'M' || lexer.chars[start] == 'n' || lexer.chars[start] == 'N' || lexer.chars[start] == 'o' || lexer.chars[start] == 'O' || lexer.chars[start] == 'p' || lexer.chars[start] == 'P' || lexer.chars[start] == 'q' || lexer.chars[start] == 'Q' || lexer.chars[start] == 'r' || lexer.chars[start] == 'R' || lexer.chars[start] == 's' || lexer.chars[start] == 'S' || lexer.chars[start] == 't' || lexer.chars[start] == 'T' || lexer.chars[start] == 'u' || lexer.chars[start] == 'U' || lexer.chars[start] == 'v' || lexer.chars[start] == 'V' || lexer.chars[start] == 'w' || lexer.chars[start] == 'W') {
+        if best_end > start && (first_char == 'a' || first_char == 'A' || first_char == 'b' || first_char == 'B' || first_char == 'c' || first_char == 'C' || first_char == 'd' || first_char == 'D' || first_char == 'e' || first_char == 'E' || first_char == 'f' || first_char == 'F' || first_char == 'g' || first_char == 'G' || first_char == 'h' || first_char == 'H' || first_char == 'i' || first_char == 'I' || first_char == 'j' || first_char == 'J' || first_char == 'k' || first_char == 'K' || first_char == 'l' || first_char == 'L' || first_char == 'm' || first_char == 'M' || first_char == 'n' || first_char == 'N' || first_char == 'o' || first_char == 'O' || first_char == 'p' || first_char == 'P' || first_char == 'q' || first_char == 'Q' || first_char == 'r' || first_char == 'R' || first_char == 's' || first_char == 'S' || first_char == 't' || first_char == 'T' || first_char == 'u' || first_char == 'U' || first_char == 'v' || first_char == 'V' || first_char == 'w' || first_char == 'W') {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
             if kw_kind >= 0 { best_kind = kw_kind; }
         }

--- a/package-gale/tests/golden/sqlite_highlight.wado
+++ b/package-gale/tests/golden/sqlite_highlight.wado
@@ -3525,325 +3525,6 @@ impl Lexer {
     }
 }
 
-fn try_scol(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != ';' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_dot(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '.' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_open_par(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '(' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_close_par(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != ')' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_comma(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != ',' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_assign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_star(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '*' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_plus(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '+' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_minus(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '-' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_tilde(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '~' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_pipe2(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '|' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '|' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_div(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '/' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_mod(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '%' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_lt2(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_gt2(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_amp(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '&' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_pipe(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '|' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_lt(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_lt_eq(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_gt(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_gt_eq(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_eq(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_not_eq1(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '!' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_not_eq2(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_k_current_date(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'c' || chars[pos] == 'C') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'u' || chars[pos] == 'U') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'r' || chars[pos] == 'R') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'r' || chars[pos] == 'R') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'e' || chars[pos] == 'E') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'n' || chars[pos] == 'N') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 't' || chars[pos] == 'T') { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '_' { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'd' || chars[pos] == 'D') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'a' || chars[pos] == 'A') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 't' || chars[pos] == 'T') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'e' || chars[pos] == 'E') { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_k_current_time(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'c' || chars[pos] == 'C') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'u' || chars[pos] == 'U') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'r' || chars[pos] == 'R') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'r' || chars[pos] == 'R') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'e' || chars[pos] == 'E') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'n' || chars[pos] == 'N') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 't' || chars[pos] == 'T') { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '_' { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 't' || chars[pos] == 'T') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'i' || chars[pos] == 'I') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'm' || chars[pos] == 'M') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'e' || chars[pos] == 'E') { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_k_current_timestamp(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'c' || chars[pos] == 'C') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'u' || chars[pos] == 'U') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'r' || chars[pos] == 'R') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'r' || chars[pos] == 'R') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'e' || chars[pos] == 'E') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'n' || chars[pos] == 'N') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 't' || chars[pos] == 'T') { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '_' { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 't' || chars[pos] == 'T') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'i' || chars[pos] == 'I') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'm' || chars[pos] == 'M') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'e' || chars[pos] == 'E') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 's' || chars[pos] == 'S') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 't' || chars[pos] == 'T') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'a' || chars[pos] == 'A') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'm' || chars[pos] == 'M') { return -1; }
-    pos += 1;
-    if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == 'p' || chars[pos] == 'P') { return -1; }
-    pos += 1;
-    return pos;
-}
-
 fn try_identifier(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
     let alts_saved_0 = pos;
@@ -4443,137 +4124,227 @@ fn try_lit_tilde(chars: &Array<char>, start: i32) -> i32 {
 fn classify_keyword(chars: &Array<char>, start: i32, end: i32) -> i32 {
     let len = end - start;
     if len == 2 {
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 's' || chars[start + 1] == 'S') { return TK_K_AS; }
-        if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'y' || chars[start + 1] == 'Y') { return TK_K_BY; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') { return TK_K_IF; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') { return TK_K_IN; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 's' || chars[start + 1] == 'S') { return TK_K_IS; }
-        if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') { return TK_K_NO; }
-        if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') { return TK_K_OF; }
-        if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') { return TK_K_ON; }
-        if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') { return TK_K_OR; }
-        if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') { return TK_K_TO; }
+        if (chars[start] == 'a' || chars[start] == 'A') {
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 's' || chars[start + 1] == 'S') { return TK_K_AS; }
+        } else if (chars[start] == 'b' || chars[start] == 'B') {
+            if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'y' || chars[start + 1] == 'Y') { return TK_K_BY; }
+        } else if (chars[start] == 'i' || chars[start] == 'I') {
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') { return TK_K_IF; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') { return TK_K_IN; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 's' || chars[start + 1] == 'S') { return TK_K_IS; }
+        } else if (chars[start] == 'n' || chars[start] == 'N') {
+            if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') { return TK_K_NO; }
+        } else if (chars[start] == 'o' || chars[start] == 'O') {
+            if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') { return TK_K_OF; }
+            if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') { return TK_K_ON; }
+            if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') { return TK_K_OR; }
+        } else if (chars[start] == 't' || chars[start] == 'T') {
+            if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') { return TK_K_TO; }
+        }
     } else if len == 3 {
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'd' || chars[start + 1] == 'D') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') { return TK_K_ADD; }
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') { return TK_K_ALL; }
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') { return TK_K_AND; }
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') { return TK_K_ASC; }
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') { return TK_K_END; }
-        if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') { return TK_K_FOR; }
-        if (chars[start + 0] == 'k' || chars[start + 0] == 'K') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'y' || chars[start + 2] == 'Y') { return TK_K_KEY; }
-        if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 't' || chars[start + 2] == 'T') { return TK_K_NOT; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'w' || chars[start + 2] == 'W') { return TK_K_ROW; }
-        if (chars[start + 0] == 's' || chars[start + 0] == 'S') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 't' || chars[start + 2] == 'T') { return TK_K_SET; }
+        if (chars[start] == 'a' || chars[start] == 'A') {
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'd' || chars[start + 1] == 'D') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') { return TK_K_ADD; }
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') { return TK_K_ALL; }
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') { return TK_K_AND; }
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') { return TK_K_ASC; }
+        } else if (chars[start] == 'e' || chars[start] == 'E') {
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') { return TK_K_END; }
+        } else if (chars[start] == 'f' || chars[start] == 'F') {
+            if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') { return TK_K_FOR; }
+        } else if (chars[start] == 'k' || chars[start] == 'K') {
+            if (chars[start + 0] == 'k' || chars[start + 0] == 'K') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'y' || chars[start + 2] == 'Y') { return TK_K_KEY; }
+        } else if (chars[start] == 'n' || chars[start] == 'N') {
+            if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 't' || chars[start + 2] == 'T') { return TK_K_NOT; }
+        } else if (chars[start] == 'r' || chars[start] == 'R') {
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'w' || chars[start + 2] == 'W') { return TK_K_ROW; }
+        } else if (chars[start] == 's' || chars[start] == 'S') {
+            if (chars[start + 0] == 's' || chars[start + 0] == 'S') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 't' || chars[start + 2] == 'T') { return TK_K_SET; }
+        }
     } else if len == 4 {
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') { return TK_K_CASE; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') { return TK_K_CAST; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') { return TK_K_DESC; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'p' || chars[start + 3] == 'P') { return TK_K_DROP; }
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') { return TK_K_EACH; }
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') { return TK_K_ELSE; }
-        if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') { return TK_K_FAIL; }
-        if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'm' || chars[start + 3] == 'M') { return TK_K_FROM; }
-        if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') { return TK_K_FULL; }
-        if (chars[start + 0] == 'g' || chars[start + 0] == 'G') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'b' || chars[start + 3] == 'B') { return TK_K_GLOB; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') { return TK_K_INTO; }
-        if (chars[start + 0] == 'j' || chars[start + 0] == 'J') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_JOIN; }
-        if (chars[start + 0] == 'l' || chars[start + 0] == 'L') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 't' || chars[start + 3] == 'T') { return TK_K_LEFT; }
-        if (chars[start + 0] == 'l' || chars[start + 0] == 'L') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'k' || chars[start + 2] == 'K') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') { return TK_K_LIKE; }
-        if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') { return TK_K_NULL; }
-        if (chars[start + 0] == 'p' || chars[start + 0] == 'P') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 'a' || chars[start + 2] == 'A') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_PLAN; }
-        if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'p' || chars[start + 3] == 'P') { return TK_K_TEMP; }
-        if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_THEN; }
-        if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'w' || chars[start + 3] == 'W') { return TK_K_VIEW; }
-        if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_WHEN; }
-        if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') { return TK_K_WITH; }
+        if (chars[start] == 'c' || chars[start] == 'C') {
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') { return TK_K_CASE; }
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') { return TK_K_CAST; }
+        } else if (chars[start] == 'd' || chars[start] == 'D') {
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') { return TK_K_DESC; }
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'p' || chars[start + 3] == 'P') { return TK_K_DROP; }
+        } else if (chars[start] == 'e' || chars[start] == 'E') {
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') { return TK_K_EACH; }
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') { return TK_K_ELSE; }
+        } else if (chars[start] == 'f' || chars[start] == 'F') {
+            if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') { return TK_K_FAIL; }
+            if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'm' || chars[start + 3] == 'M') { return TK_K_FROM; }
+            if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') { return TK_K_FULL; }
+        } else if (chars[start] == 'g' || chars[start] == 'G') {
+            if (chars[start + 0] == 'g' || chars[start + 0] == 'G') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'b' || chars[start + 3] == 'B') { return TK_K_GLOB; }
+        } else if (chars[start] == 'i' || chars[start] == 'I') {
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') { return TK_K_INTO; }
+        } else if (chars[start] == 'j' || chars[start] == 'J') {
+            if (chars[start + 0] == 'j' || chars[start + 0] == 'J') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_JOIN; }
+        } else if (chars[start] == 'l' || chars[start] == 'L') {
+            if (chars[start + 0] == 'l' || chars[start + 0] == 'L') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 't' || chars[start + 3] == 'T') { return TK_K_LEFT; }
+            if (chars[start + 0] == 'l' || chars[start + 0] == 'L') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'k' || chars[start + 2] == 'K') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') { return TK_K_LIKE; }
+        } else if (chars[start] == 'n' || chars[start] == 'N') {
+            if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') { return TK_K_NULL; }
+        } else if (chars[start] == 'p' || chars[start] == 'P') {
+            if (chars[start + 0] == 'p' || chars[start + 0] == 'P') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 'a' || chars[start + 2] == 'A') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_PLAN; }
+        } else if (chars[start] == 't' || chars[start] == 'T') {
+            if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'p' || chars[start + 3] == 'P') { return TK_K_TEMP; }
+            if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_THEN; }
+        } else if (chars[start] == 'v' || chars[start] == 'V') {
+            if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'w' || chars[start + 3] == 'W') { return TK_K_VIEW; }
+        } else if (chars[start] == 'w' || chars[start] == 'W') {
+            if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') { return TK_K_WHEN; }
+            if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') { return TK_K_WITH; }
+        }
     } else if len == 5 {
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'b' || chars[start + 1] == 'B') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 't' || chars[start + 4] == 'T') { return TK_K_ABORT; }
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_AFTER; }
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_ALTER; }
-        if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'g' || chars[start + 2] == 'G') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 'n' || chars[start + 4] == 'N') { return TK_K_BEGIN; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') && (chars[start + 4] == 'k' || chars[start + 4] == 'K') { return TK_K_CHECK; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 's' || chars[start + 4] == 'S') { return TK_K_CROSS; }
-        if (chars[start + 0] == 'g' || chars[start + 0] == 'G') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') { return TK_K_GROUP; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'x' || chars[start + 4] == 'X') { return TK_K_INDEX; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_INNER; }
-        if (chars[start + 0] == 'l' || chars[start + 0] == 'L') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 't' || chars[start + 4] == 'T') { return TK_K_LIMIT; }
-        if (chars[start + 0] == 'm' || chars[start + 0] == 'M') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') && (chars[start + 4] == 'h' || chars[start + 4] == 'H') { return TK_K_MATCH; }
-        if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_ORDER; }
-        if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_OUTER; }
-        if (chars[start + 0] == 'q' || chars[start + 0] == 'Q') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 'y' || chars[start + 4] == 'Y') { return TK_K_QUERY; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') { return TK_K_RAISE; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'g' || chars[start + 2] == 'G') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') && (chars[start + 4] == 't' || chars[start + 4] == 'T') { return TK_K_RIGHT; }
-        if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'b' || chars[start + 2] == 'B') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') { return TK_K_TABLE; }
-        if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') && (chars[start + 4] == 'n' || chars[start + 4] == 'N') { return TK_K_UNION; }
-        if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') && (chars[start + 4] == 'g' || chars[start + 4] == 'G') { return TK_K_USING; }
-        if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') { return TK_K_WHERE; }
+        if (chars[start] == 'a' || chars[start] == 'A') {
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'b' || chars[start + 1] == 'B') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 't' || chars[start + 4] == 'T') { return TK_K_ABORT; }
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_AFTER; }
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'l' || chars[start + 1] == 'L') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_ALTER; }
+        } else if (chars[start] == 'b' || chars[start] == 'B') {
+            if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'g' || chars[start + 2] == 'G') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 'n' || chars[start + 4] == 'N') { return TK_K_BEGIN; }
+        } else if (chars[start] == 'c' || chars[start] == 'C') {
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') && (chars[start + 4] == 'k' || chars[start + 4] == 'K') { return TK_K_CHECK; }
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 's' || chars[start + 4] == 'S') { return TK_K_CROSS; }
+        } else if (chars[start] == 'g' || chars[start] == 'G') {
+            if (chars[start + 0] == 'g' || chars[start + 0] == 'G') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'o' || chars[start + 2] == 'O') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') { return TK_K_GROUP; }
+        } else if (chars[start] == 'i' || chars[start] == 'I') {
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'x' || chars[start + 4] == 'X') { return TK_K_INDEX; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_INNER; }
+        } else if (chars[start] == 'l' || chars[start] == 'L') {
+            if (chars[start + 0] == 'l' || chars[start + 0] == 'L') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 't' || chars[start + 4] == 'T') { return TK_K_LIMIT; }
+        } else if (chars[start] == 'm' || chars[start] == 'M') {
+            if (chars[start + 0] == 'm' || chars[start + 0] == 'M') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') && (chars[start + 4] == 'h' || chars[start + 4] == 'H') { return TK_K_MATCH; }
+        } else if (chars[start] == 'o' || chars[start] == 'O') {
+            if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_ORDER; }
+            if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') { return TK_K_OUTER; }
+        } else if (chars[start] == 'q' || chars[start] == 'Q') {
+            if (chars[start + 0] == 'q' || chars[start + 0] == 'Q') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 'y' || chars[start + 4] == 'Y') { return TK_K_QUERY; }
+        } else if (chars[start] == 'r' || chars[start] == 'R') {
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') { return TK_K_RAISE; }
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'g' || chars[start + 2] == 'G') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') && (chars[start + 4] == 't' || chars[start + 4] == 'T') { return TK_K_RIGHT; }
+        } else if (chars[start] == 't' || chars[start] == 'T') {
+            if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'b' || chars[start + 2] == 'B') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') { return TK_K_TABLE; }
+        } else if (chars[start] == 'u' || chars[start] == 'U') {
+            if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') && (chars[start + 4] == 'n' || chars[start + 4] == 'N') { return TK_K_UNION; }
+            if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') && (chars[start + 4] == 'g' || chars[start + 4] == 'G') { return TK_K_USING; }
+        } else if (chars[start] == 'w' || chars[start] == 'W') {
+            if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'h' || chars[start + 1] == 'H') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') { return TK_K_WHERE; }
+        }
     } else if len == 6 {
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'c' || chars[start + 1] == 'C') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 'o' || chars[start + 4] == 'O') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') { return TK_K_ACTION; }
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 't' || chars[start + 1] == 'T') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'c' || chars[start + 4] == 'C') && (chars[start + 5] == 'h' || chars[start + 5] == 'H') { return TK_K_ATTACH; }
-        if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_BEFORE; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'm' || chars[start + 4] == 'M') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') { return TK_K_COLUMN; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'm' || chars[start + 3] == 'M') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_COMMIT; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_CREATE; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_DELETE; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'c' || chars[start + 4] == 'C') && (chars[start + 5] == 'h' || chars[start + 5] == 'H') { return TK_K_DETACH; }
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_ESCAPE; }
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_EXCEPT; }
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 's' || chars[start + 5] == 'S') { return TK_K_EXISTS; }
-        if (chars[start + 0] == 'h' || chars[start + 0] == 'H') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'v' || chars[start + 2] == 'V') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 'n' || chars[start + 4] == 'N') && (chars[start + 5] == 'g' || chars[start + 5] == 'G') { return TK_K_HAVING; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'g' || chars[start + 1] == 'G') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_IGNORE; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_INSERT; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'l' || chars[start + 4] == 'L') && (chars[start + 5] == 'l' || chars[start + 5] == 'L') { return TK_K_ISNULL; }
-        if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_OFFSET; }
-        if (chars[start + 0] == 'p' || chars[start + 0] == 'P') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'a' || chars[start + 2] == 'A') && (chars[start + 3] == 'g' || chars[start + 3] == 'G') && (chars[start + 4] == 'm' || chars[start + 4] == 'M') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') { return TK_K_PRAGMA; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'g' || chars[start + 2] == 'G') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'x' || chars[start + 4] == 'X') && (chars[start + 5] == 'p' || chars[start + 5] == 'P') { return TK_K_REGEXP; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'm' || chars[start + 4] == 'M') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_RENAME; }
-        if (chars[start + 0] == 's' || chars[start + 0] == 'S') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'c' || chars[start + 4] == 'C') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_SELECT; }
-        if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'q' || chars[start + 3] == 'Q') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_UNIQUE; }
-        if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 'p' || chars[start + 1] == 'P') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_UPDATE; }
-        if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'm' || chars[start + 5] == 'M') { return TK_K_VACUUM; }
-        if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 's' || chars[start + 5] == 'S') { return TK_K_VALUES; }
+        if (chars[start] == 'a' || chars[start] == 'A') {
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'c' || chars[start + 1] == 'C') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 'o' || chars[start + 4] == 'O') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') { return TK_K_ACTION; }
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 't' || chars[start + 1] == 'T') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'c' || chars[start + 4] == 'C') && (chars[start + 5] == 'h' || chars[start + 5] == 'H') { return TK_K_ATTACH; }
+        } else if (chars[start] == 'b' || chars[start] == 'B') {
+            if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_BEFORE; }
+        } else if (chars[start] == 'c' || chars[start] == 'C') {
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'm' || chars[start + 4] == 'M') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') { return TK_K_COLUMN; }
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'm' || chars[start + 3] == 'M') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_COMMIT; }
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'e' || chars[start + 2] == 'E') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_CREATE; }
+        } else if (chars[start] == 'd' || chars[start] == 'D') {
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_DELETE; }
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'c' || chars[start + 4] == 'C') && (chars[start + 5] == 'h' || chars[start + 5] == 'H') { return TK_K_DETACH; }
+        } else if (chars[start] == 'e' || chars[start] == 'E') {
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_ESCAPE; }
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_EXCEPT; }
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 's' || chars[start + 5] == 'S') { return TK_K_EXISTS; }
+        } else if (chars[start] == 'h' || chars[start] == 'H') {
+            if (chars[start + 0] == 'h' || chars[start + 0] == 'H') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'v' || chars[start + 2] == 'V') && (chars[start + 3] == 'i' || chars[start + 3] == 'I') && (chars[start + 4] == 'n' || chars[start + 4] == 'N') && (chars[start + 5] == 'g' || chars[start + 5] == 'G') { return TK_K_HAVING; }
+        } else if (chars[start] == 'i' || chars[start] == 'I') {
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'g' || chars[start + 1] == 'G') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_IGNORE; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_INSERT; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 's' || chars[start + 1] == 'S') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'l' || chars[start + 4] == 'L') && (chars[start + 5] == 'l' || chars[start + 5] == 'L') { return TK_K_ISNULL; }
+        } else if (chars[start] == 'o' || chars[start] == 'O') {
+            if (chars[start + 0] == 'o' || chars[start + 0] == 'O') && (chars[start + 1] == 'f' || chars[start + 1] == 'F') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_OFFSET; }
+        } else if (chars[start] == 'p' || chars[start] == 'P') {
+            if (chars[start + 0] == 'p' || chars[start + 0] == 'P') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'a' || chars[start + 2] == 'A') && (chars[start + 3] == 'g' || chars[start + 3] == 'G') && (chars[start + 4] == 'm' || chars[start + 4] == 'M') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') { return TK_K_PRAGMA; }
+        } else if (chars[start] == 'r' || chars[start] == 'R') {
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'g' || chars[start + 2] == 'G') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'x' || chars[start + 4] == 'X') && (chars[start + 5] == 'p' || chars[start + 5] == 'P') { return TK_K_REGEXP; }
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'm' || chars[start + 4] == 'M') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_RENAME; }
+        } else if (chars[start] == 's' || chars[start] == 'S') {
+            if (chars[start + 0] == 's' || chars[start + 0] == 'S') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'c' || chars[start + 4] == 'C') && (chars[start + 5] == 't' || chars[start + 5] == 'T') { return TK_K_SELECT; }
+        } else if (chars[start] == 'u' || chars[start] == 'U') {
+            if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'q' || chars[start + 3] == 'Q') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_UNIQUE; }
+            if (chars[start + 0] == 'u' || chars[start + 0] == 'U') && (chars[start + 1] == 'p' || chars[start + 1] == 'P') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') { return TK_K_UPDATE; }
+        } else if (chars[start] == 'v' || chars[start] == 'V') {
+            if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'm' || chars[start + 5] == 'M') { return TK_K_VACUUM; }
+            if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 's' || chars[start + 5] == 'S') { return TK_K_VALUES; }
+        }
     } else if len == 7 {
-        if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'a' || chars[start + 2] == 'A') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'y' || chars[start + 4] == 'Y') && (chars[start + 5] == 'z' || chars[start + 5] == 'Z') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_ANALYZE; }
-        if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'w' || chars[start + 3] == 'W') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') { return TK_K_BETWEEN; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'd' || chars[start + 5] == 'D') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_CASCADE; }
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 't' || chars[start + 5] == 'T') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_COLLATE; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'l' || chars[start + 5] == 'L') && (chars[start + 6] == 't' || chars[start + 6] == 'T') { return TK_K_DEFAULT; }
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'p' || chars[start + 2] == 'P') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') { return TK_K_EXPLAIN; }
-        if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 'g' || chars[start + 5] == 'G') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') { return TK_K_FOREIGN; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'x' || chars[start + 4] == 'X') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'd' || chars[start + 6] == 'D') { return TK_K_INDEXED; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'd' || chars[start + 6] == 'D') { return TK_K_INSTEAD; }
-        if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') { return TK_K_NATURAL; }
-        if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'l' || chars[start + 5] == 'L') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') { return TK_K_NOTNULL; }
-        if (chars[start + 0] == 'p' || chars[start + 0] == 'P') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'm' || chars[start + 3] == 'M') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'y' || chars[start + 6] == 'Y') { return TK_K_PRIMARY; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') && (chars[start + 4] == 'd' || chars[start + 4] == 'D') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'x' || chars[start + 6] == 'X') { return TK_K_REINDEX; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_RELEASE; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'p' || chars[start + 2] == 'P') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'c' || chars[start + 5] == 'C') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_REPLACE; }
-        if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'g' || chars[start + 3] == 'G') && (chars[start + 4] == 'g' || chars[start + 4] == 'G') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'r' || chars[start + 6] == 'R') { return TK_K_TRIGGER; }
-        if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') { return TK_K_VIRTUAL; }
-        if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') && (chars[start + 4] == 'o' || chars[start + 4] == 'O') && (chars[start + 5] == 'u' || chars[start + 5] == 'U') && (chars[start + 6] == 't' || chars[start + 6] == 'T') { return TK_K_WITHOUT; }
+        if (chars[start] == 'a' || chars[start] == 'A') {
+            if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'a' || chars[start + 2] == 'A') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'y' || chars[start + 4] == 'Y') && (chars[start + 5] == 'z' || chars[start + 5] == 'Z') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_ANALYZE; }
+        } else if (chars[start] == 'b' || chars[start] == 'B') {
+            if (chars[start + 0] == 'b' || chars[start + 0] == 'B') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'w' || chars[start + 3] == 'W') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') { return TK_K_BETWEEN; }
+        } else if (chars[start] == 'c' || chars[start] == 'C') {
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 'c' || chars[start + 3] == 'C') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'd' || chars[start + 5] == 'D') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_CASCADE; }
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 't' || chars[start + 5] == 'T') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_COLLATE; }
+        } else if (chars[start] == 'd' || chars[start] == 'D') {
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'l' || chars[start + 5] == 'L') && (chars[start + 6] == 't' || chars[start + 6] == 'T') { return TK_K_DEFAULT; }
+        } else if (chars[start] == 'e' || chars[start] == 'E') {
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'p' || chars[start + 2] == 'P') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') { return TK_K_EXPLAIN; }
+        } else if (chars[start] == 'f' || chars[start] == 'F') {
+            if (chars[start + 0] == 'f' || chars[start + 0] == 'F') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 'g' || chars[start + 5] == 'G') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') { return TK_K_FOREIGN; }
+        } else if (chars[start] == 'i' || chars[start] == 'I') {
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'd' || chars[start + 2] == 'D') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'x' || chars[start + 4] == 'X') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'd' || chars[start + 6] == 'D') { return TK_K_INDEXED; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'd' || chars[start + 6] == 'D') { return TK_K_INSTEAD; }
+        } else if (chars[start] == 'n' || chars[start] == 'N') {
+            if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') { return TK_K_NATURAL; }
+            if (chars[start + 0] == 'n' || chars[start + 0] == 'N') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'l' || chars[start + 5] == 'L') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') { return TK_K_NOTNULL; }
+        } else if (chars[start] == 'p' || chars[start] == 'P') {
+            if (chars[start + 0] == 'p' || chars[start + 0] == 'P') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'm' || chars[start + 3] == 'M') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'y' || chars[start + 6] == 'Y') { return TK_K_PRIMARY; }
+        } else if (chars[start] == 'r' || chars[start] == 'R') {
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') && (chars[start + 4] == 'd' || chars[start + 4] == 'D') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'x' || chars[start + 6] == 'X') { return TK_K_REINDEX; }
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_RELEASE; }
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'p' || chars[start + 2] == 'P') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'a' || chars[start + 4] == 'A') && (chars[start + 5] == 'c' || chars[start + 5] == 'C') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') { return TK_K_REPLACE; }
+        } else if (chars[start] == 't' || chars[start] == 'T') {
+            if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 'g' || chars[start + 3] == 'G') && (chars[start + 4] == 'g' || chars[start + 4] == 'G') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'r' || chars[start + 6] == 'R') { return TK_K_TRIGGER; }
+        } else if (chars[start] == 'v' || chars[start] == 'V') {
+            if (chars[start + 0] == 'v' || chars[start + 0] == 'V') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') { return TK_K_VIRTUAL; }
+        } else if (chars[start] == 'w' || chars[start] == 'W') {
+            if (chars[start + 0] == 'w' || chars[start + 0] == 'W') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'h' || chars[start + 3] == 'H') && (chars[start + 4] == 'o' || chars[start + 4] == 'O') && (chars[start + 5] == 'u' || chars[start + 5] == 'U') && (chars[start + 6] == 't' || chars[start + 6] == 'T') { return TK_K_WITHOUT; }
+        }
     } else if len == 8 {
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'f' || chars[start + 3] == 'F') && (chars[start + 4] == 'l' || chars[start + 4] == 'L') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 't' || chars[start + 7] == 'T') { return TK_K_CONFLICT; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'b' || chars[start + 4] == 'B') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 's' || chars[start + 6] == 'S') && (chars[start + 7] == 'e' || chars[start + 7] == 'E') { return TK_K_DATABASE; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') && (chars[start + 7] == 'd' || chars[start + 7] == 'D') { return TK_K_DEFERRED; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 't' || chars[start + 7] == 'T') { return TK_K_DISTINCT; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 't' || chars[start + 7] == 'T') { return TK_K_RESTRICT; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'b' || chars[start + 4] == 'B') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 'k' || chars[start + 7] == 'K') { return TK_K_ROLLBACK; }
+        if (chars[start] == 'c' || chars[start] == 'C') {
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 'f' || chars[start + 3] == 'F') && (chars[start + 4] == 'l' || chars[start + 4] == 'L') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 't' || chars[start + 7] == 'T') { return TK_K_CONFLICT; }
+        } else if (chars[start] == 'd' || chars[start] == 'D') {
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'a' || chars[start + 3] == 'A') && (chars[start + 4] == 'b' || chars[start + 4] == 'B') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 's' || chars[start + 6] == 'S') && (chars[start + 7] == 'e' || chars[start + 7] == 'E') { return TK_K_DATABASE; }
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') && (chars[start + 7] == 'd' || chars[start + 7] == 'D') { return TK_K_DEFERRED; }
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'i' || chars[start + 1] == 'I') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 't' || chars[start + 7] == 'T') { return TK_K_DISTINCT; }
+        } else if (chars[start] == 'r' || chars[start] == 'R') {
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 's' || chars[start + 2] == 'S') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 't' || chars[start + 7] == 'T') { return TK_K_RESTRICT; }
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'l' || chars[start + 2] == 'L') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'b' || chars[start + 4] == 'B') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 'k' || chars[start + 7] == 'K') { return TK_K_ROLLBACK; }
+        }
     } else if len == 9 {
-        if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'i' || chars[start + 6] == 'I') && (chars[start + 7] == 'v' || chars[start + 7] == 'V') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') { return TK_K_EXCLUSIVE; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'm' || chars[start + 1] == 'M') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'd' || chars[start + 4] == 'D') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 't' || chars[start + 7] == 'T') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') { return TK_K_IMMEDIATE; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') && (chars[start + 7] == 'l' || chars[start + 7] == 'L') && (chars[start + 8] == 'y' || chars[start + 8] == 'Y') { return TK_K_INITIALLY; }
-        if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') && (chars[start + 7] == 'c' || chars[start + 7] == 'C') && (chars[start + 8] == 't' || chars[start + 8] == 'T') { return TK_K_INTERSECT; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'i' || chars[start + 6] == 'I') && (chars[start + 7] == 'v' || chars[start + 7] == 'V') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') { return TK_K_RECURSIVE; }
-        if (chars[start + 0] == 's' || chars[start + 0] == 'S') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'v' || chars[start + 2] == 'V') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') && (chars[start + 5] == 'o' || chars[start + 5] == 'O') && (chars[start + 6] == 'i' || chars[start + 6] == 'I') && (chars[start + 7] == 'n' || chars[start + 7] == 'N') && (chars[start + 8] == 't' || chars[start + 8] == 'T') { return TK_K_SAVEPOINT; }
-        if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'p' || chars[start + 3] == 'P') && (chars[start + 4] == 'o' || chars[start + 4] == 'O') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 'r' || chars[start + 7] == 'R') && (chars[start + 8] == 'y' || chars[start + 8] == 'Y') { return TK_K_TEMPORARY; }
+        if (chars[start] == 'e' || chars[start] == 'E') {
+            if (chars[start + 0] == 'e' || chars[start + 0] == 'E') && (chars[start + 1] == 'x' || chars[start + 1] == 'X') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'l' || chars[start + 3] == 'L') && (chars[start + 4] == 'u' || chars[start + 4] == 'U') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'i' || chars[start + 6] == 'I') && (chars[start + 7] == 'v' || chars[start + 7] == 'V') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') { return TK_K_EXCLUSIVE; }
+        } else if (chars[start] == 'i' || chars[start] == 'I') {
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'm' || chars[start + 1] == 'M') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'd' || chars[start + 4] == 'D') && (chars[start + 5] == 'i' || chars[start + 5] == 'I') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 't' || chars[start + 7] == 'T') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') { return TK_K_IMMEDIATE; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 'i' || chars[start + 2] == 'I') && (chars[start + 3] == 't' || chars[start + 3] == 'T') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'l' || chars[start + 6] == 'L') && (chars[start + 7] == 'l' || chars[start + 7] == 'L') && (chars[start + 8] == 'y' || chars[start + 8] == 'Y') { return TK_K_INITIALLY; }
+            if (chars[start + 0] == 'i' || chars[start + 0] == 'I') && (chars[start + 1] == 'n' || chars[start + 1] == 'N') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'e' || chars[start + 6] == 'E') && (chars[start + 7] == 'c' || chars[start + 7] == 'C') && (chars[start + 8] == 't' || chars[start + 8] == 'T') { return TK_K_INTERSECT; }
+        } else if (chars[start] == 'r' || chars[start] == 'R') {
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'c' || chars[start + 2] == 'C') && (chars[start + 3] == 'u' || chars[start + 3] == 'U') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 's' || chars[start + 5] == 'S') && (chars[start + 6] == 'i' || chars[start + 6] == 'I') && (chars[start + 7] == 'v' || chars[start + 7] == 'V') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') { return TK_K_RECURSIVE; }
+        } else if (chars[start] == 's' || chars[start] == 'S') {
+            if (chars[start + 0] == 's' || chars[start + 0] == 'S') && (chars[start + 1] == 'a' || chars[start + 1] == 'A') && (chars[start + 2] == 'v' || chars[start + 2] == 'V') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'p' || chars[start + 4] == 'P') && (chars[start + 5] == 'o' || chars[start + 5] == 'O') && (chars[start + 6] == 'i' || chars[start + 6] == 'I') && (chars[start + 7] == 'n' || chars[start + 7] == 'N') && (chars[start + 8] == 't' || chars[start + 8] == 'T') { return TK_K_SAVEPOINT; }
+        } else if (chars[start] == 't' || chars[start] == 'T') {
+            if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'm' || chars[start + 2] == 'M') && (chars[start + 3] == 'p' || chars[start + 3] == 'P') && (chars[start + 4] == 'o' || chars[start + 4] == 'O') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 'r' || chars[start + 7] == 'R') && (chars[start + 8] == 'y' || chars[start + 8] == 'Y') { return TK_K_TEMPORARY; }
+        }
     } else if len == 10 {
-        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 'i' || chars[start + 7] == 'I') && (chars[start + 8] == 'n' || chars[start + 8] == 'N') && (chars[start + 9] == 't' || chars[start + 9] == 'T') { return TK_K_CONSTRAINT; }
-        if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 'b' || chars[start + 7] == 'B') && (chars[start + 8] == 'l' || chars[start + 8] == 'L') && (chars[start + 9] == 'e' || chars[start + 9] == 'E') { return TK_K_DEFERRABLE; }
-        if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') && (chars[start + 7] == 'c' || chars[start + 7] == 'C') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') && (chars[start + 9] == 's' || chars[start + 9] == 'S') { return TK_K_REFERENCES; }
+        if (chars[start] == 'c' || chars[start] == 'C') {
+            if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'o' || chars[start + 1] == 'O') && (chars[start + 2] == 'n' || chars[start + 2] == 'N') && (chars[start + 3] == 's' || chars[start + 3] == 'S') && (chars[start + 4] == 't' || chars[start + 4] == 'T') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 'i' || chars[start + 7] == 'I') && (chars[start + 8] == 'n' || chars[start + 8] == 'N') && (chars[start + 9] == 't' || chars[start + 9] == 'T') { return TK_K_CONSTRAINT; }
+        } else if (chars[start] == 'd' || chars[start] == 'D') {
+            if (chars[start + 0] == 'd' || chars[start + 0] == 'D') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'r' || chars[start + 5] == 'R') && (chars[start + 6] == 'a' || chars[start + 6] == 'A') && (chars[start + 7] == 'b' || chars[start + 7] == 'B') && (chars[start + 8] == 'l' || chars[start + 8] == 'L') && (chars[start + 9] == 'e' || chars[start + 9] == 'E') { return TK_K_DEFERRABLE; }
+        } else if (chars[start] == 'r' || chars[start] == 'R') {
+            if (chars[start + 0] == 'r' || chars[start + 0] == 'R') && (chars[start + 1] == 'e' || chars[start + 1] == 'E') && (chars[start + 2] == 'f' || chars[start + 2] == 'F') && (chars[start + 3] == 'e' || chars[start + 3] == 'E') && (chars[start + 4] == 'r' || chars[start + 4] == 'R') && (chars[start + 5] == 'e' || chars[start + 5] == 'E') && (chars[start + 6] == 'n' || chars[start + 6] == 'N') && (chars[start + 7] == 'c' || chars[start + 7] == 'C') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') && (chars[start + 9] == 's' || chars[start + 9] == 'S') { return TK_K_REFERENCES; }
+        }
     } else if len == 11 {
         if (chars[start + 0] == 't' || chars[start + 0] == 'T') && (chars[start + 1] == 'r' || chars[start + 1] == 'R') && (chars[start + 2] == 'a' || chars[start + 2] == 'A') && (chars[start + 3] == 'n' || chars[start + 3] == 'N') && (chars[start + 4] == 's' || chars[start + 4] == 'S') && (chars[start + 5] == 'a' || chars[start + 5] == 'A') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 't' || chars[start + 7] == 'T') && (chars[start + 8] == 'i' || chars[start + 8] == 'I') && (chars[start + 9] == 'o' || chars[start + 9] == 'O') && (chars[start + 10] == 'n' || chars[start + 10] == 'N') { return TK_K_TRANSACTION; }
+    } else if len == 12 {
+        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') && (chars[start + 6] == 't' || chars[start + 6] == 'T') && chars[start + 7] == '_' && (chars[start + 8] == 'd' || chars[start + 8] == 'D') && (chars[start + 9] == 'a' || chars[start + 9] == 'A') && (chars[start + 10] == 't' || chars[start + 10] == 'T') && (chars[start + 11] == 'e' || chars[start + 11] == 'E') { return TK_K_CURRENT_DATE; }
+        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') && (chars[start + 6] == 't' || chars[start + 6] == 'T') && chars[start + 7] == '_' && (chars[start + 8] == 't' || chars[start + 8] == 'T') && (chars[start + 9] == 'i' || chars[start + 9] == 'I') && (chars[start + 10] == 'm' || chars[start + 10] == 'M') && (chars[start + 11] == 'e' || chars[start + 11] == 'E') { return TK_K_CURRENT_TIME; }
     } else if len == 13 {
         if (chars[start + 0] == 'a' || chars[start + 0] == 'A') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 't' || chars[start + 2] == 'T') && (chars[start + 3] == 'o' || chars[start + 3] == 'O') && (chars[start + 4] == 'i' || chars[start + 4] == 'I') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') && (chars[start + 6] == 'c' || chars[start + 6] == 'C') && (chars[start + 7] == 'r' || chars[start + 7] == 'R') && (chars[start + 8] == 'e' || chars[start + 8] == 'E') && (chars[start + 9] == 'm' || chars[start + 9] == 'M') && (chars[start + 10] == 'e' || chars[start + 10] == 'E') && (chars[start + 11] == 'n' || chars[start + 11] == 'N') && (chars[start + 12] == 't' || chars[start + 12] == 'T') { return TK_K_AUTOINCREMENT; }
+    } else if len == 17 {
+        if (chars[start + 0] == 'c' || chars[start + 0] == 'C') && (chars[start + 1] == 'u' || chars[start + 1] == 'U') && (chars[start + 2] == 'r' || chars[start + 2] == 'R') && (chars[start + 3] == 'r' || chars[start + 3] == 'R') && (chars[start + 4] == 'e' || chars[start + 4] == 'E') && (chars[start + 5] == 'n' || chars[start + 5] == 'N') && (chars[start + 6] == 't' || chars[start + 6] == 'T') && chars[start + 7] == '_' && (chars[start + 8] == 't' || chars[start + 8] == 'T') && (chars[start + 9] == 'i' || chars[start + 9] == 'I') && (chars[start + 10] == 'm' || chars[start + 10] == 'M') && (chars[start + 11] == 'e' || chars[start + 11] == 'E') && (chars[start + 12] == 's' || chars[start + 12] == 'S') && (chars[start + 13] == 't' || chars[start + 13] == 'T') && (chars[start + 14] == 'a' || chars[start + 14] == 'A') && (chars[start + 15] == 'm' || chars[start + 15] == 'M') && (chars[start + 16] == 'p' || chars[start + 16] == 'P') { return TK_K_CURRENT_TIMESTAMP; }
     }
     return -1;
 }
@@ -4587,127 +4358,222 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
-        end = try_lit_semi(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
-        end = try_lit_dot(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
-        end = try_lit_comma(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
-        end = try_lit_lparen(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
-        end = try_lit_rparen(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
-        end = try_lit_eq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
-        end = try_lit_pipepipe(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; }
-        end = try_lit_star(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
-        end = try_lit_slash(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
-        end = try_lit_percent(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_PERCENT; }
-        end = try_lit_plus(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
-        end = try_lit_minus(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_MINUS; }
-        end = try_lit_ltlt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; }
-        end = try_lit_gtgt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
-        end = try_lit_amp(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_AMP; }
-        end = try_lit_pipe(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
-        end = try_lit_lt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LT; }
-        end = try_lit_lteq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; }
-        end = try_lit_gt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_GT; }
-        end = try_lit_gteq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; }
-        end = try_lit_eqeq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; }
-        end = try_lit_bangeq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; }
-        end = try_lit_ltgt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; }
-        end = try_lit_tilde(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LIT_TILDE; }
-        end = try_scol(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SCOL; }
-        end = try_dot(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_DOT; }
-        end = try_open_par(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_OPEN_PAR; }
-        end = try_close_par(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_CLOSE_PAR; }
-        end = try_comma(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_COMMA; }
-        end = try_assign(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_ASSIGN; }
-        end = try_star(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_STAR; }
-        end = try_plus(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PLUS; }
-        end = try_minus(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_MINUS; }
-        end = try_tilde(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_TILDE; }
-        end = try_pipe2(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PIPE2; }
-        end = try_div(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_DIV; }
-        end = try_mod(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_MOD; }
-        end = try_lt2(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LT2; }
-        end = try_gt2(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_GT2; }
-        end = try_amp(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_AMP; }
-        end = try_pipe(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_PIPE; }
-        end = try_lt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LT; }
-        end = try_lt_eq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_LT_EQ; }
-        end = try_gt(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_GT; }
-        end = try_gt_eq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_GT_EQ; }
-        end = try_eq(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_EQ; }
-        end = try_not_eq1(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_NOT_EQ1; }
-        end = try_not_eq2(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_NOT_EQ2; }
-        end = try_k_current_date(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_K_CURRENT_DATE; }
-        end = try_k_current_time(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_K_CURRENT_TIME; }
-        end = try_k_current_timestamp(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_K_CURRENT_TIMESTAMP; }
-        end = try_identifier(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
-        end = try_numeric_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
-        end = try_bind_parameter(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; }
-        end = try_string_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
-        end = try_blob_literal(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; }
-        end = try_single_line_comment(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; }
-        end = try_multiline_comment(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; }
-        end = try_spaces(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_SPACES; }
-        end = try_unexpected_char(&lexer.chars, start);
-        if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
-        if best_end > start {
+        if lexer.chars[start] == '\t' || lexer.chars[start] == '\n' || lexer.chars[start] == '\u{b}' || lexer.chars[start] == '\r' || lexer.chars[start] == ' ' {
+            end = try_spaces(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SPACES; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '!' {
+            end = try_lit_bangeq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '"' || lexer.chars[start] == '[' || lexer.chars[start] == '_' || lexer.chars[start] == '`' {
+            end = try_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '$' || lexer.chars[start] == ':' || lexer.chars[start] == '?' || lexer.chars[start] == '@' {
+            end = try_bind_parameter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '%' {
+            end = try_lit_percent(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PERCENT; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '&' {
+            end = try_lit_amp(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_AMP; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '\'' {
+            end = try_string_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '(' {
+            end = try_lit_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == ')' {
+            end = try_lit_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '*' {
+            end = try_lit_star(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '+' {
+            end = try_lit_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == ',' {
+            end = try_lit_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '-' {
+            end = try_lit_minus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_MINUS; }
+            end = try_single_line_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '.' {
+            end = try_lit_dot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
+            end = try_numeric_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '/' {
+            end = try_lit_slash(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
+            end = try_multiline_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == ';' {
+            end = try_lit_semi(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '<' {
+            end = try_lit_ltlt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; }
+            end = try_lit_lt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LT; }
+            end = try_lit_lteq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; }
+            end = try_lit_ltgt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '=' {
+            end = try_lit_eq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
+            end = try_lit_eqeq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '>' {
+            end = try_lit_gtgt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
+            end = try_lit_gt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GT; }
+            end = try_lit_gteq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == 'X' || lexer.chars[start] == 'x' {
+            end = try_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            end = try_blob_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '|' {
+            end = try_lit_pipepipe(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; }
+            end = try_lit_pipe(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if lexer.chars[start] == '~' {
+            end = try_lit_tilde(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_TILDE; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if 'a' <= lexer.chars[start] <= 'z' {
+            end = try_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if 'A' <= lexer.chars[start] <= 'Z' {
+            end = try_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else if '0' <= lexer.chars[start] <= '9' {
+            end = try_numeric_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        } else {
+            end = try_lit_semi(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
+            end = try_lit_dot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
+            end = try_lit_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
+            end = try_lit_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+            end = try_lit_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+            end = try_lit_eq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
+            end = try_lit_pipepipe(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; }
+            end = try_lit_star(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+            end = try_lit_slash(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; }
+            end = try_lit_percent(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PERCENT; }
+            end = try_lit_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+            end = try_lit_minus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_MINUS; }
+            end = try_lit_ltlt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; }
+            end = try_lit_gtgt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
+            end = try_lit_amp(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_AMP; }
+            end = try_lit_pipe(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; }
+            end = try_lit_lt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LT; }
+            end = try_lit_lteq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; }
+            end = try_lit_gt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GT; }
+            end = try_lit_gteq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; }
+            end = try_lit_eqeq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; }
+            end = try_lit_bangeq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; }
+            end = try_lit_ltgt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; }
+            end = try_lit_tilde(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_TILDE; }
+            end = try_identifier(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            end = try_numeric_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
+            end = try_bind_parameter(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; }
+            end = try_string_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
+            end = try_blob_literal(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; }
+            end = try_single_line_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; }
+            end = try_multiline_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; }
+            end = try_spaces(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SPACES; }
+            end = try_unexpected_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+        }
+        if best_end > start && (lexer.chars[start] == 'a' || lexer.chars[start] == 'A' || lexer.chars[start] == 'b' || lexer.chars[start] == 'B' || lexer.chars[start] == 'c' || lexer.chars[start] == 'C' || lexer.chars[start] == 'd' || lexer.chars[start] == 'D' || lexer.chars[start] == 'e' || lexer.chars[start] == 'E' || lexer.chars[start] == 'f' || lexer.chars[start] == 'F' || lexer.chars[start] == 'g' || lexer.chars[start] == 'G' || lexer.chars[start] == 'h' || lexer.chars[start] == 'H' || lexer.chars[start] == 'i' || lexer.chars[start] == 'I' || lexer.chars[start] == 'j' || lexer.chars[start] == 'J' || lexer.chars[start] == 'k' || lexer.chars[start] == 'K' || lexer.chars[start] == 'l' || lexer.chars[start] == 'L' || lexer.chars[start] == 'm' || lexer.chars[start] == 'M' || lexer.chars[start] == 'n' || lexer.chars[start] == 'N' || lexer.chars[start] == 'o' || lexer.chars[start] == 'O' || lexer.chars[start] == 'p' || lexer.chars[start] == 'P' || lexer.chars[start] == 'q' || lexer.chars[start] == 'Q' || lexer.chars[start] == 'r' || lexer.chars[start] == 'R' || lexer.chars[start] == 's' || lexer.chars[start] == 'S' || lexer.chars[start] == 't' || lexer.chars[start] == 'T' || lexer.chars[start] == 'u' || lexer.chars[start] == 'U' || lexer.chars[start] == 'v' || lexer.chars[start] == 'V' || lexer.chars[start] == 'w' || lexer.chars[start] == 'W') {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
             if kw_kind >= 0 { best_kind = kw_kind; }
         }

--- a/package-gale/tests/golden/typescript.wado
+++ b/package-gale/tests/golden/typescript.wado
@@ -4550,463 +4550,9 @@ fn try_regularexpressionliteral(chars: &Array<char>, start: i32) -> i32 {
     return pos;
 }
 
-fn try_openbracket(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '[' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_closebracket(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != ']' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_openparen(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '(' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_closeparen(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != ')' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_openbrace(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '{' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_templateclosebrace(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '}' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_closebrace(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '}' { return -1; }
-    pos += 1;
-    return pos;
-}
-
 fn try_semicolon(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
     if pos >= chars.len() || chars[pos] != ';' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_comma(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != ',' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_assign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_questionmark(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '?' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_questionmarkdot(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '?' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '.' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_colon(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != ':' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_ellipsis(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '.' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '.' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '.' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_dot(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '.' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_plusplus(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '+' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '+' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_minusminus(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '-' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '-' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_plus(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '+' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_minus(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '-' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_bitnot(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '~' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_not(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '!' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_multiply(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '*' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_divide(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '/' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_modulus(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '%' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_power(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '*' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '*' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_nullcoalesce(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '?' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '?' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_hashtag(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '#' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_leftshiftarithmetic(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_lessthan(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_morethan(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_lessthanequals(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_greaterthanequals(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_equals_(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_notequals(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '!' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_identityequals(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_identitynotequals(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '!' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_bitand(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '&' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_bitxor(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '^' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_bitor(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '|' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_and(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '&' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '&' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_or(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '|' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '|' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_multiplyassign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '*' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_divideassign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '/' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_modulusassign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '%' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_plusassign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '+' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_minusassign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '-' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_leftshiftarithmeticassign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '<' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_rightshiftarithmeticassign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_rightshiftlogicalassign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_bitandassign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '&' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_bitxorassign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '^' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_bitorassign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '|' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_powerassign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '*' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '*' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_nullishcoalescingassign(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '?' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '?' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_arrow(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '=' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != '>' { return -1; }
     pos += 1;
     return pos;
 }
@@ -5526,23 +5072,6 @@ fn try_instanceof(chars: &Array<char>, start: i32) -> i32 {
     return pos;
 }
 
-fn try_typeof(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != 't' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 'y' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 'p' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 'e' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 'o' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 'f' { return -1; }
-    pos += 1;
-    return pos;
-}
-
 fn try_case(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
     if pos >= chars.len() || chars[pos] != 'c' { return -1; }
@@ -5565,17 +5094,6 @@ fn try_else(chars: &Array<char>, start: i32) -> i32 {
     if pos >= chars.len() || chars[pos] != 's' { return -1; }
     pos += 1;
     if pos >= chars.len() || chars[pos] != 'e' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_new(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != 'n' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 'e' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 'w' { return -1; }
     pos += 1;
     return pos;
 }
@@ -6000,25 +5518,6 @@ fn try_enum(chars: &Array<char>, start: i32) -> i32 {
     return pos;
 }
 
-fn try_extends(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != 'e' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 'x' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 't' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 'e' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 'n' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 'd' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 's' { return -1; }
-    pos += 1;
-    return pos;
-}
-
 fn try_super(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
     if pos >= chars.len() || chars[pos] != 's' { return -1; }
@@ -6414,19 +5913,6 @@ fn try_keyof(chars: &Array<char>, start: i32) -> i32 {
     return pos;
 }
 
-fn try_typealias(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != 't' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 'y' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 'p' { return -1; }
-    pos += 1;
-    if pos >= chars.len() || chars[pos] != 'e' { return -1; }
-    pos += 1;
-    return pos;
-}
-
 fn try_constructor(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
     if pos >= chars.len() || chars[pos] != 'c' { return -1; }
@@ -6558,13 +6044,6 @@ fn try_is(chars: &Array<char>, start: i32) -> i32 {
     if pos >= chars.len() || chars[pos] != 'i' { return -1; }
     pos += 1;
     if pos >= chars.len() || chars[pos] != 's' { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_at(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || chars[pos] != '@' { return -1; }
     pos += 1;
     return pos;
 }
@@ -7854,116 +7333,8 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_SingleLineComment; best_push_mode = -1; best_pop_mode = false; }
             end = try_regularexpressionliteral(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_RegularExpressionLiteral; best_push_mode = -1; best_pop_mode = false; }
-            end = try_openbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OpenBracket; best_push_mode = -1; best_pop_mode = false; }
-            end = try_closebracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CloseBracket; best_push_mode = -1; best_pop_mode = false; }
-            end = try_openparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OpenParen; best_push_mode = -1; best_pop_mode = false; }
-            end = try_closeparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CloseParen; best_push_mode = -1; best_pop_mode = false; }
-            end = try_openbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OpenBrace; best_push_mode = -1; best_pop_mode = false; }
-            end = try_templateclosebrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TemplateCloseBrace; best_push_mode = -1; best_pop_mode = true; }
-            end = try_closebrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CloseBrace; best_push_mode = -1; best_pop_mode = false; }
             end = try_semicolon(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_SemiColon; best_push_mode = -1; best_pop_mode = false; }
-            end = try_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Comma; best_push_mode = -1; best_pop_mode = false; }
-            end = try_assign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Assign; best_push_mode = -1; best_pop_mode = false; }
-            end = try_questionmark(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_QuestionMark; best_push_mode = -1; best_pop_mode = false; }
-            end = try_questionmarkdot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_QuestionMarkDot; best_push_mode = -1; best_pop_mode = false; }
-            end = try_colon(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Colon; best_push_mode = -1; best_pop_mode = false; }
-            end = try_ellipsis(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ellipsis; best_push_mode = -1; best_pop_mode = false; }
-            end = try_dot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dot; best_push_mode = -1; best_pop_mode = false; }
-            end = try_plusplus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PlusPlus; best_push_mode = -1; best_pop_mode = false; }
-            end = try_minusminus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MinusMinus; best_push_mode = -1; best_pop_mode = false; }
-            end = try_plus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Plus; best_push_mode = -1; best_pop_mode = false; }
-            end = try_minus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Minus; best_push_mode = -1; best_pop_mode = false; }
-            end = try_bitnot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BitNot; best_push_mode = -1; best_pop_mode = false; }
-            end = try_not(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Not; best_push_mode = -1; best_pop_mode = false; }
-            end = try_multiply(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Multiply; best_push_mode = -1; best_pop_mode = false; }
-            end = try_divide(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Divide; best_push_mode = -1; best_pop_mode = false; }
-            end = try_modulus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Modulus; best_push_mode = -1; best_pop_mode = false; }
-            end = try_power(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Power; best_push_mode = -1; best_pop_mode = false; }
-            end = try_nullcoalesce(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NullCoalesce; best_push_mode = -1; best_pop_mode = false; }
-            end = try_hashtag(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Hashtag; best_push_mode = -1; best_pop_mode = false; }
-            end = try_leftshiftarithmetic(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LeftShiftArithmetic; best_push_mode = -1; best_pop_mode = false; }
-            end = try_lessthan(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LessThan; best_push_mode = -1; best_pop_mode = false; }
-            end = try_morethan(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MoreThan; best_push_mode = -1; best_pop_mode = false; }
-            end = try_lessthanequals(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LessThanEquals; best_push_mode = -1; best_pop_mode = false; }
-            end = try_greaterthanequals(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_GreaterThanEquals; best_push_mode = -1; best_pop_mode = false; }
-            end = try_equals_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Equals_; best_push_mode = -1; best_pop_mode = false; }
-            end = try_notequals(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NotEquals; best_push_mode = -1; best_pop_mode = false; }
-            end = try_identityequals(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IdentityEquals; best_push_mode = -1; best_pop_mode = false; }
-            end = try_identitynotequals(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IdentityNotEquals; best_push_mode = -1; best_pop_mode = false; }
-            end = try_bitand(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BitAnd; best_push_mode = -1; best_pop_mode = false; }
-            end = try_bitxor(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BitXOr; best_push_mode = -1; best_pop_mode = false; }
-            end = try_bitor(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BitOr; best_push_mode = -1; best_pop_mode = false; }
-            end = try_and(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_And; best_push_mode = -1; best_pop_mode = false; }
-            end = try_or(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Or; best_push_mode = -1; best_pop_mode = false; }
-            end = try_multiplyassign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MultiplyAssign; best_push_mode = -1; best_pop_mode = false; }
-            end = try_divideassign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DivideAssign; best_push_mode = -1; best_pop_mode = false; }
-            end = try_modulusassign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ModulusAssign; best_push_mode = -1; best_pop_mode = false; }
-            end = try_plusassign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PlusAssign; best_push_mode = -1; best_pop_mode = false; }
-            end = try_minusassign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MinusAssign; best_push_mode = -1; best_pop_mode = false; }
-            end = try_leftshiftarithmeticassign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LeftShiftArithmeticAssign; best_push_mode = -1; best_pop_mode = false; }
-            end = try_rightshiftarithmeticassign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RightShiftArithmeticAssign; best_push_mode = -1; best_pop_mode = false; }
-            end = try_rightshiftlogicalassign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RightShiftLogicalAssign; best_push_mode = -1; best_pop_mode = false; }
-            end = try_bitandassign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BitAndAssign; best_push_mode = -1; best_pop_mode = false; }
-            end = try_bitxorassign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BitXorAssign; best_push_mode = -1; best_pop_mode = false; }
-            end = try_bitorassign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BitOrAssign; best_push_mode = -1; best_pop_mode = false; }
-            end = try_powerassign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PowerAssign; best_push_mode = -1; best_pop_mode = false; }
-            end = try_nullishcoalescingassign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NullishCoalescingAssign; best_push_mode = -1; best_pop_mode = false; }
-            end = try_arrow(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ARROW; best_push_mode = -1; best_pop_mode = false; }
             end = try_nullliteral(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_NullLiteral; best_push_mode = -1; best_pop_mode = false; }
             end = try_booleanliteral(&lexer.chars, start);
@@ -7992,14 +7363,10 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Do; best_push_mode = -1; best_pop_mode = false; }
             end = try_instanceof(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Instanceof; best_push_mode = -1; best_pop_mode = false; }
-            end = try_typeof(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Typeof; best_push_mode = -1; best_pop_mode = false; }
             end = try_case(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Case; best_push_mode = -1; best_pop_mode = false; }
             end = try_else(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Else; best_push_mode = -1; best_pop_mode = false; }
-            end = try_new(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_New; best_push_mode = -1; best_pop_mode = false; }
             end = try_var(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Var; best_push_mode = -1; best_pop_mode = false; }
             end = try_catch(&lexer.chars, start);
@@ -8056,8 +7423,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Class; best_push_mode = -1; best_pop_mode = false; }
             end = try_enum(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Enum; best_push_mode = -1; best_pop_mode = false; }
-            end = try_extends(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Extends; best_push_mode = -1; best_pop_mode = false; }
             end = try_super(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Super; best_push_mode = -1; best_pop_mode = false; }
             end = try_const(&lexer.chars, start);
@@ -8104,8 +7469,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Of; best_push_mode = -1; best_pop_mode = false; }
             end = try_keyof(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_KeyOf; best_push_mode = -1; best_pop_mode = false; }
-            end = try_typealias(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TypeAlias; best_push_mode = -1; best_pop_mode = false; }
             end = try_constructor(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Constructor; best_push_mode = -1; best_pop_mode = false; }
             end = try_namespace(&lexer.chars, start);
@@ -8120,8 +7483,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if end > best_end { best_end = end; best_kind = TK_Abstract; best_push_mode = -1; best_pop_mode = false; }
             end = try_is(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Is; best_push_mode = -1; best_pop_mode = false; }
-            end = try_at(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_At; best_push_mode = -1; best_pop_mode = false; }
             end = try_identifier(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_Identifier; best_push_mode = -1; best_pop_mode = false; }
             end = try_stringliteral(&lexer.chars, start);

--- a/package-gale/tests/golden/typescript.wado
+++ b/package-gale/tests/golden/typescript.wado
@@ -7208,6 +7208,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
         let mut best_push_mode: i32 = -1;
         let mut best_pop_mode = false;
         if current_mode == 0 {

--- a/wado-compiler/lib/core/prelude/string.wado
+++ b/wado-compiler/lib/core/prelude/string.wado
@@ -471,7 +471,7 @@ impl String {
                 break;
             }
         }
-        return self.internal_substr_bytes(start, self.used);
+        return self.substr_bytes(start, self.used);
     }
 
     /// Returns a new string with trailing ASCII whitespace removed.
@@ -485,7 +485,7 @@ impl String {
                 break;
             }
         }
-        return self.internal_substr_bytes(0, end);
+        return self.substr_bytes(0, end);
     }
 
     /// Returns a new string with leading and trailing ASCII whitespace removed.
@@ -517,7 +517,7 @@ impl String {
                 break;
             }
         }
-        return self.internal_substr_bytes(start, self.used);
+        return self.substr_bytes(start, self.used);
     }
 
     /// Returns a new string with trailing Unicode whitespace removed.
@@ -558,7 +558,7 @@ impl String {
                 break;
             }
         }
-        return self.internal_substr_bytes(0, end);
+        return self.substr_bytes(0, end);
     }
 
     /// Returns a new string with leading and trailing Unicode whitespace removed.
@@ -597,8 +597,8 @@ impl String {
         return true;
     }
 
-    /// Internal: extract a substring by byte range [start, end).
-    fn internal_substr_bytes(&self, start: i32, end: i32) -> String {
+    /// Extract a substring by byte range [start, end).
+    pub fn substr_bytes(&self, start: i32, end: i32) -> String {
         let len = end - start;
         if len <= 0 {
             return String::with_capacity(0);

--- a/wado-compiler/tests/format.fixtures.golden/all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/all.lower.wado
@@ -11698,7 +11698,7 @@ pub fn String::trim_ascii_start(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(start, self.used);
+    return self.String::substr_bytes(start, self.used);
 }
 
 pub fn String::trim_ascii_end(self: &String) -> String {
@@ -11714,7 +11714,7 @@ pub fn String::trim_ascii_end(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(0, end);
+    return self.String::substr_bytes(0, end);
 }
 
 pub fn String::trim_ascii(self: &String) -> String {
@@ -11750,7 +11750,7 @@ pub fn String::trim_start(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(start, self.used);
+    return self.String::substr_bytes(start, self.used);
 }
 
 pub fn String::trim_end(self: &String) -> String {
@@ -11798,7 +11798,7 @@ pub fn String::trim_end(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(0, end);
+    return self.String::substr_bytes(0, end);
 }
 
 pub fn String::trim(self: &String) -> String {
@@ -11839,7 +11839,7 @@ pub fn String::eq_ignore_ascii_case(self: &String, other: String) -> bool {
     return true;
 }
 
-fn String::internal_substr_bytes(self: &String, start: i32, end: i32) -> String {
+pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
     let len: i32 = (end - start);
     if (len <= 0) {
         return "core::prelude/string.wado::String::with_capacity"(0);

--- a/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
@@ -10861,7 +10861,7 @@ pub fn String::trim_ascii_start(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(start, self.used);
+    return self.String::substr_bytes(start, self.used);
 }
 
 pub fn String::trim_ascii_end(self: &String) -> String {
@@ -10877,7 +10877,7 @@ pub fn String::trim_ascii_end(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(0, end);
+    return self.String::substr_bytes(0, end);
 }
 
 pub fn String::trim_ascii(self: &String) -> String {
@@ -10913,7 +10913,7 @@ pub fn String::trim_start(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(start, self.used);
+    return self.String::substr_bytes(start, self.used);
 }
 
 pub fn String::trim_end(self: &String) -> String {
@@ -10961,7 +10961,7 @@ pub fn String::trim_end(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(0, end);
+    return self.String::substr_bytes(0, end);
 }
 
 pub fn String::trim(self: &String) -> String {
@@ -11002,7 +11002,7 @@ pub fn String::eq_ignore_ascii_case(self: &String, other: String) -> bool {
     return true;
 }
 
-fn String::internal_substr_bytes(self: &String, start: i32, end: i32) -> String {
+pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
     let len: i32 = (end - start);
     if (len <= 0) {
         return "core::prelude/string.wado::String::with_capacity"(0);

--- a/wado-compiler/tests/format.fixtures.golden/ops.all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.all.lower.wado
@@ -10188,7 +10188,7 @@ pub fn String::trim_ascii_start(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(start, self.used);
+    return self.String::substr_bytes(start, self.used);
 }
 
 pub fn String::trim_ascii_end(self: &String) -> String {
@@ -10204,7 +10204,7 @@ pub fn String::trim_ascii_end(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(0, end);
+    return self.String::substr_bytes(0, end);
 }
 
 pub fn String::trim_ascii(self: &String) -> String {
@@ -10240,7 +10240,7 @@ pub fn String::trim_start(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(start, self.used);
+    return self.String::substr_bytes(start, self.used);
 }
 
 pub fn String::trim_end(self: &String) -> String {
@@ -10288,7 +10288,7 @@ pub fn String::trim_end(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(0, end);
+    return self.String::substr_bytes(0, end);
 }
 
 pub fn String::trim(self: &String) -> String {
@@ -10329,7 +10329,7 @@ pub fn String::eq_ignore_ascii_case(self: &String, other: String) -> bool {
     return true;
 }
 
-fn String::internal_substr_bytes(self: &String, start: i32, end: i32) -> String {
+pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
     let len: i32 = (end - start);
     if (len <= 0) {
         return "core::prelude/string.wado::String::with_capacity"(0);

--- a/wado-compiler/tests/format.fixtures.golden/ops.mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.mess.lower.wado
@@ -10188,7 +10188,7 @@ pub fn String::trim_ascii_start(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(start, self.used);
+    return self.String::substr_bytes(start, self.used);
 }
 
 pub fn String::trim_ascii_end(self: &String) -> String {
@@ -10204,7 +10204,7 @@ pub fn String::trim_ascii_end(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(0, end);
+    return self.String::substr_bytes(0, end);
 }
 
 pub fn String::trim_ascii(self: &String) -> String {
@@ -10240,7 +10240,7 @@ pub fn String::trim_start(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(start, self.used);
+    return self.String::substr_bytes(start, self.used);
 }
 
 pub fn String::trim_end(self: &String) -> String {
@@ -10288,7 +10288,7 @@ pub fn String::trim_end(self: &String) -> String {
             break;
         }
     }
-    return self.String::internal_substr_bytes(0, end);
+    return self.String::substr_bytes(0, end);
 }
 
 pub fn String::trim(self: &String) -> String {
@@ -10329,7 +10329,7 @@ pub fn String::eq_ignore_ascii_case(self: &String, other: String) -> bool {
     return true;
 }
 
-fn String::internal_substr_bytes(self: &String, start: i32, end: i32) -> String {
+pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
     let len: i32 = (end - start);
     if (len <= 0) {
         return "core::prelude/string.wado::String::with_capacity"(0);


### PR DESCRIPTION
## Summary

- **First-character dispatch in tokenize**: Instead of trying all `try_*` functions sequentially, the generated tokenizer now dispatches on `chars[start]` — single-char punctuation is inlined directly, multi-char operators are grouped by first char, and identifiers/numbers/strings each have their own branch. This reduces per-position try_* calls from ~60 to ~2-5 for most tokens.

- **Token priority bug fix**: The dispatch grouping broke ANTLR4's "first rule in grammar wins" priority — wildcard calls (from rules referencing non-fragment rules) were appended after range-based calls, causing wrong token kinds (e.g. `TK_DEC_LITERAL` instead of `TK_INTEGER_LITERAL` for `42` in Rust). Fixed by sorting each group's calls by original grammar index.

- **New driver tests**: 11 calculator and 11 sexpression tree-assertion tests to catch parser regressions.

## Benchmark results

sqlite-parse (13KB SQL, 81 statements × 100 iterations):

| | Baseline (Rust) | Wado (Gale) | Relative |
|---|---|---|---|
| Before | 187 ms | 3,001 ms | 16.05x |
| After | 181 ms | 2,943 ms | 16.26x |

syntax-highlight (Wasm-to-Wasm comparison, 100 iterations):

| | tree-sitter (Wasm) | Wado (Gale) | Relative |
|---|---|---|---|
| Before | 587 ms | 9,058 ms | 15.43x |
| After | 652 ms | 10,040 ms | 15.40x |

Performance is roughly neutral — the dispatch restructuring reduces generated code size but the tokenizer is not currently the bottleneck (parser backtracking dominates).

## Test plan

- [x] `mise run on-task-done` — all cargo tests (4845) and wado tests pass
- [x] All Rust driver tests pass (39 tests, previously 15 failed due to token priority bug)
- [x] All calculator/sexpression driver tests pass
- [x] Golden fixtures regenerated and match
- [x] Benchmarks re-run on clean system

https://claude.ai/code/session_01UoWckvKZiiZcoYLt5hzjK4