### PR TITLE
Update vendor/jco to latest and patch for P3 stream/future support

### DIFF
--- a/.claude/skills/jco/SKILL.md
+++ b/.claude/skills/jco/SKILL.md
@@ -100,18 +100,18 @@ JCO_DEBUG=1 node --experimental-wasm-jspi run.mjs
 
 ### Common error patterns
 
-| Error                                             | Likely cause                                                     |
-| ------------------------------------------------- | ---------------------------------------------------------------- |
-| `rec group usage requires 'gc' proposal`          | `WasmFeatures` in `lib.rs` or `core.rs` missing `GC` / `WASM3`  |
-| `wide arithmetic support is not enabled`          | Missing `WasmFeatures::WIDE_ARITHMETIC`                          |
-| `X is not defined` (runtime)                      | Missing intrinsic dependency in `intrinsics/mod.rs`              |
-| `cannot drop subtask before resolve is delivered`  | Subtask lifecycle issue — `deliverResolve()` not called          |
-| `task.X is not a function`                        | Method not defined on `AsyncTask` class (jco implementation gap) |
-| `invalid variant discriminant for expected`       | Async export returns `undefined` instead of result discriminant  |
-| Hang / timeout                                    | JSPI Suspending missing on a trampoline, or rendezvous deadlock  |
-| `symbolRscRep is not defined`                     | Missing `SymbolResourceRep` intrinsic dependency                 |
-| `FUTURES is not defined`                          | Missing `GlobalFutureMap` intrinsic dependency for FutureDrop    |
-| `invalid resource rep during remove, (cannot be 0)` | futureDropReadable called with handle 0 (stream hook bypass)   |
+| Error                                               | Likely cause                                                     |
+| --------------------------------------------------- | ---------------------------------------------------------------- |
+| `rec group usage requires 'gc' proposal`            | `WasmFeatures` in `lib.rs` or `core.rs` missing `GC` / `WASM3`   |
+| `wide arithmetic support is not enabled`            | Missing `WasmFeatures::WIDE_ARITHMETIC`                          |
+| `X is not defined` (runtime)                        | Missing intrinsic dependency in `intrinsics/mod.rs`              |
+| `cannot drop subtask before resolve is delivered`   | Subtask lifecycle issue — `deliverResolve()` not called          |
+| `task.X is not a function`                          | Method not defined on `AsyncTask` class (jco implementation gap) |
+| `invalid variant discriminant for expected`         | Async export returns `undefined` instead of result discriminant  |
+| Hang / timeout                                      | JSPI Suspending missing on a trampoline, or rendezvous deadlock  |
+| `symbolRscRep is not defined`                       | Missing `SymbolResourceRep` intrinsic dependency                 |
+| `FUTURES is not defined`                            | Missing `GlobalFutureMap` intrinsic dependency for FutureDrop    |
+| `invalid resource rep during remove, (cannot be 0)` | futureDropReadable called with handle 0 (stream hook bypass)     |
 
 ## Saving Patches
 

--- a/.claude/skills/jco/SKILL.md
+++ b/.claude/skills/jco/SKILL.md
@@ -5,7 +5,7 @@ description: Debug and patch jco (JS Component Tooling) for Wado wasm transpilat
 
 # jco Patching Workflow
 
-jco (`vendor/jco`) is bytecodealliance's tool for transpiling Wasm Components to JavaScript. Wado uses a patched fork because upstream jco has incomplete support for WASM3 (GC), CM async (P3 streams/futures), and JSPI integration.
+jco (`vendor/jco`) is bytecodealliance's tool for transpiling Wasm Components to JavaScript. Wado uses a patched fork because upstream jco has incomplete support for P3 async stream delivery and JSPI integration.
 
 ## Setup
 
@@ -22,13 +22,11 @@ After editing jco Rust source:
 ```sh
 cd vendor/jco
 
-# 1. Rebuild wasm component (the transpiler itself runs as wasm)
-cargo clean -p js-component-bindgen --target wasm32-wasip1
-cargo build --workspace --target wasm32-wasip1
+# 1. Build xtask (host target)
+cargo build -p xtask --target x86_64-unknown-linux-gnu
 
 # 2. Re-transpile the jco component to JS (bootstrap: uses existing jco to transpile itself)
 rm -f packages/jco/obj/js-component-bindgen-component.*
-cargo build -p xtask --target x86_64-unknown-linux-gnu
 ./target/x86_64-unknown-linux-gnu/debug/xtask build debug
 
 # 3. Test with a Wado program
@@ -46,11 +44,17 @@ node --experimental-wasm-jspi -e "
 "
 ```
 
-**IMPORTANT**: `cargo clean -p js-component-bindgen --target wasm32-wasip1` is required. Without it, cargo may not detect changes in `lib.rs` because the `WasmFeatures` bitflag values are const-evaluated and produce identical binaries. Always clean before rebuild.
+Or use mise tasks:
+
+```sh
+mise run build-jco
+mise run hello
+mise run jco-transpile example/hello.wasm
+```
 
 ## Debugging Runtime Errors
 
-jco-transpiled code is a single large JS file (~165KB for hello). Key functions to know:
+jco-transpiled code is a single large JS file (~185KB for hello). Key functions to know:
 
 | Wasm canonical built-in | jco JS function        | Trampoline                      |
 | ----------------------- | ---------------------- | ------------------------------- |
@@ -88,17 +92,26 @@ jco's async machinery swallows errors via unhandled Promise rejections. Always a
 process.on('unhandledRejection', e => { console.error('UNHANDLED:', e); process.exit(1); });
 ```
 
+### Debug technique: enable JCO_DEBUG
+
+```sh
+JCO_DEBUG=1 node --experimental-wasm-jspi run.mjs
+```
+
 ### Common error patterns
 
 | Error                                             | Likely cause                                                     |
 | ------------------------------------------------- | ---------------------------------------------------------------- |
-| `rec group usage requires 'gc' proposal`          | `WasmFeatures` in `lib.rs` or `core.rs` missing `GC` / `WASM3`   |
+| `rec group usage requires 'gc' proposal`          | `WasmFeatures` in `lib.rs` or `core.rs` missing `GC` / `WASM3`  |
 | `wide arithmetic support is not enabled`          | Missing `WasmFeatures::WIDE_ARITHMETIC`                          |
 | `X is not defined` (runtime)                      | Missing intrinsic dependency in `intrinsics/mod.rs`              |
-| `cannot drop subtask before resolve is delivered` | Subtask lifecycle issue — `deliverResolve()` not called          |
+| `cannot drop subtask before resolve is delivered`  | Subtask lifecycle issue — `deliverResolve()` not called          |
 | `task.X is not a function`                        | Method not defined on `AsyncTask` class (jco implementation gap) |
 | `invalid variant discriminant for expected`       | Async export returns `undefined` instead of result discriminant  |
 | Hang / timeout                                    | JSPI Suspending missing on a trampoline, or rendezvous deadlock  |
+| `symbolRscRep is not defined`                     | Missing `SymbolResourceRep` intrinsic dependency                 |
+| `FUTURES is not defined`                          | Missing `GlobalFutureMap` intrinsic dependency for FutureDrop    |
+| `invalid resource rep during remove, (cannot be 0)` | futureDropReadable called with handle 0 (stream hook bypass)   |
 
 ## Saving Patches
 
@@ -131,6 +144,7 @@ git commit -m "Update jco patches: <description>"
 | `crates/js-component-bindgen/src/intrinsics/mod.rs`             | Intrinsic dependency resolution           |
 | `crates/js-component-bindgen/src/intrinsics/lower.rs`           | Value lowering (Result, Variant, etc.)    |
 | `crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs` | Stream classes and operations             |
+| `crates/js-component-bindgen/src/intrinsics/p3/async_future.rs` | Future classes and drop operations        |
 | `crates/js-component-bindgen/src/intrinsics/p3/waitable.rs`     | WaitableSet wait/poll                     |
 | `crates/js-component-bindgen/src/intrinsics/p3/async_task.rs`   | AsyncTask class                           |
 
@@ -143,3 +157,10 @@ git commit -m "Update jco patches: <description>"
 - `clocks.js` — `wasi:clocks` via `process.hrtime` / `Date.now`
 
 The `--map` flag maps WASI interfaces to shim files during transpilation.
+
+## Current Patches (on top of upstream main)
+
+1. **Stream write hook** (`async_stream.rs`): `globalThis._jcoStreamWriteHook` delivers stream data directly from linear memory, bypassing the rendezvous mechanism.
+2. **Missing intrinsic dependencies** (`mod.rs`): `StreamNewFromLift` → `SymbolResourceRep`; `FutureDropReadable/Writable` → `GlobalFutureMap`, `FutureEndClass`, etc.
+3. **futureDropReadable/Writable** (`async_future.rs`, `transpile_bindgen.rs`): Pass `componentIdx` as bound parameter; accept single `futureEndIdx` from wasm; tolerate handle 0 (stream hook bypass).
+4. **Async export void return** (`function_bindgen.rs`): Fall back to `task.completionPromise()` when JSPI returns `undefined`.

--- a/example/jco-shim/cli.js
+++ b/example/jco-shim/cli.js
@@ -1,0 +1,31 @@
+// WASI P3 CLI shim for jco transpilation
+// Provides wasi:cli/stdout and wasi:cli/stderr for Node.js
+
+const encoder = new TextEncoder();
+
+// Stream write hook: jco calls this to write bytes to a stream
+globalThis._jcoStreamWriteHook = (streamId, bytes) => {
+  // streamId 0 = stdout, streamId 1 = stderr
+  if (streamId === 0) {
+    process.stdout.write(bytes);
+  } else {
+    process.stderr.write(bytes);
+  }
+  return bytes.length;
+};
+
+export function writeViaStream() {
+  return 0; // stdout stream id
+}
+
+export const stdout = {
+  writeViaStream() {
+    return 0; // stdout stream id
+  }
+};
+
+export const stderr = {
+  writeViaStream() {
+    return 1; // stderr stream id
+  }
+};

--- a/example/jco-shim/cli.js
+++ b/example/jco-shim/cli.js
@@ -1,31 +1,49 @@
-// WASI P3 CLI shim for jco transpilation
-// Provides wasi:cli/stdout and wasi:cli/stderr for Node.js
+// Minimal WASI P3 CLI shim for jco-transpiled Wado programs
+//
+// Uses a global stream write hook to intercept bulk data from stream.write,
+// bypassing the jco byte-at-a-time rendezvous mechanism.
 
-const encoder = new TextEncoder();
+// Map: writable end waitable index -> output target
+const _streamTargets = new Map();
 
-// Stream write hook: jco calls this to write bytes to a stream
-globalThis._jcoStreamWriteHook = (streamId, bytes) => {
-  // streamId 0 = stdout, streamId 1 = stderr
-  if (streamId === 0) {
-    process.stdout.write(bytes);
-  } else {
-    process.stderr.write(bytes);
+// Global hook: called by patched jco's streamWrite when data is written
+globalThis._jcoStreamWriteHook = (writableEndIdx, data) => {
+  const target = _streamTargets.get(writableEndIdx);
+  if (target) {
+    target.write(data);
+    return true;
   }
-  return bytes.length;
+  return false;
 };
 
-export function writeViaStream() {
-  return 0; // stdout stream id
-}
+export const types = {
+  OutputStream: class OutputStream {},
+};
 
 export const stdout = {
-  writeViaStream() {
-    return 0; // stdout stream id
-  }
+  writeViaStream(_stream) {
+    _defaultTarget = process.stdout;
+    return { tag: "ok" };
+  },
 };
+stdout.writeViaStream._isHostProvided = true;
 
 export const stderr = {
-  writeViaStream() {
-    return 1; // stderr stream id
+  writeViaStream(_stream) {
+    _defaultTarget = process.stderr;
+    return { tag: "ok" };
+  },
+};
+stderr.writeViaStream._isHostProvided = true;
+
+// Default target for unregistered writable ends
+let _defaultTarget = process.stdout;
+
+// Override the hook to auto-register unknown writable ends
+const _origHook = globalThis._jcoStreamWriteHook;
+globalThis._jcoStreamWriteHook = (writableEndIdx, data) => {
+  if (!_streamTargets.has(writableEndIdx) && _defaultTarget) {
+    _streamTargets.set(writableEndIdx, _defaultTarget);
   }
+  return _origHook(writableEndIdx, data);
 };

--- a/example/jco-shim/clocks.js
+++ b/example/jco-shim/clocks.js
@@ -1,0 +1,34 @@
+// Minimal WASI P3 clocks shim for jco-transpiled Wado programs
+
+export const monotonicClock = {
+  now() {
+    // Return nanoseconds as BigInt
+    const [sec, nsec] = process.hrtime();
+    return BigInt(sec) * 1000000000n + BigInt(nsec);
+  },
+  resolution() {
+    return 1n; // 1 nanosecond
+  },
+  subscribeInstant(_when) {
+    return { tag: "ok" };
+  },
+  subscribeDuration(_duration) {
+    return { tag: "ok" };
+  },
+};
+
+export const wallClock = {
+  now() {
+    const ms = Date.now();
+    return {
+      seconds: BigInt(Math.floor(ms / 1000)),
+      nanoseconds: (ms % 1000) * 1000000,
+    };
+  },
+  resolution() {
+    return {
+      seconds: 0n,
+      nanoseconds: 1000000, // 1ms
+    };
+  },
+};

--- a/example/jco-shim/random.js
+++ b/example/jco-shim/random.js
@@ -1,0 +1,32 @@
+// Minimal WASI P3 random shim for jco-transpiled Wado programs
+import { randomBytes } from "node:crypto";
+
+export const random = {
+  getRandomBytes(len) {
+    return new Uint8Array(randomBytes(len));
+  },
+  getRandomU64() {
+    const buf = randomBytes(8);
+    return new DataView(buf.buffer).getBigUint64(0, true);
+  },
+};
+
+export const insecure = {
+  getInsecureRandomBytes(len) {
+    return new Uint8Array(randomBytes(len));
+  },
+  getInsecureRandomU64() {
+    const buf = randomBytes(8);
+    return new DataView(buf.buffer).getBigUint64(0, true);
+  },
+};
+
+export const insecureSeed = {
+  insecureSeed() {
+    const buf = randomBytes(16);
+    return [
+      new DataView(buf.buffer).getBigUint64(0, true),
+      new DataView(buf.buffer).getBigUint64(8, true),
+    ];
+  },
+};

--- a/mise.toml
+++ b/mise.toml
@@ -365,3 +365,40 @@ run = "mise run -C benchmark syntax-highlight"
 [tasks.report-wasm-size]
 description = "Build all languages and report Wasm sizes"
 run = "mise run -C wasm-size report-wasm-size"
+
+[tasks.build-jco]
+description = "Build patched jco from vendor/jco"
+run = """
+#!/usr/bin/env bash
+set -xe -o pipefail
+cd vendor/jco
+PUPPETEER_SKIP_DOWNLOAD=1 npm install --ignore-scripts 2>&1 | tail -3
+cargo build -p xtask --target x86_64-unknown-linux-gnu
+./target/x86_64-unknown-linux-gnu/debug/xtask build debug
+echo "jco built successfully at vendor/jco"
+"""
+
+[tasks.jco-transpile]
+description = "Transpile a Wado .wasm component to JS via patched jco"
+usage = "jco-transpile <wasm-file> [output-dir]"
+run = """
+#!/usr/bin/env bash
+set -e -o pipefail
+WASM_FILE="${1:?Usage: mise run jco-transpile <wasm-file> [output-dir]}"
+OUTPUT_DIR="${2:-${WASM_FILE%.wasm}-jco}"
+JCO="vendor/jco/packages/jco/src/jco.js"
+SHIM_DIR="$(pwd)/example/jco-shim"
+
+if [ ! -f "vendor/jco/packages/jco/obj/js-component-bindgen-component.js" ]; then
+  echo "jco not built yet. Run: mise run build-jco"
+  exit 1
+fi
+
+rm -rf "$OUTPUT_DIR"
+node "$JCO" transpile "$WASM_FILE" -o "$OUTPUT_DIR" \
+  --map "wasi:cli/*=${SHIM_DIR}/cli.js#*" \
+  --map "wasi:random/*=${SHIM_DIR}/random.js#*" \
+  --map "wasi:clocks/*=${SHIM_DIR}/clocks.js#*"
+echo '{"type": "module"}' > "$OUTPUT_DIR/package.json"
+echo "Transpiled to: $OUTPUT_DIR"
+"""

--- a/vendor/jco.patch
+++ b/vendor/jco.patch
@@ -1,0 +1,183 @@
+diff --git a/crates/js-component-bindgen/src/function_bindgen.rs b/crates/js-component-bindgen/src/function_bindgen.rs
+index 8bb0dfbc..e5a9fcb8 100644
+--- a/crates/js-component-bindgen/src/function_bindgen.rs
++++ b/crates/js-component-bindgen/src/function_bindgen.rs
+@@ -1518,11 +1518,24 @@ impl Bindgen for FunctionBindgen<'_> {
+                               taskID: task.id(),
+                               componentIdx: task.componentIdx(),
+                               fn: () => {callee}({args}),
+-                          }});
+-                          "#,
++                          }});"#,
+                     callee = self.callee,
+                     args = operands.join(", "),
+                 );
++                // For async exports using task.return, the JSPI Promising wrapper
++                // returns undefined (void core wasm function). The task's completion
++                // promise (resolved by task.return) provides the already-lifted result.
++                if self.is_async && sig_results_length > 0 {
++                    uwriteln!(
++                        self.src,
++                        r#"
++                          if (ret === undefined) {{
++                              const taskResult = await task.completionPromise();
++                              if (taskResult !== undefined) {{ return taskResult; }}
++                          }}
++                          "#,
++                    );
++                }
+ 
+                 if self.tracing_enabled {
+                     let prefix = self.tracing_prefix;
+diff --git a/crates/js-component-bindgen/src/intrinsics/mod.rs b/crates/js-component-bindgen/src/intrinsics/mod.rs
+index db2e9e07..4b45bfe6 100644
+--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
++++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
+@@ -1492,6 +1492,7 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
+             &Intrinsic::AsyncStream(AsyncStreamIntrinsic::GlobalStreamTableMap),
+             &Intrinsic::AsyncStream(AsyncStreamIntrinsic::HostStreamClass),
+             &Intrinsic::AsyncStream(AsyncStreamIntrinsic::ExternalStreamClass),
++            &Intrinsic::SymbolResourceRep,
+         ]);
+     }
+ 
+@@ -1509,6 +1510,22 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
+         ]);
+     }
+ 
++    if args
++        .intrinsics
++        .contains(&Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureDropReadable))
++        || args
++            .intrinsics
++            .contains(&Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureDropWritable))
++    {
++        args.intrinsics.extend([
++            &Intrinsic::AsyncFuture(AsyncFutureIntrinsic::GlobalFutureMap),
++            &Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureEndClass),
++            &Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureReadableEndClass),
++            &Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureWritableEndClass),
++            &Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState),
++        ]);
++    }
++
+     if args.intrinsics.contains(&Intrinsic::GlobalBufferManager) {
+         args.intrinsics.extend([&Intrinsic::BufferManagerClass]);
+     }
+diff --git a/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs b/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
+index 1ec1529b..d1b20b25 100644
+--- a/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
++++ b/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
+@@ -496,38 +496,31 @@ impl AsyncFutureIntrinsic {
+             Self::FutureDropReadable | Self::FutureDropWritable => {
+                 let debug_log_fn = Intrinsic::DebugLog.name();
+                 let future_drop_fn = self.name();
+-                let is_writable = matches!(self, Self::FutureDropWritable);
+                 let global_future_map = Self::GlobalFutureMap.name();
+-                let future_end_class = if is_writable {
+-                    Self::FutureWritableEndClass.name()
+-                } else {
+-                    Self::FutureReadableEndClass.name()
+-                };
+                 let get_or_create_async_state_fn =
+                     Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState).name();
+                 output.push_str(&format!("
+                     function {future_drop_fn}(
+-                        futureIdx,
++                        componentIdx,
+                         futureEndIdx,
+                     ) {{
+                         {debug_log_fn}('[{future_drop_fn}()] args', {{
+-                            futureIdx,
++                            componentIdx,
+                             futureEndIdx,
+                         }});
+ 
+                         const state = {get_or_create_async_state_fn}(componentIdx);
+                         if (!state.mayLeave) {{ throw new Error('component instance is not marked as may leave'); }}
+ 
+-                        const future = {global_future_map}.remove(futureIdx);
+-
+-                        const futureEnd = {global_future_map}.remove(futureEndIdx);
+-                        if (!(futureEnd instanceof {future_end_class})) {{ throw new Error('invalid future end, expected [{future_end_class}]'); }}
++                        // futureEndIdx may be 0 when the stream write hook bypassed
++                        // the future mechanism, in which case we skip the drop.
++                        if (futureEndIdx === 0) {{ return; }}
+ 
+-                        if (futureEnd.elementTypeRep() !== future.elementTypeRep()) {{
+-                          throw new Error('future type [' + future.elementTypeRep() + '], does not match future end type [' + futureEnd.elementTypeRep() + ']');
++                        const futureEnd = {global_future_map}.get(futureEndIdx);
++                        if (futureEnd) {{
++                            {global_future_map}.remove(futureEndIdx);
++                            futureEnd.drop();
+                         }}
+-
+-                        futureEnd.drop();
+                     }}
+                 "));
+             }
+diff --git a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+index daa83c43..7ced1cb9 100644
+--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
++++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+@@ -1617,9 +1617,23 @@ impl AsyncStreamIntrinsic {
+                             throw new Error(`stream end table idx [${{streamEnd.streamTableIdx()}}] != operation table idx [${{streamTableIdx}}]`);
+                         }}
+ 
++                        const memory = getMemoryFn();
++
++                        // Host stream write hook: if a global hook is registered, deliver
++                        // stream data directly from linear memory, bypassing the rendezvous.
++                        // This enables WASI shims to receive bulk data from stream.write.
++                        if (typeof globalThis._jcoStreamWriteHook === 'function' && streamEnd.isWritable()) {{
++                            const actualCount = count >>> 0;
++                            const data = new Uint8Array(memory.buffer, ptr, actualCount);
++                            const handled = globalThis._jcoStreamWriteHook(streamEndWaitableIdx, new Uint8Array(data));
++                            if (handled) {{
++                                return (actualCount << 4) | 0;
++                            }}
++                        }}
++
+                         const result = await streamEnd.copy({{
+                             isAsync,
+-                            memory: getMemoryFn(),
++                            memory,
+                             ptr,
+                             count,
+                             eventCode: {event_code},
+diff --git a/crates/js-component-bindgen/src/transpile_bindgen.rs b/crates/js-component-bindgen/src/transpile_bindgen.rs
+index 7fe0cf5d..ccf7fd44 100644
+--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
++++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
+@@ -1730,25 +1730,25 @@ impl<'a> Instantiator<'a, '_> {
+                 );
+             }
+ 
+-            Trampoline::FutureDropReadable { ty, .. } => {
++            Trampoline::FutureDropReadable { ty: _, instance, .. } => {
+                 let future_drop_readable_fn = self.bindgen.intrinsic(Intrinsic::AsyncFuture(
+                     AsyncFutureIntrinsic::FutureDropReadable,
+                 ));
++                let instance_idx = instance.as_u32();
+                 uwriteln!(
+                     self.src.js,
+-                    "const trampoline{i} = {future_drop_readable_fn}.bind(null, {future_idx});\n",
+-                    future_idx = ty.as_u32(),
++                    "const trampoline{i} = {future_drop_readable_fn}.bind(null, {instance_idx});\n",
+                 );
+             }
+ 
+-            Trampoline::FutureDropWritable { ty, .. } => {
++            Trampoline::FutureDropWritable { ty: _, instance, .. } => {
+                 let future_drop_writable_fn = self.bindgen.intrinsic(Intrinsic::AsyncFuture(
+                     AsyncFutureIntrinsic::FutureDropWritable,
+                 ));
++                let instance_idx = instance.as_u32();
+                 uwriteln!(
+                     self.src.js,
+-                    "const trampoline{i} = {future_drop_writable_fn}.bind(null, {future_idx});\n",
+-                    future_idx = ty.as_u32(),
++                    "const trampoline{i} = {future_drop_writable_fn}.bind(null, {instance_idx});\n",
+                 );
+             }
+ 


### PR DESCRIPTION
## Summary

- Update `vendor/jco` submodule from v1.17.6 to latest `origin/main` (4bae4296), picking up 6 of 8 patches from #714 that were adopted upstream
- Apply 4 remaining patches on top for WASI P3 stream/future support (saved as `vendor/jco.patch`)
- Add WASI P3 shims for `clocks` and `random` alongside the existing `cli` shim
- Add `build-jco` and `jco-transpile` mise tasks
- Update jco skill documentation

### Patches applied (on top of upstream main)

1. **Stream write hook** (`async_stream.rs`): `globalThis._jcoStreamWriteHook` delivers stream data directly from linear memory, bypassing the rendezvous mechanism. This is needed because there's no host-side reader for P3 stdout/stderr streams.
2. **Missing intrinsic dependencies** (`mod.rs`): `StreamNewFromLift` → `SymbolResourceRep`; `FutureDropReadable/Writable` → `GlobalFutureMap`, `FutureEndClass`, `FutureReadableEndClass`, `FutureWritableEndClass`, `GetOrCreateAsyncState`.
3. **futureDropReadable/Writable** (`async_future.rs`, `transpile_bindgen.rs`): Pass `componentIdx` as bound parameter; accept single `futureEndIdx` from wasm; tolerate handle 0 (stream hook bypass).
4. **Async export void return** (`function_bindgen.rs`): Fall back to `task.completionPromise()` when JSPI returns `undefined` instead of a variant discriminant.

### Upstream plan

Patches 2–4 are straightforward bug fixes that should be contributed upstream to `bytecodealliance/jco`. Patch 1 (stream write hook via `globalThis`) is ad-hoc and needs a cleaner design before upstreaming — possibly a proper host-provided stream adapter or a transpile-time option to inject custom stream handlers.

## Test plan

- [x] `cargo run --bin wado -- compile -O2 -o /tmp/hello.wasm example/hello.wado` compiles successfully
- [x] `mise run build-jco` builds patched jco
- [x] `mise run jco-transpile /tmp/hello.wasm` transpiles to JS
- [x] `node --experimental-wasm-jspi` runs transpiled code, prints "Hello, world!" and exits cleanly
- [x] CI passes

https://claude.ai/code/session_01Tb8A69BiQ3dEX5pqeVDwtp