### PR TITLE
Eliminate parser backtracking via scan-then-parse

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -91,8 +91,8 @@ Parse 81 SQL statements (13 KB) x 100 iterations. Gale-generated parser vs sqlpa
 
 | Implementation             |     Time | vs best |
 | -------------------------- | -------: | ------: |
-| sqlparser-rs (Rust native) |   173 ms |   1.00x |
-| **Wado** (Gale)            | 2,137 ms |  12.35x |
+| sqlparser-rs (Rust native) |   189 ms |   1.00x |
+| **Wado** (Gale)            | 1,305 ms |   6.91x |
 
 ## Syntax Highlight
 

--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -12,62 +12,7 @@
 
 ## Performance: sqlite-parse Benchmark
 
-Profiling the SQLite parser benchmark (13 KB SQL, 100 iterations, ~26 ms/iter) with exhaustive guest profiling (6.9M samples) reveals the following bottlenecks.
-
-### Bottleneck 1: Backtracking (~44% inclusive)
-
-The SLL prediction engine falls back to backtracking when it cannot disambiguate alternatives within depth-5 lookahead. The top backtracking functions by inclusive time:
-
-| Function                       | Inclusive | Grammar alternatives                                 |
-| ------------------------------ | --------- | ---------------------------------------------------- |
-| `parse_result_column_bt_2`     | 12.2%     | `expr (K_AS? column_alias)?`                         |
-| `parse_expr_bt_13`             | 10.2%     | `function_name '(' ... ')'`                          |
-| `parse_expr_bt_2`              | 5.7%      | `((database_name '.')? table_name '.')? column_name` |
-| `parse_table_or_subquery_bt_1` | 4.2%      | table reference with alias                           |
-| `parse_result_column_bt_1`     | 4.1%      | `table_name '.' '*'`                                 |
-| `parse_expr_bt_21`             | 4.0%      | `(NOT? EXISTS)? '(' select_stmt ')'`                 |
-| `parse_table_or_subquery_bt_0` | 3.1%      | table reference                                      |
-
-#### `result_column` — worst case
-
-Grammar rule: `'*' | table_name '.' '*' | expr (K_AS? column_alias)?`
-
-When an IDENTIFIER token appears, the generator cannot distinguish `table_name '.' '*'` from `expr` because both start with IDENTIFIER. The RuleRef `table_name` expands to `any_name` → IDENTIFIER, so a 2-token lookahead (IDENTIFIER + `.`) would suffice, but RuleRef expansion was reverted (see CLAUDE.md "Failed Approaches"). The generated code:
-
-1. Tries `bt_1` (`table_name '.' '*'`) — parses `table_name`, expects `.`, fails, backtracks
-2. Falls through to `bt_2` (`expr`) — succeeds
-
-Every non-`*` result column pays for one full failed `table_name` parse.
-
-#### `expr` with LPAREN — 4-way backtracking
-
-When `(` appears in expression position, the generator tries 4 alternatives sequentially:
-
-1. `bt_21`: `[NOT] EXISTS '(' select_stmt ')'` — fails, backtracks
-2. `bt_14`: `'(' expr ')'` — fails, backtracks
-3. `bt_13`: `function_name '(' ... ')'` — fails, backtracks
-4. `bt_2`: `((db.)? table.)? column` — final fallback
-
-Since `expr` is called from WHERE, HAVING, SELECT columns, etc., this 4-way backtracking multiplies across the entire parse.
-
-#### `expr` with IDENTIFIER — common case, 2-3 way backtracking
-
-Most expressions in SQL are column references (bare IDENTIFIERs). The generated code tries `bt_13` (function call: `function_name '(' ...`) before `bt_2` (column reference). Since `function_name` expands to IDENTIFIER, it always matches the first token, then fails at `(`, and backtracks. Every simple column reference pays for one wasted `function_name` parse.
-
-### Bottleneck 2: `Parser::expect` error path (22% combined)
-
-| Function                     | Self-time |
-| ---------------------------- | --------- |
-| `Parser::expect`             | 12.0%     |
-| `String::push_str`           | 4.7%      |
-| `LexerSlice^Display::fmt`    | 3.4%      |
-| `String::push` (from expect) | ~2%       |
-
-`expect` constructs a `ParseError` with template string and array literal on every failure. During backtracking, most `expect` calls are speculative — the error is immediately discarded when the caller backtracks. Constructing the error message (`ParseError::new(...)` with string interpolation and `Array<String>` allocation) is pure waste on the failure path.
-
-Reducing backtracking (Bottleneck 1) would eliminate most of this cost.
-
-### Bottleneck 3: `Parser::last_end` (11.7%)
+### Remaining Bottleneck: `Parser::last_end` (11.7%)
 
 | Function           | Self-time |
 | ------------------ | --------- |
@@ -77,13 +22,10 @@ Called after every token consumption to compute node spans via `Span::new(start,
 
 Possible improvement: cache `last_end` in a field on `Parser` updated by `advance()`, avoiding repeated array indexing.
 
-### Summary
+### Resolved
 
-| Category                                   | Estimated share | Priority                                  |
-| ------------------------------------------ | --------------- | ----------------------------------------- |
-| Backtracking                               | ~44% inclusive  | High                                      |
-| expect error path (driven by backtracking) | ~22%            | High (addressed by reducing backtracking) |
-| last_end overhead                          | ~12%            | Medium                                    |
+- **Backtracking (~44%)**: Eliminated by scan-then-parse optimization. Lightweight scan functions check token kinds to pick the correct alternative before calling the real parse function once.
+- **`Parser::expect` error path (~22%)**: Largely eliminated — scan functions avoid speculative parse failures that triggered error construction.
 
 ## Generated Parser Bugs
 

--- a/package-gale/src/gen_context.wado
+++ b/package-gale/src/gen_context.wado
@@ -9,6 +9,7 @@ pub struct GenContext {
     rule_index: TreeMap<String, i32>,
     first_cache: TreeMap<String, Array<String>>,
     single_token_cache: TreeMap<String, bool>,
+    scannable_cache: TreeMap<String, bool>,
     pub current_rule_name: String,
     pub group_counter: i32,
     pub alt_gc_starts: Array<i32>,
@@ -30,6 +31,7 @@ impl GenContext {
             rule_index,
             first_cache: TreeMap::<String, Array<String>>::new(),
             single_token_cache: TreeMap::<String, bool>::new(),
+            scannable_cache: TreeMap::<String, bool>::new(),
             current_rule_name: "",
             group_counter: 0,
             alt_gc_starts: [],
@@ -207,6 +209,85 @@ impl GenContext {
         return result;
     }
 
+    /// Returns true if the rule can be recognized by a bounded token scan.
+    /// A rule is scannable if it does not transitively reference any rule that
+    /// has left-recursive alternatives. Left-recursive rules (like `expr`) can
+    /// span arbitrarily large input, making scanning as expensive as parsing.
+    /// Self-recursive but non-left-recursive rules (like `any_name`) are
+    /// scannable because their recursion is bounded by delimiters.
+    pub fn is_rule_scannable(&mut self, name: &String, visiting: &mut Array<String>) -> bool {
+        let cached = self.scannable_cache.get(*name);
+        if let Some(val) = cached {
+            return val;
+        }
+
+        let visiting_set = str_set_from(visiting);
+        if visiting_set.contains(*name) {
+            // Cycle back to a rule we're already checking — this is fine for
+            // non-left-recursive rules (bounded recursion). Return true here;
+            // if the rule is left-recursive, it will be caught by the
+            // has_left_recursive_alt check on the initial call.
+            return true;
+        }
+
+        let is_top_level = visiting.is_empty();
+        visiting.push(*name);
+
+        let mut result = false;
+        let rule = self.find_rule(name);
+        if let Some(rule) = rule {
+            if has_left_recursive_alt(&rule.alternatives, name) {
+                // Left-recursive rules are not scannable.
+                result = false;
+            } else {
+                let mut all_ok = true;
+                for let alt of &rule.alternatives {
+                    if !self.is_alt_scannable(&alt.elements, visiting) {
+                        all_ok = false;
+                        break;
+                    }
+                }
+                result = all_ok;
+            }
+        }
+
+        remove_from_visiting(visiting, name);
+
+        if is_top_level {
+            self.scannable_cache[*name] = result;
+        }
+
+        return result;
+    }
+
+    /// Returns true if every element in the sequence is scannable.
+    fn is_alt_scannable(&mut self, elements: &Array<Element>, visiting: &mut Array<String>) -> bool {
+        for let elem of elements {
+            if !self.is_element_scannable(elem, visiting) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// Returns true if a single element is scannable.
+    fn is_element_scannable(&mut self, elem: &Element, visiting: &mut Array<String>) -> bool {
+        return match elem {
+            TokenRef(_) | Literal(_) => true,
+            RuleRef(name) => self.is_rule_scannable(name, visiting),
+            Label(lab) => self.is_element_scannable(&lab.element, visiting),
+            Repeat(rep) => self.is_element_scannable(&rep.element, visiting),
+            Group(alts) => {
+                for let alt of alts {
+                    if !self.is_alt_scannable(&alt.elements, visiting) {
+                        return false;
+                    }
+                }
+                return true;
+            },
+        };
+    }
+
     /// Get the rule name that owns the general group types inside a given
     /// single-alt group. Returns the current_rule_name if no shared group found.
     pub fn general_group_rule_name(&self, single_alt_type_name: &String) -> String {
@@ -272,6 +353,33 @@ fn extract_group_alts_for_scan(elem: &Element) -> Option<&Array<Alternative>> {
         }
     }
     return null;
+}
+
+/// Returns true if any alternative starts with a direct reference to the
+/// given rule name (left-recursive). Unwraps labels and skips nullable
+/// elements to find the first non-nullable element.
+fn has_left_recursive_alt(alternatives: &Array<Alternative>, rule_name: &String) -> bool {
+    for let alt of alternatives {
+        for let elem of &alt.elements {
+            let inner = unwrap_labels(elem);
+            if let RuleRef(name) = inner {
+                if *name == *rule_name {
+                    return true;
+                }
+            }
+            if !is_nullable(elem) {
+                break;
+            }
+        }
+    }
+    return false;
+}
+
+fn unwrap_labels(elem: &Element) -> &Element with stores[elem] {
+    if let Label(lab) = elem {
+        return unwrap_labels(&lab.element);
+    }
+    return elem;
 }
 
 pub fn is_nullable(elem: &Element) -> bool {

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -1179,6 +1179,12 @@ fn alt_has_scan(elements: &Array<Element>, ctx: &mut GenContext) -> bool {
     return scannable_prefix_len(elements, ctx) > 0;
 }
 
+/// Returns true if the scan function covers the entire alternative (all elements are scannable).
+/// When true, a scan success guarantees parse success so no fallthrough is needed.
+fn alt_scan_is_full(elements: &Array<Element>, ctx: &mut GenContext) -> bool {
+    return scannable_prefix_len(elements, ctx) == elements.len();
+}
+
 // --- Scan Function Generation ---
 // Scan functions recognize parser rules by walking token kinds without building
 // CST nodes or constructing error messages. They return the token position after
@@ -3918,16 +3924,67 @@ fn gen_prediction_code_inner(w: &mut CodeWriter, node: &PredictionNode, fn_name:
 
             if all_have_scans && sorted_indices.len() >= 2 {
                 // All non-last alternatives have scan functions.
-                // Use scan-then-parse: no backtracking needed.
-                for let mut i = 0; i < sorted_indices.len(); i += 1 {
+                // Check if ALL scans are full (cover entire alternative).
+                let mut all_full = true;
+                for let mut i = 0; i < sorted_indices.len() - 1; i += 1 {
                     let idx = sorted_indices[i];
-                    let is_last = i == sorted_indices.len() - 1;
-                    if is_last {
-                        w.line(`return {*fn_name}_bt_{idx}(p);`);
-                    } else {
-                        w.begin(`if {*fn_name}_scan_{idx}(&p.tokens, p.pos) >= 0`);
-                        w.line(`return {*fn_name}_bt_{idx}(p);`);
-                        w.end();
+                    if !alt_scan_is_full(&alts[idx].elements, ctx) {
+                        all_full = false;
+                        break;
+                    }
+                }
+
+                if all_full {
+                    // All scans cover entire alternatives — scan success
+                    // guarantees parse success, no save/restore needed.
+                    for let mut i = 0; i < sorted_indices.len(); i += 1 {
+                        let idx = sorted_indices[i];
+                        let is_last = i == sorted_indices.len() - 1;
+                        if is_last {
+                            w.line(`return {*fn_name}_bt_{idx}(p);`);
+                        } else {
+                            w.begin(`if {*fn_name}_scan_{idx}(&p.tokens, p.pos) >= 0`);
+                            w.line(`return {*fn_name}_bt_{idx}(p);`);
+                            w.end();
+                        }
+                    }
+                } else {
+                    // Some scans are partial — scan success is a hint,
+                    // not a guarantee. Use save/restore with scan guards.
+                    w.line("let saved = p.pos;");
+                    for let mut i = 0; i < sorted_indices.len(); i += 1 {
+                        let idx = sorted_indices[i];
+                        let is_last = i == sorted_indices.len() - 1;
+                        if is_last {
+                            w.line(`return {*fn_name}_bt_{idx}(p);`);
+                        } else {
+                            let has_scan = alt_has_scan(&alts[idx].elements, ctx);
+                            let is_full = has_scan && alt_scan_is_full(&alts[idx].elements, ctx);
+                            if is_full {
+                                // Full scan: success guarantees parse success.
+                                w.begin(`if {*fn_name}_scan_{idx}(&p.tokens, p.pos) >= 0`);
+                                w.line(`return {*fn_name}_bt_{idx}(p);`);
+                                w.end();
+                            } else if has_scan {
+                                // Partial scan: try parse, fall through on failure.
+                                w.begin(`if {*fn_name}_scan_{idx}(&p.tokens, p.pos) >= 0`);
+                                w.line(`let r_{idx} = {*fn_name}_bt_{idx}(p);`);
+                                w.begin(`if let Err(_) = r_{idx}`);
+                                w.line("p.pos = saved;");
+                                w.else_begin("else");
+                                w.line(`return r_{idx};`);
+                                w.end();
+                                w.end();
+                            } else {
+                                // No scan: full backtracking.
+                                w.line(`let r_{idx} = {*fn_name}_bt_{idx}(p);`);
+                                w.begin(`if let Err(_) = r_{idx}`);
+                                w.line("p.pos = saved;");
+                                w.else_begin("else");
+                                w.line(`return r_{idx};`);
+                                w.end();
+                            }
+                        }
                     }
                 }
             } else {

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -1,4 +1,4 @@
-use { Grammar, ParserRule, Alternative, Element, RepeatElement, LabelElement } from "./ir.wado";
+use { Grammar, ParserRule, Alternative, Element, RepeatElement, RepeatKind, LabelElement } from "./ir.wado";
 use {
     to_lower,
     to_snake_case,
@@ -1019,6 +1019,7 @@ fn count_leaf_nodes(node: &PredictionNode) -> i32 {
 
 pub fn gen_parser(w: &mut CodeWriter, grammar: &Grammar, ctx: &mut GenContext) {
     gen_parser_struct(w);
+    gen_scan_functions(w, grammar, ctx);
     for let rule of grammar.parser_rules {
         gen_parse_fn(w, &rule, ctx);
     }
@@ -1127,6 +1128,297 @@ fn gen_parser_struct(w: &mut CodeWriter) {
     w.blank();
 }
 
+// --- Alternative Scan Helpers ---
+// For each alternative in a Backtrack group that has a scannable prefix,
+// generate a scan_<rule>_bt_<N> function. This function scans only the
+// scannable prefix of the alternative, which is enough to distinguish it
+// from other alternatives without full speculative parsing.
+
+/// Returns the number of leading elements in the alternative that are scannable.
+/// Stops at the first unscannable element (e.g., a RuleRef to `expr`).
+fn scannable_prefix_len(elements: &Array<Element>, ctx: &mut GenContext) -> i32 {
+    let mut count: i32 = 0;
+    for let elem of elements {
+        let mut visiting: Array<String> = [];
+        if !ctx.is_element_scannable(elem, &mut visiting) {
+            break;
+        }
+        count += 1;
+    }
+    return count;
+}
+
+/// Generate a scan function for a backtracking alternative if it has at least
+/// one scannable leading element. The scan covers the scannable prefix only.
+fn gen_bt_scan_if_possible(w: &mut CodeWriter, alt: &Alternative, fn_name: &String, alt_idx: i32, ctx: &mut GenContext) {
+    let prefix_len = scannable_prefix_len(&alt.elements, ctx);
+    if prefix_len == 0 {
+        return;
+    }
+
+    let scan_name = `{*fn_name}_scan_{alt_idx}`;
+
+    let mut f = FnSpec::new(&scan_name);
+    f.add_param("tokens", "&Array<Token>");
+    f.add_param("pos", "i32");
+    f.set_return_type("i32");
+    f.emit_begin(w);
+    w.line("let mut pos = pos;");
+
+    for let mut i = 0; i < prefix_len; i += 1 {
+        gen_scan_element(w, &alt.elements[i], ctx);
+    }
+
+    w.line("return pos;");
+    w.end();
+    w.blank();
+}
+
+/// Returns true if the alternative has a generated scan function (has scannable prefix).
+fn alt_has_scan(elements: &Array<Element>, ctx: &mut GenContext) -> bool {
+    return scannable_prefix_len(elements, ctx) > 0;
+}
+
+// --- Scan Function Generation ---
+// Scan functions recognize parser rules by walking token kinds without building
+// CST nodes or constructing error messages. They return the token position after
+// successful recognition, or -1 on failure. Used to disambiguate Backtrack
+// alternatives without expensive speculative parsing.
+
+fn gen_scan_functions(w: &mut CodeWriter, grammar: &Grammar, ctx: &mut GenContext) {
+    for let rule of grammar.parser_rules {
+        let mut visiting: Array<String> = [];
+        if ctx.is_rule_scannable(&rule.name, &mut visiting) {
+            gen_scan_function(w, &rule, ctx);
+        }
+    }
+}
+
+fn gen_scan_function(w: &mut CodeWriter, rule: &ParserRule, ctx: &mut GenContext) {
+    let fn_name = `scan_{to_snake_case(&rule.name)}`;
+
+    let mut f = FnSpec::new(&fn_name);
+    f.add_param("tokens", "&Array<Token>");
+    f.add_param("pos", "i32");
+    f.set_return_type("i32");
+    f.emit_begin(w);
+
+    if rule.alternatives.len() == 1 {
+        w.line("let mut pos = pos;");
+        for let elem of &rule.alternatives[0].elements {
+            gen_scan_element(w, elem, ctx);
+        }
+        w.line("return pos;");
+    } else {
+        gen_scan_multi_alt(w, &rule.alternatives, ctx);
+    }
+
+    w.end();
+    w.blank();
+}
+
+/// Generate scan code that tries multiple alternatives in order.
+/// Uses an outer labeled block: on success, `break` skips remaining alts.
+/// The last alternative uses `return -1` on failure.
+fn gen_scan_multi_alt(w: &mut CodeWriter, alts: &Array<Alternative>, ctx: &mut GenContext) {
+    w.line("let mut pos = pos;");
+    w.line("let start = pos;");
+    w.begin("scan_alts:");
+    for let mut i = 0; i < alts.len(); i += 1 {
+        let alt = &alts[i];
+        let is_last = i == alts.len() - 1;
+        if is_last {
+            w.line("pos = start;");
+            for let elem of &alt.elements {
+                gen_scan_element(w, elem, ctx);
+            }
+        } else {
+            let label = `try_{i}`;
+            w.line("pos = start;");
+            w.begin(`{label}:`);
+            for let elem of &alt.elements {
+                gen_scan_element_in_block(w, elem, ctx, &label);
+            }
+            w.line("break scan_alts;");
+            w.end();
+        }
+    }
+    w.end();
+    w.line("return pos;");
+}
+
+/// Generate scan code for a single element. On failure, emits `return -1;`.
+fn gen_scan_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext) {
+    if let Label(lab) = elem {
+        gen_scan_element(w, &lab.element, ctx);
+        return;
+    }
+    if let TokenRef(name) = elem {
+        let const_name = `TK_{name}`;
+        w.line(`if pos >= tokens.len() || tokens[pos].kind != {const_name} \{ return -1; \}`);
+        w.line("pos += 1;");
+        return;
+    }
+    if let Literal(text) = elem {
+        let const_name = literal_const_name(text);
+        w.line(`if pos >= tokens.len() || tokens[pos].kind != {const_name} \{ return -1; \}`);
+        w.line("pos += 1;");
+        return;
+    }
+    if let RuleRef(name) = elem {
+        let fn_name = `scan_{to_snake_case(name)}`;
+        w.line(`pos = {fn_name}(tokens, pos);`);
+        w.line("if pos < 0 { return -1; }");
+        return;
+    }
+    if let Repeat(rep) = elem {
+        gen_scan_repeat(w, rep, ctx);
+        return;
+    }
+    if let Group(alts) = elem {
+        gen_scan_group(w, alts, ctx);
+        return;
+    }
+}
+
+/// Generate scan code for a single element inside a labeled block.
+/// On failure, emits `break <label>;` instead of `return -1;`.
+fn gen_scan_element_in_block(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, label: &String) {
+    if let Label(lab) = elem {
+        gen_scan_element_in_block(w, &lab.element, ctx, label);
+        return;
+    }
+    if let TokenRef(name) = elem {
+        let const_name = `TK_{name}`;
+        w.line(`if pos >= tokens.len() || tokens[pos].kind != {const_name} \{ break {*label}; \}`);
+        w.line("pos += 1;");
+        return;
+    }
+    if let Literal(text) = elem {
+        let const_name = literal_const_name(text);
+        w.line(`if pos >= tokens.len() || tokens[pos].kind != {const_name} \{ break {*label}; \}`);
+        w.line("pos += 1;");
+        return;
+    }
+    if let RuleRef(name) = elem {
+        let fn_name = `scan_{to_snake_case(name)}`;
+        w.line(`pos = {fn_name}(tokens, pos);`);
+        w.line(`if pos < 0 \{ break {*label}; \}`);
+        return;
+    }
+    if let Repeat(rep) = elem {
+        gen_scan_repeat(w, rep, ctx);
+        return;
+    }
+    if let Group(alts) = elem {
+        gen_scan_group(w, alts, ctx);
+        return;
+    }
+}
+
+fn gen_scan_repeat(w: &mut CodeWriter, rep: &RepeatElement, ctx: &mut GenContext) {
+    let mut visiting: Array<String> = [];
+    let inner_first = ctx.first_of_element(&rep.element, &mut visiting);
+    let check = kind_check_str(&inner_first, "tokens[pos].kind");
+
+    if let Optional = rep.kind {
+        w.begin(`if pos < tokens.len() && {check}`);
+        w.line("let sp = pos;");
+        gen_scan_element_assign(w, &rep.element, ctx);
+        w.line("if pos < 0 { pos = sp; }");
+        w.end();
+        return;
+    }
+    if let Star = rep.kind {
+        w.begin(`while pos < tokens.len() && {check}`);
+        w.line("let sp = pos;");
+        gen_scan_element_assign(w, &rep.element, ctx);
+        w.line("if pos < 0 { pos = sp; break; }");
+        w.end();
+        return;
+    }
+    if let Plus = rep.kind {
+        // First iteration is mandatory.
+        gen_scan_element(w, &rep.element, ctx);
+        w.begin(`while pos < tokens.len() && {check}`);
+        w.line("let sp = pos;");
+        gen_scan_element_assign(w, &rep.element, ctx);
+        w.line("if pos < 0 { pos = sp; break; }");
+        w.end();
+        return;
+    }
+}
+
+/// Emit scan code for an element that assigns to `pos` (may set -1 on failure).
+/// Used inside optional/repetition blocks where failure means backtrack, not abort.
+fn gen_scan_element_assign(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext) {
+    if let Label(lab) = elem {
+        gen_scan_element_assign(w, &lab.element, ctx);
+        return;
+    }
+    if let TokenRef(name) = elem {
+        let const_name = `TK_{name}`;
+        w.line(`if pos >= tokens.len() || tokens[pos].kind != {const_name} \{ pos = -1; \} else \{ pos += 1; \}`);
+        return;
+    }
+    if let Literal(text) = elem {
+        let const_name = literal_const_name(text);
+        w.line(`if pos >= tokens.len() || tokens[pos].kind != {const_name} \{ pos = -1; \} else \{ pos += 1; \}`);
+        return;
+    }
+    if let RuleRef(name) = elem {
+        let fn_name = `scan_{to_snake_case(name)}`;
+        w.line(`pos = {fn_name}(tokens, pos);`);
+        return;
+    }
+    if let Group(alts) = elem {
+        gen_scan_group(w, alts, ctx);
+        return;
+    }
+    if let Repeat(rep) = elem {
+        gen_scan_repeat(w, rep, ctx);
+        return;
+    }
+}
+
+global mut SCAN_GROUP_COUNTER: i32 = 0;
+
+fn gen_scan_group(w: &mut CodeWriter, alts: &Array<Alternative>, ctx: &mut GenContext) {
+    if alts.len() == 1 {
+        for let elem of &alts[0].elements {
+            gen_scan_element(w, elem, ctx);
+        }
+        return;
+    }
+    // Multi-alternative group: try each alternative.
+    let gc = SCAN_GROUP_COUNTER;
+    SCAN_GROUP_COUNTER += 1;
+    let outer = `sg_{gc}`;
+    let gp_var = `gp_{gc}`;
+    w.line(`let {gp_var} = pos;`);
+    w.begin(`{outer}:`);
+    for let mut i = 0; i < alts.len(); i += 1 {
+        let alt = &alts[i];
+        let is_last = i == alts.len() - 1;
+        if is_last {
+            w.line(`pos = {gp_var};`);
+            for let elem of &alt.elements {
+                gen_scan_element(w, elem, ctx);
+            }
+        } else {
+            let inner = `sg_{gc}_{i}`;
+            w.line(`pos = {gp_var};`);
+            w.begin(`{inner}:`);
+            for let elem of &alt.elements {
+                gen_scan_element_in_block(w, elem, ctx, &inner);
+            }
+            w.line(`break {outer};`);
+            w.end();
+        }
+    }
+    w.end();
+}
+
 fn gen_parse_fn(w: &mut CodeWriter, rule: &ParserRule, ctx: &mut GenContext) {
     ctx.current_rule_name = rule.name;
     ctx.group_counter = 0;
@@ -1219,6 +1511,11 @@ fn gen_parse_fn(w: &mut CodeWriter, rule: &ParserRule, ctx: &mut GenContext) {
                     );
                     w.end();
                     w.blank();
+
+                    // Generate scan helper for this alternative if it has a
+                    // scannable prefix (at least one scannable element before
+                    // the first unscannable one).
+                    gen_bt_scan_if_possible(w, alt, &fn_name, alt_idx, ctx);
                 }
             }
         }
@@ -3606,19 +3903,49 @@ fn gen_prediction_code_inner(w: &mut CodeWriter, node: &PredictionNode, fn_name:
         let mut sorted_indices = indices.sorted();
         sort_group_by_element_count(&mut sorted_indices, alts);
         if skip == 0 {
-            w.line("let saved = p.pos;");
-            for let mut i = 0; i < sorted_indices.len(); i += 1 {
+            // Check if any alternatives have scan functions available.
+            // If ALL non-last alternatives have scans, we can eliminate
+            // backtracking entirely: scan each, parse the winner.
+            // If some have scans and some don't, use a hybrid approach.
+            let mut all_have_scans = true;
+            for let mut i = 0; i < sorted_indices.len() - 1; i += 1 {
                 let idx = sorted_indices[i];
-                let is_last = i == sorted_indices.len() - 1;
-                if is_last {
-                    w.line(`return {*fn_name}_bt_{idx}(p);`);
-                } else {
-                    w.line(`let r_{idx} = {*fn_name}_bt_{idx}(p);`);
-                    w.begin(`if let Err(_) = r_{idx}`);
-                    w.line("p.pos = saved;");
-                    w.else_begin("else");
-                    w.line(`return r_{idx};`);
-                    w.end();
+                if !alt_has_scan(&alts[idx].elements, ctx) {
+                    all_have_scans = false;
+                    break;
+                }
+            }
+
+            if all_have_scans && sorted_indices.len() >= 2 {
+                // All non-last alternatives have scan functions.
+                // Use scan-then-parse: no backtracking needed.
+                for let mut i = 0; i < sorted_indices.len(); i += 1 {
+                    let idx = sorted_indices[i];
+                    let is_last = i == sorted_indices.len() - 1;
+                    if is_last {
+                        w.line(`return {*fn_name}_bt_{idx}(p);`);
+                    } else {
+                        w.begin(`if {*fn_name}_scan_{idx}(&p.tokens, p.pos) >= 0`);
+                        w.line(`return {*fn_name}_bt_{idx}(p);`);
+                        w.end();
+                    }
+                }
+            } else {
+                // Fallback: original backtracking pattern.
+                w.line("let saved = p.pos;");
+                for let mut i = 0; i < sorted_indices.len(); i += 1 {
+                    let idx = sorted_indices[i];
+                    let is_last = i == sorted_indices.len() - 1;
+                    if is_last {
+                        w.line(`return {*fn_name}_bt_{idx}(p);`);
+                    } else {
+                        w.line(`let r_{idx} = {*fn_name}_bt_{idx}(p);`);
+                        w.begin(`if let Err(_) = r_{idx}`);
+                        w.line("p.pos = saved;");
+                        w.else_begin("else");
+                        w.line(`return r_{idx};`);
+                        w.end();
+                    }
                 }
             }
         } else {

--- a/package-gale/tests/golden/antlr4.wado
+++ b/package-gale/tests/golden/antlr4.wado
@@ -3763,6 +3763,1356 @@ impl Parser {
     }
 }
 
+fn scan_grammar_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_grammar_decl(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_OPTIONS | TK_IMPORT | TK_TOKENS | TK_CHANNELS | TK_AT } {
+        let sp = pos;
+        pos = scan_prequel_construct(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    pos = scan_rules(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_MODE {
+        let sp = pos;
+        pos = scan_mode_spec(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_grammar_decl(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_grammar_type(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_grammar_type(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LEXER { break try_0; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_GRAMMAR { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_PARSER { break try_1; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_GRAMMAR { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_GRAMMAR { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_prequel_construct(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_options_spec(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_delegate_grammars(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_tokens_spec(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            pos = scan_channels_spec(tokens, pos);
+            if pos < 0 { break try_3; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_action_(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_options_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_OPTIONS { return -1; }
+    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_RULE_REF | TK_TOKEN_REF } {
+        let sp = pos;
+        pos = scan_option(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RBRACE { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_option(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { return -1; }
+    pos += 1;
+    pos = scan_option_value(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_option_value(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break try_0; }
+            while pos < tokens.len() && tokens[pos].kind == TK_DOT {
+                let sp = pos;
+                if pos >= tokens.len() || tokens[pos].kind != TK_DOT { return -1; }
+                pos += 1;
+                pos = scan_identifier(tokens, pos);
+                if pos < 0 { return -1; }
+                if pos < 0 { pos = sp; break; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_action_block(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_delegate_grammars(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_IMPORT { return -1; }
+    pos += 1;
+    pos = scan_delegate_grammar(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { return -1; }
+        pos += 1;
+        pos = scan_delegate_grammar(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_delegate_grammar(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { break try_0; }
+            pos += 1;
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_identifier(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_tokens_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_TOKENS { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_RULE_REF | TK_TOKEN_REF } {
+        let sp = pos;
+        pos = scan_id_list(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RBRACE { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_channels_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_CHANNELS { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_RULE_REF | TK_TOKEN_REF } {
+        let sp = pos;
+        pos = scan_id_list(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RBRACE { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_id_list(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { return -1; }
+        pos += 1;
+        pos = scan_identifier(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_action_(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_AT { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_RULE_REF | TK_TOKEN_REF | TK_LEXER | TK_PARSER } {
+        let sp = pos;
+        pos = scan_action_scope_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_COLONCOLON { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_action_block(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_action_scope_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LEXER { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_PARSER { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_action_block(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_ACTION { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_arg_action_block(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_BEGIN_ARGUMENT { return -1; }
+    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind == TK_ARGUMENT_CONTENT {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_ARGUMENT_CONTENT { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_END_ARGUMENT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_mode_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_MODE { return -1; }
+    pos += 1;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_FRAGMENT | TK_TOKEN_REF } {
+        let sp = pos;
+        pos = scan_lexer_rule_spec(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_rules(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_PUBLIC | TK_PRIVATE | TK_PROTECTED | TK_FRAGMENT | TK_RULE_REF | TK_TOKEN_REF } {
+        let sp = pos;
+        pos = scan_rule_spec(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_rule_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_parser_rule_spec(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_lexer_rule_spec(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_parser_rule_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_PUBLIC | TK_PRIVATE | TK_PROTECTED | TK_FRAGMENT } {
+        let sp = pos;
+        pos = scan_rule_modifiers(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RULE_REF { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_BEGIN_ARGUMENT {
+        let sp = pos;
+        pos = scan_arg_action_block(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_RETURNS {
+        let sp = pos;
+        pos = scan_rule_returns(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_THROWS {
+        let sp = pos;
+        pos = scan_throws_spec(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_LOCALS {
+        let sp = pos;
+        pos = scan_locals_spec(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_OPTIONS | TK_AT } {
+        let sp = pos;
+        pos = scan_rule_prequel(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
+    pos += 1;
+    pos = scan_rule_block(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+    pos += 1;
+    pos = scan_exception_group(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_exception_group(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && tokens[pos].kind == TK_CATCH {
+        let sp = pos;
+        pos = scan_exception_handler(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_FINALLY {
+        let sp = pos;
+        pos = scan_finally_clause(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_exception_handler(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_CATCH { return -1; }
+    pos += 1;
+    pos = scan_arg_action_block(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_action_block(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_finally_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_FINALLY { return -1; }
+    pos += 1;
+    pos = scan_action_block(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_rule_prequel(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_options_spec(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_rule_action(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_rule_returns(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_RETURNS { return -1; }
+    pos += 1;
+    pos = scan_arg_action_block(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_throws_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_THROWS { return -1; }
+    pos += 1;
+    pos = scan_qualified_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { return -1; }
+        pos += 1;
+        pos = scan_qualified_identifier(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_locals_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LOCALS { return -1; }
+    pos += 1;
+    pos = scan_arg_action_block(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_rule_action(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_AT { return -1; }
+    pos += 1;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_action_block(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_rule_modifiers(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_rule_modifier(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_PUBLIC | TK_PRIVATE | TK_PROTECTED | TK_FRAGMENT } {
+        let sp = pos;
+        pos = scan_rule_modifier(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_rule_modifier(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_PUBLIC { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_PRIVATE { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_PROTECTED { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_FRAGMENT { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_rule_block(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_rule_alt_list(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_rule_alt_list(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_labeled_alt(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_OR {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_OR { return -1; }
+        pos += 1;
+        pos = scan_labeled_alt(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_labeled_alt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_alternative(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind == TK_POUND {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_POUND { return -1; }
+        pos += 1;
+        pos = scan_identifier(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_lexer_rule_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind == TK_FRAGMENT {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_FRAGMENT { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_TOKEN_REF { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_OPTIONS {
+        let sp = pos;
+        pos = scan_options_spec(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
+    pos += 1;
+    pos = scan_lexer_rule_block(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_lexer_rule_block(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_lexer_alt_list(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_lexer_alt_list(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_lexer_alt(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_OR {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_OR { return -1; }
+        pos += 1;
+        pos = scan_lexer_alt(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_lexer_alt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_lexer_elements(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos < tokens.len() && tokens[pos].kind == TK_RARROW {
+                let sp = pos;
+                pos = scan_lexer_commands(tokens, pos);
+                if pos < 0 { pos = sp; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+    }
+    return pos;
+}
+
+fn scan_lexer_elements(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_lexer_element(tokens, pos);
+            if pos < 0 { return -1; }
+            while pos < tokens.len() && tokens[pos].kind matches { TK_STRING_LITERAL | TK_TOKEN_REF | TK_NOT | TK_LEXER_CHAR_SET | TK_DOT | TK_LPAREN | TK_ACTION } {
+                let sp = pos;
+                pos = scan_lexer_element(tokens, pos);
+                if pos < 0 { pos = sp; break; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+    }
+    return pos;
+}
+
+fn scan_lexer_element(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_lexer_atom(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos < tokens.len() && tokens[pos].kind matches { TK_QUESTION | TK_STAR | TK_PLUS } {
+                let sp = pos;
+                pos = scan_ebnf_suffix(tokens, pos);
+                if pos < 0 { pos = sp; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_lexer_block(tokens, pos);
+            if pos < 0 { break try_1; }
+            if pos < tokens.len() && tokens[pos].kind matches { TK_QUESTION | TK_STAR | TK_PLUS } {
+                let sp = pos;
+                pos = scan_ebnf_suffix(tokens, pos);
+                if pos < 0 { pos = sp; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_action_block(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < tokens.len() && tokens[pos].kind == TK_QUESTION {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_QUESTION { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; }
+        }
+    }
+    return pos;
+}
+
+fn scan_lexer_block(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+    pos += 1;
+    pos = scan_lexer_alt_list(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_lexer_commands(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_RARROW { return -1; }
+    pos += 1;
+    pos = scan_lexer_command(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { return -1; }
+        pos += 1;
+        pos = scan_lexer_command(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_lexer_command(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_lexer_command_name(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { break try_0; }
+            pos += 1;
+            pos = scan_lexer_command_expr(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_lexer_command_name(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_lexer_command_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_MODE { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_lexer_command_expr(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_alt_list(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_alternative(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_OR {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_OR { return -1; }
+        pos += 1;
+        pos = scan_alternative(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_alternative(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos < tokens.len() && tokens[pos].kind == TK_LT {
+                let sp = pos;
+                pos = scan_element_options(tokens, pos);
+                if pos < 0 { pos = sp; }
+            }
+            pos = scan_element(tokens, pos);
+            if pos < 0 { return -1; }
+            while pos < tokens.len() && tokens[pos].kind matches { TK_RULE_REF | TK_TOKEN_REF | TK_STRING_LITERAL | TK_NOT | TK_DOT | TK_LPAREN | TK_ACTION } {
+                let sp = pos;
+                pos = scan_element(tokens, pos);
+                if pos < 0 { pos = sp; break; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+    }
+    return pos;
+}
+
+fn scan_element(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_labeled_element(tokens, pos);
+            if pos < 0 { break try_0; }
+            let gp_0 = pos;
+            sg_0: {
+                pos = gp_0;
+                sg_0_0: {
+                    pos = scan_ebnf_suffix(tokens, pos);
+                    if pos < 0 { break sg_0_0; }
+                    break sg_0;
+                }
+                pos = gp_0;
+            }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_atom(tokens, pos);
+            if pos < 0 { break try_1; }
+            let gp_1 = pos;
+            sg_1: {
+                pos = gp_1;
+                sg_1_0: {
+                    pos = scan_ebnf_suffix(tokens, pos);
+                    if pos < 0 { break sg_1_0; }
+                    break sg_1;
+                }
+                pos = gp_1;
+            }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_ebnf(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_action_block(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < tokens.len() && tokens[pos].kind == TK_QUESTION {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_QUESTION { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; }
+        }
+        if pos < tokens.len() && tokens[pos].kind == TK_LT {
+            let sp = pos;
+            pos = scan_predicate_options(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+    }
+    return pos;
+}
+
+fn scan_predicate_options(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
+    pos += 1;
+    pos = scan_predicate_option(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { return -1; }
+        pos += 1;
+        pos = scan_predicate_option(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_GT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_predicate_option(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_element_option(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_identifier(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { return -1; }
+        pos += 1;
+        let gp_2 = pos;
+        sg_2: {
+            pos = gp_2;
+            sg_2_0: {
+                pos = scan_action_block(tokens, pos);
+                if pos < 0 { break sg_2_0; }
+                break sg_2;
+            }
+            pos = gp_2;
+            sg_2_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_INT { break sg_2_1; }
+                pos += 1;
+                break sg_2;
+            }
+            pos = gp_2;
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
+            pos += 1;
+        }
+    }
+    return pos;
+}
+
+fn scan_labeled_element(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    let gp_3 = pos;
+    sg_3: {
+        pos = gp_3;
+        sg_3_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { break sg_3_0; }
+            pos += 1;
+            break sg_3;
+        }
+        pos = gp_3;
+        if pos >= tokens.len() || tokens[pos].kind != TK_PLUS_ASSIGN { return -1; }
+        pos += 1;
+    }
+    let gp_4 = pos;
+    sg_4: {
+        pos = gp_4;
+        sg_4_0: {
+            pos = scan_atom(tokens, pos);
+            if pos < 0 { break sg_4_0; }
+            break sg_4;
+        }
+        pos = gp_4;
+        pos = scan_block(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_ebnf(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_block(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_QUESTION | TK_STAR | TK_PLUS } {
+        let sp = pos;
+        pos = scan_block_suffix(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_block_suffix(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_ebnf_suffix(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_ebnf_suffix(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_QUESTION { break try_0; }
+            pos += 1;
+            if pos < tokens.len() && tokens[pos].kind == TK_QUESTION {
+                let sp = pos;
+                if pos >= tokens.len() || tokens[pos].kind != TK_QUESTION { pos = -1; } else { pos += 1; }
+                if pos < 0 { pos = sp; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STAR { break try_1; }
+            pos += 1;
+            if pos < tokens.len() && tokens[pos].kind == TK_QUESTION {
+                let sp = pos;
+                if pos >= tokens.len() || tokens[pos].kind != TK_QUESTION { pos = -1; } else { pos += 1; }
+                if pos < 0 { pos = sp; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_PLUS { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind == TK_QUESTION {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_QUESTION { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; }
+        }
+    }
+    return pos;
+}
+
+fn scan_lexer_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_character_range(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_terminal_def(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_not_set(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LEXER_CHAR_SET { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_wildcard(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_terminal_def(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_ruleref(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_not_set(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_wildcard(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_wildcard(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_DOT { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_LT {
+        let sp = pos;
+        pos = scan_element_options(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_not_set(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_NOT { break try_0; }
+            pos += 1;
+            pos = scan_set_element(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
+        pos += 1;
+        pos = scan_block_set(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_block_set(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+    pos += 1;
+    pos = scan_set_element(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_OR {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_OR { return -1; }
+        pos += 1;
+        pos = scan_set_element(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_set_element(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_TOKEN_REF { break try_0; }
+            pos += 1;
+            if pos < tokens.len() && tokens[pos].kind == TK_LT {
+                let sp = pos;
+                pos = scan_element_options(tokens, pos);
+                if pos < 0 { pos = sp; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { break try_1; }
+            pos += 1;
+            if pos < tokens.len() && tokens[pos].kind == TK_LT {
+                let sp = pos;
+                pos = scan_element_options(tokens, pos);
+                if pos < 0 { pos = sp; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_character_range(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LEXER_CHAR_SET { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_block(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_OPTIONS | TK_AT | TK_COLON } {
+        let sp = pos;
+        if pos < tokens.len() && tokens[pos].kind == TK_OPTIONS {
+            let sp = pos;
+            pos = scan_options_spec(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        while pos < tokens.len() && tokens[pos].kind == TK_AT {
+            let sp = pos;
+            pos = scan_rule_action(tokens, pos);
+            if pos < 0 { pos = sp; break; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_alt_list(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_ruleref(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_RULE_REF { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_BEGIN_ARGUMENT {
+        let sp = pos;
+        pos = scan_arg_action_block(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_LT {
+        let sp = pos;
+        pos = scan_element_options(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_character_range(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_RANGE { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_terminal_def(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_TOKEN_REF { break try_0; }
+            pos += 1;
+            if pos < tokens.len() && tokens[pos].kind == TK_LT {
+                let sp = pos;
+                pos = scan_element_options(tokens, pos);
+                if pos < 0 { pos = sp; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind == TK_LT {
+            let sp = pos;
+            pos = scan_element_options(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+    }
+    return pos;
+}
+
+fn scan_element_options(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
+    pos += 1;
+    pos = scan_element_option(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { return -1; }
+        pos += 1;
+        pos = scan_element_option(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_GT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_element_option(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_qualified_identifier(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_identifier(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { return -1; }
+        pos += 1;
+        let gp_5 = pos;
+        sg_5: {
+            pos = gp_5;
+            sg_5_0: {
+                pos = scan_qualified_identifier(tokens, pos);
+                if pos < 0 { break sg_5_0; }
+                break sg_5;
+            }
+            pos = gp_5;
+            sg_5_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { break sg_5_1; }
+                pos += 1;
+                break sg_5;
+            }
+            pos = gp_5;
+            if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
+            pos += 1;
+        }
+    }
+    return pos;
+}
+
+fn scan_identifier(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_RULE_REF { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_TOKEN_REF { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_qualified_identifier(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_DOT {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_DOT { return -1; }
+        pos += 1;
+        pos = scan_identifier(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
 fn parse_grammar_spec(p: &mut Parser) -> Result<GrammarSpecNode, ParseError> {
     let start = p.peek().span.start;
     let grammar_decl = parse_grammar_decl(p)?;
@@ -3998,6 +5348,13 @@ fn parse_delegate_grammar_bt_1(p: &mut Parser) -> Result<DelegateGrammarNode, Pa
     }));
 }
 
+fn parse_delegate_grammar_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_delegate_grammar_bt_0(p: &mut Parser) -> Result<DelegateGrammarNode, ParseError> {
     let start = p.peek().span.start;
     let identifier = parse_identifier(p)?;
@@ -4009,6 +5366,17 @@ fn parse_delegate_grammar_bt_0(p: &mut Parser) -> Result<DelegateGrammarNode, Pa
         assign,
         identifier_2,
     }));
+}
+
+fn parse_delegate_grammar_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { return -1; }
+    pos += 1;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_delegate_grammar(p: &mut Parser) -> Result<DelegateGrammarNode, ParseError> {
@@ -4227,6 +5595,13 @@ fn parse_rule_spec_bt_1(p: &mut Parser) -> Result<RuleSpecNode, ParseError> {
     }));
 }
 
+fn parse_rule_spec_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_lexer_rule_spec(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_rule_spec_bt_0(p: &mut Parser) -> Result<RuleSpecNode, ParseError> {
     let start = p.peek().span.start;
     let parser_rule_spec = parse_parser_rule_spec(p)?;
@@ -4234,6 +5609,13 @@ fn parse_rule_spec_bt_0(p: &mut Parser) -> Result<RuleSpecNode, ParseError> {
         span: Span::new(start, p.last_end()),
         parser_rule_spec,
     }));
+}
+
+fn parse_rule_spec_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_parser_rule_spec(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_rule_spec(p: &mut Parser) -> Result<RuleSpecNode, ParseError> {
@@ -4756,6 +6138,13 @@ fn parse_lexer_command_bt_1(p: &mut Parser) -> Result<LexerCommandNode, ParseErr
     }));
 }
 
+fn parse_lexer_command_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_lexer_command_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_lexer_command_bt_0(p: &mut Parser) -> Result<LexerCommandNode, ParseError> {
     let start = p.peek().span.start;
     let lexer_command_name = parse_lexer_command_name(p)?;
@@ -4769,6 +6158,19 @@ fn parse_lexer_command_bt_0(p: &mut Parser) -> Result<LexerCommandNode, ParseErr
         lexer_command_expr,
         rparen,
     }));
+}
+
+fn parse_lexer_command_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_lexer_command_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+    pos += 1;
+    pos = scan_lexer_command_expr(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_lexer_command(p: &mut Parser) -> Result<LexerCommandNode, ParseError> {
@@ -4921,6 +6323,23 @@ fn parse_element_bt_0(p: &mut Parser) -> Result<ElementNode, ParseError> {
     }));
 }
 
+fn parse_element_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_labeled_element(tokens, pos);
+    if pos < 0 { return -1; }
+    let gp_6 = pos;
+    sg_6: {
+        pos = gp_6;
+        sg_6_0: {
+            pos = scan_ebnf_suffix(tokens, pos);
+            if pos < 0 { break sg_6_0; }
+            break sg_6;
+        }
+        pos = gp_6;
+    }
+    return pos;
+}
+
 fn parse_element_bt_1(p: &mut Parser) -> Result<ElementNode, ParseError> {
     let start = p.peek().span.start;
     let atom = parse_atom(p)?;
@@ -4941,6 +6360,23 @@ fn parse_element_bt_1(p: &mut Parser) -> Result<ElementNode, ParseError> {
         atom,
         group_1,
     }));
+}
+
+fn parse_element_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    let gp_7 = pos;
+    sg_7: {
+        pos = gp_7;
+        sg_7_0: {
+            pos = scan_ebnf_suffix(tokens, pos);
+            if pos < 0 { break sg_7_0; }
+            break sg_7;
+        }
+        pos = gp_7;
+    }
+    return pos;
 }
 
 fn parse_element(p: &mut Parser) -> Result<ElementNode, ParseError> {
@@ -5031,6 +6467,13 @@ fn parse_predicate_option_bt_0(p: &mut Parser) -> Result<PredicateOptionNode, Pa
     }));
 }
 
+fn parse_predicate_option_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_element_option(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_predicate_option_bt_1(p: &mut Parser) -> Result<PredicateOptionNode, ParseError> {
     let start = p.peek().span.start;
     let identifier = parse_identifier(p)?;
@@ -5062,17 +6505,40 @@ fn parse_predicate_option_bt_1(p: &mut Parser) -> Result<PredicateOptionNode, Pa
     }));
 }
 
+fn parse_predicate_option_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { return -1; }
+    pos += 1;
+    let gp_8 = pos;
+    sg_8: {
+        pos = gp_8;
+        sg_8_0: {
+            pos = scan_action_block(tokens, pos);
+            if pos < 0 { break sg_8_0; }
+            break sg_8;
+        }
+        pos = gp_8;
+        sg_8_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_INT { break sg_8_1; }
+            pos += 1;
+            break sg_8;
+        }
+        pos = gp_8;
+        if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
 fn parse_predicate_option(p: &mut Parser) -> Result<PredicateOptionNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_RULE_REF | TK_TOKEN_REF } {
         if p.peek_kind() matches { TK_RULE_REF | TK_TOKEN_REF } {
-            let saved = p.pos;
-            let r_0 = parse_predicate_option_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_predicate_option_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_predicate_option_bt_0(p);
             }
             return parse_predicate_option_bt_1(p);
         }
@@ -5192,6 +6658,13 @@ fn parse_lexer_atom_bt_0(p: &mut Parser) -> Result<LexerAtomNode, ParseError> {
     }));
 }
 
+fn parse_lexer_atom_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_character_range(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_lexer_atom_bt_1(p: &mut Parser) -> Result<LexerAtomNode, ParseError> {
     let start = p.peek().span.start;
     let terminal_def = parse_terminal_def(p)?;
@@ -5201,17 +6674,20 @@ fn parse_lexer_atom_bt_1(p: &mut Parser) -> Result<LexerAtomNode, ParseError> {
     }));
 }
 
+fn parse_lexer_atom_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_terminal_def(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_lexer_atom(p: &mut Parser) -> Result<LexerAtomNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_STRING_LITERAL | TK_TOKEN_REF } {
         if p.peek_kind() == TK_STRING_LITERAL {
-            let saved = p.pos;
-            let r_0 = parse_lexer_atom_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_lexer_atom_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_lexer_atom_bt_0(p);
             }
             return parse_lexer_atom_bt_1(p);
         } else if p.peek_kind() == TK_TOKEN_REF {
@@ -5311,6 +6787,15 @@ fn parse_not_set_bt_0(p: &mut Parser) -> Result<NotSetNode, ParseError> {
     }));
 }
 
+fn parse_not_set_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
+    pos += 1;
+    pos = scan_set_element(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_not_set_bt_1(p: &mut Parser) -> Result<NotSetNode, ParseError> {
     let start = p.peek().span.start;
     let not = p.expect(TK_NOT)?;
@@ -5320,6 +6805,15 @@ fn parse_not_set_bt_1(p: &mut Parser) -> Result<NotSetNode, ParseError> {
         not,
         block_set,
     }));
+}
+
+fn parse_not_set_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
+    pos += 1;
+    pos = scan_block_set(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_not_set(p: &mut Parser) -> Result<NotSetNode, ParseError> {
@@ -5390,6 +6884,18 @@ fn parse_set_element_bt_1(p: &mut Parser) -> Result<SetElementNode, ParseError> 
     }));
 }
 
+fn parse_set_element_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_LT {
+        let sp = pos;
+        pos = scan_element_options(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
 fn parse_set_element_bt_2(p: &mut Parser) -> Result<SetElementNode, ParseError> {
     let start = p.peek().span.start;
     let character_range = parse_character_range(p)?;
@@ -5397,6 +6903,13 @@ fn parse_set_element_bt_2(p: &mut Parser) -> Result<SetElementNode, ParseError> 
         span: Span::new(start, p.last_end()),
         character_range,
     }));
+}
+
+fn parse_set_element_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_character_range(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_set_element(p: &mut Parser) -> Result<SetElementNode, ParseError> {
@@ -5418,12 +6931,8 @@ fn parse_set_element(p: &mut Parser) -> Result<SetElementNode, ParseError> {
     }
     if kind == TK_STRING_LITERAL {
         if p.peek_kind() == TK_STRING_LITERAL {
-            let saved = p.pos;
-            let r_1 = parse_set_element_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_set_element_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_set_element_bt_1(p);
             }
             return parse_set_element_bt_2(p);
         }
@@ -5624,6 +7133,13 @@ fn parse_element_option_bt_0(p: &mut Parser) -> Result<ElementOptionNode, ParseE
     }));
 }
 
+fn parse_element_option_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_qualified_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_element_option_bt_1(p: &mut Parser) -> Result<ElementOptionNode, ParseError> {
     let start = p.peek().span.start;
     let identifier = parse_identifier(p)?;
@@ -5653,6 +7169,33 @@ fn parse_element_option_bt_1(p: &mut Parser) -> Result<ElementOptionNode, ParseE
         assign,
         group_0,
     }));
+}
+
+fn parse_element_option_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { return -1; }
+    pos += 1;
+    let gp_9 = pos;
+    sg_9: {
+        pos = gp_9;
+        sg_9_0: {
+            pos = scan_qualified_identifier(tokens, pos);
+            if pos < 0 { break sg_9_0; }
+            break sg_9;
+        }
+        pos = gp_9;
+        sg_9_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { break sg_9_1; }
+            pos += 1;
+            break sg_9;
+        }
+        pos = gp_9;
+        if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
+        pos += 1;
+    }
+    return pos;
 }
 
 fn parse_element_option(p: &mut Parser) -> Result<ElementOptionNode, ParseError> {

--- a/package-gale/tests/golden/calculator.wado
+++ b/package-gale/tests/golden/calculator.wado
@@ -1407,6 +1407,290 @@ impl Parser {
     }
 }
 
+fn scan_equation(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_expression(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_relop(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_expression(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_multiplying_expression(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_PLUS | TK_MINUS } {
+        let sp = pos;
+        let gp_0 = pos;
+        sg_0: {
+            pos = gp_0;
+            sg_0_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_PLUS { break sg_0_0; }
+                pos += 1;
+                break sg_0;
+            }
+            pos = gp_0;
+            if pos >= tokens.len() || tokens[pos].kind != TK_MINUS { return -1; }
+            pos += 1;
+        }
+        pos = scan_multiplying_expression(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_multiplying_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_pow_expression(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_TIMES | TK_DIV } {
+        let sp = pos;
+        let gp_1 = pos;
+        sg_1: {
+            pos = gp_1;
+            sg_1_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_TIMES { break sg_1_0; }
+                pos += 1;
+                break sg_1;
+            }
+            pos = gp_1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_DIV { return -1; }
+            pos += 1;
+        }
+        pos = scan_pow_expression(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_pow_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_signed_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_POW {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_POW { return -1; }
+        pos += 1;
+        pos = scan_signed_atom(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_signed_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_PLUS { break try_0; }
+            pos += 1;
+            pos = scan_signed_atom(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_MINUS { break try_1; }
+            pos += 1;
+            pos = scan_signed_atom(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_func_(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_atom(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_scientific(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_variable(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_constant(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+        pos += 1;
+        pos = scan_expression(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_scientific(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_SCIENTIFIC_NUMBER { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_constant(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_PI { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_EULER { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_I { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_variable(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_VARIABLE { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_func_(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_funcname(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+    pos += 1;
+    pos = scan_expression(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { return -1; }
+        pos += 1;
+        pos = scan_expression(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_funcname(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_COS { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_TAN { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_SIN { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_ACOS { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_ATAN { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_ASIN { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LOG { break try_6; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LN { break try_7; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_SQRT { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_relop(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_EQ { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_GT { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
 fn parse_equation(p: &mut Parser) -> Result<EquationNode, ParseError> {
     let start = p.peek().span.start;
     let expression = parse_expression(p)?;

--- a/package-gale/tests/golden/css3.wado
+++ b/package-gale/tests/golden/css3.wado
@@ -29295,6 +29295,2783 @@ impl Parser {
     }
 }
 
+fn scan_stylesheet(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_Charset {
+        let sp = pos;
+        pos = scan_charset(tokens, pos);
+        if pos < 0 { return -1; }
+        while pos < tokens.len() && tokens[pos].kind matches { TK_Comment | TK_Space | TK_Cdo | TK_Cdc } {
+            let sp = pos;
+            let gp_0 = pos;
+            sg_0: {
+                pos = gp_0;
+                sg_0_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_Comment { break sg_0_0; }
+                    pos += 1;
+                    break sg_0;
+                }
+                pos = gp_0;
+                sg_0_1: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_Space { break sg_0_1; }
+                    pos += 1;
+                    break sg_0;
+                }
+                pos = gp_0;
+                sg_0_2: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_Cdo { break sg_0_2; }
+                    pos += 1;
+                    break sg_0;
+                }
+                pos = gp_0;
+                if pos >= tokens.len() || tokens[pos].kind != TK_Cdc { return -1; }
+                pos += 1;
+            }
+            if pos < 0 { pos = sp; break; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    while pos < tokens.len() && tokens[pos].kind == TK_Import {
+        let sp = pos;
+        pos = scan_imports(tokens, pos);
+        if pos < 0 { return -1; }
+        while pos < tokens.len() && tokens[pos].kind matches { TK_Comment | TK_Space | TK_Cdo | TK_Cdc } {
+            let sp = pos;
+            let gp_1 = pos;
+            sg_1: {
+                pos = gp_1;
+                sg_1_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_Comment { break sg_1_0; }
+                    pos += 1;
+                    break sg_1;
+                }
+                pos = gp_1;
+                sg_1_1: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_Space { break sg_1_1; }
+                    pos += 1;
+                    break sg_1;
+                }
+                pos = gp_1;
+                sg_1_2: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_Cdo { break sg_1_2; }
+                    pos += 1;
+                    break sg_1;
+                }
+                pos = gp_1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_Cdc { return -1; }
+                pos += 1;
+            }
+            if pos < 0 { pos = sp; break; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    while pos < tokens.len() && tokens[pos].kind == TK_Namespace {
+        let sp = pos;
+        pos = scan_namespace_(tokens, pos);
+        if pos < 0 { return -1; }
+        while pos < tokens.len() && tokens[pos].kind matches { TK_Comment | TK_Space | TK_Cdo | TK_Cdc } {
+            let sp = pos;
+            let gp_2 = pos;
+            sg_2: {
+                pos = gp_2;
+                sg_2_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_Comment { break sg_2_0; }
+                    pos += 1;
+                    break sg_2;
+                }
+                pos = gp_2;
+                sg_2_1: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_Space { break sg_2_1; }
+                    pos += 1;
+                    break sg_2;
+                }
+                pos = gp_2;
+                sg_2_2: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_Cdo { break sg_2_2; }
+                    pos += 1;
+                    break sg_2;
+                }
+                pos = gp_2;
+                if pos >= tokens.len() || tokens[pos].kind != TK_Cdc { return -1; }
+                pos += 1;
+            }
+            if pos < 0 { pos = sp; break; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_LIT_STAR | TK_LIT_PIPE | TK_Hash | TK_LIT_DOT | TK_LIT_LBRACKET | TK_LIT_COLON | TK_PseudoNot | TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_UnknownDimension | TK_String_ | TK_Url_ | TK_Url | TK_UnicodeRange | TK_Includes | TK_DashMatch | TK_Function_ | TK_LIT_LPAREN | TK_LIT_LBRACE | TK_Media | TK_Page | TK_FontFace | TK_Keyframes | TK_Supports | TK_Viewport | TK_CounterStyle | TK_FontFeatureValues | TK_AtKeyword } {
+        let sp = pos;
+        pos = scan_nested_statement(tokens, pos);
+        if pos < 0 { return -1; }
+        while pos < tokens.len() && tokens[pos].kind matches { TK_Comment | TK_Space | TK_Cdo | TK_Cdc } {
+            let sp = pos;
+            let gp_3 = pos;
+            sg_3: {
+                pos = gp_3;
+                sg_3_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_Comment { break sg_3_0; }
+                    pos += 1;
+                    break sg_3;
+                }
+                pos = gp_3;
+                sg_3_1: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_Space { break sg_3_1; }
+                    pos += 1;
+                    break sg_3;
+                }
+                pos = gp_3;
+                sg_3_2: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_Cdo { break sg_3_2; }
+                    pos += 1;
+                    break sg_3;
+                }
+                pos = gp_3;
+                if pos >= tokens.len() || tokens[pos].kind != TK_Cdc { return -1; }
+                pos += 1;
+            }
+            if pos < 0 { pos = sp; break; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_charset(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Charset { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Charset { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_String_ { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_imports(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Import { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            let gp_4 = pos;
+            sg_4: {
+                pos = gp_4;
+                sg_4_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break sg_4_0; }
+                    pos += 1;
+                    break sg_4;
+                }
+                pos = gp_4;
+                pos = scan_url(tokens, pos);
+                if pos < 0 { return -1; }
+            }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            pos = scan_media_query_list(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Import { break try_1; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_1; }
+            let gp_5 = pos;
+            sg_5: {
+                pos = gp_5;
+                sg_5_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break sg_5_0; }
+                    pos += 1;
+                    break sg_5;
+                }
+                pos = gp_5;
+                pos = scan_url(tokens, pos);
+                if pos < 0 { return -1; }
+            }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_1; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break try_1; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Import { break try_2; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_2; }
+            let gp_6 = pos;
+            sg_6: {
+                pos = gp_6;
+                sg_6_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break sg_6_0; }
+                    pos += 1;
+                    break sg_6;
+                }
+                pos = gp_6;
+                pos = scan_url(tokens, pos);
+                if pos < 0 { return -1; }
+            }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_2; }
+            pos = scan_media_query_list(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Import { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        let gp_7 = pos;
+        sg_7: {
+            pos = gp_7;
+            sg_7_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break sg_7_0; }
+                pos += 1;
+                break sg_7;
+            }
+            pos = gp_7;
+            pos = scan_url(tokens, pos);
+            if pos < 0 { return -1; }
+        }
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_namespace_(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Namespace { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To } {
+                let sp = pos;
+                pos = scan_namespace_prefix(tokens, pos);
+                if pos < 0 { return -1; }
+                pos = scan_ws(tokens, pos);
+                if pos < 0 { return -1; }
+                if pos < 0 { pos = sp; }
+            }
+            let gp_8 = pos;
+            sg_8: {
+                pos = gp_8;
+                sg_8_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break sg_8_0; }
+                    pos += 1;
+                    break sg_8;
+                }
+                pos = gp_8;
+                pos = scan_url(tokens, pos);
+                if pos < 0 { return -1; }
+            }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Namespace { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To } {
+            let sp = pos;
+            pos = scan_namespace_prefix(tokens, pos);
+            if pos < 0 { return -1; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos < 0 { pos = sp; }
+        }
+        let gp_9 = pos;
+        sg_9: {
+            pos = gp_9;
+            sg_9_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break sg_9_0; }
+                pos += 1;
+                break sg_9;
+            }
+            pos = gp_9;
+            pos = scan_url(tokens, pos);
+            if pos < 0 { return -1; }
+        }
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_namespace_prefix(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_ident(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_media(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Media { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_media_query_list(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_group_rule_body(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_media_query_list(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_MediaOnly | TK_Not | TK_Comment | TK_Space | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_media_query(tokens, pos);
+        if pos < 0 { return -1; }
+        while pos < tokens.len() && tokens[pos].kind == TK_Comma {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_Comma { return -1; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { return -1; }
+            pos = scan_media_query(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos < 0 { pos = sp; break; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_media_query(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos < tokens.len() && tokens[pos].kind matches { TK_MediaOnly | TK_Not } {
+                let sp = pos;
+                let gp_10 = pos;
+                sg_10: {
+                    pos = gp_10;
+                    sg_10_0: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_MediaOnly { break sg_10_0; }
+                        pos += 1;
+                        break sg_10;
+                    }
+                    pos = gp_10;
+                    if pos >= tokens.len() || tokens[pos].kind != TK_Not { return -1; }
+                    pos += 1;
+                }
+                if pos < 0 { pos = sp; }
+            }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            pos = scan_media_type(tokens, pos);
+            if pos < 0 { break try_0; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            while pos < tokens.len() && tokens[pos].kind == TK_And {
+                let sp = pos;
+                if pos >= tokens.len() || tokens[pos].kind != TK_And { return -1; }
+                pos += 1;
+                pos = scan_ws(tokens, pos);
+                if pos < 0 { return -1; }
+                pos = scan_media_expression(tokens, pos);
+                if pos < 0 { return -1; }
+                if pos < 0 { pos = sp; break; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_media_expression(tokens, pos);
+        if pos < 0 { return -1; }
+        while pos < tokens.len() && tokens[pos].kind == TK_And {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_And { return -1; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { return -1; }
+            pos = scan_media_expression(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos < 0 { pos = sp; break; }
+        }
+    }
+    return pos;
+}
+
+fn scan_media_type(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_ident(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_media_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_media_feature(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        pos = scan_expr(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_media_feature(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_ident(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_page(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Page { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
+        let sp = pos;
+        pos = scan_pseudo_page(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
+        let sp = pos;
+        pos = scan_declaration(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    while pos < tokens.len() && tokens[pos].kind == TK_LIT_SEMI {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
+            let sp = pos;
+            pos = scan_declaration(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_pseudo_page(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
+    pos += 1;
+    pos = scan_ident(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_selector_group(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_selector(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_Comma {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Comma { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        pos = scan_selector(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_selector(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_simple_selector_sequence(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Plus | TK_Greater | TK_Tilde | TK_Space } {
+        let sp = pos;
+        pos = scan_combinator(tokens, pos);
+        if pos < 0 { return -1; }
+        pos = scan_simple_selector_sequence(tokens, pos);
+        if pos < 0 { return -1; }
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_combinator(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Plus { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Greater { break try_1; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Tilde { break try_2; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_simple_selector_sequence(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            let gp_11 = pos;
+            sg_11: {
+                pos = gp_11;
+                sg_11_0: {
+                    pos = scan_type_selector(tokens, pos);
+                    if pos < 0 { break sg_11_0; }
+                    break sg_11;
+                }
+                pos = gp_11;
+                pos = scan_universal(tokens, pos);
+                if pos < 0 { return -1; }
+            }
+            while pos < tokens.len() && tokens[pos].kind matches { TK_Hash | TK_LIT_DOT | TK_LIT_LBRACKET | TK_LIT_COLON | TK_PseudoNot } {
+                let sp = pos;
+                let gp_12 = pos;
+                sg_12: {
+                    pos = gp_12;
+                    sg_12_0: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_Hash { break sg_12_0; }
+                        pos += 1;
+                        break sg_12;
+                    }
+                    pos = gp_12;
+                    sg_12_1: {
+                        pos = scan_class_name(tokens, pos);
+                        if pos < 0 { break sg_12_1; }
+                        break sg_12;
+                    }
+                    pos = gp_12;
+                    sg_12_2: {
+                        pos = scan_attrib(tokens, pos);
+                        if pos < 0 { break sg_12_2; }
+                        break sg_12;
+                    }
+                    pos = gp_12;
+                    sg_12_3: {
+                        pos = scan_pseudo(tokens, pos);
+                        if pos < 0 { break sg_12_3; }
+                        break sg_12;
+                    }
+                    pos = gp_12;
+                    pos = scan_negation(tokens, pos);
+                    if pos < 0 { return -1; }
+                }
+                if pos < 0 { pos = sp; break; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+        let gp_13 = pos;
+        sg_13: {
+            pos = gp_13;
+            sg_13_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_Hash { break sg_13_0; }
+                pos += 1;
+                break sg_13;
+            }
+            pos = gp_13;
+            sg_13_1: {
+                pos = scan_class_name(tokens, pos);
+                if pos < 0 { break sg_13_1; }
+                break sg_13;
+            }
+            pos = gp_13;
+            sg_13_2: {
+                pos = scan_attrib(tokens, pos);
+                if pos < 0 { break sg_13_2; }
+                break sg_13;
+            }
+            pos = gp_13;
+            sg_13_3: {
+                pos = scan_pseudo(tokens, pos);
+                if pos < 0 { break sg_13_3; }
+                break sg_13;
+            }
+            pos = gp_13;
+            pos = scan_negation(tokens, pos);
+            if pos < 0 { return -1; }
+        }
+        while pos < tokens.len() && tokens[pos].kind matches { TK_Hash | TK_LIT_DOT | TK_LIT_LBRACKET | TK_LIT_COLON | TK_PseudoNot } {
+            let sp = pos;
+            let gp_14 = pos;
+            sg_14: {
+                pos = gp_14;
+                sg_14_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_Hash { break sg_14_0; }
+                    pos += 1;
+                    break sg_14;
+                }
+                pos = gp_14;
+                sg_14_1: {
+                    pos = scan_class_name(tokens, pos);
+                    if pos < 0 { break sg_14_1; }
+                    break sg_14;
+                }
+                pos = gp_14;
+                sg_14_2: {
+                    pos = scan_attrib(tokens, pos);
+                    if pos < 0 { break sg_14_2; }
+                    break sg_14;
+                }
+                pos = gp_14;
+                sg_14_3: {
+                    pos = scan_pseudo(tokens, pos);
+                    if pos < 0 { break sg_14_3; }
+                    break sg_14;
+                }
+                pos = gp_14;
+                pos = scan_negation(tokens, pos);
+                if pos < 0 { return -1; }
+            }
+            if pos < 0 { pos = sp; break; }
+        }
+    }
+    return pos;
+}
+
+fn scan_type_selector(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_LIT_STAR | TK_LIT_PIPE } {
+        let sp = pos;
+        pos = scan_type_namespace_prefix(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_element_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_type_namespace_prefix(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_LIT_STAR } {
+        let sp = pos;
+        let gp_15 = pos;
+        sg_15: {
+            pos = gp_15;
+            sg_15_0: {
+                pos = scan_ident(tokens, pos);
+                if pos < 0 { break sg_15_0; }
+                break sg_15;
+            }
+            pos = gp_15;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_PIPE { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_element_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_ident(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_universal(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_LIT_STAR | TK_LIT_PIPE } {
+        let sp = pos;
+        pos = scan_type_namespace_prefix(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_class_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+    pos += 1;
+    pos = scan_ident(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_attrib(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_LIT_STAR | TK_LIT_PIPE } {
+        let sp = pos;
+        pos = scan_type_namespace_prefix(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_ident(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_PrefixMatch | TK_SuffixMatch | TK_SubstringMatch | TK_LIT_EQ | TK_Includes | TK_DashMatch } {
+        let sp = pos;
+        let gp_16 = pos;
+        sg_16: {
+            pos = gp_16;
+            sg_16_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_PrefixMatch { break sg_16_0; }
+                pos += 1;
+                break sg_16;
+            }
+            pos = gp_16;
+            sg_16_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_SuffixMatch { break sg_16_1; }
+                pos += 1;
+                break sg_16;
+            }
+            pos = gp_16;
+            sg_16_2: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_SubstringMatch { break sg_16_2; }
+                pos += 1;
+                break sg_16;
+            }
+            pos = gp_16;
+            sg_16_3: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sg_16_3; }
+                pos += 1;
+                break sg_16;
+            }
+            pos = gp_16;
+            sg_16_4: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_Includes { break sg_16_4; }
+                pos += 1;
+                break sg_16;
+            }
+            pos = gp_16;
+            if pos >= tokens.len() || tokens[pos].kind != TK_DashMatch { return -1; }
+            pos += 1;
+        }
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        let gp_17 = pos;
+        sg_17: {
+            pos = gp_17;
+            sg_17_0: {
+                pos = scan_ident(tokens, pos);
+                if pos < 0 { break sg_17_0; }
+                break sg_17;
+            }
+            pos = gp_17;
+            if pos >= tokens.len() || tokens[pos].kind != TK_String_ { return -1; }
+            pos += 1;
+        }
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_pseudo(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    let gp_18 = pos;
+    sg_18: {
+        pos = gp_18;
+        sg_18_0: {
+            pos = scan_ident(tokens, pos);
+            if pos < 0 { break sg_18_0; }
+            break sg_18;
+        }
+        pos = gp_18;
+        pos = scan_functional_pseudo(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_functional_pseudo(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Function_ { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_expression(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let gp_19 = pos;
+    sg_19: {
+        pos = gp_19;
+        sg_19_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Plus { break sg_19_0; }
+            pos += 1;
+            break sg_19;
+        }
+        pos = gp_19;
+        sg_19_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Minus { break sg_19_1; }
+            pos += 1;
+            break sg_19;
+        }
+        pos = gp_19;
+        sg_19_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Dimension { break sg_19_2; }
+            pos += 1;
+            break sg_19;
+        }
+        pos = gp_19;
+        sg_19_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_UnknownDimension { break sg_19_3; }
+            pos += 1;
+            break sg_19;
+        }
+        pos = gp_19;
+        sg_19_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Number { break sg_19_4; }
+            pos += 1;
+            break sg_19;
+        }
+        pos = gp_19;
+        sg_19_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break sg_19_5; }
+            pos += 1;
+            break sg_19;
+        }
+        pos = gp_19;
+        pos = scan_ident(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Plus | TK_Minus | TK_Dimension | TK_UnknownDimension | TK_Number | TK_String_ | TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To } {
+        let sp = pos;
+        let gp_20 = pos;
+        sg_20: {
+            pos = gp_20;
+            sg_20_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_Plus { break sg_20_0; }
+                pos += 1;
+                break sg_20;
+            }
+            pos = gp_20;
+            sg_20_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_Minus { break sg_20_1; }
+                pos += 1;
+                break sg_20;
+            }
+            pos = gp_20;
+            sg_20_2: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_Dimension { break sg_20_2; }
+                pos += 1;
+                break sg_20;
+            }
+            pos = gp_20;
+            sg_20_3: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_UnknownDimension { break sg_20_3; }
+                pos += 1;
+                break sg_20;
+            }
+            pos = gp_20;
+            sg_20_4: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_Number { break sg_20_4; }
+                pos += 1;
+                break sg_20;
+            }
+            pos = gp_20;
+            sg_20_5: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break sg_20_5; }
+                pos += 1;
+                break sg_20;
+            }
+            pos = gp_20;
+            pos = scan_ident(tokens, pos);
+            if pos < 0 { return -1; }
+        }
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_negation(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_PseudoNot { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_negation_arg(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_negation_arg(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_type_selector(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_universal(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Hash { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            pos = scan_class_name(tokens, pos);
+            if pos < 0 { break try_3; }
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            pos = scan_attrib(tokens, pos);
+            if pos < 0 { break try_4; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_pseudo(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_operator_(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SLASH { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Comma { break try_1; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Space { break try_2; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_property_(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_ident(tokens, pos);
+            if pos < 0 { break try_0; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Variable { break try_1; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break try_2; }
+            pos += 1;
+            pos = scan_ident(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT__ { return -1; }
+        pos += 1;
+        pos = scan_ident(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_ruleset(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_selector_group(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos < tokens.len() && tokens[pos].kind matches { TK_LIT_SEMI | TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
+                let sp = pos;
+                pos = scan_declaration_list(tokens, pos);
+                if pos < 0 { pos = sp; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        while pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_UnknownDimension | TK_String_ | TK_Url_ | TK_Url | TK_Hash | TK_UnicodeRange | TK_Includes | TK_DashMatch | TK_LIT_COLON | TK_Function_ | TK_LIT_LPAREN | TK_LIT_LBRACKET } {
+            let sp = pos;
+            pos = scan_any_(tokens, pos);
+            if pos < 0 { pos = sp; break; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < tokens.len() && tokens[pos].kind matches { TK_LIT_SEMI | TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
+            let sp = pos;
+            pos = scan_declaration_list(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_declaration_list(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && tokens[pos].kind == TK_LIT_SEMI {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    pos = scan_declaration(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_LIT_SEMI {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
+            let sp = pos;
+            pos = scan_declaration(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_property_(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            pos = scan_expr(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos < tokens.len() && tokens[pos].kind == TK_Important {
+                let sp = pos;
+                pos = scan_prio(tokens, pos);
+                if pos < 0 { pos = sp; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_property_(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        pos = scan_value(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_prio(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Important { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let gp_21 = pos;
+    sg_21: {
+        pos = gp_21;
+        sg_21_0: {
+            pos = scan_any_(tokens, pos);
+            if pos < 0 { break sg_21_0; }
+            break sg_21;
+        }
+        pos = gp_21;
+        sg_21_1: {
+            pos = scan_block(tokens, pos);
+            if pos < 0 { break sg_21_1; }
+            break sg_21;
+        }
+        pos = gp_21;
+        if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_UnknownDimension | TK_String_ | TK_Url_ | TK_Url | TK_Hash | TK_UnicodeRange | TK_Includes | TK_DashMatch | TK_LIT_COLON | TK_Function_ | TK_LIT_LPAREN | TK_LIT_LBRACKET | TK_LIT_LBRACE | TK_AtKeyword } {
+        let sp = pos;
+        let gp_22 = pos;
+        sg_22: {
+            pos = gp_22;
+            sg_22_0: {
+                pos = scan_any_(tokens, pos);
+                if pos < 0 { break sg_22_0; }
+                break sg_22;
+            }
+            pos = gp_22;
+            sg_22_1: {
+                pos = scan_block(tokens, pos);
+                if pos < 0 { break sg_22_1; }
+                break sg_22;
+            }
+            pos = gp_22;
+            if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { return -1; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { return -1; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_expr(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_term(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_LIT_SLASH | TK_Comma | TK_Space | TK_LIT_EQ | TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_String_ | TK_UnicodeRange | TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Var | TK_Url_ | TK_Url | TK_Hash | TK_Calc | TK_Function_ | TK_UnknownDimension | TK_DxImageTransform } {
+        let sp = pos;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_LIT_SLASH | TK_Comma | TK_Space | TK_LIT_EQ } {
+            let sp = pos;
+            pos = scan_operator_(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        pos = scan_term(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_number(tokens, pos);
+            if pos < 0 { break try_0; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_percentage(tokens, pos);
+            if pos < 0 { break try_1; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_dimension(tokens, pos);
+            if pos < 0 { break try_2; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break try_3; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_3; }
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_UnicodeRange { break try_4; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_4; }
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            pos = scan_ident(tokens, pos);
+            if pos < 0 { break try_5; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_5; }
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            pos = scan_var_(tokens, pos);
+            if pos < 0 { break try_6; }
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            pos = scan_url(tokens, pos);
+            if pos < 0 { break try_7; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_7; }
+            break scan_alts;
+        }
+        pos = start;
+        try_8: {
+            pos = scan_hexcolor(tokens, pos);
+            if pos < 0 { break try_8; }
+            break scan_alts;
+        }
+        pos = start;
+        try_9: {
+            pos = scan_calc(tokens, pos);
+            if pos < 0 { break try_9; }
+            break scan_alts;
+        }
+        pos = start;
+        try_10: {
+            pos = scan_function_(tokens, pos);
+            if pos < 0 { break try_10; }
+            break scan_alts;
+        }
+        pos = start;
+        try_11: {
+            pos = scan_unknown_dimension(tokens, pos);
+            if pos < 0 { break try_11; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_11; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_dx_image_transform(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_function_(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Function_ { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_expr(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_dx_image_transform(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_DxImageTransform { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_expr(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_hexcolor(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Hash { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_number(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Plus | TK_Minus } {
+        let sp = pos;
+        let gp_23 = pos;
+        sg_23: {
+            pos = gp_23;
+            sg_23_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_Plus { break sg_23_0; }
+                pos += 1;
+                break sg_23;
+            }
+            pos = gp_23;
+            if pos >= tokens.len() || tokens[pos].kind != TK_Minus { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_Number { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_percentage(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Plus | TK_Minus } {
+        let sp = pos;
+        let gp_24 = pos;
+        sg_24: {
+            pos = gp_24;
+            sg_24_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_Plus { break sg_24_0; }
+                pos += 1;
+                break sg_24;
+            }
+            pos = gp_24;
+            if pos >= tokens.len() || tokens[pos].kind != TK_Minus { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_Percentage { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_dimension(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Plus | TK_Minus } {
+        let sp = pos;
+        let gp_25 = pos;
+        sg_25: {
+            pos = gp_25;
+            sg_25_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_Plus { break sg_25_0; }
+                pos += 1;
+                break sg_25;
+            }
+            pos = gp_25;
+            if pos >= tokens.len() || tokens[pos].kind != TK_Minus { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_Dimension { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_unknown_dimension(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Plus | TK_Minus } {
+        let sp = pos;
+        let gp_26 = pos;
+        sg_26: {
+            pos = gp_26;
+            sg_26_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_Plus { break sg_26_0; }
+                pos += 1;
+                break sg_26;
+            }
+            pos = gp_26;
+            if pos >= tokens.len() || tokens[pos].kind != TK_Minus { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_UnknownDimension { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_ident(tokens, pos);
+            if pos < 0 { break try_0; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_number(tokens, pos);
+            if pos < 0 { break try_1; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_percentage(tokens, pos);
+            if pos < 0 { break try_2; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            pos = scan_dimension(tokens, pos);
+            if pos < 0 { break try_3; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_3; }
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            pos = scan_unknown_dimension(tokens, pos);
+            if pos < 0 { break try_4; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_4; }
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break try_5; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_5; }
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            pos = scan_url(tokens, pos);
+            if pos < 0 { break try_6; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_6; }
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Hash { break try_7; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_7; }
+            break scan_alts;
+        }
+        pos = start;
+        try_8: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_UnicodeRange { break try_8; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_8; }
+            break scan_alts;
+        }
+        pos = start;
+        try_9: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Includes { break try_9; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_9; }
+            break scan_alts;
+        }
+        pos = start;
+        try_10: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_DashMatch { break try_10; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_10; }
+            break scan_alts;
+        }
+        pos = start;
+        try_11: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { break try_11; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_11; }
+            break scan_alts;
+        }
+        pos = start;
+        try_12: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Function_ { break try_12; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_12; }
+            while pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_UnknownDimension | TK_String_ | TK_Url_ | TK_Url | TK_Hash | TK_UnicodeRange | TK_Includes | TK_DashMatch | TK_LIT_COLON | TK_Function_ | TK_LIT_LPAREN | TK_LIT_LBRACKET | TK_LIT_LBRACE | TK_AtKeyword | TK_LIT_SEMI | TK_Cdo | TK_Cdc } {
+                let sp = pos;
+                let gp_27 = pos;
+                sg_27: {
+                    pos = gp_27;
+                    sg_27_0: {
+                        pos = scan_any_(tokens, pos);
+                        if pos < 0 { break sg_27_0; }
+                        break sg_27;
+                    }
+                    pos = gp_27;
+                    pos = scan_unused(tokens, pos);
+                    if pos < 0 { return -1; }
+                }
+                if pos < 0 { pos = sp; break; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_12; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_12; }
+            break scan_alts;
+        }
+        pos = start;
+        try_13: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_13; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_13; }
+            while pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_UnknownDimension | TK_String_ | TK_Url_ | TK_Url | TK_Hash | TK_UnicodeRange | TK_Includes | TK_DashMatch | TK_LIT_COLON | TK_Function_ | TK_LIT_LPAREN | TK_LIT_LBRACKET | TK_LIT_LBRACE | TK_AtKeyword | TK_LIT_SEMI | TK_Cdo | TK_Cdc } {
+                let sp = pos;
+                let gp_28 = pos;
+                sg_28: {
+                    pos = gp_28;
+                    sg_28_0: {
+                        pos = scan_any_(tokens, pos);
+                        if pos < 0 { break sg_28_0; }
+                        break sg_28;
+                    }
+                    pos = gp_28;
+                    pos = scan_unused(tokens, pos);
+                    if pos < 0 { return -1; }
+                }
+                if pos < 0 { pos = sp; break; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_13; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_13; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        while pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_UnknownDimension | TK_String_ | TK_Url_ | TK_Url | TK_Hash | TK_UnicodeRange | TK_Includes | TK_DashMatch | TK_LIT_COLON | TK_Function_ | TK_LIT_LPAREN | TK_LIT_LBRACKET | TK_LIT_LBRACE | TK_AtKeyword | TK_LIT_SEMI | TK_Cdo | TK_Cdc } {
+            let sp = pos;
+            let gp_29 = pos;
+            sg_29: {
+                pos = gp_29;
+                sg_29_0: {
+                    pos = scan_any_(tokens, pos);
+                    if pos < 0 { break sg_29_0; }
+                    break sg_29;
+                }
+                pos = gp_29;
+                pos = scan_unused(tokens, pos);
+                if pos < 0 { return -1; }
+            }
+            if pos < 0 { pos = sp; break; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_at_rule(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_UnknownDimension | TK_String_ | TK_Url_ | TK_Url | TK_Hash | TK_UnicodeRange | TK_Includes | TK_DashMatch | TK_LIT_COLON | TK_Function_ | TK_LIT_LPAREN | TK_LIT_LBRACKET } {
+        let sp = pos;
+        pos = scan_any_(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    let gp_30 = pos;
+    sg_30: {
+        pos = gp_30;
+        sg_30_0: {
+            pos = scan_block(tokens, pos);
+            if pos < 0 { break sg_30_0; }
+            break sg_30;
+        }
+        pos = gp_30;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_unused(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_block(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { break try_1; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break try_2; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Cdo { break try_3; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_3; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Cdc { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_block(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_LIT_SEMI | TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ | TK_LIT_PIPE | TK_Hash | TK_LIT_DOT | TK_LIT_LBRACKET | TK_LIT_COLON | TK_PseudoNot | TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_UnknownDimension | TK_String_ | TK_Url_ | TK_Url | TK_UnicodeRange | TK_Includes | TK_DashMatch | TK_Function_ | TK_LIT_LPAREN | TK_LIT_LBRACE | TK_Media | TK_Page | TK_FontFace | TK_Keyframes | TK_Supports | TK_Viewport | TK_CounterStyle | TK_FontFeatureValues | TK_AtKeyword } {
+        let sp = pos;
+        let gp_31 = pos;
+        sg_31: {
+            pos = gp_31;
+            sg_31_0: {
+                pos = scan_declaration_list(tokens, pos);
+                if pos < 0 { break sg_31_0; }
+                break sg_31;
+            }
+            pos = gp_31;
+            sg_31_1: {
+                pos = scan_nested_statement(tokens, pos);
+                if pos < 0 { break sg_31_1; }
+                break sg_31;
+            }
+            pos = gp_31;
+            sg_31_2: {
+                pos = scan_any_(tokens, pos);
+                if pos < 0 { break sg_31_2; }
+                break sg_31;
+            }
+            pos = gp_31;
+            sg_31_3: {
+                pos = scan_block(tokens, pos);
+                if pos < 0 { break sg_31_3; }
+                break sg_31;
+            }
+            pos = gp_31;
+            sg_31_4: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { break sg_31_4; }
+                pos += 1;
+                pos = scan_ws(tokens, pos);
+                if pos < 0 { break sg_31_4; }
+                break sg_31;
+            }
+            pos = gp_31;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { return -1; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_nested_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_ruleset(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_media(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_page(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            pos = scan_font_face_rule(tokens, pos);
+            if pos < 0 { break try_3; }
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            pos = scan_keyframes_rule(tokens, pos);
+            if pos < 0 { break try_4; }
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            pos = scan_supports_rule(tokens, pos);
+            if pos < 0 { break try_5; }
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            pos = scan_viewport(tokens, pos);
+            if pos < 0 { break try_6; }
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            pos = scan_counter_style(tokens, pos);
+            if pos < 0 { break try_7; }
+            break scan_alts;
+        }
+        pos = start;
+        try_8: {
+            pos = scan_font_feature_values_rule(tokens, pos);
+            if pos < 0 { break try_8; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_at_rule(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_group_rule_body(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_LIT_STAR | TK_LIT_PIPE | TK_Hash | TK_LIT_DOT | TK_LIT_LBRACKET | TK_LIT_COLON | TK_PseudoNot | TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_UnknownDimension | TK_String_ | TK_Url_ | TK_Url | TK_UnicodeRange | TK_Includes | TK_DashMatch | TK_Function_ | TK_LIT_LPAREN | TK_LIT_LBRACE | TK_Media | TK_Page | TK_FontFace | TK_Keyframes | TK_Supports | TK_Viewport | TK_CounterStyle | TK_FontFeatureValues | TK_AtKeyword } {
+        let sp = pos;
+        pos = scan_nested_statement(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_supports_rule(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Supports { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_supports_condition(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_group_rule_body(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_supports_condition(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_supports_negation(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_supports_conjunction(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_supports_disjunction(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_supports_condition_in_parens(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_supports_condition_in_parens(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            pos = scan_supports_condition(tokens, pos);
+            if pos < 0 { break try_0; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_supports_declaration_condition(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_general_enclosed(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_supports_negation(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Not { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_supports_condition_in_parens(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_supports_conjunction(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_supports_condition_in_parens(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_And { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_supports_condition_in_parens(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Comment | TK_Space } {
+        let sp = pos;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_And { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        pos = scan_supports_condition_in_parens(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_supports_disjunction(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_supports_condition_in_parens(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_Or { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_supports_condition_in_parens(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Comment | TK_Space } {
+        let sp = pos;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_Or { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        pos = scan_supports_condition_in_parens(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_supports_declaration_condition(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_declaration(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_general_enclosed(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let gp_32 = pos;
+    sg_32: {
+        pos = gp_32;
+        sg_32_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Function_ { break sg_32_0; }
+            pos += 1;
+            break sg_32;
+        }
+        pos = gp_32;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+        pos += 1;
+    }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_UnknownDimension | TK_String_ | TK_Url_ | TK_Url | TK_Hash | TK_UnicodeRange | TK_Includes | TK_DashMatch | TK_LIT_COLON | TK_Function_ | TK_LIT_LPAREN | TK_LIT_LBRACKET | TK_LIT_LBRACE | TK_AtKeyword | TK_LIT_SEMI | TK_Cdo | TK_Cdc } {
+        let sp = pos;
+        let gp_33 = pos;
+        sg_33: {
+            pos = gp_33;
+            sg_33_0: {
+                pos = scan_any_(tokens, pos);
+                if pos < 0 { break sg_33_0; }
+                break sg_33;
+            }
+            pos = gp_33;
+            pos = scan_unused(tokens, pos);
+            if pos < 0 { return -1; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_url(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Url_ { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Url { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_var_(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Var { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_Variable { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_calc(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Calc { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_calc_sum(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_calc_sum(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_calc_product(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_Space {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        let gp_34 = pos;
+        sg_34: {
+            pos = gp_34;
+            sg_34_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_Plus { break sg_34_0; }
+                pos += 1;
+                break sg_34;
+            }
+            pos = gp_34;
+            if pos >= tokens.len() || tokens[pos].kind != TK_Minus { return -1; }
+            pos += 1;
+        }
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        pos = scan_calc_product(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_calc_product(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_calc_value(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_LIT_STAR | TK_LIT_SLASH } {
+        let sp = pos;
+        let gp_35 = pos;
+        sg_35: {
+            pos = gp_35;
+            sg_35_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break sg_35_0; }
+                pos += 1;
+                pos = scan_ws(tokens, pos);
+                if pos < 0 { break sg_35_0; }
+                pos = scan_calc_value(tokens, pos);
+                if pos < 0 { break sg_35_0; }
+                break sg_35;
+            }
+            pos = gp_35;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SLASH { return -1; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { return -1; }
+            pos = scan_number(tokens, pos);
+            if pos < 0 { return -1; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { return -1; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_calc_value(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_number(tokens, pos);
+            if pos < 0 { break try_0; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_dimension(tokens, pos);
+            if pos < 0 { break try_1; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_unknown_dimension(tokens, pos);
+            if pos < 0 { break try_2; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            pos = scan_percentage(tokens, pos);
+            if pos < 0 { break try_3; }
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_3; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        pos = scan_calc_sum(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_font_face_rule(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_FontFace { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
+        let sp = pos;
+        pos = scan_font_face_declaration(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    while pos < tokens.len() && tokens[pos].kind == TK_LIT_SEMI {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
+            let sp = pos;
+            pos = scan_font_face_declaration(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_font_face_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_property_(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { break try_0; }
+            pos += 1;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { break try_0; }
+            pos = scan_expr(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_property_(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        pos = scan_value(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_keyframes_rule(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Keyframes { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ident(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_From | TK_To | TK_Percentage } {
+        let sp = pos;
+        pos = scan_keyframe_block(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_keyframe_block(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_keyframe_selector(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_LIT_SEMI | TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
+        let sp = pos;
+        pos = scan_declaration_list(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_keyframe_selector(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let gp_36 = pos;
+    sg_36: {
+        pos = gp_36;
+        sg_36_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_From { break sg_36_0; }
+            pos += 1;
+            break sg_36;
+        }
+        pos = gp_36;
+        sg_36_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_To { break sg_36_1; }
+            pos += 1;
+            break sg_36;
+        }
+        pos = gp_36;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Percentage { return -1; }
+        pos += 1;
+    }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_Comma {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Comma { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        let gp_37 = pos;
+        sg_37: {
+            pos = gp_37;
+            sg_37_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_From { break sg_37_0; }
+                pos += 1;
+                break sg_37;
+            }
+            pos = gp_37;
+            sg_37_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_To { break sg_37_1; }
+                pos += 1;
+                break sg_37;
+            }
+            pos = gp_37;
+            if pos >= tokens.len() || tokens[pos].kind != TK_Percentage { return -1; }
+            pos += 1;
+        }
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_viewport(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Viewport { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_LIT_SEMI | TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
+        let sp = pos;
+        pos = scan_declaration_list(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_counter_style(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_CounterStyle { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ident(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_LIT_SEMI | TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
+        let sp = pos;
+        pos = scan_declaration_list(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_font_feature_values_rule(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_FontFeatureValues { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_font_family_name_list(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_AtKeyword {
+        let sp = pos;
+        pos = scan_feature_value_block(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_font_family_name_list(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_font_family_name(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Comment | TK_Space } {
+        let sp = pos;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_Comma { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        pos = scan_font_family_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_font_family_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_ident(tokens, pos);
+        if pos < 0 { return -1; }
+        while pos < tokens.len() && tokens[pos].kind matches { TK_Comment | TK_Space } {
+            let sp = pos;
+            pos = scan_ws(tokens, pos);
+            if pos < 0 { return -1; }
+            pos = scan_ident(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos < 0 { pos = sp; break; }
+        }
+    }
+    return pos;
+}
+
+fn scan_feature_value_block(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_feature_type(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To } {
+        let sp = pos;
+        pos = scan_feature_value_definition(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Comment | TK_Space } {
+        let sp = pos;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
+        pos += 1;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To } {
+            let sp = pos;
+            pos = scan_feature_value_definition(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_feature_type(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_feature_value_definition(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_ident(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_number(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Comment | TK_Space } {
+        let sp = pos;
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        pos = scan_number(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_ident(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Ident { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_MediaOnly { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Not { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_And { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Or { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_From { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_To { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_ws(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Comment | TK_Space } {
+        let sp = pos;
+        let gp_38 = pos;
+        sg_38: {
+            pos = gp_38;
+            sg_38_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_Comment { break sg_38_0; }
+                pos += 1;
+                break sg_38;
+            }
+            pos = gp_38;
+            if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
 fn parse_stylesheet(p: &mut Parser) -> Result<StylesheetNode, ParseError> {
     let start = p.peek().span.start;
     let ws = parse_ws(p)?;
@@ -29385,6 +32162,23 @@ fn parse_charset_bt_0(p: &mut Parser) -> Result<CharsetNode, ParseError> {
     }));
 }
 
+fn parse_charset_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Charset { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_String_ { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_charset_bt_1(p: &mut Parser) -> Result<CharsetNode, ParseError> {
     let start = p.peek().span.start;
     let charset = p.expect(TK_Charset)?;
@@ -29400,16 +32194,25 @@ fn parse_charset_bt_1(p: &mut Parser) -> Result<CharsetNode, ParseError> {
     }));
 }
 
+fn parse_charset_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Charset { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_String_ { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_charset(p: &mut Parser) -> Result<CharsetNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_Charset {
-        let saved = p.pos;
-        let r_0 = parse_charset_bt_0(p);
-        if let Err(_) = r_0 {
-            p.pos = saved;
-        } else {
-            return r_0;
+        if parse_charset_scan_0(&p.tokens, p.pos) >= 0 {
+            return parse_charset_bt_0(p);
         }
         return parse_charset_bt_1(p);
     }
@@ -29454,6 +32257,35 @@ fn parse_imports_bt_0(p: &mut Parser) -> Result<ImportsNode, ParseError> {
     }));
 }
 
+fn parse_imports_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Import { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    let gp_39 = pos;
+    sg_39: {
+        pos = gp_39;
+        sg_39_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break sg_39_0; }
+            pos += 1;
+            break sg_39;
+        }
+        pos = gp_39;
+        pos = scan_url(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_media_query_list(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_imports_bt_1(p: &mut Parser) -> Result<ImportsNode, ParseError> {
     let start = p.peek().span.start;
     let import_ = p.expect(TK_Import)?;
@@ -29486,6 +32318,33 @@ fn parse_imports_bt_1(p: &mut Parser) -> Result<ImportsNode, ParseError> {
     }));
 }
 
+fn parse_imports_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Import { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    let gp_40 = pos;
+    sg_40: {
+        pos = gp_40;
+        sg_40_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break sg_40_0; }
+            pos += 1;
+            break sg_40;
+        }
+        pos = gp_40;
+        pos = scan_url(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_imports_bt_2(p: &mut Parser) -> Result<ImportsNode, ParseError> {
     let start = p.peek().span.start;
     let import_ = p.expect(TK_Import)?;
@@ -29516,6 +32375,31 @@ fn parse_imports_bt_2(p: &mut Parser) -> Result<ImportsNode, ParseError> {
     }));
 }
 
+fn parse_imports_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Import { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    let gp_41 = pos;
+    sg_41: {
+        pos = gp_41;
+        sg_41_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break sg_41_0; }
+            pos += 1;
+            break sg_41;
+        }
+        pos = gp_41;
+        pos = scan_url(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_media_query_list(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_imports_bt_3(p: &mut Parser) -> Result<ImportsNode, ParseError> {
     let start = p.peek().span.start;
     let import_ = p.expect(TK_Import)?;
@@ -29544,28 +32428,41 @@ fn parse_imports_bt_3(p: &mut Parser) -> Result<ImportsNode, ParseError> {
     }));
 }
 
+fn parse_imports_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Import { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    let gp_42 = pos;
+    sg_42: {
+        pos = gp_42;
+        sg_42_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break sg_42_0; }
+            pos += 1;
+            break sg_42;
+        }
+        pos = gp_42;
+        pos = scan_url(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_imports(p: &mut Parser) -> Result<ImportsNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_Import {
-        let saved = p.pos;
-        let r_0 = parse_imports_bt_0(p);
-        if let Err(_) = r_0 {
-            p.pos = saved;
-        } else {
-            return r_0;
+        if parse_imports_scan_0(&p.tokens, p.pos) >= 0 {
+            return parse_imports_bt_0(p);
         }
-        let r_1 = parse_imports_bt_1(p);
-        if let Err(_) = r_1 {
-            p.pos = saved;
-        } else {
-            return r_1;
+        if parse_imports_scan_1(&p.tokens, p.pos) >= 0 {
+            return parse_imports_bt_1(p);
         }
-        let r_2 = parse_imports_bt_2(p);
-        if let Err(_) = r_2 {
-            p.pos = saved;
-        } else {
-            return r_2;
+        if parse_imports_scan_2(&p.tokens, p.pos) >= 0 {
+            return parse_imports_bt_2(p);
         }
         return parse_imports_bt_3(p);
     }
@@ -29629,6 +32526,41 @@ fn parse_namespace__bt_0(p: &mut Parser) -> Result<NamespaceNode, ParseError> {
     }));
 }
 
+fn parse_namespace__scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Namespace { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To } {
+        let sp = pos;
+        pos = scan_namespace_prefix(tokens, pos);
+        if pos < 0 { return -1; }
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    let gp_43 = pos;
+    sg_43: {
+        pos = gp_43;
+        sg_43_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break sg_43_0; }
+            pos += 1;
+            break sg_43;
+        }
+        pos = gp_43;
+        pos = scan_url(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_namespace__bt_1(p: &mut Parser) -> Result<NamespaceNode, ParseError> {
     let start = p.peek().span.start;
     let namespace = p.expect(TK_Namespace)?;
@@ -29678,16 +32610,43 @@ fn parse_namespace__bt_1(p: &mut Parser) -> Result<NamespaceNode, ParseError> {
     }));
 }
 
+fn parse_namespace__scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Namespace { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To } {
+        let sp = pos;
+        pos = scan_namespace_prefix(tokens, pos);
+        if pos < 0 { return -1; }
+        pos = scan_ws(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    let gp_44 = pos;
+    sg_44: {
+        pos = gp_44;
+        sg_44_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break sg_44_0; }
+            pos += 1;
+            break sg_44;
+        }
+        pos = gp_44;
+        pos = scan_url(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_namespace_(p: &mut Parser) -> Result<NamespaceNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_Namespace {
-        let saved = p.pos;
-        let r_0 = parse_namespace__bt_0(p);
-        if let Err(_) = r_0 {
-            p.pos = saved;
-        } else {
-            return r_0;
+        if parse_namespace__scan_0(&p.tokens, p.pos) >= 0 {
+            return parse_namespace__bt_0(p);
         }
         return parse_namespace__bt_1(p);
     }
@@ -30411,6 +33370,13 @@ fn parse_negation_arg_bt_0(p: &mut Parser) -> Result<NegationArgNode, ParseError
     }));
 }
 
+fn parse_negation_arg_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_type_selector(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_negation_arg_bt_1(p: &mut Parser) -> Result<NegationArgNode, ParseError> {
     let start = p.peek().span.start;
     let universal = parse_universal(p)?;
@@ -30420,17 +33386,20 @@ fn parse_negation_arg_bt_1(p: &mut Parser) -> Result<NegationArgNode, ParseError
     }));
 }
 
+fn parse_negation_arg_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_universal(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_negation_arg(p: &mut Parser) -> Result<NegationArgNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_LIT_STAR | TK_LIT_PIPE } {
         if p.peek_kind() matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_LIT_STAR | TK_LIT_PIPE } {
-            let saved = p.pos;
-            let r_0 = parse_negation_arg_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_negation_arg_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_negation_arg_bt_0(p);
             }
             return parse_negation_arg_bt_1(p);
         }
@@ -30590,6 +33559,29 @@ fn parse_ruleset_bt_1(p: &mut Parser) -> Result<RulesetNode, ParseError> {
     }));
 }
 
+fn parse_ruleset_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_UnknownDimension | TK_String_ | TK_Url_ | TK_Url | TK_Hash | TK_UnicodeRange | TK_Includes | TK_DashMatch | TK_LIT_COLON | TK_Function_ | TK_LIT_LPAREN | TK_LIT_LBRACKET } {
+        let sp = pos;
+        pos = scan_any_(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_LIT_SEMI | TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
+        let sp = pos;
+        pos = scan_declaration_list(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_ruleset_bt_0(p: &mut Parser) -> Result<RulesetNode, ParseError> {
     let start = p.peek().span.start;
     let selector_group = parse_selector_group(p)?;
@@ -30614,17 +33606,33 @@ fn parse_ruleset_bt_0(p: &mut Parser) -> Result<RulesetNode, ParseError> {
     }));
 }
 
+fn parse_ruleset_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_selector_group(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_LIT_SEMI | TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
+        let sp = pos;
+        pos = scan_declaration_list(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_ruleset(p: &mut Parser) -> Result<RulesetNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_UnknownDimension | TK_String_ | TK_Url_ | TK_Url | TK_Hash | TK_UnicodeRange | TK_Includes | TK_DashMatch | TK_LIT_COLON | TK_Function_ | TK_LIT_LPAREN | TK_LIT_LBRACKET | TK_LIT_LBRACE | TK_LIT_STAR | TK_LIT_PIPE | TK_LIT_DOT | TK_PseudoNot } {
         if p.peek_kind() matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Hash | TK_LIT_LBRACKET | TK_LIT_COLON } {
-            let saved = p.pos;
-            let r_1 = parse_ruleset_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_ruleset_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_ruleset_bt_1(p);
             }
             return parse_ruleset_bt_0(p);
         } else if p.peek_kind() matches { TK_LIT_STAR | TK_LIT_PIPE | TK_LIT_DOT | TK_PseudoNot } {
@@ -30702,6 +33710,24 @@ fn parse_declaration_bt_0(p: &mut Parser) -> Result<DeclarationNode, ParseError>
     }));
 }
 
+fn parse_declaration_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_property_(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_expr(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind == TK_Important {
+        let sp = pos;
+        pos = scan_prio(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
 fn parse_declaration_bt_1(p: &mut Parser) -> Result<DeclarationNode, ParseError> {
     let start = p.peek().span.start;
     let property_ = parse_property_(p)?;
@@ -30717,17 +33743,26 @@ fn parse_declaration_bt_1(p: &mut Parser) -> Result<DeclarationNode, ParseError>
     }));
 }
 
+fn parse_declaration_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_property_(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_value(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_declaration(p: &mut Parser) -> Result<DeclarationNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
         if p.peek_kind() matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
-            let saved = p.pos;
-            let r_0 = parse_declaration_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_declaration_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_declaration_bt_0(p);
             }
             return parse_declaration_bt_1(p);
         }
@@ -30818,6 +33853,15 @@ fn parse_term_bt_0(p: &mut Parser) -> Result<TermNode, ParseError> {
     }));
 }
 
+fn parse_term_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_number(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_term_bt_1(p: &mut Parser) -> Result<TermNode, ParseError> {
     let start = p.peek().span.start;
     let percentage = parse_percentage(p)?;
@@ -30827,6 +33871,15 @@ fn parse_term_bt_1(p: &mut Parser) -> Result<TermNode, ParseError> {
         percentage,
         ws,
     }));
+}
+
+fn parse_term_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_percentage(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_term_bt_2(p: &mut Parser) -> Result<TermNode, ParseError> {
@@ -30840,6 +33893,15 @@ fn parse_term_bt_2(p: &mut Parser) -> Result<TermNode, ParseError> {
     }));
 }
 
+fn parse_term_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_dimension(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_term_bt_11(p: &mut Parser) -> Result<TermNode, ParseError> {
     let start = p.peek().span.start;
     let unknown_dimension = parse_unknown_dimension(p)?;
@@ -30851,53 +33913,42 @@ fn parse_term_bt_11(p: &mut Parser) -> Result<TermNode, ParseError> {
     }));
 }
 
+fn parse_term_scan_11(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_unknown_dimension(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_term(p: &mut Parser) -> Result<TermNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_UnknownDimension } {
         if p.peek_kind() == TK_Plus {
             if p.peek_at(1) matches { TK_Comment | TK_Space } {
-                let saved = p.pos;
-                let r_0 = parse_term_bt_0(p);
-                if let Err(_) = r_0 {
-                    p.pos = saved;
-                } else {
-                    return r_0;
+                if parse_term_scan_0(&p.tokens, p.pos) >= 0 {
+                    return parse_term_bt_0(p);
                 }
-                let r_1 = parse_term_bt_1(p);
-                if let Err(_) = r_1 {
-                    p.pos = saved;
-                } else {
-                    return r_1;
+                if parse_term_scan_1(&p.tokens, p.pos) >= 0 {
+                    return parse_term_bt_1(p);
                 }
-                let r_2 = parse_term_bt_2(p);
-                if let Err(_) = r_2 {
-                    p.pos = saved;
-                } else {
-                    return r_2;
+                if parse_term_scan_2(&p.tokens, p.pos) >= 0 {
+                    return parse_term_bt_2(p);
                 }
                 return parse_term_bt_11(p);
             }
         } else if p.peek_kind() == TK_Minus {
             if p.peek_at(1) matches { TK_Comment | TK_Space } {
-                let saved = p.pos;
-                let r_0 = parse_term_bt_0(p);
-                if let Err(_) = r_0 {
-                    p.pos = saved;
-                } else {
-                    return r_0;
+                if parse_term_scan_0(&p.tokens, p.pos) >= 0 {
+                    return parse_term_bt_0(p);
                 }
-                let r_1 = parse_term_bt_1(p);
-                if let Err(_) = r_1 {
-                    p.pos = saved;
-                } else {
-                    return r_1;
+                if parse_term_scan_1(&p.tokens, p.pos) >= 0 {
+                    return parse_term_bt_1(p);
                 }
-                let r_2 = parse_term_bt_2(p);
-                if let Err(_) = r_2 {
-                    p.pos = saved;
-                } else {
-                    return r_2;
+                if parse_term_scan_2(&p.tokens, p.pos) >= 0 {
+                    return parse_term_bt_2(p);
                 }
                 return parse_term_bt_11(p);
             }
@@ -31129,6 +34180,15 @@ fn parse_any__bt_1(p: &mut Parser) -> Result<AnyNode, ParseError> {
     }));
 }
 
+fn parse_any__scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_number(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_any__bt_2(p: &mut Parser) -> Result<AnyNode, ParseError> {
     let start = p.peek().span.start;
     let percentage = parse_percentage(p)?;
@@ -31138,6 +34198,15 @@ fn parse_any__bt_2(p: &mut Parser) -> Result<AnyNode, ParseError> {
         percentage,
         ws,
     }));
+}
+
+fn parse_any__scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_percentage(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_any__bt_3(p: &mut Parser) -> Result<AnyNode, ParseError> {
@@ -31151,6 +34220,15 @@ fn parse_any__bt_3(p: &mut Parser) -> Result<AnyNode, ParseError> {
     }));
 }
 
+fn parse_any__scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_dimension(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_any__bt_4(p: &mut Parser) -> Result<AnyNode, ParseError> {
     let start = p.peek().span.start;
     let unknown_dimension = parse_unknown_dimension(p)?;
@@ -31160,6 +34238,15 @@ fn parse_any__bt_4(p: &mut Parser) -> Result<AnyNode, ParseError> {
         unknown_dimension,
         ws,
     }));
+}
+
+fn parse_any__scan_4(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_unknown_dimension(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_any_(p: &mut Parser) -> Result<AnyNode, ParseError> {
@@ -31177,47 +34264,27 @@ fn parse_any_(p: &mut Parser) -> Result<AnyNode, ParseError> {
     if kind matches { TK_Plus | TK_Minus | TK_Number | TK_Percentage | TK_Dimension | TK_UnknownDimension } {
         if p.peek_kind() == TK_Plus {
             if p.peek_at(1) matches { TK_Comment | TK_Space } {
-                let saved = p.pos;
-                let r_1 = parse_any__bt_1(p);
-                if let Err(_) = r_1 {
-                    p.pos = saved;
-                } else {
-                    return r_1;
+                if parse_any__scan_1(&p.tokens, p.pos) >= 0 {
+                    return parse_any__bt_1(p);
                 }
-                let r_2 = parse_any__bt_2(p);
-                if let Err(_) = r_2 {
-                    p.pos = saved;
-                } else {
-                    return r_2;
+                if parse_any__scan_2(&p.tokens, p.pos) >= 0 {
+                    return parse_any__bt_2(p);
                 }
-                let r_3 = parse_any__bt_3(p);
-                if let Err(_) = r_3 {
-                    p.pos = saved;
-                } else {
-                    return r_3;
+                if parse_any__scan_3(&p.tokens, p.pos) >= 0 {
+                    return parse_any__bt_3(p);
                 }
                 return parse_any__bt_4(p);
             }
         } else if p.peek_kind() == TK_Minus {
             if p.peek_at(1) matches { TK_Comment | TK_Space } {
-                let saved = p.pos;
-                let r_1 = parse_any__bt_1(p);
-                if let Err(_) = r_1 {
-                    p.pos = saved;
-                } else {
-                    return r_1;
+                if parse_any__scan_1(&p.tokens, p.pos) >= 0 {
+                    return parse_any__bt_1(p);
                 }
-                let r_2 = parse_any__bt_2(p);
-                if let Err(_) = r_2 {
-                    p.pos = saved;
-                } else {
-                    return r_2;
+                if parse_any__scan_2(&p.tokens, p.pos) >= 0 {
+                    return parse_any__bt_2(p);
                 }
-                let r_3 = parse_any__bt_3(p);
-                if let Err(_) = r_3 {
-                    p.pos = saved;
-                } else {
-                    return r_3;
+                if parse_any__scan_3(&p.tokens, p.pos) >= 0 {
+                    return parse_any__bt_3(p);
                 }
                 return parse_any__bt_4(p);
             }
@@ -31689,6 +34756,13 @@ fn parse_supports_condition_bt_1(p: &mut Parser) -> Result<SupportsConditionNode
     }));
 }
 
+fn parse_supports_condition_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_supports_conjunction(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_supports_condition_bt_2(p: &mut Parser) -> Result<SupportsConditionNode, ParseError> {
     let start = p.peek().span.start;
     let supports_disjunction = parse_supports_disjunction(p)?;
@@ -31698,6 +34772,13 @@ fn parse_supports_condition_bt_2(p: &mut Parser) -> Result<SupportsConditionNode
     }));
 }
 
+fn parse_supports_condition_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_supports_disjunction(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_supports_condition_bt_3(p: &mut Parser) -> Result<SupportsConditionNode, ParseError> {
     let start = p.peek().span.start;
     let supports_condition_in_parens = parse_supports_condition_in_parens(p)?;
@@ -31705,6 +34786,13 @@ fn parse_supports_condition_bt_3(p: &mut Parser) -> Result<SupportsConditionNode
         span: Span::new(start, p.last_end()),
         supports_condition_in_parens,
     }));
+}
+
+fn parse_supports_condition_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_supports_condition_in_parens(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_supports_condition(p: &mut Parser) -> Result<SupportsConditionNode, ParseError> {
@@ -31719,18 +34807,11 @@ fn parse_supports_condition(p: &mut Parser) -> Result<SupportsConditionNode, Par
     }
     if kind matches { TK_LIT_LPAREN | TK_Function_ } {
         if p.peek_kind() matches { TK_LIT_LPAREN | TK_Function_ } {
-            let saved = p.pos;
-            let r_1 = parse_supports_condition_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_supports_condition_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_supports_condition_bt_1(p);
             }
-            let r_2 = parse_supports_condition_bt_2(p);
-            if let Err(_) = r_2 {
-                p.pos = saved;
-            } else {
-                return r_2;
+            if parse_supports_condition_scan_2(&p.tokens, p.pos) >= 0 {
+                return parse_supports_condition_bt_2(p);
             }
             return parse_supports_condition_bt_3(p);
         }
@@ -31759,6 +34840,21 @@ fn parse_supports_condition_in_parens_bt_0(p: &mut Parser) -> Result<SupportsCon
     }));
 }
 
+fn parse_supports_condition_in_parens_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_supports_condition(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_supports_condition_in_parens_bt_1(p: &mut Parser) -> Result<SupportsConditionInParensNode, ParseError> {
     let start = p.peek().span.start;
     let supports_declaration_condition = parse_supports_declaration_condition(p)?;
@@ -31766,6 +34862,13 @@ fn parse_supports_condition_in_parens_bt_1(p: &mut Parser) -> Result<SupportsCon
         span: Span::new(start, p.last_end()),
         supports_declaration_condition,
     }));
+}
+
+fn parse_supports_condition_in_parens_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_supports_declaration_condition(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_supports_condition_in_parens_bt_2(p: &mut Parser) -> Result<SupportsConditionInParensNode, ParseError> {
@@ -31777,23 +34880,23 @@ fn parse_supports_condition_in_parens_bt_2(p: &mut Parser) -> Result<SupportsCon
     }));
 }
 
+fn parse_supports_condition_in_parens_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_general_enclosed(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_supports_condition_in_parens(p: &mut Parser) -> Result<SupportsConditionInParensNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_LIT_LPAREN | TK_Function_ } {
         if p.peek_kind() == TK_LIT_LPAREN {
-            let saved = p.pos;
-            let r_0 = parse_supports_condition_in_parens_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_supports_condition_in_parens_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_supports_condition_in_parens_bt_0(p);
             }
-            let r_1 = parse_supports_condition_in_parens_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_supports_condition_in_parens_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_supports_condition_in_parens_bt_1(p);
             }
             return parse_supports_condition_in_parens_bt_2(p);
         } else if p.peek_kind() == TK_Function_ {
@@ -32074,6 +35177,15 @@ fn parse_calc_value_bt_0(p: &mut Parser) -> Result<CalcValueNode, ParseError> {
     }));
 }
 
+fn parse_calc_value_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_number(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_calc_value_bt_1(p: &mut Parser) -> Result<CalcValueNode, ParseError> {
     let start = p.peek().span.start;
     let dimension = parse_dimension(p)?;
@@ -32083,6 +35195,15 @@ fn parse_calc_value_bt_1(p: &mut Parser) -> Result<CalcValueNode, ParseError> {
         dimension,
         ws,
     }));
+}
+
+fn parse_calc_value_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_dimension(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_calc_value_bt_2(p: &mut Parser) -> Result<CalcValueNode, ParseError> {
@@ -32096,6 +35217,15 @@ fn parse_calc_value_bt_2(p: &mut Parser) -> Result<CalcValueNode, ParseError> {
     }));
 }
 
+fn parse_calc_value_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_unknown_dimension(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_calc_value_bt_3(p: &mut Parser) -> Result<CalcValueNode, ParseError> {
     let start = p.peek().span.start;
     let percentage = parse_percentage(p)?;
@@ -32107,53 +35237,42 @@ fn parse_calc_value_bt_3(p: &mut Parser) -> Result<CalcValueNode, ParseError> {
     }));
 }
 
+fn parse_calc_value_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_percentage(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_calc_value(p: &mut Parser) -> Result<CalcValueNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_Plus | TK_Minus | TK_Number | TK_Dimension | TK_UnknownDimension | TK_Percentage } {
         if p.peek_kind() == TK_Plus {
             if p.peek_at(1) matches { TK_Comment | TK_Space } {
-                let saved = p.pos;
-                let r_0 = parse_calc_value_bt_0(p);
-                if let Err(_) = r_0 {
-                    p.pos = saved;
-                } else {
-                    return r_0;
+                if parse_calc_value_scan_0(&p.tokens, p.pos) >= 0 {
+                    return parse_calc_value_bt_0(p);
                 }
-                let r_1 = parse_calc_value_bt_1(p);
-                if let Err(_) = r_1 {
-                    p.pos = saved;
-                } else {
-                    return r_1;
+                if parse_calc_value_scan_1(&p.tokens, p.pos) >= 0 {
+                    return parse_calc_value_bt_1(p);
                 }
-                let r_2 = parse_calc_value_bt_2(p);
-                if let Err(_) = r_2 {
-                    p.pos = saved;
-                } else {
-                    return r_2;
+                if parse_calc_value_scan_2(&p.tokens, p.pos) >= 0 {
+                    return parse_calc_value_bt_2(p);
                 }
                 return parse_calc_value_bt_3(p);
             }
         } else if p.peek_kind() == TK_Minus {
             if p.peek_at(1) matches { TK_Comment | TK_Space } {
-                let saved = p.pos;
-                let r_0 = parse_calc_value_bt_0(p);
-                if let Err(_) = r_0 {
-                    p.pos = saved;
-                } else {
-                    return r_0;
+                if parse_calc_value_scan_0(&p.tokens, p.pos) >= 0 {
+                    return parse_calc_value_bt_0(p);
                 }
-                let r_1 = parse_calc_value_bt_1(p);
-                if let Err(_) = r_1 {
-                    p.pos = saved;
-                } else {
-                    return r_1;
+                if parse_calc_value_scan_1(&p.tokens, p.pos) >= 0 {
+                    return parse_calc_value_bt_1(p);
                 }
-                let r_2 = parse_calc_value_bt_2(p);
-                if let Err(_) = r_2 {
-                    p.pos = saved;
-                } else {
-                    return r_2;
+                if parse_calc_value_scan_2(&p.tokens, p.pos) >= 0 {
+                    return parse_calc_value_bt_2(p);
                 }
                 return parse_calc_value_bt_3(p);
             }
@@ -32248,6 +35367,19 @@ fn parse_font_face_declaration_bt_0(p: &mut Parser) -> Result<FontFaceDeclaratio
     }));
 }
 
+fn parse_font_face_declaration_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_property_(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_expr(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_font_face_declaration_bt_1(p: &mut Parser) -> Result<FontFaceDeclarationNode, ParseError> {
     let start = p.peek().span.start;
     let property_ = parse_property_(p)?;
@@ -32263,17 +35395,26 @@ fn parse_font_face_declaration_bt_1(p: &mut Parser) -> Result<FontFaceDeclaratio
     }));
 }
 
+fn parse_font_face_declaration_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_property_(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
+    pos += 1;
+    pos = scan_ws(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_value(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_font_face_declaration(p: &mut Parser) -> Result<FontFaceDeclarationNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
         if p.peek_kind() matches { TK_Ident | TK_MediaOnly | TK_Not | TK_And | TK_Or | TK_From | TK_To | TK_Variable | TK_LIT_STAR | TK_LIT__ } {
-            let saved = p.pos;
-            let r_0 = parse_font_face_declaration_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_font_face_declaration_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_font_face_declaration_bt_0(p);
             }
             return parse_font_face_declaration_bt_1(p);
         }

--- a/package-gale/tests/golden/html.wado
+++ b/package-gale/tests/golden/html.wado
@@ -1972,6 +1972,278 @@ impl Parser {
     }
 }
 
+fn scan_html_document(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_SCRIPTLET | TK_SEA_WS } {
+        let sp = pos;
+        pos = scan_scriptlet_or_sea_ws(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_XML {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_XML { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_SCRIPTLET | TK_SEA_WS } {
+        let sp = pos;
+        pos = scan_scriptlet_or_sea_ws(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_DTD {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_DTD { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_SCRIPTLET | TK_SEA_WS } {
+        let sp = pos;
+        pos = scan_scriptlet_or_sea_ws(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_HTML_COMMENT | TK_HTML_CONDITIONAL_COMMENT | TK_SEA_WS | TK_TAG_OPEN | TK_SCRIPTLET | TK_SCRIPT_OPEN | TK_STYLE_OPEN } {
+        let sp = pos;
+        pos = scan_html_elements(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_scriptlet_or_sea_ws(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_SCRIPTLET { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_SEA_WS { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_html_elements(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_HTML_COMMENT | TK_HTML_CONDITIONAL_COMMENT | TK_SEA_WS } {
+        let sp = pos;
+        pos = scan_html_misc(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    pos = scan_html_element(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_HTML_COMMENT | TK_HTML_CONDITIONAL_COMMENT | TK_SEA_WS } {
+        let sp = pos;
+        pos = scan_html_misc(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_html_element(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_TAG_OPEN { break try_0; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_TAG_NAME { break try_0; }
+            pos += 1;
+            while pos < tokens.len() && tokens[pos].kind == TK_TAG_NAME {
+                let sp = pos;
+                pos = scan_html_attribute(tokens, pos);
+                if pos < 0 { pos = sp; break; }
+            }
+            let gp_0 = pos;
+            sg_0: {
+                pos = gp_0;
+                sg_0_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_TAG_CLOSE { break sg_0_0; }
+                    pos += 1;
+                    if pos < tokens.len() && tokens[pos].kind matches { TK_HTML_TEXT | TK_SEA_WS | TK_TAG_OPEN | TK_SCRIPTLET | TK_SCRIPT_OPEN | TK_STYLE_OPEN | TK_CDATA | TK_HTML_COMMENT | TK_HTML_CONDITIONAL_COMMENT } {
+                        let sp = pos;
+                        pos = scan_html_content(tokens, pos);
+                        if pos < 0 { return -1; }
+                        if pos >= tokens.len() || tokens[pos].kind != TK_TAG_OPEN { return -1; }
+                        pos += 1;
+                        if pos >= tokens.len() || tokens[pos].kind != TK_TAG_SLASH { return -1; }
+                        pos += 1;
+                        if pos >= tokens.len() || tokens[pos].kind != TK_TAG_NAME { return -1; }
+                        pos += 1;
+                        if pos >= tokens.len() || tokens[pos].kind != TK_TAG_CLOSE { return -1; }
+                        pos += 1;
+                        if pos < 0 { pos = sp; }
+                    }
+                    break sg_0;
+                }
+                pos = gp_0;
+                if pos >= tokens.len() || tokens[pos].kind != TK_TAG_SLASH_CLOSE { return -1; }
+                pos += 1;
+            }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_SCRIPTLET { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_script(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_style(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_html_content(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_HTML_TEXT | TK_SEA_WS } {
+        let sp = pos;
+        pos = scan_html_chardata(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_TAG_OPEN | TK_SCRIPTLET | TK_SCRIPT_OPEN | TK_STYLE_OPEN | TK_CDATA | TK_HTML_COMMENT | TK_HTML_CONDITIONAL_COMMENT } {
+        let sp = pos;
+        let gp_1 = pos;
+        sg_1: {
+            pos = gp_1;
+            sg_1_0: {
+                pos = scan_html_element(tokens, pos);
+                if pos < 0 { break sg_1_0; }
+                break sg_1;
+            }
+            pos = gp_1;
+            sg_1_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_CDATA { break sg_1_1; }
+                pos += 1;
+                break sg_1;
+            }
+            pos = gp_1;
+            pos = scan_html_comment(tokens, pos);
+            if pos < 0 { return -1; }
+        }
+        if pos < tokens.len() && tokens[pos].kind matches { TK_HTML_TEXT | TK_SEA_WS } {
+            let sp = pos;
+            pos = scan_html_chardata(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_html_attribute(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_TAG_NAME { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_TAG_EQUALS {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_TAG_EQUALS { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_ATTVALUE_VALUE { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_html_chardata(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_HTML_TEXT { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_SEA_WS { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_html_misc(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_html_comment(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_SEA_WS { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_html_comment(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_HTML_COMMENT { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_HTML_CONDITIONAL_COMMENT { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_script(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_SCRIPT_OPEN { return -1; }
+    pos += 1;
+    let gp_2 = pos;
+    sg_2: {
+        pos = gp_2;
+        sg_2_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_SCRIPT_BODY { break sg_2_0; }
+            pos += 1;
+            break sg_2;
+        }
+        pos = gp_2;
+        if pos >= tokens.len() || tokens[pos].kind != TK_SCRIPT_SHORT_BODY { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_style(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_STYLE_OPEN { return -1; }
+    pos += 1;
+    let gp_3 = pos;
+    sg_3: {
+        pos = gp_3;
+        sg_3_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STYLE_BODY { break sg_3_0; }
+            pos += 1;
+            break sg_3;
+        }
+        pos = gp_3;
+        if pos >= tokens.len() || tokens[pos].kind != TK_STYLE_SHORT_BODY { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
 fn parse_html_document(p: &mut Parser) -> Result<HtmlDocumentNode, ParseError> {
     let start = p.peek().span.start;
     let mut scriptlet_or_sea_ws_list: Array<ScriptletOrSeaWsNode> = [];

--- a/package-gale/tests/golden/json.wado
+++ b/package-gale/tests/golden/json.wado
@@ -1013,6 +1013,135 @@ impl Parser {
     }
 }
 
+fn scan_json(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_value(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_obj(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break try_0; }
+            pos += 1;
+            pos = scan_pair(tokens, pos);
+            if pos < 0 { break try_0; }
+            while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
+                let sp = pos;
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+                pos += 1;
+                pos = scan_pair(tokens, pos);
+                if pos < 0 { return -1; }
+                if pos < 0 { pos = sp; break; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_pair(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_STRING { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
+    pos += 1;
+    pos = scan_value(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_arr(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break try_0; }
+            pos += 1;
+            pos = scan_value(tokens, pos);
+            if pos < 0 { break try_0; }
+            while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
+                let sp = pos;
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+                pos += 1;
+                pos = scan_value(tokens, pos);
+                if pos < 0 { return -1; }
+                if pos < 0 { pos = sp; break; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_NUMBER { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_obj(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            pos = scan_arr(tokens, pos);
+            if pos < 0 { break try_3; }
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_TRUE { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_FALSE { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NULL { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
 fn parse_json(p: &mut Parser) -> Result<JsonNode, ParseError> {
     let start = p.peek().span.start;
     let value = parse_value(p)?;
@@ -1048,6 +1177,25 @@ fn parse_obj_bt_0(p: &mut Parser) -> Result<ObjNode, ParseError> {
     }));
 }
 
+fn parse_obj_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    pos = scan_pair(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+        pos += 1;
+        pos = scan_pair(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_obj_bt_1(p: &mut Parser) -> Result<ObjNode, ParseError> {
     let start = p.peek().span.start;
     let lbrace = p.expect(TK_LIT_LBRACE)?;
@@ -1057,6 +1205,15 @@ fn parse_obj_bt_1(p: &mut Parser) -> Result<ObjNode, ParseError> {
         lbrace,
         rbrace,
     }));
+}
+
+fn parse_obj_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_obj(p: &mut Parser) -> Result<ObjNode, ParseError> {
@@ -1137,6 +1294,25 @@ fn parse_arr_bt_0(p: &mut Parser) -> Result<ArrNode, ParseError> {
     }));
 }
 
+fn parse_arr_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
+    pos += 1;
+    pos = scan_value(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+        pos += 1;
+        pos = scan_value(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_arr_bt_1(p: &mut Parser) -> Result<ArrNode, ParseError> {
     let start = p.peek().span.start;
     let lbracket = p.expect(TK_LIT_LBRACKET)?;
@@ -1146,6 +1322,15 @@ fn parse_arr_bt_1(p: &mut Parser) -> Result<ArrNode, ParseError> {
         lbracket,
         rbracket,
     }));
+}
+
+fn parse_arr_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_arr(p: &mut Parser) -> Result<ArrNode, ParseError> {

--- a/package-gale/tests/golden/json_highlight.wado
+++ b/package-gale/tests/golden/json_highlight.wado
@@ -1013,6 +1013,135 @@ impl Parser {
     }
 }
 
+fn scan_json(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_value(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_obj(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break try_0; }
+            pos += 1;
+            pos = scan_pair(tokens, pos);
+            if pos < 0 { break try_0; }
+            while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
+                let sp = pos;
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+                pos += 1;
+                pos = scan_pair(tokens, pos);
+                if pos < 0 { return -1; }
+                if pos < 0 { pos = sp; break; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_pair(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_STRING { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
+    pos += 1;
+    pos = scan_value(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_arr(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break try_0; }
+            pos += 1;
+            pos = scan_value(tokens, pos);
+            if pos < 0 { break try_0; }
+            while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
+                let sp = pos;
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+                pos += 1;
+                pos = scan_value(tokens, pos);
+                if pos < 0 { return -1; }
+                if pos < 0 { pos = sp; break; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_NUMBER { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_obj(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            pos = scan_arr(tokens, pos);
+            if pos < 0 { break try_3; }
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_TRUE { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_FALSE { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NULL { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
 fn parse_json(p: &mut Parser) -> Result<JsonNode, ParseError> {
     let start = p.peek().span.start;
     let value = parse_value(p)?;
@@ -1048,6 +1177,25 @@ fn parse_obj_bt_0(p: &mut Parser) -> Result<ObjNode, ParseError> {
     }));
 }
 
+fn parse_obj_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    pos = scan_pair(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+        pos += 1;
+        pos = scan_pair(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_obj_bt_1(p: &mut Parser) -> Result<ObjNode, ParseError> {
     let start = p.peek().span.start;
     let lbrace = p.expect(TK_LIT_LBRACE)?;
@@ -1057,6 +1205,15 @@ fn parse_obj_bt_1(p: &mut Parser) -> Result<ObjNode, ParseError> {
         lbrace,
         rbrace,
     }));
+}
+
+fn parse_obj_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_obj(p: &mut Parser) -> Result<ObjNode, ParseError> {
@@ -1137,6 +1294,25 @@ fn parse_arr_bt_0(p: &mut Parser) -> Result<ArrNode, ParseError> {
     }));
 }
 
+fn parse_arr_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
+    pos += 1;
+    pos = scan_value(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+        pos += 1;
+        pos = scan_value(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_arr_bt_1(p: &mut Parser) -> Result<ArrNode, ParseError> {
     let start = p.peek().span.start;
     let lbracket = p.expect(TK_LIT_LBRACKET)?;
@@ -1146,6 +1322,15 @@ fn parse_arr_bt_1(p: &mut Parser) -> Result<ArrNode, ParseError> {
         lbracket,
         rbracket,
     }));
+}
+
+fn parse_arr_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_arr(p: &mut Parser) -> Result<ArrNode, ParseError> {

--- a/package-gale/tests/golden/rust.wado
+++ b/package-gale/tests/golden/rust.wado
@@ -14540,8 +14540,14 @@ fn parse_expression_atom(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
         }));
     }
     if kind == TK_LPAREN {
+        let saved = p.pos;
         if parse_expression_scan_32(&p.tokens, p.pos) >= 0 {
-            return parse_expression_bt_32(p);
+            let r_32 = parse_expression_bt_32(p);
+            if let Err(_) = r_32 {
+                p.pos = saved;
+            } else {
+                return r_32;
+            }
         }
         return parse_expression_bt_34(p);
     }
@@ -18966,14 +18972,30 @@ fn parse_generic_args(p: &mut Parser) -> Result<GenericArgsNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_LT {
+        let saved = p.pos;
         if parse_generic_args_scan_1(&p.tokens, p.pos) >= 0 {
-            return parse_generic_args_bt_1(p);
+            let r_1 = parse_generic_args_bt_1(p);
+            if let Err(_) = r_1 {
+                p.pos = saved;
+            } else {
+                return r_1;
+            }
         }
         if parse_generic_args_scan_2(&p.tokens, p.pos) >= 0 {
-            return parse_generic_args_bt_2(p);
+            let r_2 = parse_generic_args_bt_2(p);
+            if let Err(_) = r_2 {
+                p.pos = saved;
+            } else {
+                return r_2;
+            }
         }
         if parse_generic_args_scan_3(&p.tokens, p.pos) >= 0 {
-            return parse_generic_args_bt_3(p);
+            let r_3 = parse_generic_args_bt_3(p);
+            if let Err(_) = r_3 {
+                p.pos = saved;
+            } else {
+                return r_3;
+            }
         }
         return parse_generic_args_bt_0(p);
     }

--- a/package-gale/tests/golden/rust.wado
+++ b/package-gale/tests/golden/rust.wado
@@ -8940,6 +8940,1955 @@ impl Parser {
     }
 }
 
+fn scan_macro_invocation(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_simple_path(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
+    pos += 1;
+    pos = scan_delim_token_tree(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_delim_token_tree(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { break try_0; }
+            pos += 1;
+            while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_DOLLAR | TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE } {
+                let sp = pos;
+                pos = scan_token_tree(tokens, pos);
+                if pos < 0 { pos = sp; break; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LSQUAREBRACKET { break try_1; }
+            pos += 1;
+            while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_DOLLAR | TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE } {
+                let sp = pos;
+                pos = scan_token_tree(tokens, pos);
+                if pos < 0 { pos = sp; break; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_RSQUAREBRACKET { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
+        pos += 1;
+        while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_DOLLAR | TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE } {
+            let sp = pos;
+            pos = scan_token_tree(tokens, pos);
+            if pos < 0 { pos = sp; break; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_token_tree(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_token_tree_token(tokens, pos);
+            if pos < 0 { return -1; }
+            while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_DOLLAR } {
+                let sp = pos;
+                pos = scan_token_tree_token(tokens, pos);
+                if pos < 0 { pos = sp; break; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_delim_token_tree(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_token_tree_token(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_macro_identifier_like_token(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_macro_literal_token(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_macro_punctuation_token(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            pos = scan_macro_rep_op(tokens, pos);
+            if pos < 0 { break try_3; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_DOLLAR { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_macro_invocation_semi(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_simple_path(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_NOT { break try_0; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { break try_0; }
+            pos += 1;
+            while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_DOLLAR | TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE } {
+                let sp = pos;
+                pos = scan_token_tree(tokens, pos);
+                if pos < 0 { pos = sp; break; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { break try_0; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_simple_path(tokens, pos);
+            if pos < 0 { break try_1; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_NOT { break try_1; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LSQUAREBRACKET { break try_1; }
+            pos += 1;
+            while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_DOLLAR | TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE } {
+                let sp = pos;
+                pos = scan_token_tree(tokens, pos);
+                if pos < 0 { pos = sp; break; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_RSQUAREBRACKET { break try_1; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_simple_path(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
+        pos += 1;
+        while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_DOLLAR | TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE } {
+            let sp = pos;
+            pos = scan_token_tree(tokens, pos);
+            if pos < 0 { pos = sp; break; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_macro_rules_definition(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_KW_MACRORULES { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
+    pos += 1;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    pos = scan_macro_rules_def(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_macro_rules_def(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { break try_0; }
+            pos += 1;
+            pos = scan_macro_rules(tokens, pos);
+            if pos < 0 { break try_0; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { break try_0; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LSQUAREBRACKET { break try_1; }
+            pos += 1;
+            pos = scan_macro_rules(tokens, pos);
+            if pos < 0 { break try_1; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_RSQUAREBRACKET { break try_1; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
+        pos += 1;
+        pos = scan_macro_rules(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_macro_rules(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_macro_rule(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_SEMI {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+        pos += 1;
+        pos = scan_macro_rule(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_SEMI {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_macro_rule(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_macro_matcher(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_FATARROW { return -1; }
+    pos += 1;
+    pos = scan_macro_transcriber(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_macro_matcher(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { break try_0; }
+            pos += 1;
+            while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE | TK_DOLLAR } {
+                let sp = pos;
+                pos = scan_macro_match(tokens, pos);
+                if pos < 0 { pos = sp; break; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LSQUAREBRACKET { break try_1; }
+            pos += 1;
+            while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE | TK_DOLLAR } {
+                let sp = pos;
+                pos = scan_macro_match(tokens, pos);
+                if pos < 0 { pos = sp; break; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_RSQUAREBRACKET { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
+        pos += 1;
+        while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE | TK_DOLLAR } {
+            let sp = pos;
+            pos = scan_macro_match(tokens, pos);
+            if pos < 0 { pos = sp; break; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_macro_match(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_macro_match_token(tokens, pos);
+            if pos < 0 { return -1; }
+            while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION } {
+                let sp = pos;
+                pos = scan_macro_match_token(tokens, pos);
+                if pos < 0 { pos = sp; break; }
+            }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_macro_matcher(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_DOLLAR { break try_2; }
+            pos += 1;
+            let gp_0 = pos;
+            sg_0: {
+                pos = gp_0;
+                sg_0_0: {
+                    pos = scan_identifier(tokens, pos);
+                    if pos < 0 { break sg_0_0; }
+                    break sg_0;
+                }
+                pos = gp_0;
+                if pos >= tokens.len() || tokens[pos].kind != TK_KW_SELFVALUE { return -1; }
+                pos += 1;
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break try_2; }
+            pos += 1;
+            pos = scan_macro_frag_spec(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_DOLLAR { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+        pos += 1;
+        pos = scan_macro_match(tokens, pos);
+        if pos < 0 { return -1; }
+        while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE | TK_DOLLAR } {
+            let sp = pos;
+            pos = scan_macro_match(tokens, pos);
+            if pos < 0 { pos = sp; break; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_DOLLAR } {
+            let sp = pos;
+            pos = scan_macro_rep_sep(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        pos = scan_macro_rep_op(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_macro_match_token(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_macro_identifier_like_token(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_macro_literal_token(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_macro_punctuation_token(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_macro_rep_op(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_macro_frag_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_macro_rep_sep(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_macro_identifier_like_token(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_macro_literal_token(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            pos = scan_macro_punctuation_token(tokens, pos);
+            if pos < 0 { break try_2; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_DOLLAR { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_macro_rep_op(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STAR { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_PLUS { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_QUESTION { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_macro_transcriber(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_delim_token_tree(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_macro_item(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_macro_invocation_semi(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_macro_rules_definition(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_extern_crate(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_KW_EXTERN { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_KW_CRATE { return -1; }
+    pos += 1;
+    pos = scan_crate_ref(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind == TK_KW_AS {
+        let sp = pos;
+        pos = scan_as_clause(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_crate_ref(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_SELFVALUE { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_as_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_KW_AS { return -1; }
+    pos += 1;
+    let gp_1 = pos;
+    sg_1: {
+        pos = gp_1;
+        sg_1_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break sg_1_0; }
+            break sg_1;
+        }
+        pos = gp_1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_UNDERSCORE { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_use_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_KW_USE { return -1; }
+    pos += 1;
+    pos = scan_use_tree(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos < tokens.len() && tokens[pos].kind matches { TK_PATHSEP | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_SUPER | TK_KW_SELFVALUE | TK_KW_CRATE | TK_KW_DOLLARCRATE } {
+                let sp = pos;
+                if pos < tokens.len() && tokens[pos].kind matches { TK_PATHSEP | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_SUPER | TK_KW_SELFVALUE | TK_KW_CRATE | TK_KW_DOLLARCRATE } {
+                    let sp = pos;
+                    pos = scan_simple_path(tokens, pos);
+                    if pos < 0 { pos = sp; }
+                }
+                if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { return -1; }
+                pos += 1;
+                if pos < 0 { pos = sp; }
+            }
+            let gp_2 = pos;
+            sg_2: {
+                pos = gp_2;
+                sg_2_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_STAR { break sg_2_0; }
+                    pos += 1;
+                    break sg_2;
+                }
+                pos = gp_2;
+                if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
+                pos += 1;
+                if pos < tokens.len() && tokens[pos].kind matches { TK_PATHSEP | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_SUPER | TK_KW_SELFVALUE | TK_KW_CRATE | TK_KW_DOLLARCRATE | TK_STAR | TK_LCURLYBRACE } {
+                    let sp = pos;
+                    pos = scan_use_tree(tokens, pos);
+                    if pos < 0 { return -1; }
+                    while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+                        let sp = pos;
+                        if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { return -1; }
+                        pos += 1;
+                        pos = scan_use_tree(tokens, pos);
+                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = sp; break; }
+                    }
+                    if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+                        let sp = pos;
+                        if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { pos = -1; } else { pos += 1; }
+                        if pos < 0 { pos = sp; }
+                    }
+                    if pos < 0 { pos = sp; }
+                }
+                if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { return -1; }
+                pos += 1;
+            }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_simple_path(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < tokens.len() && tokens[pos].kind == TK_KW_AS {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_AS { return -1; }
+            pos += 1;
+            let gp_3 = pos;
+            sg_3: {
+                pos = gp_3;
+                sg_3_0: {
+                    pos = scan_identifier(tokens, pos);
+                    if pos < 0 { break sg_3_0; }
+                    break sg_3;
+                }
+                pos = gp_3;
+                if pos >= tokens.len() || tokens[pos].kind != TK_UNDERSCORE { return -1; }
+                pos += 1;
+            }
+            if pos < 0 { pos = sp; }
+        }
+    }
+    return pos;
+}
+
+fn scan_function_qualifiers(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind == TK_KW_CONST {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_CONST { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_KW_ASYNC {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_ASYNC { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_KW_UNSAFE {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_UNSAFE { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_KW_EXTERN {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_EXTERN { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_STRING_LITERAL | TK_RAW_STRING_LITERAL } {
+            let sp = pos;
+            pos = scan_abi(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_abi(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_RAW_STRING_LITERAL { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_shorthand_self(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind == TK_AND {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_AND { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_LIFETIME_OR_LABEL | TK_KW_STATICLIFETIME | TK_KW_UNDERLINELIFETIME } {
+            let sp = pos;
+            pos = scan_lifetime(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_KW_MUT {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_MUT { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_KW_SELFVALUE { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_lifetime_param(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind == TK_POUND {
+        let sp = pos;
+        pos = scan_outer_attribute(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIFETIME_OR_LABEL { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_COLON {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
+        pos += 1;
+        pos = scan_lifetime_bounds(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_lifetime_where_clause_item(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_lifetime(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
+    pos += 1;
+    pos = scan_lifetime_bounds(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_inner_attribute(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_POUND { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LSQUAREBRACKET { return -1; }
+    pos += 1;
+    pos = scan_attr(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RSQUAREBRACKET { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_outer_attribute(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_POUND { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LSQUAREBRACKET { return -1; }
+    pos += 1;
+    pos = scan_attr(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RSQUAREBRACKET { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_attr(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_simple_path(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE | TK_EQ } {
+        let sp = pos;
+        pos = scan_attr_input(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_attr_input(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_delim_token_tree(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_EQ { return -1; }
+        pos += 1;
+        pos = scan_literal_expression(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_comparison_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_EQEQ { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_NE { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_GT { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LT { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_GE { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LE { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_compound_assign_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_PLUSEQ { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_MINUSEQ { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STAREQ { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_SLASHEQ { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_PERCENTEQ { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_ANDEQ { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_OREQ { break try_6; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_CARETEQ { break try_7; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_8: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_SHLEQ { break try_8; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_SHREQ { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_literal_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_CHAR_LITERAL { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_RAW_STRING_LITERAL { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_BYTE_LITERAL { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_BYTE_STRING_LITERAL { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_RAW_BYTE_STRING_LITERAL { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_INTEGER_LITERAL { break try_6; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_FLOAT_LITERAL { break try_7; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_8: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_TRUE { break try_8; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_FALSE { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_tuple_index(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_INTEGER_LITERAL { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_loop_label(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIFETIME_OR_LABEL { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_literal_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_TRUE { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_FALSE { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_CHAR_LITERAL { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_BYTE_LITERAL { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_RAW_STRING_LITERAL { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_BYTE_STRING_LITERAL { break try_6; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_RAW_BYTE_STRING_LITERAL { break try_7; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_8: {
+            if pos < tokens.len() && tokens[pos].kind == TK_MINUS {
+                let sp = pos;
+                if pos >= tokens.len() || tokens[pos].kind != TK_MINUS { pos = -1; } else { pos += 1; }
+                if pos < 0 { pos = sp; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_INTEGER_LITERAL { break try_8; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos < tokens.len() && tokens[pos].kind == TK_MINUS {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_MINUS { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_FLOAT_LITERAL { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_wildcard_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_UNDERSCORE { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_rest_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_DOTDOT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_struct_pattern_et_cetera(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && tokens[pos].kind == TK_POUND {
+        let sp = pos;
+        pos = scan_outer_attribute(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_DOTDOT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_never_type(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_function_type_qualifiers(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind == TK_KW_UNSAFE {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_UNSAFE { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_KW_EXTERN {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_EXTERN { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_STRING_LITERAL | TK_RAW_STRING_LITERAL } {
+            let sp = pos;
+            pos = scan_abi(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_inferred_type(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_UNDERSCORE { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_lifetime_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_LIFETIME_OR_LABEL | TK_KW_STATICLIFETIME | TK_KW_UNDERLINELIFETIME } {
+        let sp = pos;
+        pos = scan_lifetime(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_PLUS { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_LIFETIME_OR_LABEL | TK_KW_STATICLIFETIME | TK_KW_UNDERLINELIFETIME } {
+        let sp = pos;
+        pos = scan_lifetime(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_lifetime(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIFETIME_OR_LABEL { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_STATICLIFETIME { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_UNDERLINELIFETIME { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_simple_path(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind == TK_PATHSEP {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_simple_path_segment(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_PATHSEP {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { return -1; }
+        pos += 1;
+        pos = scan_simple_path_segment(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_simple_path_segment(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_SUPER { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_SELFVALUE { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_CRATE { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_DOLLARCRATE { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_path_ident_segment(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_SUPER { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_SELFVALUE { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_SELFTYPE { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_CRATE { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_DOLLARCRATE { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_generic_args_lifetimes(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_lifetime(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { return -1; }
+        pos += 1;
+        pos = scan_lifetime(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_visibility(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_KW_PUB { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_LPAREN {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+        pos += 1;
+        let gp_4 = pos;
+        sg_4: {
+            pos = gp_4;
+            sg_4_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_KW_CRATE { break sg_4_0; }
+                pos += 1;
+                break sg_4;
+            }
+            pos = gp_4;
+            sg_4_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_KW_SELFVALUE { break sg_4_1; }
+                pos += 1;
+                break sg_4;
+            }
+            pos = gp_4;
+            sg_4_2: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_KW_SUPER { break sg_4_2; }
+                pos += 1;
+                break sg_4;
+            }
+            pos = gp_4;
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_IN { return -1; }
+            pos += 1;
+            pos = scan_simple_path(tokens, pos);
+            if pos < 0 { return -1; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_identifier(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_NON_KEYWORD_IDENTIFIER { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_RAW_IDENTIFIER { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_MACRORULES { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_keyword(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_AS { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_BREAK { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_CONST { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_CONTINUE { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_CRATE { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_ELSE { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_ENUM { break try_6; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_EXTERN { break try_7; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_8: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_FALSE { break try_8; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_9: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_FN { break try_9; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_10: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_FOR { break try_10; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_11: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_IF { break try_11; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_12: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_IMPL { break try_12; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_13: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_IN { break try_13; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_14: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_LET { break try_14; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_15: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_LOOP { break try_15; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_16: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_MATCH { break try_16; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_17: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_MOD { break try_17; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_18: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_MOVE { break try_18; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_19: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_MUT { break try_19; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_20: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_PUB { break try_20; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_21: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_REF { break try_21; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_22: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_RETURN { break try_22; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_23: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_SELFVALUE { break try_23; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_24: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_SELFTYPE { break try_24; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_25: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_STATIC { break try_25; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_26: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_STRUCT { break try_26; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_27: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_SUPER { break try_27; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_28: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_TRAIT { break try_28; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_29: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_TRUE { break try_29; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_30: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_TYPE { break try_30; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_31: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_UNSAFE { break try_31; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_32: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_USE { break try_32; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_33: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_WHERE { break try_33; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_34: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_WHILE { break try_34; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_35: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_ASYNC { break try_35; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_36: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_AWAIT { break try_36; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_37: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_DYN { break try_37; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_38: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_ABSTRACT { break try_38; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_39: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_BECOME { break try_39; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_40: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_BOX { break try_40; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_41: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_DO { break try_41; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_42: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_FINAL { break try_42; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_43: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_MACRO { break try_43; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_44: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_OVERRIDE { break try_44; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_45: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_PRIV { break try_45; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_46: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_TYPEOF { break try_46; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_47: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_UNSIZED { break try_47; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_48: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_VIRTUAL { break try_48; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_49: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_YIELD { break try_49; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_50: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_TRY { break try_50; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_51: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_UNION { break try_51; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_STATICLIFETIME { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_macro_identifier_like_token(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_keyword(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_MACRORULES { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_UNDERLINELIFETIME { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KW_DOLLARCRATE { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIFETIME_OR_LABEL { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_macro_literal_token(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_literal_expression(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_macro_punctuation_token(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_MINUS { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_SLASH { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_PERCENT { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_CARET { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_NOT { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_AND { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_OR { break try_6; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_ANDAND { break try_7; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_8: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_OROR { break try_8; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_9: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_PLUSEQ { break try_9; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_10: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_MINUSEQ { break try_10; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_11: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STAREQ { break try_11; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_12: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_SLASHEQ { break try_12; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_13: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_PERCENTEQ { break try_13; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_14: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_CARETEQ { break try_14; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_15: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_ANDEQ { break try_15; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_16: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_OREQ { break try_16; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_17: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_SHLEQ { break try_17; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_18: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_SHREQ { break try_18; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_19: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_EQ { break try_19; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_20: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_EQEQ { break try_20; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_21: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_NE { break try_21; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_22: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_GT { break try_22; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_23: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LT { break try_23; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_24: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_GE { break try_24; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_25: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LE { break try_25; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_26: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_AT { break try_26; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_27: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_UNDERSCORE { break try_27; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_28: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_DOT { break try_28; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_29: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_DOTDOT { break try_29; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_30: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_DOTDOTDOT { break try_30; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_31: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_DOTDOTEQ { break try_31; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_32: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break try_32; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_33: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { break try_33; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_34: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break try_34; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_35: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break try_35; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_36: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_RARROW { break try_36; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_37: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_FATARROW { break try_37; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_POUND { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_shl(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_shr(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_GT { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_GT { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_crate(p: &mut Parser) -> Result<CrateNode, ParseError> {
     let start = p.peek().span.start;
     let mut inner_attribute_list: Array<InnerAttributeNode> = [];
@@ -9068,6 +11017,13 @@ fn parse_token_tree_token_bt_1(p: &mut Parser) -> Result<TokenTreeTokenNode, Par
     }));
 }
 
+fn parse_token_tree_token_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_macro_literal_token(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_token_tree_token_bt_0(p: &mut Parser) -> Result<TokenTreeTokenNode, ParseError> {
     let start = p.peek().span.start;
     let macro_identifier_like_token = parse_macro_identifier_like_token(p)?;
@@ -9077,6 +11033,13 @@ fn parse_token_tree_token_bt_0(p: &mut Parser) -> Result<TokenTreeTokenNode, Par
     }));
 }
 
+fn parse_token_tree_token_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_macro_identifier_like_token(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_token_tree_token(p: &mut Parser) -> Result<TokenTreeTokenNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
@@ -9084,12 +11047,8 @@ fn parse_token_tree_token(p: &mut Parser) -> Result<TokenTreeTokenNode, ParseErr
         if p.peek_kind() matches { TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL } {
             return parse_token_tree_token_bt_1(p);
         } else if p.peek_kind() matches { TK_KW_TRUE | TK_KW_FALSE } {
-            let saved = p.pos;
-            let r_0 = parse_token_tree_token_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_token_tree_token_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_token_tree_token_bt_0(p);
             }
             return parse_token_tree_token_bt_1(p);
         } else if p.peek_kind() matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL } {
@@ -9147,6 +11106,26 @@ fn parse_macro_invocation_semi_bt_0(p: &mut Parser) -> Result<MacroInvocationSem
     }));
 }
 
+fn parse_macro_invocation_semi_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_simple_path(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_DOLLAR | TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE } {
+        let sp = pos;
+        pos = scan_token_tree(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_macro_invocation_semi_bt_1(p: &mut Parser) -> Result<MacroInvocationSemiNode, ParseError> {
     let start = p.peek().span.start;
     let simple_path = parse_simple_path(p)?;
@@ -9170,6 +11149,26 @@ fn parse_macro_invocation_semi_bt_1(p: &mut Parser) -> Result<MacroInvocationSem
     }));
 }
 
+fn parse_macro_invocation_semi_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_simple_path(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LSQUAREBRACKET { return -1; }
+    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_DOLLAR | TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE } {
+        let sp = pos;
+        pos = scan_token_tree(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RSQUAREBRACKET { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_macro_invocation_semi_bt_2(p: &mut Parser) -> Result<MacroInvocationSemiNode, ParseError> {
     let start = p.peek().span.start;
     let simple_path = parse_simple_path(p)?;
@@ -9189,6 +11188,24 @@ fn parse_macro_invocation_semi_bt_2(p: &mut Parser) -> Result<MacroInvocationSem
         token_tree_list,
         rcurlybrace,
     }));
+}
+
+fn parse_macro_invocation_semi_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_simple_path(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
+    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_DOLLAR | TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE } {
+        let sp = pos;
+        pos = scan_token_tree(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_macro_invocation_semi(p: &mut Parser) -> Result<MacroInvocationSemiNode, ParseError> {
@@ -9455,6 +11472,31 @@ fn parse_macro_match_bt_3(p: &mut Parser) -> Result<MacroMatchNode, ParseError> 
     }));
 }
 
+fn parse_macro_match_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_DOLLAR { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+    pos += 1;
+    pos = scan_macro_match(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_STAR | TK_PLUS | TK_QUESTION | TK_LPAREN | TK_LSQUAREBRACKET | TK_LCURLYBRACE | TK_DOLLAR } {
+        let sp = pos;
+        pos = scan_macro_match(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FALSE | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TRUE | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_MINUS | TK_SLASH | TK_PERCENT | TK_CARET | TK_NOT | TK_AND | TK_OR | TK_ANDAND | TK_OROR | TK_PLUSEQ | TK_MINUSEQ | TK_STAREQ | TK_SLASHEQ | TK_PERCENTEQ | TK_CARETEQ | TK_ANDEQ | TK_OREQ | TK_SHLEQ | TK_SHREQ | TK_EQ | TK_EQEQ | TK_NE | TK_GT | TK_LT | TK_GE | TK_LE | TK_AT | TK_UNDERSCORE | TK_DOT | TK_DOTDOT | TK_DOTDOTDOT | TK_DOTDOTEQ | TK_COMMA | TK_SEMI | TK_COLON | TK_PATHSEP | TK_RARROW | TK_FATARROW | TK_POUND | TK_DOLLAR } {
+        let sp = pos;
+        pos = scan_macro_rep_sep(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_macro_rep_op(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_macro_match_bt_2(p: &mut Parser) -> Result<MacroMatchNode, ParseError> {
     let start = p.peek().span.start;
     let dollar = p.expect(TK_DOLLAR)?;
@@ -9481,6 +11523,29 @@ fn parse_macro_match_bt_2(p: &mut Parser) -> Result<MacroMatchNode, ParseError> 
         colon,
         macro_frag_spec,
     }));
+}
+
+fn parse_macro_match_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_DOLLAR { return -1; }
+    pos += 1;
+    let gp_5 = pos;
+    sg_5: {
+        pos = gp_5;
+        sg_5_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break sg_5_0; }
+            break sg_5;
+        }
+        pos = gp_5;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_SELFVALUE { return -1; }
+        pos += 1;
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
+    pos += 1;
+    pos = scan_macro_frag_spec(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_macro_match(p: &mut Parser) -> Result<MacroMatchNode, ParseError> {
@@ -9529,6 +11594,13 @@ fn parse_macro_match_token_bt_1(p: &mut Parser) -> Result<MacroMatchTokenNode, P
     }));
 }
 
+fn parse_macro_match_token_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_macro_literal_token(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_macro_match_token_bt_0(p: &mut Parser) -> Result<MacroMatchTokenNode, ParseError> {
     let start = p.peek().span.start;
     let macro_identifier_like_token = parse_macro_identifier_like_token(p)?;
@@ -9538,6 +11610,13 @@ fn parse_macro_match_token_bt_0(p: &mut Parser) -> Result<MacroMatchTokenNode, P
     }));
 }
 
+fn parse_macro_match_token_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_macro_identifier_like_token(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_macro_match_token(p: &mut Parser) -> Result<MacroMatchTokenNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
@@ -9545,12 +11624,8 @@ fn parse_macro_match_token(p: &mut Parser) -> Result<MacroMatchTokenNode, ParseE
         if p.peek_kind() matches { TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL } {
             return parse_macro_match_token_bt_1(p);
         } else if p.peek_kind() matches { TK_KW_TRUE | TK_KW_FALSE } {
-            let saved = p.pos;
-            let r_0 = parse_macro_match_token_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_macro_match_token_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_macro_match_token_bt_0(p);
             }
             return parse_macro_match_token_bt_1(p);
         } else if p.peek_kind() matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL } {
@@ -9596,6 +11671,13 @@ fn parse_macro_rep_sep_bt_1(p: &mut Parser) -> Result<MacroRepSepNode, ParseErro
     }));
 }
 
+fn parse_macro_rep_sep_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_macro_literal_token(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_macro_rep_sep_bt_0(p: &mut Parser) -> Result<MacroRepSepNode, ParseError> {
     let start = p.peek().span.start;
     let macro_identifier_like_token = parse_macro_identifier_like_token(p)?;
@@ -9605,6 +11687,13 @@ fn parse_macro_rep_sep_bt_0(p: &mut Parser) -> Result<MacroRepSepNode, ParseErro
     }));
 }
 
+fn parse_macro_rep_sep_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_macro_identifier_like_token(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_macro_rep_sep(p: &mut Parser) -> Result<MacroRepSepNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
@@ -9612,12 +11701,8 @@ fn parse_macro_rep_sep(p: &mut Parser) -> Result<MacroRepSepNode, ParseError> {
         if p.peek_kind() matches { TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL } {
             return parse_macro_rep_sep_bt_1(p);
         } else if p.peek_kind() matches { TK_KW_TRUE | TK_KW_FALSE } {
-            let saved = p.pos;
-            let r_0 = parse_macro_rep_sep_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_macro_rep_sep_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_macro_rep_sep_bt_0(p);
             }
             return parse_macro_rep_sep_bt_1(p);
         } else if p.peek_kind() matches { TK_KW_AS | TK_KW_BREAK | TK_KW_CONST | TK_KW_CONTINUE | TK_KW_CRATE | TK_KW_ELSE | TK_KW_ENUM | TK_KW_EXTERN | TK_KW_FN | TK_KW_FOR | TK_KW_IF | TK_KW_IMPL | TK_KW_IN | TK_KW_LET | TK_KW_LOOP | TK_KW_MATCH | TK_KW_MOD | TK_KW_MOVE | TK_KW_MUT | TK_KW_PUB | TK_KW_REF | TK_KW_RETURN | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_STATIC | TK_KW_STRUCT | TK_KW_SUPER | TK_KW_TRAIT | TK_KW_TYPE | TK_KW_UNSAFE | TK_KW_USE | TK_KW_WHERE | TK_KW_WHILE | TK_KW_ASYNC | TK_KW_AWAIT | TK_KW_DYN | TK_KW_ABSTRACT | TK_KW_BECOME | TK_KW_BOX | TK_KW_DO | TK_KW_FINAL | TK_KW_MACRO | TK_KW_OVERRIDE | TK_KW_PRIV | TK_KW_TYPEOF | TK_KW_UNSIZED | TK_KW_VIRTUAL | TK_KW_YIELD | TK_KW_TRY | TK_KW_UNION | TK_KW_STATICLIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_UNDERLINELIFETIME | TK_KW_DOLLARCRATE | TK_LIFETIME_OR_LABEL } {
@@ -9810,6 +11895,13 @@ fn parse_macro_item_bt_1(p: &mut Parser) -> Result<MacroItemNode, ParseError> {
     }));
 }
 
+fn parse_macro_item_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_macro_rules_definition(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_macro_item_bt_0(p: &mut Parser) -> Result<MacroItemNode, ParseError> {
     let start = p.peek().span.start;
     let macro_invocation_semi = parse_macro_invocation_semi(p)?;
@@ -9819,17 +11911,20 @@ fn parse_macro_item_bt_0(p: &mut Parser) -> Result<MacroItemNode, ParseError> {
     }));
 }
 
+fn parse_macro_item_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_macro_invocation_semi(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_macro_item(p: &mut Parser) -> Result<MacroItemNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_KW_MACRORULES | TK_PATHSEP | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_SUPER | TK_KW_SELFVALUE | TK_KW_CRATE | TK_KW_DOLLARCRATE } {
         if p.peek_kind() == TK_KW_MACRORULES {
-            let saved = p.pos;
-            let r_0 = parse_macro_item_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_macro_item_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_macro_item_bt_0(p);
             }
             return parse_macro_item_bt_1(p);
         } else if p.peek_kind() matches { TK_PATHSEP | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_SUPER | TK_KW_SELFVALUE | TK_KW_CRATE | TK_KW_DOLLARCRATE } {
@@ -10007,6 +12102,31 @@ fn parse_use_tree_bt_1(p: &mut Parser) -> Result<UseTreeNode, ParseError> {
     }));
 }
 
+fn parse_use_tree_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_simple_path(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind == TK_KW_AS {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_KW_AS { return -1; }
+        pos += 1;
+        let gp_6 = pos;
+        sg_6: {
+            pos = gp_6;
+            sg_6_0: {
+                pos = scan_identifier(tokens, pos);
+                if pos < 0 { break sg_6_0; }
+                break sg_6;
+            }
+            pos = gp_6;
+            if pos >= tokens.len() || tokens[pos].kind != TK_UNDERSCORE { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
 fn parse_use_tree_bt_0(p: &mut Parser) -> Result<UseTreeNode, ParseError> {
     let start = p.peek().span.start;
     let simple_path_pathsep: Option<SimplePathOptPathsepItem> = if (p.peek_kind() == TK_PATHSEP || p.peek_kind() == TK_NON_KEYWORD_IDENTIFIER || p.peek_kind() == TK_RAW_IDENTIFIER || p.peek_kind() == TK_KW_MACRORULES || p.peek_kind() == TK_KW_SUPER || p.peek_kind() == TK_KW_SELFVALUE || p.peek_kind() == TK_KW_CRATE || p.peek_kind() == TK_KW_DOLLARCRATE) && p.peek_at(1) == TK_PATHSEP {
@@ -10126,6 +12246,55 @@ fn parse_use_tree_bt_0(p: &mut Parser) -> Result<UseTreeNode, ParseError> {
         simple_path_pathsep,
         group_0,
     }));
+}
+
+fn parse_use_tree_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_PATHSEP | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_SUPER | TK_KW_SELFVALUE | TK_KW_CRATE | TK_KW_DOLLARCRATE } {
+        let sp = pos;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_PATHSEP | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_SUPER | TK_KW_SELFVALUE | TK_KW_CRATE | TK_KW_DOLLARCRATE } {
+            let sp = pos;
+            pos = scan_simple_path(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    let gp_7 = pos;
+    sg_7: {
+        pos = gp_7;
+        sg_7_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STAR { break sg_7_0; }
+            pos += 1;
+            break sg_7;
+        }
+        pos = gp_7;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_PATHSEP | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_SUPER | TK_KW_SELFVALUE | TK_KW_CRATE | TK_KW_DOLLARCRATE | TK_STAR | TK_LCURLYBRACE } {
+            let sp = pos;
+            pos = scan_use_tree(tokens, pos);
+            if pos < 0 { return -1; }
+            while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+                let sp = pos;
+                if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { return -1; }
+                pos += 1;
+                pos = scan_use_tree(tokens, pos);
+                if pos < 0 { return -1; }
+                if pos < 0 { pos = sp; break; }
+            }
+            if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+                let sp = pos;
+                if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { pos = -1; } else { pos += 1; }
+                if pos < 0 { pos = sp; }
+            }
+            if pos < 0 { pos = sp; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { return -1; }
+        pos += 1;
+    }
+    return pos;
 }
 
 fn parse_use_tree(p: &mut Parser) -> Result<UseTreeNode, ParseError> {
@@ -11632,6 +13801,13 @@ fn parse_where_clause_item_bt_0(p: &mut Parser) -> Result<WhereClauseItemNode, P
     }));
 }
 
+fn parse_where_clause_item_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_lifetime_where_clause_item(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_where_clause_item_bt_1(p: &mut Parser) -> Result<WhereClauseItemNode, ParseError> {
     let start = p.peek().span.start;
     let type_bound_where_clause_item = parse_type_bound_where_clause_item(p)?;
@@ -11646,12 +13822,8 @@ fn parse_where_clause_item(p: &mut Parser) -> Result<WhereClauseItemNode, ParseE
     let kind = p.peek_kind();
     if kind matches { TK_LIFETIME_OR_LABEL | TK_KW_STATICLIFETIME | TK_KW_UNDERLINELIFETIME | TK_KW_FOR | TK_LPAREN | TK_KW_IMPL | TK_KW_DYN | TK_QUESTION | TK_PATHSEP | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_SUPER | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_CRATE | TK_KW_DOLLARCRATE | TK_NOT | TK_STAR | TK_AND | TK_LSQUAREBRACKET | TK_UNDERSCORE | TK_LT | TK_KW_UNSAFE | TK_KW_EXTERN } {
         if p.peek_kind() matches { TK_LIFETIME_OR_LABEL | TK_KW_STATICLIFETIME | TK_KW_UNDERLINELIFETIME } {
-            let saved = p.pos;
-            let r_0 = parse_where_clause_item_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_where_clause_item_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_where_clause_item_bt_0(p);
             }
             return parse_where_clause_item_bt_1(p);
         } else if p.peek_kind() matches { TK_KW_FOR | TK_LPAREN | TK_KW_IMPL | TK_KW_DYN | TK_QUESTION | TK_PATHSEP | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_SUPER | TK_KW_SELFVALUE | TK_KW_SELFTYPE | TK_KW_CRATE | TK_KW_DOLLARCRATE | TK_NOT | TK_STAR | TK_AND | TK_LSQUAREBRACKET | TK_UNDERSCORE | TK_LT | TK_KW_UNSAFE | TK_KW_EXTERN } {
@@ -11857,6 +14029,13 @@ fn parse_statement_bt_4(p: &mut Parser) -> Result<StatementNode, ParseError> {
     }));
 }
 
+fn parse_statement_scan_4(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_macro_invocation_semi(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_statement_bt_1(p: &mut Parser) -> Result<StatementNode, ParseError> {
     let start = p.peek().span.start;
     let item = parse_item(p)?;
@@ -12060,6 +14239,18 @@ fn parse_expression_bt_0(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
     }));
 }
 
+fn parse_expression_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_outer_attribute(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_POUND {
+        let sp = pos;
+        pos = scan_outer_attribute(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
 fn parse_expression_bt_39(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let macro_invocation = parse_macro_invocation(p)?;
@@ -12067,6 +14258,13 @@ fn parse_expression_bt_39(p: &mut Parser) -> Result<ExpressionNode, ParseError> 
         span: Span::new(start, p.last_end()),
         macro_invocation,
     }));
+}
+
+fn parse_expression_scan_39(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_macro_invocation(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_expression_bt_36(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
@@ -12115,6 +14313,18 @@ fn parse_expression_bt_32(p: &mut Parser) -> Result<ExpressionNode, ParseError> 
     }));
 }
 
+fn parse_expression_scan_32(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind == TK_POUND {
+        let sp = pos;
+        pos = scan_inner_attribute(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
 fn parse_expression_bt_34(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let lparen = p.expect(TK_LPAREN)?;
@@ -12137,6 +14347,18 @@ fn parse_expression_bt_34(p: &mut Parser) -> Result<ExpressionNode, ParseError> 
         tuple_elements,
         rparen,
     }));
+}
+
+fn parse_expression_scan_34(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind == TK_POUND {
+        let sp = pos;
+        pos = scan_inner_attribute(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
 }
 
 fn parse_expression_atom(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
@@ -12318,12 +14540,8 @@ fn parse_expression_atom(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
         }));
     }
     if kind == TK_LPAREN {
-        let saved = p.pos;
-        let r_32 = parse_expression_bt_32(p);
-        if let Err(_) = r_32 {
-            p.pos = saved;
-        } else {
-            return r_32;
+        if parse_expression_scan_32(&p.tokens, p.pos) >= 0 {
+            return parse_expression_bt_32(p);
         }
         return parse_expression_bt_34(p);
     }
@@ -13840,6 +16058,13 @@ fn parse_enum_expr_field_bt_0(p: &mut Parser) -> Result<EnumExprFieldNode, Parse
     }));
 }
 
+fn parse_enum_expr_field_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_enum_expr_field_bt_1(p: &mut Parser) -> Result<EnumExprFieldNode, ParseError> {
     let start = p.peek().span.start;
     let mut identifier_or_tuple_index_inner: Option<IdentifierOrTupleIndexGroup> = null;
@@ -13860,6 +16085,25 @@ fn parse_enum_expr_field_bt_1(p: &mut Parser) -> Result<EnumExprFieldNode, Parse
         colon,
         expression,
     }));
+}
+
+fn parse_enum_expr_field_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let gp_8 = pos;
+    sg_8: {
+        pos = gp_8;
+        sg_8_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break sg_8_0; }
+            break sg_8;
+        }
+        pos = gp_8;
+        pos = scan_tuple_index(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_enum_expr_field(p: &mut Parser) -> Result<EnumExprFieldNode, ParseError> {
@@ -14562,6 +16806,13 @@ fn parse_pattern_without_range_bt_11(p: &mut Parser) -> Result<PatternWithoutRan
     }));
 }
 
+fn parse_pattern_without_range_scan_11(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_macro_invocation(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_pattern_without_range_bt_6(p: &mut Parser) -> Result<PatternWithoutRangeNode, ParseError> {
     let start = p.peek().span.start;
     let tuple_struct_pattern = parse_tuple_struct_pattern(p)?;
@@ -14750,6 +17001,18 @@ fn parse_literal_pattern_bt_8(p: &mut Parser) -> Result<LiteralPatternNode, Pars
     }));
 }
 
+fn parse_literal_pattern_scan_8(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind == TK_MINUS {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_MINUS { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_INTEGER_LITERAL { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_literal_pattern_bt_9(p: &mut Parser) -> Result<LiteralPatternNode, ParseError> {
     let start = p.peek().span.start;
     let minus: Option<Token> = if p.peek_kind() == TK_MINUS {
@@ -14764,6 +17027,18 @@ fn parse_literal_pattern_bt_9(p: &mut Parser) -> Result<LiteralPatternNode, Pars
         minus,
         float_literal,
     }));
+}
+
+fn parse_literal_pattern_scan_9(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind == TK_MINUS {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_MINUS { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_FLOAT_LITERAL { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_literal_pattern(p: &mut Parser) -> Result<LiteralPatternNode, ParseError> {
@@ -14979,6 +17254,18 @@ fn parse_range_pattern_bound_bt_2(p: &mut Parser) -> Result<RangePatternBoundNod
     }));
 }
 
+fn parse_range_pattern_bound_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind == TK_MINUS {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_MINUS { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_INTEGER_LITERAL { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_range_pattern_bound_bt_3(p: &mut Parser) -> Result<RangePatternBoundNode, ParseError> {
     let start = p.peek().span.start;
     let minus: Option<Token> = if p.peek_kind() == TK_MINUS {
@@ -14993,6 +17280,18 @@ fn parse_range_pattern_bound_bt_3(p: &mut Parser) -> Result<RangePatternBoundNod
         minus,
         float_literal,
     }));
+}
+
+fn parse_range_pattern_bound_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind == TK_MINUS {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_MINUS { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_FLOAT_LITERAL { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_range_pattern_bound(p: &mut Parser) -> Result<RangePatternBoundNode, ParseError> {
@@ -15086,6 +17385,13 @@ fn parse_struct_pattern_elements_bt_1(p: &mut Parser) -> Result<StructPatternEle
     }));
 }
 
+fn parse_struct_pattern_elements_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_struct_pattern_et_cetera(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_struct_pattern_elements_bt_0(p: &mut Parser) -> Result<StructPatternElementsNode, ParseError> {
     let start = p.peek().span.start;
     let struct_pattern_fields = parse_struct_pattern_fields(p)?;
@@ -15117,12 +17423,8 @@ fn parse_struct_pattern_elements(p: &mut Parser) -> Result<StructPatternElements
     let kind = p.peek_kind();
     if kind matches { TK_POUND | TK_DOTDOT | TK_INTEGER_LITERAL | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_KW_REF | TK_KW_MUT } {
         if p.peek_kind() == TK_POUND {
-            let saved = p.pos;
-            let r_1 = parse_struct_pattern_elements_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_struct_pattern_elements_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_struct_pattern_elements_bt_1(p);
             }
             return parse_struct_pattern_elements_bt_0(p);
         } else if p.peek_kind() == TK_DOTDOT {
@@ -15314,6 +17616,13 @@ fn parse_tuple_pattern_items_bt_1(p: &mut Parser) -> Result<TuplePatternItemsNod
         span: Span::new(start, p.last_end()),
         rest_pattern,
     }));
+}
+
+fn parse_tuple_pattern_items_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_rest_pattern(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_tuple_pattern_items_bt_2(p: &mut Parser) -> Result<TuplePatternItemsNode, ParseError> {
@@ -15571,6 +17880,13 @@ fn parse_type_no_bounds_bt_13(p: &mut Parser) -> Result<TypeNoBoundsNode, ParseE
         span: Span::new(start, p.last_end()),
         macro_invocation,
     }));
+}
+
+fn parse_type_no_bounds_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_macro_invocation(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_type_no_bounds_bt_3(p: &mut Parser) -> Result<TypeNoBoundsNode, ParseError> {
@@ -16540,6 +18856,15 @@ fn parse_generic_args_bt_1(p: &mut Parser) -> Result<GenericArgsNode, ParseError
     }));
 }
 
+fn parse_generic_args_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
+    pos += 1;
+    pos = scan_generic_args_lifetimes(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_generic_args_bt_2(p: &mut Parser) -> Result<GenericArgsNode, ParseError> {
     let start = p.peek().span.start;
     let lt = p.expect(TK_LT)?;
@@ -16570,6 +18895,13 @@ fn parse_generic_args_bt_2(p: &mut Parser) -> Result<GenericArgsNode, ParseError
         comma,
         gt,
     }));
+}
+
+fn parse_generic_args_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_generic_args_bt_3(p: &mut Parser) -> Result<GenericArgsNode, ParseError> {
@@ -16603,6 +18935,13 @@ fn parse_generic_args_bt_3(p: &mut Parser) -> Result<GenericArgsNode, ParseError
     }));
 }
 
+fn parse_generic_args_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_generic_args_bt_0(p: &mut Parser) -> Result<GenericArgsNode, ParseError> {
     let start = p.peek().span.start;
     let lt = p.expect(TK_LT)?;
@@ -16614,28 +18953,27 @@ fn parse_generic_args_bt_0(p: &mut Parser) -> Result<GenericArgsNode, ParseError
     }));
 }
 
+fn parse_generic_args_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_GT { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_generic_args(p: &mut Parser) -> Result<GenericArgsNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_LT {
-        let saved = p.pos;
-        let r_1 = parse_generic_args_bt_1(p);
-        if let Err(_) = r_1 {
-            p.pos = saved;
-        } else {
-            return r_1;
+        if parse_generic_args_scan_1(&p.tokens, p.pos) >= 0 {
+            return parse_generic_args_bt_1(p);
         }
-        let r_2 = parse_generic_args_bt_2(p);
-        if let Err(_) = r_2 {
-            p.pos = saved;
-        } else {
-            return r_2;
+        if parse_generic_args_scan_2(&p.tokens, p.pos) >= 0 {
+            return parse_generic_args_bt_2(p);
         }
-        let r_3 = parse_generic_args_bt_3(p);
-        if let Err(_) = r_3 {
-            p.pos = saved;
-        } else {
-            return r_3;
+        if parse_generic_args_scan_3(&p.tokens, p.pos) >= 0 {
+            return parse_generic_args_bt_3(p);
         }
         return parse_generic_args_bt_0(p);
     }
@@ -16653,6 +18991,13 @@ fn parse_generic_arg_bt_0(p: &mut Parser) -> Result<GenericArgNode, ParseError> 
         span: Span::new(start, p.last_end()),
         lifetime,
     }));
+}
+
+fn parse_generic_arg_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_lifetime(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_generic_arg_bt_3(p: &mut Parser) -> Result<GenericArgNode, ParseError> {
@@ -16687,12 +19032,8 @@ fn parse_generic_arg(p: &mut Parser) -> Result<GenericArgNode, ParseError> {
     let kind = p.peek_kind();
     if kind matches { TK_LIFETIME_OR_LABEL | TK_KW_STATICLIFETIME | TK_KW_UNDERLINELIFETIME | TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES | TK_LCURLYBRACE | TK_MINUS | TK_CHAR_LITERAL | TK_STRING_LITERAL | TK_RAW_STRING_LITERAL | TK_BYTE_LITERAL | TK_BYTE_STRING_LITERAL | TK_RAW_BYTE_STRING_LITERAL | TK_INTEGER_LITERAL | TK_FLOAT_LITERAL | TK_KW_TRUE | TK_KW_FALSE | TK_KW_SUPER | TK_KW_SELFVALUE | TK_KW_CRATE | TK_KW_DOLLARCRATE | TK_LPAREN | TK_KW_IMPL | TK_KW_DYN | TK_QUESTION | TK_KW_FOR | TK_PATHSEP | TK_KW_SELFTYPE | TK_NOT | TK_STAR | TK_AND | TK_LSQUAREBRACKET | TK_UNDERSCORE | TK_LT | TK_KW_UNSAFE | TK_KW_EXTERN } {
         if p.peek_kind() matches { TK_LIFETIME_OR_LABEL | TK_KW_STATICLIFETIME | TK_KW_UNDERLINELIFETIME } {
-            let saved = p.pos;
-            let r_0 = parse_generic_arg_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_generic_arg_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_generic_arg_bt_0(p);
             }
             return parse_generic_arg_bt_1(p);
         } else if p.peek_kind() matches { TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES } {
@@ -17499,6 +19840,13 @@ fn parse_macro_identifier_like_token_bt_1(p: &mut Parser) -> Result<MacroIdentif
     }));
 }
 
+fn parse_macro_identifier_like_token_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_macro_identifier_like_token_bt_2(p: &mut Parser) -> Result<MacroIdentifierLikeTokenNode, ParseError> {
     let start = p.peek().span.start;
     let kw_macrorules = p.expect(TK_KW_MACRORULES)?;
@@ -17506,6 +19854,13 @@ fn parse_macro_identifier_like_token_bt_2(p: &mut Parser) -> Result<MacroIdentif
         span: Span::new(start, p.last_end()),
         kw_macrorules,
     }));
+}
+
+fn parse_macro_identifier_like_token_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_KW_MACRORULES { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_macro_identifier_like_token(p: &mut Parser) -> Result<MacroIdentifierLikeTokenNode, ParseError> {
@@ -17520,12 +19875,8 @@ fn parse_macro_identifier_like_token(p: &mut Parser) -> Result<MacroIdentifierLi
     }
     if kind matches { TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER | TK_KW_MACRORULES } {
         if p.peek_kind() == TK_KW_MACRORULES {
-            let saved = p.pos;
-            let r_1 = parse_macro_identifier_like_token_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_macro_identifier_like_token_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_macro_identifier_like_token_bt_1(p);
             }
             return parse_macro_identifier_like_token_bt_2(p);
         } else if p.peek_kind() matches { TK_NON_KEYWORD_IDENTIFIER | TK_RAW_IDENTIFIER } {

--- a/package-gale/tests/golden/sexpression.wado
+++ b/package-gale/tests/golden/sexpression.wado
@@ -1079,6 +1079,92 @@ impl Parser {
     }
 }
 
+fn scan_sexpr(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_STRING | TK_SYMBOL | TK_NUMBER | TK_DOT | TK_LPAREN } {
+        let sp = pos;
+        pos = scan_item(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_item(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_atom(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_list_(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+        pos += 1;
+        pos = scan_item(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_DOT { return -1; }
+        pos += 1;
+        pos = scan_item(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_list_(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_STRING | TK_SYMBOL | TK_NUMBER | TK_DOT | TK_LPAREN } {
+        let sp = pos;
+        pos = scan_item(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_SYMBOL { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_NUMBER { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_DOT { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
 fn parse_sexpr(p: &mut Parser) -> Result<SexprNode, ParseError> {
     let start = p.peek().span.start;
     let mut item_list: Array<ItemNode> = [];
@@ -1111,6 +1197,21 @@ fn parse_item_bt_2(p: &mut Parser) -> Result<ItemNode, ParseError> {
     }));
 }
 
+fn parse_item_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
+    pos += 1;
+    pos = scan_item(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_DOT { return -1; }
+    pos += 1;
+    pos = scan_item(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_item_bt_1(p: &mut Parser) -> Result<ItemNode, ParseError> {
     let start = p.peek().span.start;
     let list_ = parse_list_(p)?;
@@ -1118,6 +1219,13 @@ fn parse_item_bt_1(p: &mut Parser) -> Result<ItemNode, ParseError> {
         span: Span::new(start, p.last_end()),
         list_,
     }));
+}
+
+fn parse_item_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_list_(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_item(p: &mut Parser) -> Result<ItemNode, ParseError> {
@@ -1132,12 +1240,8 @@ fn parse_item(p: &mut Parser) -> Result<ItemNode, ParseError> {
     }
     if kind == TK_LPAREN {
         if p.peek_kind() == TK_LPAREN {
-            let saved = p.pos;
-            let r_2 = parse_item_bt_2(p);
-            if let Err(_) = r_2 {
-                p.pos = saved;
-            } else {
-                return r_2;
+            if parse_item_scan_2(&p.tokens, p.pos) >= 0 {
+                return parse_item_bt_2(p);
             }
             return parse_item_bt_1(p);
         }

--- a/package-gale/tests/golden/sqlite.wado
+++ b/package-gale/tests/golden/sqlite.wado
@@ -10147,57 +10147,123 @@ fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let kind = p.peek_kind();
     if kind matches { TK_K_CAST | TK_K_CASE | TK_K_NOT | TK_K_EXISTS | TK_LIT_LPAREN | TK_K_RAISE | TK_NUMERIC_LITERAL | TK_STRING_LITERAL | TK_BLOB_LITERAL | TK_K_NULL | TK_K_CURRENT_TIME | TK_K_CURRENT_DATE | TK_K_CURRENT_TIMESTAMP | TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOTNULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_LIT_MINUS | TK_LIT_PLUS | TK_LIT_TILDE } {
         if p.peek_kind() == TK_LIT_LPAREN {
+            let saved = p.pos;
             if parse_expr_scan_21(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_21(p);
+                let r_21 = parse_expr_bt_21(p);
+                if let Err(_) = r_21 {
+                    p.pos = saved;
+                } else {
+                    return r_21;
+                }
             }
             if parse_expr_scan_14(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_14(p);
+                let r_14 = parse_expr_bt_14(p);
+                if let Err(_) = r_14 {
+                    p.pos = saved;
+                } else {
+                    return r_14;
+                }
             }
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_CAST {
+            let saved = p.pos;
             if parse_expr_scan_15(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_15(p);
+                let r_15 = parse_expr_bt_15(p);
+                if let Err(_) = r_15 {
+                    p.pos = saved;
+                } else {
+                    return r_15;
+                }
             }
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_CASE {
+            let saved = p.pos;
             if parse_expr_scan_22(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_22(p);
+                let r_22 = parse_expr_bt_22(p);
+                if let Err(_) = r_22 {
+                    p.pos = saved;
+                } else {
+                    return r_22;
+                }
             }
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_RAISE {
+            let saved = p.pos;
             if parse_expr_scan_23(&p.tokens, p.pos) >= 0 {
                 return parse_expr_bt_23(p);
             }
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_NOT {
+            let saved = p.pos;
             if parse_expr_scan_21(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_21(p);
+                let r_21 = parse_expr_bt_21(p);
+                if let Err(_) = r_21 {
+                    p.pos = saved;
+                } else {
+                    return r_21;
+                }
             }
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             if parse_expr_scan_2(&p.tokens, p.pos) >= 0 {
                 return parse_expr_bt_2(p);
             }
             return parse_expr_bt_3(p);
         } else if p.peek_kind() == TK_K_EXISTS {
+            let saved = p.pos;
             if parse_expr_scan_21(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_21(p);
+                let r_21 = parse_expr_bt_21(p);
+                if let Err(_) = r_21 {
+                    p.pos = saved;
+                } else {
+                    return r_21;
+                }
             }
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() matches { TK_LIT_MINUS | TK_LIT_PLUS | TK_LIT_TILDE } {
@@ -10205,16 +10271,28 @@ fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
         } else if p.peek_kind() matches { TK_NUMERIC_LITERAL | TK_BLOB_LITERAL } {
             return parse_expr_bt_0(p);
         } else if p.peek_kind() matches { TK_STRING_LITERAL | TK_K_NULL | TK_K_CURRENT_TIME | TK_K_CURRENT_DATE | TK_K_CURRENT_TIMESTAMP } {
+            let saved = p.pos;
             if parse_expr_scan_0(&p.tokens, p.pos) >= 0 {
                 return parse_expr_bt_0(p);
             }
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOTNULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT } {
+            let saved = p.pos;
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             return parse_expr_bt_2(p);
         }
@@ -11750,19 +11828,41 @@ fn parse_table_or_subquery(p: &mut Parser) -> Result<TableOrSubqueryNode, ParseE
     let kind = p.peek_kind();
     if kind matches { TK_LIT_LPAREN | TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL } {
         if p.peek_kind() == TK_LIT_LPAREN {
+            let saved = p.pos;
             if parse_table_or_subquery_scan_3(&p.tokens, p.pos) >= 0 {
-                return parse_table_or_subquery_bt_3(p);
+                let r_3 = parse_table_or_subquery_bt_3(p);
+                if let Err(_) = r_3 {
+                    p.pos = saved;
+                } else {
+                    return r_3;
+                }
             }
             if parse_table_or_subquery_scan_2(&p.tokens, p.pos) >= 0 {
-                return parse_table_or_subquery_bt_2(p);
+                let r_2 = parse_table_or_subquery_bt_2(p);
+                if let Err(_) = r_2 {
+                    p.pos = saved;
+                } else {
+                    return r_2;
+                }
             }
             if parse_table_or_subquery_scan_1(&p.tokens, p.pos) >= 0 {
-                return parse_table_or_subquery_bt_1(p);
+                let r_1 = parse_table_or_subquery_bt_1(p);
+                if let Err(_) = r_1 {
+                    p.pos = saved;
+                } else {
+                    return r_1;
+                }
             }
             return parse_table_or_subquery_bt_0(p);
         } else if p.peek_kind() matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL } {
+            let saved = p.pos;
             if parse_table_or_subquery_scan_1(&p.tokens, p.pos) >= 0 {
-                return parse_table_or_subquery_bt_1(p);
+                let r_1 = parse_table_or_subquery_bt_1(p);
+                if let Err(_) = r_1 {
+                    p.pos = saved;
+                } else {
+                    return r_1;
+                }
             }
             return parse_table_or_subquery_bt_0(p);
         }

--- a/package-gale/tests/golden/sqlite.wado
+++ b/package-gale/tests/golden/sqlite.wado
@@ -4800,6 +4800,1856 @@ impl Parser {
     }
 }
 
+fn scan_error(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_UNEXPECTED_CHAR { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_analyze_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_ANALYZE { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        let gp_0 = pos;
+        sg_0: {
+            pos = gp_0;
+            sg_0_0: {
+                pos = scan_database_name(tokens, pos);
+                if pos < 0 { break sg_0_0; }
+                break sg_0;
+            }
+            pos = gp_0;
+            sg_0_1: {
+                pos = scan_table_or_index_name(tokens, pos);
+                if pos < 0 { break sg_0_1; }
+                break sg_0;
+            }
+            pos = gp_0;
+            pos = scan_database_name(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+            pos += 1;
+            pos = scan_table_or_index_name(tokens, pos);
+            if pos < 0 { return -1; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_begin_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_BEGIN { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_K_DEFERRED | TK_K_IMMEDIATE | TK_K_EXCLUSIVE } {
+        let sp = pos;
+        let gp_1 = pos;
+        sg_1: {
+            pos = gp_1;
+            sg_1_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_DEFERRED { break sg_1_0; }
+                pos += 1;
+                break sg_1;
+            }
+            pos = gp_1;
+            sg_1_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_IMMEDIATE { break sg_1_1; }
+                pos += 1;
+                break sg_1;
+            }
+            pos = gp_1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_EXCLUSIVE { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_K_TRANSACTION {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_TRANSACTION { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+            let sp = pos;
+            pos = scan_transaction_name(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_commit_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let gp_2 = pos;
+    sg_2: {
+        pos = gp_2;
+        sg_2_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_COMMIT { break sg_2_0; }
+            pos += 1;
+            break sg_2;
+        }
+        pos = gp_2;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_END { return -1; }
+        pos += 1;
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_K_TRANSACTION {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_TRANSACTION { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+            let sp = pos;
+            pos = scan_transaction_name(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_detach_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_DETACH { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_DATABASE {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_DATABASE { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_database_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_drop_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_INDEX { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_IF {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_IF { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_EXISTS { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_database_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_index_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_drop_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_TABLE { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_IF {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_IF { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_EXISTS { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_database_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_table_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_drop_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_TRIGGER { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_IF {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_IF { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_EXISTS { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_database_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_trigger_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_drop_view_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_VIEW { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_IF {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_IF { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_EXISTS { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_database_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_view_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_PRAGMA { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_database_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_pragma_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_LIT_EQ | TK_LIT_LPAREN } {
+        let sp = pos;
+        let gp_3 = pos;
+        sg_3: {
+            pos = gp_3;
+            sg_3_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sg_3_0; }
+                pos += 1;
+                pos = scan_pragma_value(tokens, pos);
+                if pos < 0 { break sg_3_0; }
+                break sg_3;
+            }
+            pos = gp_3;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+            pos += 1;
+            pos = scan_pragma_value(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_reindex_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_REINDEX { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        let gp_4 = pos;
+        sg_4: {
+            pos = gp_4;
+            sg_4_0: {
+                pos = scan_collation_name(tokens, pos);
+                if pos < 0 { break sg_4_0; }
+                break sg_4;
+            }
+            pos = gp_4;
+            if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+                let sp = pos;
+                pos = scan_database_name(tokens, pos);
+                if pos < 0 { return -1; }
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+                pos += 1;
+                if pos < 0 { pos = sp; }
+            }
+            let gp_5 = pos;
+            sg_5: {
+                pos = gp_5;
+                sg_5_0: {
+                    pos = scan_table_name(tokens, pos);
+                    if pos < 0 { break sg_5_0; }
+                    break sg_5;
+                }
+                pos = gp_5;
+                pos = scan_index_name(tokens, pos);
+                if pos < 0 { return -1; }
+            }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_release_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_RELEASE { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_SAVEPOINT {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_SAVEPOINT { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_savepoint_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_rollback_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_ROLLBACK { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_TRANSACTION {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_TRANSACTION { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+            let sp = pos;
+            pos = scan_transaction_name(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_K_TO {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_TO { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind == TK_K_SAVEPOINT {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_SAVEPOINT { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; }
+        }
+        pos = scan_savepoint_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_savepoint_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_SAVEPOINT { return -1; }
+    pos += 1;
+    pos = scan_savepoint_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_vacuum_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_VACUUM { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_type_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_name(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_name(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_LIT_LPAREN {
+        let sp = pos;
+        let gp_6 = pos;
+        sg_6: {
+            pos = gp_6;
+            sg_6_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_6_0; }
+                pos += 1;
+                pos = scan_signed_number(tokens, pos);
+                if pos < 0 { break sg_6_0; }
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_6_0; }
+                pos += 1;
+                break sg_6;
+            }
+            pos = gp_6;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+            pos += 1;
+            pos = scan_signed_number(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+            pos += 1;
+            pos = scan_signed_number(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_conflict_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_ON {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_ON { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_CONFLICT { return -1; }
+        pos += 1;
+        let gp_7 = pos;
+        sg_7: {
+            pos = gp_7;
+            sg_7_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_ROLLBACK { break sg_7_0; }
+                pos += 1;
+                break sg_7;
+            }
+            pos = gp_7;
+            sg_7_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_ABORT { break sg_7_1; }
+                pos += 1;
+                break sg_7;
+            }
+            pos = gp_7;
+            sg_7_2: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_FAIL { break sg_7_2; }
+                pos += 1;
+                break sg_7;
+            }
+            pos = gp_7;
+            sg_7_3: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_IGNORE { break sg_7_3; }
+                pos += 1;
+                break sg_7;
+            }
+            pos = gp_7;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_REPLACE { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_foreign_key_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_REFERENCES { return -1; }
+    pos += 1;
+    pos = scan_foreign_table(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind == TK_LIT_LPAREN {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+        pos += 1;
+        pos = scan_column_name(tokens, pos);
+        if pos < 0 { return -1; }
+        while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+            pos += 1;
+            pos = scan_column_name(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos < 0 { pos = sp; break; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_K_ON | TK_K_MATCH } {
+        let sp = pos;
+        let gp_8 = pos;
+        sg_8: {
+            pos = gp_8;
+            sg_8_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_ON { break sg_8_0; }
+                pos += 1;
+                let gp_9 = pos;
+                sg_9: {
+                    pos = gp_9;
+                    sg_9_0: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_DELETE { break sg_9_0; }
+                        pos += 1;
+                        break sg_9;
+                    }
+                    pos = gp_9;
+                    if pos >= tokens.len() || tokens[pos].kind != TK_K_UPDATE { return -1; }
+                    pos += 1;
+                }
+                let gp_10 = pos;
+                sg_10: {
+                    pos = gp_10;
+                    sg_10_0: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_SET { break sg_10_0; }
+                        pos += 1;
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_NULL { break sg_10_0; }
+                        pos += 1;
+                        break sg_10;
+                    }
+                    pos = gp_10;
+                    sg_10_1: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_SET { break sg_10_1; }
+                        pos += 1;
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_DEFAULT { break sg_10_1; }
+                        pos += 1;
+                        break sg_10;
+                    }
+                    pos = gp_10;
+                    sg_10_2: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_CASCADE { break sg_10_2; }
+                        pos += 1;
+                        break sg_10;
+                    }
+                    pos = gp_10;
+                    sg_10_3: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_RESTRICT { break sg_10_3; }
+                        pos += 1;
+                        break sg_10;
+                    }
+                    pos = gp_10;
+                    if pos >= tokens.len() || tokens[pos].kind != TK_K_NO { return -1; }
+                    pos += 1;
+                    if pos >= tokens.len() || tokens[pos].kind != TK_K_ACTION { return -1; }
+                    pos += 1;
+                }
+                break sg_8;
+            }
+            pos = gp_8;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_MATCH { return -1; }
+            pos += 1;
+            pos = scan_name(tokens, pos);
+            if pos < 0 { return -1; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_K_NOT | TK_K_DEFERRABLE } {
+        let sp = pos;
+        if pos < tokens.len() && tokens[pos].kind == TK_K_NOT {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NOT { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_DEFERRABLE { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind == TK_K_INITIALLY {
+            let sp = pos;
+            let gp_11 = pos;
+            sg_11: {
+                pos = gp_11;
+                sg_11_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_K_INITIALLY { break sg_11_0; }
+                    pos += 1;
+                    if pos >= tokens.len() || tokens[pos].kind != TK_K_DEFERRED { break sg_11_0; }
+                    pos += 1;
+                    break sg_11;
+                }
+                pos = gp_11;
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_INITIALLY { return -1; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_IMMEDIATE { return -1; }
+                pos += 1;
+            }
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_raise_function(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_RAISE { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    let gp_12 = pos;
+    sg_12: {
+        pos = gp_12;
+        sg_12_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_IGNORE { break sg_12_0; }
+            pos += 1;
+            break sg_12;
+        }
+        pos = gp_12;
+        let gp_13 = pos;
+        sg_13: {
+            pos = gp_13;
+            sg_13_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_ROLLBACK { break sg_13_0; }
+                pos += 1;
+                break sg_13;
+            }
+            pos = gp_13;
+            sg_13_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_ABORT { break sg_13_1; }
+                pos += 1;
+                break sg_13;
+            }
+            pos = gp_13;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_FAIL { return -1; }
+            pos += 1;
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+        pos += 1;
+        pos = scan_error_message(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_indexed_column(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_column_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind == TK_K_COLLATE {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_COLLATE { return -1; }
+        pos += 1;
+        pos = scan_collation_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_K_ASC | TK_K_DESC } {
+        let sp = pos;
+        let gp_14 = pos;
+        sg_14: {
+            pos = gp_14;
+            sg_14_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_ASC { break sg_14_0; }
+                pos += 1;
+                break sg_14;
+            }
+            pos = gp_14;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DESC { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_qualified_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_database_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_table_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_K_INDEXED | TK_K_NOT } {
+        let sp = pos;
+        let gp_15 = pos;
+        sg_15: {
+            pos = gp_15;
+            sg_15_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_INDEXED { break sg_15_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_15_0; }
+                pos += 1;
+                pos = scan_index_name(tokens, pos);
+                if pos < 0 { break sg_15_0; }
+                break sg_15;
+            }
+            pos = gp_15;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NOT { return -1; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INDEXED { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_pragma_value(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_signed_number(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_name(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_join_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos < tokens.len() && tokens[pos].kind == TK_K_NATURAL {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NATURAL { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; }
+        }
+        if pos < tokens.len() && tokens[pos].kind matches { TK_K_LEFT | TK_K_INNER | TK_K_CROSS } {
+            let sp = pos;
+            let gp_16 = pos;
+            sg_16: {
+                pos = gp_16;
+                sg_16_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_K_LEFT { break sg_16_0; }
+                    pos += 1;
+                    if pos < tokens.len() && tokens[pos].kind == TK_K_OUTER {
+                        let sp = pos;
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_OUTER { pos = -1; } else { pos += 1; }
+                        if pos < 0 { pos = sp; }
+                    }
+                    break sg_16;
+                }
+                pos = gp_16;
+                sg_16_1: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_K_INNER { break sg_16_1; }
+                    pos += 1;
+                    break sg_16;
+                }
+                pos = gp_16;
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_CROSS { return -1; }
+                pos += 1;
+            }
+            if pos < 0 { pos = sp; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_JOIN { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_compound_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_UNION { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_UNION { break try_1; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ALL { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INTERSECT { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_EXCEPT { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_signed_number(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_LIT_PLUS | TK_LIT_MINUS } {
+        let sp = pos;
+        let gp_17 = pos;
+        sg_17: {
+            pos = gp_17;
+            sg_17_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_PLUS { break sg_17_0; }
+                pos += 1;
+                break sg_17;
+            }
+            pos = gp_17;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_MINUS { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_NUMERIC_LITERAL { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_literal_value(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_NUMERIC_LITERAL { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_BLOB_LITERAL { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NULL { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CURRENT_TIME { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CURRENT_DATE { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_CURRENT_TIMESTAMP { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_unary_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_MINUS { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_PLUS { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_TILDE { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_NOT { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_error_message(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_column_alias(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_IDENTIFIER { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_keyword(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ABORT { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ACTION { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ADD { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_AFTER { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ALL { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ALTER { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ANALYZE { break try_6; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_AND { break try_7; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_8: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break try_8; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_9: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ASC { break try_9; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_10: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ATTACH { break try_10; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_11: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_AUTOINCREMENT { break try_11; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_12: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_BEFORE { break try_12; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_13: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_BEGIN { break try_13; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_14: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_BETWEEN { break try_14; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_15: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break try_15; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_16: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CASCADE { break try_16; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_17: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CASE { break try_17; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_18: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CAST { break try_18; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_19: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CHECK { break try_19; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_20: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_COLLATE { break try_20; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_21: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_COLUMN { break try_21; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_22: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_COMMIT { break try_22; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_23: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CONFLICT { break try_23; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_24: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CONSTRAINT { break try_24; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_25: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CREATE { break try_25; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_26: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CROSS { break try_26; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_27: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CURRENT_DATE { break try_27; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_28: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CURRENT_TIME { break try_28; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_29: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CURRENT_TIMESTAMP { break try_29; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_30: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DATABASE { break try_30; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_31: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DEFAULT { break try_31; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_32: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DEFERRABLE { break try_32; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_33: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DEFERRED { break try_33; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_34: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DELETE { break try_34; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_35: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DESC { break try_35; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_36: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DETACH { break try_36; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_37: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { break try_37; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_38: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { break try_38; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_39: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_EACH { break try_39; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_40: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ELSE { break try_40; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_41: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_END { break try_41; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_42: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ESCAPE { break try_42; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_43: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_EXCEPT { break try_43; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_44: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_EXCLUSIVE { break try_44; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_45: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_EXISTS { break try_45; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_46: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_EXPLAIN { break try_46; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_47: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_FAIL { break try_47; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_48: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_FOR { break try_48; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_49: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_FOREIGN { break try_49; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_50: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_FROM { break try_50; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_51: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_FULL { break try_51; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_52: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_GLOB { break try_52; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_53: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_GROUP { break try_53; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_54: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_HAVING { break try_54; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_55: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_IF { break try_55; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_56: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_IGNORE { break try_56; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_57: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_IMMEDIATE { break try_57; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_58: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_IN { break try_58; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_59: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INDEX { break try_59; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_60: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INDEXED { break try_60; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_61: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INITIALLY { break try_61; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_62: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INNER { break try_62; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_63: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INSERT { break try_63; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_64: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INSTEAD { break try_64; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_65: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INTERSECT { break try_65; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_66: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INTO { break try_66; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_67: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_IS { break try_67; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_68: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ISNULL { break try_68; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_69: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_JOIN { break try_69; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_70: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_KEY { break try_70; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_71: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_LEFT { break try_71; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_72: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_LIKE { break try_72; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_73: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break try_73; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_74: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_MATCH { break try_74; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_75: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NATURAL { break try_75; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_76: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NO { break try_76; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_77: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NOT { break try_77; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_78: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NOTNULL { break try_78; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_79: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NULL { break try_79; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_80: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_OF { break try_80; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_81: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_OFFSET { break try_81; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_82: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ON { break try_82; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_83: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_OR { break try_83; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_84: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ORDER { break try_84; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_85: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_OUTER { break try_85; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_86: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_PLAN { break try_86; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_87: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_PRAGMA { break try_87; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_88: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_PRIMARY { break try_88; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_89: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_QUERY { break try_89; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_90: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_RAISE { break try_90; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_91: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_RECURSIVE { break try_91; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_92: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_REFERENCES { break try_92; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_93: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_REGEXP { break try_93; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_94: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_REINDEX { break try_94; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_95: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_RELEASE { break try_95; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_96: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_RENAME { break try_96; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_97: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_REPLACE { break try_97; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_98: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_RESTRICT { break try_98; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_99: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_RIGHT { break try_99; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_100: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ROLLBACK { break try_100; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_101: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ROW { break try_101; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_102: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_SAVEPOINT { break try_102; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_103: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_SELECT { break try_103; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_104: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_SET { break try_104; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_105: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_TABLE { break try_105; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_106: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_TEMP { break try_106; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_107: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_TEMPORARY { break try_107; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_108: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_THEN { break try_108; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_109: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_TO { break try_109; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_110: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_TRANSACTION { break try_110; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_111: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_TRIGGER { break try_111; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_112: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_UNION { break try_112; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_113: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_UNIQUE { break try_113; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_114: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_UPDATE { break try_114; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_115: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_USING { break try_115; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_116: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_VACUUM { break try_116; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_117: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_VALUES { break try_117; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_118: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_VIEW { break try_118; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_119: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_VIRTUAL { break try_119; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_120: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_WHEN { break try_120; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_121: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break try_121; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_122: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_WITH { break try_122; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_WITHOUT { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_function_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_database_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_schema_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_table_function_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_table_or_index_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_new_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_column_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_collation_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_foreign_table(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_index_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_trigger_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_view_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_module_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_pragma_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_savepoint_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_table_alias(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_IDENTIFIER { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+        pos += 1;
+        pos = scan_table_alias(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_transaction_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_any_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_IDENTIFIER { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_keyword(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+        pos += 1;
+        pos = scan_any_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
 fn parse_parse(p: &mut Parser) -> Result<ParseNode, ParseError> {
     let start = p.peek().span.start;
     let mut sql_stmt_list_or_error_list: Array<SqlStmtListOrErrorGroup> = [];
@@ -7971,6 +9821,15 @@ fn parse_expr_bt_15(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }));
 }
 
+fn parse_expr_scan_15(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_CAST { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let k_case = p.expect(TK_K_CASE)?;
@@ -8018,6 +9877,13 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }));
 }
 
+fn parse_expr_scan_22(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_CASE { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_expr_bt_21(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let item_k_exists: Option<ItemOptKExistsItem> = if p.peek_kind() == TK_K_NOT && p.peek_at(1) == TK_K_EXISTS {
@@ -8050,6 +9916,25 @@ fn parse_expr_bt_21(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }));
 }
 
+fn parse_expr_scan_21(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_K_NOT | TK_K_EXISTS } {
+        let sp = pos;
+        if pos < tokens.len() && tokens[pos].kind == TK_K_NOT {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NOT { return -1; }
+            pos += 1;
+            if pos < 0 { pos = sp; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_EXISTS { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_expr_bt_14(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let lparen = p.expect(TK_LIT_LPAREN)?;
@@ -8063,6 +9948,13 @@ fn parse_expr_bt_14(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }));
 }
 
+fn parse_expr_scan_14(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_expr_bt_23(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let raise_function = parse_raise_function(p)?;
@@ -8072,6 +9964,13 @@ fn parse_expr_bt_23(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }));
 }
 
+fn parse_expr_scan_23(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_raise_function(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_expr_bt_0(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let literal_value = parse_literal_value(p)?;
@@ -8079,6 +9978,13 @@ fn parse_expr_bt_0(p: &mut Parser) -> Result<ExprNode, ParseError> {
         span: Span::new(start, p.last_end()),
         literal_value,
     }));
+}
+
+fn parse_expr_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_literal_value(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
@@ -8134,6 +10040,15 @@ fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }));
 }
 
+fn parse_expr_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_function_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_expr_bt_3(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let unary_operator = parse_unary_operator(p)?;
@@ -8143,6 +10058,13 @@ fn parse_expr_bt_3(p: &mut Parser) -> Result<ExprNode, ParseError> {
         unary_operator,
         expr,
     }));
+}
+
+fn parse_expr_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_unary_operator(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_expr_bt_2(p: &mut Parser) -> Result<ExprNode, ParseError> {
@@ -8197,110 +10119,85 @@ fn parse_expr_bt_2(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }));
 }
 
+fn parse_expr_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+            let sp = pos;
+            pos = scan_database_name(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+            pos += 1;
+            if pos < 0 { pos = sp; }
+        }
+        pos = scan_table_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_column_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_K_CAST | TK_K_CASE | TK_K_NOT | TK_K_EXISTS | TK_LIT_LPAREN | TK_K_RAISE | TK_NUMERIC_LITERAL | TK_STRING_LITERAL | TK_BLOB_LITERAL | TK_K_NULL | TK_K_CURRENT_TIME | TK_K_CURRENT_DATE | TK_K_CURRENT_TIMESTAMP | TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOTNULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_LIT_MINUS | TK_LIT_PLUS | TK_LIT_TILDE } {
         if p.peek_kind() == TK_LIT_LPAREN {
-            let saved = p.pos;
-            let r_21 = parse_expr_bt_21(p);
-            if let Err(_) = r_21 {
-                p.pos = saved;
-            } else {
-                return r_21;
+            if parse_expr_scan_21(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_21(p);
             }
-            let r_14 = parse_expr_bt_14(p);
-            if let Err(_) = r_14 {
-                p.pos = saved;
-            } else {
-                return r_14;
+            if parse_expr_scan_14(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_14(p);
             }
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_CAST {
-            let saved = p.pos;
-            let r_15 = parse_expr_bt_15(p);
-            if let Err(_) = r_15 {
-                p.pos = saved;
-            } else {
-                return r_15;
+            if parse_expr_scan_15(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_15(p);
             }
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_CASE {
-            let saved = p.pos;
-            let r_22 = parse_expr_bt_22(p);
-            if let Err(_) = r_22 {
-                p.pos = saved;
-            } else {
-                return r_22;
+            if parse_expr_scan_22(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_22(p);
             }
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_RAISE {
-            let saved = p.pos;
-            let r_23 = parse_expr_bt_23(p);
-            if let Err(_) = r_23 {
-                p.pos = saved;
-            } else {
-                return r_23;
+            if parse_expr_scan_23(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_23(p);
             }
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_NOT {
-            let saved = p.pos;
-            let r_21 = parse_expr_bt_21(p);
-            if let Err(_) = r_21 {
-                p.pos = saved;
-            } else {
-                return r_21;
+            if parse_expr_scan_21(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_21(p);
             }
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
-            let r_2 = parse_expr_bt_2(p);
-            if let Err(_) = r_2 {
-                p.pos = saved;
-            } else {
-                return r_2;
+            if parse_expr_scan_2(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_2(p);
             }
             return parse_expr_bt_3(p);
         } else if p.peek_kind() == TK_K_EXISTS {
-            let saved = p.pos;
-            let r_21 = parse_expr_bt_21(p);
-            if let Err(_) = r_21 {
-                p.pos = saved;
-            } else {
-                return r_21;
+            if parse_expr_scan_21(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_21(p);
             }
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() matches { TK_LIT_MINUS | TK_LIT_PLUS | TK_LIT_TILDE } {
@@ -8308,27 +10205,16 @@ fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
         } else if p.peek_kind() matches { TK_NUMERIC_LITERAL | TK_BLOB_LITERAL } {
             return parse_expr_bt_0(p);
         } else if p.peek_kind() matches { TK_STRING_LITERAL | TK_K_NULL | TK_K_CURRENT_TIME | TK_K_CURRENT_DATE | TK_K_CURRENT_TIMESTAMP } {
-            let saved = p.pos;
-            let r_0 = parse_expr_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_expr_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_0(p);
             }
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOTNULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT } {
-            let saved = p.pos;
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
             return parse_expr_bt_2(p);
         }
@@ -9348,6 +11234,13 @@ fn parse_pragma_value_bt_1(p: &mut Parser) -> Result<PragmaValueNode, ParseError
     }));
 }
 
+fn parse_pragma_value_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_pragma_value_bt_2(p: &mut Parser) -> Result<PragmaValueNode, ParseError> {
     let start = p.peek().span.start;
     let string_literal = p.expect(TK_STRING_LITERAL)?;
@@ -9355,6 +11248,13 @@ fn parse_pragma_value_bt_2(p: &mut Parser) -> Result<PragmaValueNode, ParseError
         span: Span::new(start, p.last_end()),
         string_literal,
     }));
+}
+
+fn parse_pragma_value_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_pragma_value(p: &mut Parser) -> Result<PragmaValueNode, ParseError> {
@@ -9369,12 +11269,8 @@ fn parse_pragma_value(p: &mut Parser) -> Result<PragmaValueNode, ParseError> {
     }
     if kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
         if p.peek_kind() == TK_STRING_LITERAL {
-            let saved = p.pos;
-            let r_1 = parse_pragma_value_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_pragma_value_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_pragma_value_bt_1(p);
             }
             return parse_pragma_value_bt_2(p);
         } else if p.peek_kind() matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_LIT_LPAREN } {
@@ -9443,6 +11339,17 @@ fn parse_result_column_bt_1(p: &mut Parser) -> Result<ResultColumnNode, ParseErr
     }));
 }
 
+fn parse_result_column_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_table_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_result_column_bt_2(p: &mut Parser) -> Result<ResultColumnNode, ParseError> {
     let start = p.peek().span.start;
     let expr = parse_expr(p)?;
@@ -9489,12 +11396,8 @@ fn parse_result_column(p: &mut Parser) -> Result<ResultColumnNode, ParseError> {
     }
     if kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN | TK_NUMERIC_LITERAL | TK_BLOB_LITERAL | TK_BIND_PARAMETER | TK_LIT_MINUS | TK_LIT_PLUS | TK_LIT_TILDE } {
         if p.peek_kind() matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
-            let saved = p.pos;
-            let r_1 = parse_result_column_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_result_column_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_result_column_bt_1(p);
             }
             return parse_result_column_bt_2(p);
         } else if p.peek_kind() matches { TK_NUMERIC_LITERAL | TK_BLOB_LITERAL | TK_BIND_PARAMETER | TK_LIT_MINUS | TK_LIT_PLUS | TK_LIT_TILDE } {
@@ -9546,6 +11449,13 @@ fn parse_table_or_subquery_bt_3(p: &mut Parser) -> Result<TableOrSubqueryNode, P
     }));
 }
 
+fn parse_table_or_subquery_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_table_or_subquery_bt_2(p: &mut Parser) -> Result<TableOrSubqueryNode, ParseError> {
     let start = p.peek().span.start;
     let lparen = p.expect(TK_LIT_LPAREN)?;
@@ -9591,6 +11501,13 @@ fn parse_table_or_subquery_bt_2(p: &mut Parser) -> Result<TableOrSubqueryNode, P
         group_1,
         rparen,
     }));
+}
+
+fn parse_table_or_subquery_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_table_or_subquery_bt_1(p: &mut Parser) -> Result<TableOrSubqueryNode, ParseError> {
@@ -9680,6 +11597,23 @@ fn parse_table_or_subquery_bt_1(p: &mut Parser) -> Result<TableOrSubqueryNode, P
     }));
 }
 
+fn parse_table_or_subquery_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_schema_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_table_function_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_table_or_subquery_bt_0(p: &mut Parser) -> Result<TableOrSubqueryNode, ParseError> {
     let start = p.peek().span.start;
     let schema_name_dot: Option<SchemaNameDotItem> = if p.peek_kind() matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
@@ -9763,38 +11697,72 @@ fn parse_table_or_subquery_bt_0(p: &mut Parser) -> Result<TableOrSubqueryNode, P
     }));
 }
 
+fn parse_table_or_subquery_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_schema_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_table_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_K_AS | TK_IDENTIFIER | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        if pos < tokens.len() && tokens[pos].kind == TK_K_AS {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; }
+        }
+        pos = scan_table_alias(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_K_INDEXED | TK_K_NOT } {
+        let sp = pos;
+        let gp_18 = pos;
+        sg_18: {
+            pos = gp_18;
+            sg_18_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_INDEXED { break sg_18_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_18_0; }
+                pos += 1;
+                pos = scan_index_name(tokens, pos);
+                if pos < 0 { break sg_18_0; }
+                break sg_18;
+            }
+            pos = gp_18;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NOT { return -1; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INDEXED { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
 fn parse_table_or_subquery(p: &mut Parser) -> Result<TableOrSubqueryNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_LIT_LPAREN | TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL } {
         if p.peek_kind() == TK_LIT_LPAREN {
-            let saved = p.pos;
-            let r_3 = parse_table_or_subquery_bt_3(p);
-            if let Err(_) = r_3 {
-                p.pos = saved;
-            } else {
-                return r_3;
+            if parse_table_or_subquery_scan_3(&p.tokens, p.pos) >= 0 {
+                return parse_table_or_subquery_bt_3(p);
             }
-            let r_2 = parse_table_or_subquery_bt_2(p);
-            if let Err(_) = r_2 {
-                p.pos = saved;
-            } else {
-                return r_2;
+            if parse_table_or_subquery_scan_2(&p.tokens, p.pos) >= 0 {
+                return parse_table_or_subquery_bt_2(p);
             }
-            let r_1 = parse_table_or_subquery_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_table_or_subquery_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_table_or_subquery_bt_1(p);
             }
             return parse_table_or_subquery_bt_0(p);
         } else if p.peek_kind() matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL } {
-            let saved = p.pos;
-            let r_1 = parse_table_or_subquery_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_table_or_subquery_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_table_or_subquery_bt_1(p);
             }
             return parse_table_or_subquery_bt_0(p);
         }
@@ -10139,6 +12107,15 @@ fn parse_compound_operator_bt_1(p: &mut Parser) -> Result<CompoundOperatorNode, 
     }));
 }
 
+fn parse_compound_operator_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_UNION { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_ALL { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_compound_operator_bt_0(p: &mut Parser) -> Result<CompoundOperatorNode, ParseError> {
     let start = p.peek().span.start;
     let k_union = p.expect(TK_K_UNION)?;
@@ -10146,6 +12123,13 @@ fn parse_compound_operator_bt_0(p: &mut Parser) -> Result<CompoundOperatorNode, 
         span: Span::new(start, p.last_end()),
         k_union,
     }));
+}
+
+fn parse_compound_operator_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_UNION { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_compound_operator(p: &mut Parser) -> Result<CompoundOperatorNode, ParseError> {

--- a/package-gale/tests/golden/sqlite_highlight.wado
+++ b/package-gale/tests/golden/sqlite_highlight.wado
@@ -10147,57 +10147,123 @@ fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let kind = p.peek_kind();
     if kind matches { TK_K_CAST | TK_K_CASE | TK_K_NOT | TK_K_EXISTS | TK_LIT_LPAREN | TK_K_RAISE | TK_NUMERIC_LITERAL | TK_STRING_LITERAL | TK_BLOB_LITERAL | TK_K_NULL | TK_K_CURRENT_TIME | TK_K_CURRENT_DATE | TK_K_CURRENT_TIMESTAMP | TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOTNULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_LIT_MINUS | TK_LIT_PLUS | TK_LIT_TILDE } {
         if p.peek_kind() == TK_LIT_LPAREN {
+            let saved = p.pos;
             if parse_expr_scan_21(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_21(p);
+                let r_21 = parse_expr_bt_21(p);
+                if let Err(_) = r_21 {
+                    p.pos = saved;
+                } else {
+                    return r_21;
+                }
             }
             if parse_expr_scan_14(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_14(p);
+                let r_14 = parse_expr_bt_14(p);
+                if let Err(_) = r_14 {
+                    p.pos = saved;
+                } else {
+                    return r_14;
+                }
             }
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_CAST {
+            let saved = p.pos;
             if parse_expr_scan_15(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_15(p);
+                let r_15 = parse_expr_bt_15(p);
+                if let Err(_) = r_15 {
+                    p.pos = saved;
+                } else {
+                    return r_15;
+                }
             }
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_CASE {
+            let saved = p.pos;
             if parse_expr_scan_22(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_22(p);
+                let r_22 = parse_expr_bt_22(p);
+                if let Err(_) = r_22 {
+                    p.pos = saved;
+                } else {
+                    return r_22;
+                }
             }
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_RAISE {
+            let saved = p.pos;
             if parse_expr_scan_23(&p.tokens, p.pos) >= 0 {
                 return parse_expr_bt_23(p);
             }
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_NOT {
+            let saved = p.pos;
             if parse_expr_scan_21(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_21(p);
+                let r_21 = parse_expr_bt_21(p);
+                if let Err(_) = r_21 {
+                    p.pos = saved;
+                } else {
+                    return r_21;
+                }
             }
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             if parse_expr_scan_2(&p.tokens, p.pos) >= 0 {
                 return parse_expr_bt_2(p);
             }
             return parse_expr_bt_3(p);
         } else if p.peek_kind() == TK_K_EXISTS {
+            let saved = p.pos;
             if parse_expr_scan_21(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_21(p);
+                let r_21 = parse_expr_bt_21(p);
+                if let Err(_) = r_21 {
+                    p.pos = saved;
+                } else {
+                    return r_21;
+                }
             }
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() matches { TK_LIT_MINUS | TK_LIT_PLUS | TK_LIT_TILDE } {
@@ -10205,16 +10271,28 @@ fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
         } else if p.peek_kind() matches { TK_NUMERIC_LITERAL | TK_BLOB_LITERAL } {
             return parse_expr_bt_0(p);
         } else if p.peek_kind() matches { TK_STRING_LITERAL | TK_K_NULL | TK_K_CURRENT_TIME | TK_K_CURRENT_DATE | TK_K_CURRENT_TIMESTAMP } {
+            let saved = p.pos;
             if parse_expr_scan_0(&p.tokens, p.pos) >= 0 {
                 return parse_expr_bt_0(p);
             }
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOTNULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT } {
+            let saved = p.pos;
             if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
-                return parse_expr_bt_13(p);
+                let r_13 = parse_expr_bt_13(p);
+                if let Err(_) = r_13 {
+                    p.pos = saved;
+                } else {
+                    return r_13;
+                }
             }
             return parse_expr_bt_2(p);
         }
@@ -11750,19 +11828,41 @@ fn parse_table_or_subquery(p: &mut Parser) -> Result<TableOrSubqueryNode, ParseE
     let kind = p.peek_kind();
     if kind matches { TK_LIT_LPAREN | TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL } {
         if p.peek_kind() == TK_LIT_LPAREN {
+            let saved = p.pos;
             if parse_table_or_subquery_scan_3(&p.tokens, p.pos) >= 0 {
-                return parse_table_or_subquery_bt_3(p);
+                let r_3 = parse_table_or_subquery_bt_3(p);
+                if let Err(_) = r_3 {
+                    p.pos = saved;
+                } else {
+                    return r_3;
+                }
             }
             if parse_table_or_subquery_scan_2(&p.tokens, p.pos) >= 0 {
-                return parse_table_or_subquery_bt_2(p);
+                let r_2 = parse_table_or_subquery_bt_2(p);
+                if let Err(_) = r_2 {
+                    p.pos = saved;
+                } else {
+                    return r_2;
+                }
             }
             if parse_table_or_subquery_scan_1(&p.tokens, p.pos) >= 0 {
-                return parse_table_or_subquery_bt_1(p);
+                let r_1 = parse_table_or_subquery_bt_1(p);
+                if let Err(_) = r_1 {
+                    p.pos = saved;
+                } else {
+                    return r_1;
+                }
             }
             return parse_table_or_subquery_bt_0(p);
         } else if p.peek_kind() matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL } {
+            let saved = p.pos;
             if parse_table_or_subquery_scan_1(&p.tokens, p.pos) >= 0 {
-                return parse_table_or_subquery_bt_1(p);
+                let r_1 = parse_table_or_subquery_bt_1(p);
+                if let Err(_) = r_1 {
+                    p.pos = saved;
+                } else {
+                    return r_1;
+                }
             }
             return parse_table_or_subquery_bt_0(p);
         }

--- a/package-gale/tests/golden/sqlite_highlight.wado
+++ b/package-gale/tests/golden/sqlite_highlight.wado
@@ -4800,6 +4800,1856 @@ impl Parser {
     }
 }
 
+fn scan_error(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_UNEXPECTED_CHAR { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_analyze_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_ANALYZE { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        let gp_0 = pos;
+        sg_0: {
+            pos = gp_0;
+            sg_0_0: {
+                pos = scan_database_name(tokens, pos);
+                if pos < 0 { break sg_0_0; }
+                break sg_0;
+            }
+            pos = gp_0;
+            sg_0_1: {
+                pos = scan_table_or_index_name(tokens, pos);
+                if pos < 0 { break sg_0_1; }
+                break sg_0;
+            }
+            pos = gp_0;
+            pos = scan_database_name(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+            pos += 1;
+            pos = scan_table_or_index_name(tokens, pos);
+            if pos < 0 { return -1; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_begin_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_BEGIN { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_K_DEFERRED | TK_K_IMMEDIATE | TK_K_EXCLUSIVE } {
+        let sp = pos;
+        let gp_1 = pos;
+        sg_1: {
+            pos = gp_1;
+            sg_1_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_DEFERRED { break sg_1_0; }
+                pos += 1;
+                break sg_1;
+            }
+            pos = gp_1;
+            sg_1_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_IMMEDIATE { break sg_1_1; }
+                pos += 1;
+                break sg_1;
+            }
+            pos = gp_1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_EXCLUSIVE { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_K_TRANSACTION {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_TRANSACTION { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+            let sp = pos;
+            pos = scan_transaction_name(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_commit_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let gp_2 = pos;
+    sg_2: {
+        pos = gp_2;
+        sg_2_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_COMMIT { break sg_2_0; }
+            pos += 1;
+            break sg_2;
+        }
+        pos = gp_2;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_END { return -1; }
+        pos += 1;
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_K_TRANSACTION {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_TRANSACTION { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+            let sp = pos;
+            pos = scan_transaction_name(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_detach_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_DETACH { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_DATABASE {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_DATABASE { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_database_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_drop_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_INDEX { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_IF {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_IF { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_EXISTS { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_database_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_index_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_drop_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_TABLE { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_IF {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_IF { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_EXISTS { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_database_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_table_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_drop_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_TRIGGER { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_IF {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_IF { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_EXISTS { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_database_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_trigger_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_drop_view_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_VIEW { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_IF {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_IF { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_EXISTS { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_database_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_view_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_PRAGMA { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_database_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_pragma_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_LIT_EQ | TK_LIT_LPAREN } {
+        let sp = pos;
+        let gp_3 = pos;
+        sg_3: {
+            pos = gp_3;
+            sg_3_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sg_3_0; }
+                pos += 1;
+                pos = scan_pragma_value(tokens, pos);
+                if pos < 0 { break sg_3_0; }
+                break sg_3;
+            }
+            pos = gp_3;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+            pos += 1;
+            pos = scan_pragma_value(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_reindex_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_REINDEX { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        let gp_4 = pos;
+        sg_4: {
+            pos = gp_4;
+            sg_4_0: {
+                pos = scan_collation_name(tokens, pos);
+                if pos < 0 { break sg_4_0; }
+                break sg_4;
+            }
+            pos = gp_4;
+            if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+                let sp = pos;
+                pos = scan_database_name(tokens, pos);
+                if pos < 0 { return -1; }
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+                pos += 1;
+                if pos < 0 { pos = sp; }
+            }
+            let gp_5 = pos;
+            sg_5: {
+                pos = gp_5;
+                sg_5_0: {
+                    pos = scan_table_name(tokens, pos);
+                    if pos < 0 { break sg_5_0; }
+                    break sg_5;
+                }
+                pos = gp_5;
+                pos = scan_index_name(tokens, pos);
+                if pos < 0 { return -1; }
+            }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_release_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_RELEASE { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_SAVEPOINT {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_SAVEPOINT { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_savepoint_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_rollback_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_ROLLBACK { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_TRANSACTION {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_TRANSACTION { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+            let sp = pos;
+            pos = scan_transaction_name(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_K_TO {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_TO { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind == TK_K_SAVEPOINT {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_SAVEPOINT { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; }
+        }
+        pos = scan_savepoint_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_savepoint_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_SAVEPOINT { return -1; }
+    pos += 1;
+    pos = scan_savepoint_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_vacuum_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_VACUUM { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_type_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_name(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_name(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_LIT_LPAREN {
+        let sp = pos;
+        let gp_6 = pos;
+        sg_6: {
+            pos = gp_6;
+            sg_6_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_6_0; }
+                pos += 1;
+                pos = scan_signed_number(tokens, pos);
+                if pos < 0 { break sg_6_0; }
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_6_0; }
+                pos += 1;
+                break sg_6;
+            }
+            pos = gp_6;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+            pos += 1;
+            pos = scan_signed_number(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+            pos += 1;
+            pos = scan_signed_number(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_conflict_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind == TK_K_ON {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_ON { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_CONFLICT { return -1; }
+        pos += 1;
+        let gp_7 = pos;
+        sg_7: {
+            pos = gp_7;
+            sg_7_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_ROLLBACK { break sg_7_0; }
+                pos += 1;
+                break sg_7;
+            }
+            pos = gp_7;
+            sg_7_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_ABORT { break sg_7_1; }
+                pos += 1;
+                break sg_7;
+            }
+            pos = gp_7;
+            sg_7_2: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_FAIL { break sg_7_2; }
+                pos += 1;
+                break sg_7;
+            }
+            pos = gp_7;
+            sg_7_3: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_IGNORE { break sg_7_3; }
+                pos += 1;
+                break sg_7;
+            }
+            pos = gp_7;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_REPLACE { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_foreign_key_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_REFERENCES { return -1; }
+    pos += 1;
+    pos = scan_foreign_table(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind == TK_LIT_LPAREN {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+        pos += 1;
+        pos = scan_column_name(tokens, pos);
+        if pos < 0 { return -1; }
+        while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+            pos += 1;
+            pos = scan_column_name(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos < 0 { pos = sp; break; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_K_ON | TK_K_MATCH } {
+        let sp = pos;
+        let gp_8 = pos;
+        sg_8: {
+            pos = gp_8;
+            sg_8_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_ON { break sg_8_0; }
+                pos += 1;
+                let gp_9 = pos;
+                sg_9: {
+                    pos = gp_9;
+                    sg_9_0: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_DELETE { break sg_9_0; }
+                        pos += 1;
+                        break sg_9;
+                    }
+                    pos = gp_9;
+                    if pos >= tokens.len() || tokens[pos].kind != TK_K_UPDATE { return -1; }
+                    pos += 1;
+                }
+                let gp_10 = pos;
+                sg_10: {
+                    pos = gp_10;
+                    sg_10_0: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_SET { break sg_10_0; }
+                        pos += 1;
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_NULL { break sg_10_0; }
+                        pos += 1;
+                        break sg_10;
+                    }
+                    pos = gp_10;
+                    sg_10_1: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_SET { break sg_10_1; }
+                        pos += 1;
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_DEFAULT { break sg_10_1; }
+                        pos += 1;
+                        break sg_10;
+                    }
+                    pos = gp_10;
+                    sg_10_2: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_CASCADE { break sg_10_2; }
+                        pos += 1;
+                        break sg_10;
+                    }
+                    pos = gp_10;
+                    sg_10_3: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_RESTRICT { break sg_10_3; }
+                        pos += 1;
+                        break sg_10;
+                    }
+                    pos = gp_10;
+                    if pos >= tokens.len() || tokens[pos].kind != TK_K_NO { return -1; }
+                    pos += 1;
+                    if pos >= tokens.len() || tokens[pos].kind != TK_K_ACTION { return -1; }
+                    pos += 1;
+                }
+                break sg_8;
+            }
+            pos = gp_8;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_MATCH { return -1; }
+            pos += 1;
+            pos = scan_name(tokens, pos);
+            if pos < 0 { return -1; }
+        }
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_K_NOT | TK_K_DEFERRABLE } {
+        let sp = pos;
+        if pos < tokens.len() && tokens[pos].kind == TK_K_NOT {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NOT { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_DEFERRABLE { return -1; }
+        pos += 1;
+        if pos < tokens.len() && tokens[pos].kind == TK_K_INITIALLY {
+            let sp = pos;
+            let gp_11 = pos;
+            sg_11: {
+                pos = gp_11;
+                sg_11_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_K_INITIALLY { break sg_11_0; }
+                    pos += 1;
+                    if pos >= tokens.len() || tokens[pos].kind != TK_K_DEFERRED { break sg_11_0; }
+                    pos += 1;
+                    break sg_11;
+                }
+                pos = gp_11;
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_INITIALLY { return -1; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_IMMEDIATE { return -1; }
+                pos += 1;
+            }
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_raise_function(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_RAISE { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    let gp_12 = pos;
+    sg_12: {
+        pos = gp_12;
+        sg_12_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_IGNORE { break sg_12_0; }
+            pos += 1;
+            break sg_12;
+        }
+        pos = gp_12;
+        let gp_13 = pos;
+        sg_13: {
+            pos = gp_13;
+            sg_13_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_ROLLBACK { break sg_13_0; }
+                pos += 1;
+                break sg_13;
+            }
+            pos = gp_13;
+            sg_13_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_ABORT { break sg_13_1; }
+                pos += 1;
+                break sg_13;
+            }
+            pos = gp_13;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_FAIL { return -1; }
+            pos += 1;
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+        pos += 1;
+        pos = scan_error_message(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_indexed_column(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_column_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind == TK_K_COLLATE {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_COLLATE { return -1; }
+        pos += 1;
+        pos = scan_collation_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_K_ASC | TK_K_DESC } {
+        let sp = pos;
+        let gp_14 = pos;
+        sg_14: {
+            pos = gp_14;
+            sg_14_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_ASC { break sg_14_0; }
+                pos += 1;
+                break sg_14;
+            }
+            pos = gp_14;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DESC { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_qualified_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_database_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_table_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_K_INDEXED | TK_K_NOT } {
+        let sp = pos;
+        let gp_15 = pos;
+        sg_15: {
+            pos = gp_15;
+            sg_15_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_INDEXED { break sg_15_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_15_0; }
+                pos += 1;
+                pos = scan_index_name(tokens, pos);
+                if pos < 0 { break sg_15_0; }
+                break sg_15;
+            }
+            pos = gp_15;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NOT { return -1; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INDEXED { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_pragma_value(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_signed_number(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_name(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_join_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos < tokens.len() && tokens[pos].kind == TK_K_NATURAL {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NATURAL { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; }
+        }
+        if pos < tokens.len() && tokens[pos].kind matches { TK_K_LEFT | TK_K_INNER | TK_K_CROSS } {
+            let sp = pos;
+            let gp_16 = pos;
+            sg_16: {
+                pos = gp_16;
+                sg_16_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_K_LEFT { break sg_16_0; }
+                    pos += 1;
+                    if pos < tokens.len() && tokens[pos].kind == TK_K_OUTER {
+                        let sp = pos;
+                        if pos >= tokens.len() || tokens[pos].kind != TK_K_OUTER { pos = -1; } else { pos += 1; }
+                        if pos < 0 { pos = sp; }
+                    }
+                    break sg_16;
+                }
+                pos = gp_16;
+                sg_16_1: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_K_INNER { break sg_16_1; }
+                    pos += 1;
+                    break sg_16;
+                }
+                pos = gp_16;
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_CROSS { return -1; }
+                pos += 1;
+            }
+            if pos < 0 { pos = sp; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_JOIN { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_compound_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_UNION { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_UNION { break try_1; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ALL { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INTERSECT { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_EXCEPT { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_signed_number(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_LIT_PLUS | TK_LIT_MINUS } {
+        let sp = pos;
+        let gp_17 = pos;
+        sg_17: {
+            pos = gp_17;
+            sg_17_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_PLUS { break sg_17_0; }
+                pos += 1;
+                break sg_17;
+            }
+            pos = gp_17;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_MINUS { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_NUMERIC_LITERAL { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_literal_value(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_NUMERIC_LITERAL { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_BLOB_LITERAL { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NULL { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CURRENT_TIME { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CURRENT_DATE { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_CURRENT_TIMESTAMP { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_unary_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_MINUS { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_PLUS { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_TILDE { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_NOT { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_error_message(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_column_alias(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_IDENTIFIER { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_keyword(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ABORT { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ACTION { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ADD { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_AFTER { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ALL { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ALTER { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ANALYZE { break try_6; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_AND { break try_7; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_8: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break try_8; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_9: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ASC { break try_9; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_10: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ATTACH { break try_10; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_11: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_AUTOINCREMENT { break try_11; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_12: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_BEFORE { break try_12; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_13: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_BEGIN { break try_13; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_14: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_BETWEEN { break try_14; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_15: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break try_15; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_16: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CASCADE { break try_16; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_17: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CASE { break try_17; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_18: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CAST { break try_18; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_19: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CHECK { break try_19; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_20: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_COLLATE { break try_20; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_21: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_COLUMN { break try_21; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_22: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_COMMIT { break try_22; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_23: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CONFLICT { break try_23; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_24: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CONSTRAINT { break try_24; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_25: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CREATE { break try_25; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_26: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CROSS { break try_26; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_27: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CURRENT_DATE { break try_27; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_28: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CURRENT_TIME { break try_28; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_29: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_CURRENT_TIMESTAMP { break try_29; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_30: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DATABASE { break try_30; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_31: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DEFAULT { break try_31; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_32: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DEFERRABLE { break try_32; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_33: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DEFERRED { break try_33; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_34: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DELETE { break try_34; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_35: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DESC { break try_35; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_36: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DETACH { break try_36; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_37: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { break try_37; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_38: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { break try_38; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_39: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_EACH { break try_39; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_40: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ELSE { break try_40; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_41: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_END { break try_41; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_42: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ESCAPE { break try_42; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_43: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_EXCEPT { break try_43; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_44: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_EXCLUSIVE { break try_44; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_45: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_EXISTS { break try_45; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_46: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_EXPLAIN { break try_46; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_47: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_FAIL { break try_47; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_48: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_FOR { break try_48; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_49: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_FOREIGN { break try_49; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_50: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_FROM { break try_50; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_51: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_FULL { break try_51; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_52: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_GLOB { break try_52; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_53: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_GROUP { break try_53; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_54: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_HAVING { break try_54; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_55: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_IF { break try_55; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_56: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_IGNORE { break try_56; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_57: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_IMMEDIATE { break try_57; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_58: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_IN { break try_58; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_59: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INDEX { break try_59; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_60: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INDEXED { break try_60; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_61: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INITIALLY { break try_61; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_62: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INNER { break try_62; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_63: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INSERT { break try_63; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_64: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INSTEAD { break try_64; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_65: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INTERSECT { break try_65; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_66: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INTO { break try_66; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_67: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_IS { break try_67; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_68: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ISNULL { break try_68; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_69: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_JOIN { break try_69; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_70: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_KEY { break try_70; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_71: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_LEFT { break try_71; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_72: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_LIKE { break try_72; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_73: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break try_73; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_74: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_MATCH { break try_74; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_75: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NATURAL { break try_75; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_76: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NO { break try_76; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_77: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NOT { break try_77; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_78: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NOTNULL { break try_78; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_79: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NULL { break try_79; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_80: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_OF { break try_80; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_81: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_OFFSET { break try_81; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_82: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ON { break try_82; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_83: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_OR { break try_83; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_84: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ORDER { break try_84; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_85: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_OUTER { break try_85; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_86: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_PLAN { break try_86; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_87: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_PRAGMA { break try_87; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_88: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_PRIMARY { break try_88; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_89: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_QUERY { break try_89; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_90: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_RAISE { break try_90; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_91: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_RECURSIVE { break try_91; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_92: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_REFERENCES { break try_92; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_93: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_REGEXP { break try_93; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_94: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_REINDEX { break try_94; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_95: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_RELEASE { break try_95; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_96: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_RENAME { break try_96; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_97: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_REPLACE { break try_97; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_98: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_RESTRICT { break try_98; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_99: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_RIGHT { break try_99; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_100: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ROLLBACK { break try_100; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_101: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_ROW { break try_101; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_102: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_SAVEPOINT { break try_102; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_103: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_SELECT { break try_103; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_104: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_SET { break try_104; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_105: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_TABLE { break try_105; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_106: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_TEMP { break try_106; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_107: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_TEMPORARY { break try_107; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_108: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_THEN { break try_108; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_109: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_TO { break try_109; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_110: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_TRANSACTION { break try_110; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_111: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_TRIGGER { break try_111; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_112: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_UNION { break try_112; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_113: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_UNIQUE { break try_113; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_114: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_UPDATE { break try_114; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_115: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_USING { break try_115; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_116: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_VACUUM { break try_116; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_117: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_VALUES { break try_117; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_118: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_VIEW { break try_118; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_119: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_VIRTUAL { break try_119; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_120: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_WHEN { break try_120; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_121: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break try_121; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_122: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_WITH { break try_122; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_WITHOUT { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_function_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_database_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_schema_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_table_function_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_table_or_index_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_new_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_column_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_collation_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_foreign_table(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_index_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_trigger_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_view_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_module_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_pragma_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_savepoint_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_table_alias(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_IDENTIFIER { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+        pos += 1;
+        pos = scan_table_alias(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_transaction_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_any_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_any_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_IDENTIFIER { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            pos = scan_keyword(tokens, pos);
+            if pos < 0 { break try_1; }
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+        pos += 1;
+        pos = scan_any_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
 fn parse_parse(p: &mut Parser) -> Result<ParseNode, ParseError> {
     let start = p.peek().span.start;
     let mut sql_stmt_list_or_error_list: Array<SqlStmtListOrErrorGroup> = [];
@@ -7971,6 +9821,15 @@ fn parse_expr_bt_15(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }));
 }
 
+fn parse_expr_scan_15(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_CAST { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let k_case = p.expect(TK_K_CASE)?;
@@ -8018,6 +9877,13 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }));
 }
 
+fn parse_expr_scan_22(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_CASE { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_expr_bt_21(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let item_k_exists: Option<ItemOptKExistsItem> = if p.peek_kind() == TK_K_NOT && p.peek_at(1) == TK_K_EXISTS {
@@ -8050,6 +9916,25 @@ fn parse_expr_bt_21(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }));
 }
 
+fn parse_expr_scan_21(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_K_NOT | TK_K_EXISTS } {
+        let sp = pos;
+        if pos < tokens.len() && tokens[pos].kind == TK_K_NOT {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NOT { return -1; }
+            pos += 1;
+            if pos < 0 { pos = sp; }
+        }
+        if pos >= tokens.len() || tokens[pos].kind != TK_K_EXISTS { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_expr_bt_14(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let lparen = p.expect(TK_LIT_LPAREN)?;
@@ -8063,6 +9948,13 @@ fn parse_expr_bt_14(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }));
 }
 
+fn parse_expr_scan_14(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_expr_bt_23(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let raise_function = parse_raise_function(p)?;
@@ -8072,6 +9964,13 @@ fn parse_expr_bt_23(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }));
 }
 
+fn parse_expr_scan_23(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_raise_function(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_expr_bt_0(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let literal_value = parse_literal_value(p)?;
@@ -8079,6 +9978,13 @@ fn parse_expr_bt_0(p: &mut Parser) -> Result<ExprNode, ParseError> {
         span: Span::new(start, p.last_end()),
         literal_value,
     }));
+}
+
+fn parse_expr_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_literal_value(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
@@ -8134,6 +10040,15 @@ fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }));
 }
 
+fn parse_expr_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_function_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_expr_bt_3(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let unary_operator = parse_unary_operator(p)?;
@@ -8143,6 +10058,13 @@ fn parse_expr_bt_3(p: &mut Parser) -> Result<ExprNode, ParseError> {
         unary_operator,
         expr,
     }));
+}
+
+fn parse_expr_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_unary_operator(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_expr_bt_2(p: &mut Parser) -> Result<ExprNode, ParseError> {
@@ -8197,110 +10119,85 @@ fn parse_expr_bt_2(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }));
 }
 
+fn parse_expr_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+            let sp = pos;
+            pos = scan_database_name(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+            pos += 1;
+            if pos < 0 { pos = sp; }
+        }
+        pos = scan_table_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_column_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_K_CAST | TK_K_CASE | TK_K_NOT | TK_K_EXISTS | TK_LIT_LPAREN | TK_K_RAISE | TK_NUMERIC_LITERAL | TK_STRING_LITERAL | TK_BLOB_LITERAL | TK_K_NULL | TK_K_CURRENT_TIME | TK_K_CURRENT_DATE | TK_K_CURRENT_TIMESTAMP | TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOTNULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_LIT_MINUS | TK_LIT_PLUS | TK_LIT_TILDE } {
         if p.peek_kind() == TK_LIT_LPAREN {
-            let saved = p.pos;
-            let r_21 = parse_expr_bt_21(p);
-            if let Err(_) = r_21 {
-                p.pos = saved;
-            } else {
-                return r_21;
+            if parse_expr_scan_21(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_21(p);
             }
-            let r_14 = parse_expr_bt_14(p);
-            if let Err(_) = r_14 {
-                p.pos = saved;
-            } else {
-                return r_14;
+            if parse_expr_scan_14(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_14(p);
             }
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_CAST {
-            let saved = p.pos;
-            let r_15 = parse_expr_bt_15(p);
-            if let Err(_) = r_15 {
-                p.pos = saved;
-            } else {
-                return r_15;
+            if parse_expr_scan_15(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_15(p);
             }
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_CASE {
-            let saved = p.pos;
-            let r_22 = parse_expr_bt_22(p);
-            if let Err(_) = r_22 {
-                p.pos = saved;
-            } else {
-                return r_22;
+            if parse_expr_scan_22(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_22(p);
             }
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_RAISE {
-            let saved = p.pos;
-            let r_23 = parse_expr_bt_23(p);
-            if let Err(_) = r_23 {
-                p.pos = saved;
-            } else {
-                return r_23;
+            if parse_expr_scan_23(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_23(p);
             }
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() == TK_K_NOT {
-            let saved = p.pos;
-            let r_21 = parse_expr_bt_21(p);
-            if let Err(_) = r_21 {
-                p.pos = saved;
-            } else {
-                return r_21;
+            if parse_expr_scan_21(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_21(p);
             }
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
-            let r_2 = parse_expr_bt_2(p);
-            if let Err(_) = r_2 {
-                p.pos = saved;
-            } else {
-                return r_2;
+            if parse_expr_scan_2(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_2(p);
             }
             return parse_expr_bt_3(p);
         } else if p.peek_kind() == TK_K_EXISTS {
-            let saved = p.pos;
-            let r_21 = parse_expr_bt_21(p);
-            if let Err(_) = r_21 {
-                p.pos = saved;
-            } else {
-                return r_21;
+            if parse_expr_scan_21(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_21(p);
             }
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() matches { TK_LIT_MINUS | TK_LIT_PLUS | TK_LIT_TILDE } {
@@ -8308,27 +10205,16 @@ fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
         } else if p.peek_kind() matches { TK_NUMERIC_LITERAL | TK_BLOB_LITERAL } {
             return parse_expr_bt_0(p);
         } else if p.peek_kind() matches { TK_STRING_LITERAL | TK_K_NULL | TK_K_CURRENT_TIME | TK_K_CURRENT_DATE | TK_K_CURRENT_TIMESTAMP } {
-            let saved = p.pos;
-            let r_0 = parse_expr_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_expr_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_0(p);
             }
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
             return parse_expr_bt_2(p);
         } else if p.peek_kind() matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOTNULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT } {
-            let saved = p.pos;
-            let r_13 = parse_expr_bt_13(p);
-            if let Err(_) = r_13 {
-                p.pos = saved;
-            } else {
-                return r_13;
+            if parse_expr_scan_13(&p.tokens, p.pos) >= 0 {
+                return parse_expr_bt_13(p);
             }
             return parse_expr_bt_2(p);
         }
@@ -9348,6 +11234,13 @@ fn parse_pragma_value_bt_1(p: &mut Parser) -> Result<PragmaValueNode, ParseError
     }));
 }
 
+fn parse_pragma_value_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_pragma_value_bt_2(p: &mut Parser) -> Result<PragmaValueNode, ParseError> {
     let start = p.peek().span.start;
     let string_literal = p.expect(TK_STRING_LITERAL)?;
@@ -9355,6 +11248,13 @@ fn parse_pragma_value_bt_2(p: &mut Parser) -> Result<PragmaValueNode, ParseError
         span: Span::new(start, p.last_end()),
         string_literal,
     }));
+}
+
+fn parse_pragma_value_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_pragma_value(p: &mut Parser) -> Result<PragmaValueNode, ParseError> {
@@ -9369,12 +11269,8 @@ fn parse_pragma_value(p: &mut Parser) -> Result<PragmaValueNode, ParseError> {
     }
     if kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
         if p.peek_kind() == TK_STRING_LITERAL {
-            let saved = p.pos;
-            let r_1 = parse_pragma_value_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_pragma_value_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_pragma_value_bt_1(p);
             }
             return parse_pragma_value_bt_2(p);
         } else if p.peek_kind() matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_LIT_LPAREN } {
@@ -9443,6 +11339,17 @@ fn parse_result_column_bt_1(p: &mut Parser) -> Result<ResultColumnNode, ParseErr
     }));
 }
 
+fn parse_result_column_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_table_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_result_column_bt_2(p: &mut Parser) -> Result<ResultColumnNode, ParseError> {
     let start = p.peek().span.start;
     let expr = parse_expr(p)?;
@@ -9489,12 +11396,8 @@ fn parse_result_column(p: &mut Parser) -> Result<ResultColumnNode, ParseError> {
     }
     if kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN | TK_NUMERIC_LITERAL | TK_BLOB_LITERAL | TK_BIND_PARAMETER | TK_LIT_MINUS | TK_LIT_PLUS | TK_LIT_TILDE } {
         if p.peek_kind() matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
-            let saved = p.pos;
-            let r_1 = parse_result_column_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_result_column_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_result_column_bt_1(p);
             }
             return parse_result_column_bt_2(p);
         } else if p.peek_kind() matches { TK_NUMERIC_LITERAL | TK_BLOB_LITERAL | TK_BIND_PARAMETER | TK_LIT_MINUS | TK_LIT_PLUS | TK_LIT_TILDE } {
@@ -9546,6 +11449,13 @@ fn parse_table_or_subquery_bt_3(p: &mut Parser) -> Result<TableOrSubqueryNode, P
     }));
 }
 
+fn parse_table_or_subquery_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_table_or_subquery_bt_2(p: &mut Parser) -> Result<TableOrSubqueryNode, ParseError> {
     let start = p.peek().span.start;
     let lparen = p.expect(TK_LIT_LPAREN)?;
@@ -9591,6 +11501,13 @@ fn parse_table_or_subquery_bt_2(p: &mut Parser) -> Result<TableOrSubqueryNode, P
         group_1,
         rparen,
     }));
+}
+
+fn parse_table_or_subquery_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_table_or_subquery_bt_1(p: &mut Parser) -> Result<TableOrSubqueryNode, ParseError> {
@@ -9680,6 +11597,23 @@ fn parse_table_or_subquery_bt_1(p: &mut Parser) -> Result<TableOrSubqueryNode, P
     }));
 }
 
+fn parse_table_or_subquery_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_schema_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_table_function_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_table_or_subquery_bt_0(p: &mut Parser) -> Result<TableOrSubqueryNode, ParseError> {
     let start = p.peek().span.start;
     let schema_name_dot: Option<SchemaNameDotItem> = if p.peek_kind() matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
@@ -9763,38 +11697,72 @@ fn parse_table_or_subquery_bt_0(p: &mut Parser) -> Result<TableOrSubqueryNode, P
     }));
 }
 
+fn parse_table_or_subquery_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        pos = scan_schema_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_table_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_K_AS | TK_IDENTIFIER | TK_STRING_LITERAL | TK_LIT_LPAREN } {
+        let sp = pos;
+        if pos < tokens.len() && tokens[pos].kind == TK_K_AS {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; }
+        }
+        pos = scan_table_alias(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_K_INDEXED | TK_K_NOT } {
+        let sp = pos;
+        let gp_18 = pos;
+        sg_18: {
+            pos = gp_18;
+            sg_18_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_INDEXED { break sg_18_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_18_0; }
+                pos += 1;
+                pos = scan_index_name(tokens, pos);
+                if pos < 0 { break sg_18_0; }
+                break sg_18;
+            }
+            pos = gp_18;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_NOT { return -1; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_K_INDEXED { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
 fn parse_table_or_subquery(p: &mut Parser) -> Result<TableOrSubqueryNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_LIT_LPAREN | TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL } {
         if p.peek_kind() == TK_LIT_LPAREN {
-            let saved = p.pos;
-            let r_3 = parse_table_or_subquery_bt_3(p);
-            if let Err(_) = r_3 {
-                p.pos = saved;
-            } else {
-                return r_3;
+            if parse_table_or_subquery_scan_3(&p.tokens, p.pos) >= 0 {
+                return parse_table_or_subquery_bt_3(p);
             }
-            let r_2 = parse_table_or_subquery_bt_2(p);
-            if let Err(_) = r_2 {
-                p.pos = saved;
-            } else {
-                return r_2;
+            if parse_table_or_subquery_scan_2(&p.tokens, p.pos) >= 0 {
+                return parse_table_or_subquery_bt_2(p);
             }
-            let r_1 = parse_table_or_subquery_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_table_or_subquery_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_table_or_subquery_bt_1(p);
             }
             return parse_table_or_subquery_bt_0(p);
         } else if p.peek_kind() matches { TK_IDENTIFIER | TK_K_ABORT | TK_K_ACTION | TK_K_ADD | TK_K_AFTER | TK_K_ALL | TK_K_ALTER | TK_K_ANALYZE | TK_K_AND | TK_K_AS | TK_K_ASC | TK_K_ATTACH | TK_K_AUTOINCREMENT | TK_K_BEFORE | TK_K_BEGIN | TK_K_BETWEEN | TK_K_BY | TK_K_CASCADE | TK_K_CASE | TK_K_CAST | TK_K_CHECK | TK_K_COLLATE | TK_K_COLUMN | TK_K_COMMIT | TK_K_CONFLICT | TK_K_CONSTRAINT | TK_K_CREATE | TK_K_CROSS | TK_K_CURRENT_DATE | TK_K_CURRENT_TIME | TK_K_CURRENT_TIMESTAMP | TK_K_DATABASE | TK_K_DEFAULT | TK_K_DEFERRABLE | TK_K_DEFERRED | TK_K_DELETE | TK_K_DESC | TK_K_DETACH | TK_K_DISTINCT | TK_K_DROP | TK_K_EACH | TK_K_ELSE | TK_K_END | TK_K_ESCAPE | TK_K_EXCEPT | TK_K_EXCLUSIVE | TK_K_EXISTS | TK_K_EXPLAIN | TK_K_FAIL | TK_K_FOR | TK_K_FOREIGN | TK_K_FROM | TK_K_FULL | TK_K_GLOB | TK_K_GROUP | TK_K_HAVING | TK_K_IF | TK_K_IGNORE | TK_K_IMMEDIATE | TK_K_IN | TK_K_INDEX | TK_K_INDEXED | TK_K_INITIALLY | TK_K_INNER | TK_K_INSERT | TK_K_INSTEAD | TK_K_INTERSECT | TK_K_INTO | TK_K_IS | TK_K_ISNULL | TK_K_JOIN | TK_K_KEY | TK_K_LEFT | TK_K_LIKE | TK_K_LIMIT | TK_K_MATCH | TK_K_NATURAL | TK_K_NO | TK_K_NOT | TK_K_NOTNULL | TK_K_NULL | TK_K_OF | TK_K_OFFSET | TK_K_ON | TK_K_OR | TK_K_ORDER | TK_K_OUTER | TK_K_PLAN | TK_K_PRAGMA | TK_K_PRIMARY | TK_K_QUERY | TK_K_RAISE | TK_K_RECURSIVE | TK_K_REFERENCES | TK_K_REGEXP | TK_K_REINDEX | TK_K_RELEASE | TK_K_RENAME | TK_K_REPLACE | TK_K_RESTRICT | TK_K_RIGHT | TK_K_ROLLBACK | TK_K_ROW | TK_K_SAVEPOINT | TK_K_SELECT | TK_K_SET | TK_K_TABLE | TK_K_TEMP | TK_K_TEMPORARY | TK_K_THEN | TK_K_TO | TK_K_TRANSACTION | TK_K_TRIGGER | TK_K_UNION | TK_K_UNIQUE | TK_K_UPDATE | TK_K_USING | TK_K_VACUUM | TK_K_VALUES | TK_K_VIEW | TK_K_VIRTUAL | TK_K_WHEN | TK_K_WHERE | TK_K_WITH | TK_K_WITHOUT | TK_STRING_LITERAL } {
-            let saved = p.pos;
-            let r_1 = parse_table_or_subquery_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_table_or_subquery_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_table_or_subquery_bt_1(p);
             }
             return parse_table_or_subquery_bt_0(p);
         }
@@ -10139,6 +12107,15 @@ fn parse_compound_operator_bt_1(p: &mut Parser) -> Result<CompoundOperatorNode, 
     }));
 }
 
+fn parse_compound_operator_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_UNION { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_ALL { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_compound_operator_bt_0(p: &mut Parser) -> Result<CompoundOperatorNode, ParseError> {
     let start = p.peek().span.start;
     let k_union = p.expect(TK_K_UNION)?;
@@ -10146,6 +12123,13 @@ fn parse_compound_operator_bt_0(p: &mut Parser) -> Result<CompoundOperatorNode, 
         span: Span::new(start, p.last_end()),
         k_union,
     }));
+}
+
+fn parse_compound_operator_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_K_UNION { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_compound_operator(p: &mut Parser) -> Result<CompoundOperatorNode, ParseError> {

--- a/package-gale/tests/golden/typescript.wado
+++ b/package-gale/tests/golden/typescript.wado
@@ -7898,6 +7898,1256 @@ impl Parser {
     }
 }
 
+fn scan_predefined_type(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Any { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_NullLiteral { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Number { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_DecimalLiteral { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Boolean { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_BooleanLiteral { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_String { break try_6; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_StringLiteral { break try_7; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_8: {
+            if pos < tokens.len() && tokens[pos].kind == TK_Unique {
+                let sp = pos;
+                if pos >= tokens.len() || tokens[pos].kind != TK_Unique { pos = -1; } else { pos += 1; }
+                if pos < 0 { pos = sp; }
+            }
+            if pos >= tokens.len() || tokens[pos].kind != TK_Symbol { break try_8; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_9: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Never { break try_9; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_10: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Undefined { break try_10; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_11: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Object { break try_11; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Void { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_type_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_namespace_name(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_type_query(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_TYPEOF { return -1; }
+    pos += 1;
+    pos = scan_type_query_expression(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_type_query_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_identifier_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        while pos < tokens.len() && tokens[pos].kind matches { TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Break | TK_Do | TK_Instanceof | TK_Typeof | TK_Case | TK_Else | TK_New | TK_Var | TK_Catch | TK_Finally | TK_Return | TK_Void | TK_Continue | TK_For | TK_Switch | TK_While | TK_Debugger | TK_Function_ | TK_This | TK_With | TK_Default | TK_If | TK_Throw | TK_Delete | TK_In | TK_Try | TK_Class | TK_Enum | TK_Extends | TK_Super | TK_Const | TK_Export | TK_Import | TK_Implements | TK_Let | TK_Private | TK_Public | TK_Interface | TK_Package | TK_Protected | TK_Static | TK_Await | TK_ReadOnly | TK_Require | TK_Module | TK_NullLiteral | TK_BooleanLiteral } {
+            let sp = pos;
+            pos = scan_identifier_name(tokens, pos);
+            if pos < 0 { return -1; }
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+            pos += 1;
+            if pos < 0 { pos = sp; break; }
+        }
+        pos = scan_identifier_name(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_accessibility_modifier(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Public { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Private { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Protected { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_namespace_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos].kind == TK_LIT_DOT {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        while pos < tokens.len() && tokens[pos].kind == TK_LIT_DOT {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; break; }
+        }
+        pos = scan_identifier(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; break; }
+    }
+    return pos;
+}
+
+fn scan_import_alias_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { return -1; }
+    pos += 1;
+    pos = scan_namespace_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_import_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Import { return -1; }
+    pos += 1;
+    pos = scan_import_from_block(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_import_from_block(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos < tokens.len() && tokens[pos].kind matches { TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Break | TK_Do | TK_Instanceof | TK_Typeof | TK_Case | TK_Else | TK_New | TK_Var | TK_Catch | TK_Finally | TK_Return | TK_Void | TK_Continue | TK_For | TK_Switch | TK_While | TK_Debugger | TK_Function_ | TK_This | TK_With | TK_Default | TK_If | TK_Throw | TK_Delete | TK_In | TK_Try | TK_Class | TK_Enum | TK_Extends | TK_Super | TK_Const | TK_Export | TK_Import | TK_Implements | TK_Let | TK_Private | TK_Public | TK_Interface | TK_Package | TK_Protected | TK_Static | TK_Await | TK_ReadOnly | TK_Require | TK_Module | TK_NullLiteral | TK_BooleanLiteral } {
+                let sp = pos;
+                pos = scan_import_default(tokens, pos);
+                if pos < 0 { pos = sp; }
+            }
+            let gp_0 = pos;
+            sg_0: {
+                pos = gp_0;
+                sg_0_0: {
+                    pos = scan_import_namespace(tokens, pos);
+                    if pos < 0 { break sg_0_0; }
+                    break sg_0;
+                }
+                pos = gp_0;
+                pos = scan_import_module_items(tokens, pos);
+                if pos < 0 { return -1; }
+            }
+            pos = scan_import_from(tokens, pos);
+            if pos < 0 { break try_0; }
+            pos = scan_eos(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_StringLiteral { return -1; }
+        pos += 1;
+        pos = scan_eos(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_import_module_items(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Break | TK_Do | TK_Instanceof | TK_Typeof | TK_Case | TK_Else | TK_New | TK_Var | TK_Catch | TK_Finally | TK_Return | TK_Void | TK_Continue | TK_For | TK_Switch | TK_While | TK_Debugger | TK_Function_ | TK_This | TK_With | TK_Default | TK_If | TK_Throw | TK_Delete | TK_In | TK_Try | TK_Class | TK_Enum | TK_Extends | TK_Super | TK_Const | TK_Export | TK_Import | TK_Implements | TK_Let | TK_Private | TK_Public | TK_Interface | TK_Package | TK_Protected | TK_Static | TK_Await | TK_ReadOnly | TK_Require | TK_Module | TK_NullLiteral | TK_BooleanLiteral | TK_StringLiteral } {
+        let sp = pos;
+        pos = scan_import_alias_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Break | TK_Do | TK_Instanceof | TK_Typeof | TK_Case | TK_Else | TK_New | TK_Var | TK_Catch | TK_Finally | TK_Return | TK_Void | TK_Continue | TK_For | TK_Switch | TK_While | TK_Debugger | TK_Function_ | TK_This | TK_With | TK_Default | TK_If | TK_Throw | TK_Delete | TK_In | TK_Try | TK_Class | TK_Enum | TK_Extends | TK_Super | TK_Const | TK_Export | TK_Import | TK_Implements | TK_Let | TK_Private | TK_Public | TK_Interface | TK_Package | TK_Protected | TK_Static | TK_Await | TK_ReadOnly | TK_Require | TK_Module | TK_NullLiteral | TK_BooleanLiteral | TK_StringLiteral } {
+        let sp = pos;
+        pos = scan_import_alias_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_import_alias_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_module_export_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind == TK_As {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_As { return -1; }
+        pos += 1;
+        pos = scan_imported_binding(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_module_export_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_identifier_name(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_StringLiteral { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_imported_binding(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Identifier { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Yield { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Await { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_import_default(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_alias_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_import_namespace(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let gp_1 = pos;
+    sg_1: {
+        pos = gp_1;
+        sg_1_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break sg_1_0; }
+            pos += 1;
+            break sg_1;
+        }
+        pos = gp_1;
+        pos = scan_identifier_name(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_As {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_As { return -1; }
+        pos += 1;
+        pos = scan_identifier_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_import_from(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_From { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_StringLiteral { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_alias_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind == TK_As {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_As { return -1; }
+        pos += 1;
+        pos = scan_identifier_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_export_from_block(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_import_namespace(tokens, pos);
+            if pos < 0 { break try_0; }
+            pos = scan_import_from(tokens, pos);
+            if pos < 0 { break try_0; }
+            pos = scan_eos(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_export_module_items(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < tokens.len() && tokens[pos].kind == TK_From {
+            let sp = pos;
+            pos = scan_import_from(tokens, pos);
+            if pos < 0 { pos = sp; }
+        }
+        pos = scan_eos(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_export_module_items(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Break | TK_Do | TK_Instanceof | TK_Typeof | TK_Case | TK_Else | TK_New | TK_Var | TK_Catch | TK_Finally | TK_Return | TK_Void | TK_Continue | TK_For | TK_Switch | TK_While | TK_Debugger | TK_Function_ | TK_This | TK_With | TK_Default | TK_If | TK_Throw | TK_Delete | TK_In | TK_Try | TK_Class | TK_Enum | TK_Extends | TK_Super | TK_Const | TK_Export | TK_Import | TK_Implements | TK_Let | TK_Private | TK_Public | TK_Interface | TK_Package | TK_Protected | TK_Static | TK_Await | TK_ReadOnly | TK_Require | TK_Module | TK_NullLiteral | TK_BooleanLiteral | TK_StringLiteral } {
+        let sp = pos;
+        pos = scan_export_alias_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; break; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Break | TK_Do | TK_Instanceof | TK_Typeof | TK_Case | TK_Else | TK_New | TK_Var | TK_Catch | TK_Finally | TK_Return | TK_Void | TK_Continue | TK_For | TK_Switch | TK_While | TK_Debugger | TK_Function_ | TK_This | TK_With | TK_Default | TK_If | TK_Throw | TK_Delete | TK_In | TK_Try | TK_Class | TK_Enum | TK_Extends | TK_Super | TK_Const | TK_Export | TK_Import | TK_Implements | TK_Let | TK_Private | TK_Public | TK_Interface | TK_Package | TK_Protected | TK_Static | TK_Await | TK_ReadOnly | TK_Require | TK_Module | TK_NullLiteral | TK_BooleanLiteral | TK_StringLiteral } {
+        let sp = pos;
+        pos = scan_export_alias_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
+            let sp = pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { pos = -1; } else { pos += 1; }
+            if pos < 0 { pos = sp; }
+        }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_export_alias_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_module_export_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind == TK_As {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_As { return -1; }
+        pos += 1;
+        pos = scan_module_export_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_empty_statement_(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_var_modifier(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Var { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Let { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Const { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_continue_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Continue { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract } {
+        let sp = pos;
+        pos = scan_identifier(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_eos(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_break_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Break { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract } {
+        let sp = pos;
+        pos = scan_identifier(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos < 0 { pos = sp; }
+    }
+    pos = scan_eos(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_debugger_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Debugger { return -1; }
+    pos += 1;
+    pos = scan_eos(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_property_member_base(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Public | TK_Private | TK_Protected } {
+        let sp = pos;
+        pos = scan_accessibility_modifier(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_Async {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Async { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_Static {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Static { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_ReadOnly {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_ReadOnly { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
+fn scan_private_identifier(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT__ { return -1; }
+    pos += 1;
+    pos = scan_identifier_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_assignment_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAREQ { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SLASHEQ { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_PERCENTEQ { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_PLUSEQ { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_MINUSEQ { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LTLTEQ { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_GTGTEQ { break try_6; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_GTGTGTEQ { break try_7; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_8: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_AMPEQ { break try_8; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_9: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_CARETEQ { break try_9; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_10: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_PIPEEQ { break try_10; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_11: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STARSTAREQ { break try_11; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT___EQ { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_numeric_literal(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_DecimalLiteral { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_HexIntegerLiteral { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_OctalIntegerLiteral { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_OctalIntegerLiteral2 { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_BinaryIntegerLiteral { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_bigint_literal(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_BigDecimalIntegerLiteral { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_BigHexIntegerLiteral { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_BigOctalIntegerLiteral { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_BigBinaryIntegerLiteral { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_identifier_name(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        pos = scan_reserved_word(tokens, pos);
+        if pos < 0 { return -1; }
+    }
+    return pos;
+}
+
+fn scan_identifier(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Identifier { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Async { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_As { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_From { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Yield { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Of { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Any { break try_6; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Any { break try_7; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_8: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Number { break try_8; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_9: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Boolean { break try_9; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_10: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_String { break try_10; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_11: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Unique { break try_11; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_12: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Symbol { break try_12; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_13: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Never { break try_13; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_14: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Undefined { break try_14; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_15: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Object { break try_15; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_16: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KeyOf { break try_16; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_17: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_TypeAlias { break try_17; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_18: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Constructor { break try_18; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_19: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Namespace { break try_19; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Abstract { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_identifier_or_key_word(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_identifier(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_TypeAlias { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Require { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_reserved_word(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            pos = scan_keyword(tokens, pos);
+            if pos < 0 { break try_0; }
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_NullLiteral { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_BooleanLiteral { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_keyword(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Break { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Do { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Instanceof { break try_2; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_3: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Typeof { break try_3; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_4: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Case { break try_4; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_5: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Else { break try_5; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_6: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_New { break try_6; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_7: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Var { break try_7; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_8: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Catch { break try_8; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_9: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Finally { break try_9; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_10: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Return { break try_10; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_11: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Void { break try_11; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_12: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Continue { break try_12; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_13: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_For { break try_13; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_14: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Switch { break try_14; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_15: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_While { break try_15; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_16: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Debugger { break try_16; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_17: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Function_ { break try_17; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_18: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_This { break try_18; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_19: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_With { break try_19; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_20: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Default { break try_20; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_21: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_If { break try_21; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_22: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Throw { break try_22; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_23: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Delete { break try_23; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_24: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_In { break try_24; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_25: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Try { break try_25; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_26: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Class { break try_26; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_27: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Enum { break try_27; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_28: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Extends { break try_28; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_29: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Super { break try_29; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_30: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Const { break try_30; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_31: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Export { break try_31; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_32: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Import { break try_32; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_33: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Implements { break try_33; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_34: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Let { break try_34; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_35: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Private { break try_35; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_36: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Public { break try_36; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_37: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Interface { break try_37; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_38: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Package { break try_38; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_39: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Protected { break try_39; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_40: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Static { break try_40; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_41: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Yield { break try_41; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_42: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Async { break try_42; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_43: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Await { break try_43; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_44: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_ReadOnly { break try_44; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_45: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_From { break try_45; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_46: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_As { break try_46; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_47: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Require { break try_47; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_48: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_TypeAlias { break try_48; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_49: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_String { break try_49; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_50: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Boolean { break try_50; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_51: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_Number { break try_51; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Module { return -1; }
+        pos += 1;
+    }
+    return pos;
+}
+
+fn scan_eos(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let start = pos;
+    scan_alts: {
+        pos = start;
+        try_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { break try_0; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_EOF { break try_1; }
+            pos += 1;
+            break scan_alts;
+        }
+        pos = start;
+        try_2: {
+            break scan_alts;
+        }
+        pos = start;
+    }
+    return pos;
+}
+
 fn parse_initializer(p: &mut Parser) -> Result<InitializerNode, ParseError> {
     let start = p.peek().span.start;
     let eq = p.expect(TK_LIT_EQ)?;
@@ -7978,6 +9228,15 @@ fn parse_type_parameter_bt_1(p: &mut Parser) -> Result<TypeParameterNode, ParseE
     }));
 }
 
+fn parse_type_parameter_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_type_parameter_bt_0(p: &mut Parser) -> Result<TypeParameterNode, ParseError> {
     let start = p.peek().span.start;
     let identifier = parse_identifier(p)?;
@@ -7992,6 +9251,13 @@ fn parse_type_parameter_bt_0(p: &mut Parser) -> Result<TypeParameterNode, ParseE
         identifier,
         constraint,
     }));
+}
+
+fn parse_type_parameter_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_type_parameter(p: &mut Parser) -> Result<TypeParameterNode, ParseError> {
@@ -8231,6 +9497,27 @@ fn parse_type__bt_0(p: &mut Parser) -> Result<TypeNode, ParseError> {
     }));
 }
 
+fn parse_type__scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_LIT_PIPE | TK_LIT_AMP } {
+        let sp = pos;
+        let gp_2 = pos;
+        sg_2: {
+            pos = gp_2;
+            sg_2_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_PIPE { break sg_2_0; }
+                pos += 1;
+                break sg_2;
+            }
+            pos = gp_2;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_AMP { return -1; }
+            pos += 1;
+        }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
 fn parse_type_(p: &mut Parser) -> Result<TypeNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
@@ -8371,6 +9658,13 @@ fn parse_primary_type_bt_9(p: &mut Parser) -> Result<PrimaryTypeNode, ParseError
     }));
 }
 
+fn parse_primary_type_scan_9(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_KeyOf { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_primary_type_bt_1(p: &mut Parser) -> Result<PrimaryTypeNode, ParseError> {
     let start = p.peek().span.start;
     let predefined_type = parse_predefined_type(p)?;
@@ -8378,6 +9672,13 @@ fn parse_primary_type_bt_1(p: &mut Parser) -> Result<PrimaryTypeNode, ParseError
         span: Span::new(start, p.last_end()),
         predefined_type,
     }));
+}
+
+fn parse_primary_type_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_predefined_type(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_primary_type_bt_2(p: &mut Parser) -> Result<PrimaryTypeNode, ParseError> {
@@ -8735,6 +10036,13 @@ fn parse_type_name_bt_0(p: &mut Parser) -> Result<TypeNameNode, ParseError> {
     }));
 }
 
+fn parse_type_name_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_type_name_bt_1(p: &mut Parser) -> Result<TypeNameNode, ParseError> {
     let start = p.peek().span.start;
     let namespace_name = parse_namespace_name(p)?;
@@ -8744,17 +10052,20 @@ fn parse_type_name_bt_1(p: &mut Parser) -> Result<TypeNameNode, ParseError> {
     }));
 }
 
+fn parse_type_name_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_namespace_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_type_name(p: &mut Parser) -> Result<TypeNameNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract } {
         if p.peek_kind() matches { TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract } {
-            let saved = p.pos;
-            let r_0 = parse_type_name_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_type_name_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_type_name_bt_0(p);
             }
             return parse_type_name_bt_1(p);
         }
@@ -9048,6 +10359,13 @@ fn parse_type_query_expression_bt_0(p: &mut Parser) -> Result<TypeQueryExpressio
     }));
 }
 
+fn parse_type_query_expression_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_type_query_expression_bt_1(p: &mut Parser) -> Result<TypeQueryExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let mut identifier_name_dot_list: Array<IdentifierNameDotItem> = [];
@@ -9068,6 +10386,25 @@ fn parse_type_query_expression_bt_1(p: &mut Parser) -> Result<TypeQueryExpressio
         identifier_name_dot_list,
         identifier_name,
     }));
+}
+
+fn parse_type_query_expression_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier_name(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Break | TK_Do | TK_Instanceof | TK_Typeof | TK_Case | TK_Else | TK_New | TK_Var | TK_Catch | TK_Finally | TK_Return | TK_Void | TK_Continue | TK_For | TK_Switch | TK_While | TK_Debugger | TK_Function_ | TK_This | TK_With | TK_Default | TK_If | TK_Throw | TK_Delete | TK_In | TK_Try | TK_Class | TK_Enum | TK_Extends | TK_Super | TK_Const | TK_Export | TK_Import | TK_Implements | TK_Let | TK_Private | TK_Public | TK_Interface | TK_Package | TK_Protected | TK_Static | TK_Await | TK_ReadOnly | TK_Require | TK_Module | TK_NullLiteral | TK_BooleanLiteral } {
+        let sp = pos;
+        pos = scan_identifier_name(tokens, pos);
+        if pos < 0 { return -1; }
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; break; }
+    }
+    pos = scan_identifier_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_type_query_expression(p: &mut Parser) -> Result<TypeQueryExpressionNode, ParseError> {
@@ -10080,6 +11417,13 @@ fn parse_statement_bt_27(p: &mut Parser) -> Result<StatementNode, ParseError> {
     }));
 }
 
+fn parse_statement_scan_27(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Export { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_statement_bt_2(p: &mut Parser) -> Result<StatementNode, ParseError> {
     let start = p.peek().span.start;
     let import_statement = parse_import_statement(p)?;
@@ -10087,6 +11431,13 @@ fn parse_statement_bt_2(p: &mut Parser) -> Result<StatementNode, ParseError> {
         span: Span::new(start, p.last_end()),
         import_statement,
     }));
+}
+
+fn parse_statement_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_import_statement(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_statement_bt_3(p: &mut Parser) -> Result<StatementNode, ParseError> {
@@ -10125,6 +11476,13 @@ fn parse_statement_bt_13(p: &mut Parser) -> Result<StatementNode, ParseError> {
     }));
 }
 
+fn parse_statement_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_continue_statement(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_statement_bt_14(p: &mut Parser) -> Result<StatementNode, ParseError> {
     let start = p.peek().span.start;
     let break_statement = parse_break_statement(p)?;
@@ -10132,6 +11490,13 @@ fn parse_statement_bt_14(p: &mut Parser) -> Result<StatementNode, ParseError> {
         span: Span::new(start, p.last_end()),
         break_statement,
     }));
+}
+
+fn parse_statement_scan_14(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_break_statement(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_statement_bt_15(p: &mut Parser) -> Result<StatementNode, ParseError> {
@@ -10186,6 +11551,13 @@ fn parse_statement_bt_22(p: &mut Parser) -> Result<StatementNode, ParseError> {
         span: Span::new(start, p.last_end()),
         debugger_statement,
     }));
+}
+
+fn parse_statement_scan_22(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_debugger_statement(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_statement_bt_0(p: &mut Parser) -> Result<StatementNode, ParseError> {
@@ -11196,6 +12568,18 @@ fn parse_export_statement_bt_0(p: &mut Parser) -> Result<ExportStatementNode, Pa
     }));
 }
 
+fn parse_export_statement_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Export { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_Default {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Default { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
 fn parse_export_statement_bt_1(p: &mut Parser) -> Result<ExportStatementNode, ParseError> {
     let start = p.peek().span.start;
     let export_ = p.expect(TK_Export)?;
@@ -11211,16 +12595,21 @@ fn parse_export_statement_bt_1(p: &mut Parser) -> Result<ExportStatementNode, Pa
     }));
 }
 
+fn parse_export_statement_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Export { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Default { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_export_statement(p: &mut Parser) -> Result<ExportStatementNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_Export {
-        let saved = p.pos;
-        let r_0 = parse_export_statement_bt_0(p);
-        if let Err(_) = r_0 {
-            p.pos = saved;
-        } else {
-            return r_0;
+        if parse_export_statement_scan_0(&p.tokens, p.pos) >= 0 {
+            return parse_export_statement_bt_0(p);
         }
         return parse_export_statement_bt_1(p);
     }
@@ -11437,6 +12826,26 @@ fn parse_variable_statement_bt_1(p: &mut Parser) -> Result<VariableStatementNode
     }));
 }
 
+fn parse_variable_statement_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Public | TK_Private | TK_Protected } {
+        let sp = pos;
+        pos = scan_accessibility_modifier(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Var | TK_Let | TK_Const } {
+        let sp = pos;
+        pos = scan_var_modifier(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    if pos < tokens.len() && tokens[pos].kind == TK_ReadOnly {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_ReadOnly { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
 fn parse_variable_statement_bt_0(p: &mut Parser) -> Result<VariableStatementNode, ParseError> {
     let start = p.peek().span.start;
     let binding_pattern = parse_binding_pattern(p)?;
@@ -11467,12 +12876,8 @@ fn parse_variable_statement(p: &mut Parser) -> Result<VariableStatementNode, Par
     let kind = p.peek_kind();
     if kind matches { TK_Public | TK_Private | TK_Protected | TK_Var | TK_Let | TK_Const | TK_ReadOnly | TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Require | TK_LIT_LBRACKET | TK_LIT_LBRACE } {
         if p.peek_kind() matches { TK_LIT_LBRACKET | TK_LIT_LBRACE } {
-            let saved = p.pos;
-            let r_1 = parse_variable_statement_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_variable_statement_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_variable_statement_bt_1(p);
             }
             return parse_variable_statement_bt_0(p);
         } else if p.peek_kind() matches { TK_Public | TK_Private | TK_Protected | TK_Var | TK_Let | TK_Const | TK_ReadOnly | TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Require } {
@@ -11674,6 +13079,17 @@ fn parse_iteration_statement_bt_3(p: &mut Parser) -> Result<IterationStatementNo
     }));
 }
 
+fn parse_iteration_statement_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_For { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    pos = scan_var_modifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_iteration_statement_bt_7(p: &mut Parser) -> Result<IterationStatementNode, ParseError> {
     let start = p.peek().span.start;
     let for_ = p.expect(TK_For)?;
@@ -11716,6 +13132,22 @@ fn parse_iteration_statement_bt_7(p: &mut Parser) -> Result<IterationStatementNo
     }));
 }
 
+fn parse_iteration_statement_scan_7(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_For { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_Await {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Await { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    pos = scan_var_modifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_iteration_statement_bt_6(p: &mut Parser) -> Result<IterationStatementNode, ParseError> {
     let start = p.peek().span.start;
     let for_ = p.expect(TK_For)?;
@@ -11754,6 +13186,20 @@ fn parse_iteration_statement_bt_6(p: &mut Parser) -> Result<IterationStatementNo
         rparen,
         statement,
     }));
+}
+
+fn parse_iteration_statement_scan_6(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_For { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_Await {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Await { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_iteration_statement_bt_2(p: &mut Parser) -> Result<IterationStatementNode, ParseError> {
@@ -11796,6 +13242,15 @@ fn parse_iteration_statement_bt_2(p: &mut Parser) -> Result<IterationStatementNo
     }));
 }
 
+fn parse_iteration_statement_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_For { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_iteration_statement_bt_5(p: &mut Parser) -> Result<IterationStatementNode, ParseError> {
     let start = p.peek().span.start;
     let for_ = p.expect(TK_For)?;
@@ -11819,6 +13274,17 @@ fn parse_iteration_statement_bt_5(p: &mut Parser) -> Result<IterationStatementNo
     }));
 }
 
+fn parse_iteration_statement_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_For { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    pos = scan_var_modifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_iteration_statement_bt_4(p: &mut Parser) -> Result<IterationStatementNode, ParseError> {
     let start = p.peek().span.start;
     let for_ = p.expect(TK_For)?;
@@ -11838,6 +13304,15 @@ fn parse_iteration_statement_bt_4(p: &mut Parser) -> Result<IterationStatementNo
         rparen,
         statement,
     }));
+}
+
+fn parse_iteration_statement_scan_4(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_For { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_iteration_statement(p: &mut Parser) -> Result<IterationStatementNode, ParseError> {
@@ -11878,36 +13353,20 @@ fn parse_iteration_statement(p: &mut Parser) -> Result<IterationStatementNode, P
         }));
     }
     if kind == TK_For {
-        let saved = p.pos;
-        let r_3 = parse_iteration_statement_bt_3(p);
-        if let Err(_) = r_3 {
-            p.pos = saved;
-        } else {
-            return r_3;
+        if parse_iteration_statement_scan_3(&p.tokens, p.pos) >= 0 {
+            return parse_iteration_statement_bt_3(p);
         }
-        let r_7 = parse_iteration_statement_bt_7(p);
-        if let Err(_) = r_7 {
-            p.pos = saved;
-        } else {
-            return r_7;
+        if parse_iteration_statement_scan_7(&p.tokens, p.pos) >= 0 {
+            return parse_iteration_statement_bt_7(p);
         }
-        let r_6 = parse_iteration_statement_bt_6(p);
-        if let Err(_) = r_6 {
-            p.pos = saved;
-        } else {
-            return r_6;
+        if parse_iteration_statement_scan_6(&p.tokens, p.pos) >= 0 {
+            return parse_iteration_statement_bt_6(p);
         }
-        let r_2 = parse_iteration_statement_bt_2(p);
-        if let Err(_) = r_2 {
-            p.pos = saved;
-        } else {
-            return r_2;
+        if parse_iteration_statement_scan_2(&p.tokens, p.pos) >= 0 {
+            return parse_iteration_statement_bt_2(p);
         }
-        let r_5 = parse_iteration_statement_bt_5(p);
-        if let Err(_) = r_5 {
-            p.pos = saved;
-        } else {
-            return r_5;
+        if parse_iteration_statement_scan_5(&p.tokens, p.pos) >= 0 {
+            return parse_iteration_statement_bt_5(p);
         }
         return parse_iteration_statement_bt_4(p);
     }
@@ -12560,6 +14019,13 @@ fn parse_property_member_declaration_bt_0(p: &mut Parser) -> Result<PropertyMemb
     }));
 }
 
+fn parse_property_member_declaration_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_property_member_base(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_property_member_declaration_bt_1(p: &mut Parser) -> Result<PropertyMemberDeclarationNode, ParseError> {
     let start = p.peek().span.start;
     let property_member_base = parse_property_member_base(p)?;
@@ -12595,6 +14061,13 @@ fn parse_property_member_declaration_bt_1(p: &mut Parser) -> Result<PropertyMemb
     }));
 }
 
+fn parse_property_member_declaration_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_property_member_base(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_property_member_declaration_bt_2(p: &mut Parser) -> Result<PropertyMemberDeclarationNode, ParseError> {
     let start = p.peek().span.start;
     let property_member_base = parse_property_member_base(p)?;
@@ -12624,23 +14097,23 @@ fn parse_property_member_declaration_bt_2(p: &mut Parser) -> Result<PropertyMemb
     }));
 }
 
+fn parse_property_member_declaration_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_property_member_base(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_property_member_declaration(p: &mut Parser) -> Result<PropertyMemberDeclarationNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_Public | TK_Private | TK_Protected | TK_Async | TK_Static | TK_ReadOnly } {
         if p.peek_kind() matches { TK_Public | TK_Private | TK_Protected | TK_Async | TK_Static | TK_ReadOnly } {
-            let saved = p.pos;
-            let r_0 = parse_property_member_declaration_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_property_member_declaration_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_property_member_declaration_bt_0(p);
             }
-            let r_1 = parse_property_member_declaration_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_property_member_declaration_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_property_member_declaration_bt_1(p);
             }
             return parse_property_member_declaration_bt_2(p);
         }
@@ -13321,6 +14794,13 @@ fn parse_property_assignment_bt_1(p: &mut Parser) -> Result<PropertyAssignmentNo
     }));
 }
 
+fn parse_property_assignment_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_property_assignment_bt_2(p: &mut Parser) -> Result<PropertyAssignmentNode, ParseError> {
     let start = p.peek().span.start;
     let get_accessor = parse_get_accessor(p)?;
@@ -13346,6 +14826,13 @@ fn parse_property_assignment_bt_5(p: &mut Parser) -> Result<PropertyAssignmentNo
         span: Span::new(start, p.last_end()),
         identifier_or_key_word,
     }));
+}
+
+fn parse_property_assignment_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier_or_key_word(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
 }
 
 fn parse_property_assignment_bt_4(p: &mut Parser) -> Result<PropertyAssignmentNode, ParseError> {
@@ -13384,6 +14871,16 @@ fn parse_property_assignment_bt_6(p: &mut Parser) -> Result<PropertyAssignmentNo
         ellipsis,
         single_expression,
     }));
+}
+
+fn parse_property_assignment_scan_6(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind == TK_Ellipsis {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Ellipsis { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
 }
 
 fn parse_property_assignment(p: &mut Parser) -> Result<PropertyAssignmentNode, ParseError> {
@@ -13731,6 +15228,18 @@ fn parse_single_expression_bt_1(p: &mut Parser) -> Result<SingleExpressionNode, 
     }));
 }
 
+fn parse_single_expression_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Class { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind matches { TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract } {
+        let sp = pos;
+        pos = scan_identifier(tokens, pos);
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
 fn parse_single_expression_bt_6(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let new = p.expect(TK_New)?;
@@ -13751,6 +15260,13 @@ fn parse_single_expression_bt_6(p: &mut Parser) -> Result<SingleExpressionNode, 
     }));
 }
 
+fn parse_single_expression_scan_6(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_New { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_single_expression_bt_7(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let new = p.expect(TK_New)?;
@@ -13769,6 +15285,13 @@ fn parse_single_expression_bt_7(p: &mut Parser) -> Result<SingleExpressionNode, 
     }));
 }
 
+fn parse_single_expression_scan_7(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_New { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_single_expression_bt_49(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let lparen = p.expect(TK_LIT_LPAREN)?;
@@ -13782,6 +15305,13 @@ fn parse_single_expression_bt_49(p: &mut Parser) -> Result<SingleExpressionNode,
     }));
 }
 
+fn parse_single_expression_scan_49(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_single_expression_bt_12(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let void = p.expect(TK_Void)?;
@@ -13791,6 +15321,13 @@ fn parse_single_expression_bt_12(p: &mut Parser) -> Result<SingleExpressionNode,
         void,
         single_expression,
     }));
+}
+
+fn parse_single_expression_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Void { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_single_expression_bt_13(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
@@ -13804,6 +15341,13 @@ fn parse_single_expression_bt_13(p: &mut Parser) -> Result<SingleExpressionNode,
     }));
 }
 
+fn parse_single_expression_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Typeof { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_single_expression_bt_20(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let await = p.expect(TK_Await)?;
@@ -13815,6 +15359,13 @@ fn parse_single_expression_bt_20(p: &mut Parser) -> Result<SingleExpressionNode,
     }));
 }
 
+fn parse_single_expression_scan_20(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Await { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_single_expression_bt_11(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let delete = p.expect(TK_Delete)?;
@@ -13824,6 +15375,13 @@ fn parse_single_expression_bt_11(p: &mut Parser) -> Result<SingleExpressionNode,
         delete,
         single_expression,
     }));
+}
+
+fn parse_single_expression_scan_11(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Delete { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_single_expression_bt_47(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
@@ -13887,6 +15445,13 @@ fn parse_single_expression_bt_44(p: &mut Parser) -> Result<SingleExpressionNode,
     }));
 }
 
+fn parse_single_expression_scan_44(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier_name(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_single_expression_bt_45(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let super = p.expect(TK_Super)?;
@@ -13896,6 +15461,13 @@ fn parse_single_expression_bt_45(p: &mut Parser) -> Result<SingleExpressionNode,
     }));
 }
 
+fn parse_single_expression_scan_45(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Super { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_single_expression_bt_43(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let this = p.expect(TK_This)?;
@@ -13903,6 +15475,13 @@ fn parse_single_expression_bt_43(p: &mut Parser) -> Result<SingleExpressionNode,
         span: Span::new(start, p.last_end()),
         this,
     }));
+}
+
+fn parse_single_expression_scan_43(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_This { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_single_expression_bt_39(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
@@ -14072,12 +15651,8 @@ fn parse_single_expression_atom(p: &mut Parser) -> Result<SingleExpressionNode, 
             }
             return parse_single_expression_bt_47(p);
         } else if p.peek_kind() == TK_LIT_LPAREN {
-            let saved = p.pos;
-            let r_49 = parse_single_expression_bt_49(p);
-            if let Err(_) = r_49 {
-                p.pos = saved;
-            } else {
-                return r_49;
+            if parse_single_expression_scan_49(&p.tokens, p.pos) >= 0 {
+                return parse_single_expression_bt_49(p);
             }
             return parse_single_expression_bt_0(p);
         } else if p.peek_kind() matches { TK_Async | TK_Function_ } {
@@ -14888,6 +16463,21 @@ fn parse_as_expression_bt_0(p: &mut Parser) -> Result<AsExpressionNode, ParseErr
     }));
 }
 
+fn parse_as_expression_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_predefined_type(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos < tokens.len() && tokens[pos].kind == TK_LIT_LBRACKET {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
+        pos += 1;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
+        pos += 1;
+        if pos < 0 { pos = sp; }
+    }
+    return pos;
+}
+
 fn parse_as_expression(p: &mut Parser) -> Result<AsExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
@@ -14921,6 +16511,13 @@ fn parse_assignable_bt_0(p: &mut Parser) -> Result<AssignableNode, ParseError> {
     }));
 }
 
+fn parse_assignable_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_assignable_bt_1(p: &mut Parser) -> Result<AssignableNode, ParseError> {
     let start = p.peek().span.start;
     let keyword = parse_keyword(p)?;
@@ -14930,6 +16527,13 @@ fn parse_assignable_bt_1(p: &mut Parser) -> Result<AssignableNode, ParseError> {
     }));
 }
 
+fn parse_assignable_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_keyword(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_assignable(p: &mut Parser) -> Result<AssignableNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
@@ -14937,12 +16541,8 @@ fn parse_assignable(p: &mut Parser) -> Result<AssignableNode, ParseError> {
         if p.peek_kind() matches { TK_Identifier | TK_Of | TK_Any | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_Constructor | TK_Namespace | TK_Abstract } {
             return parse_assignable_bt_0(p);
         } else if p.peek_kind() matches { TK_Async | TK_As | TK_From | TK_Yield | TK_Number | TK_Boolean | TK_String | TK_TypeAlias } {
-            let saved = p.pos;
-            let r_0 = parse_assignable_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_assignable_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_assignable_bt_0(p);
             }
             return parse_assignable_bt_1(p);
         } else if p.peek_kind() matches { TK_Break | TK_Do | TK_Instanceof | TK_Typeof | TK_Case | TK_Else | TK_New | TK_Var | TK_Catch | TK_Finally | TK_Return | TK_Void | TK_Continue | TK_For | TK_Switch | TK_While | TK_Debugger | TK_Function_ | TK_This | TK_With | TK_Default | TK_If | TK_Throw | TK_Delete | TK_In | TK_Try | TK_Class | TK_Enum | TK_Extends | TK_Super | TK_Const | TK_Export | TK_Import | TK_Implements | TK_Let | TK_Private | TK_Public | TK_Interface | TK_Package | TK_Protected | TK_Static | TK_Await | TK_ReadOnly | TK_Require | TK_Module } {
@@ -15015,6 +16615,25 @@ fn parse_anonymous_function_bt_1(p: &mut Parser) -> Result<AnonymousFunctionNode
         function_body,
         rbrace,
     }));
+}
+
+fn parse_anonymous_function_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos < tokens.len() && tokens[pos].kind == TK_Async {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_Async { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_Function_ { return -1; }
+    pos += 1;
+    if pos < tokens.len() && tokens[pos].kind == TK_LIT_STAR {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_anonymous_function_bt_0(p: &mut Parser) -> Result<AnonymousFunctionNode, ParseError> {
@@ -15138,6 +16757,13 @@ fn parse_arrow_function_body_bt_1(p: &mut Parser) -> Result<ArrowFunctionBodyNod
     }));
 }
 
+fn parse_arrow_function_body_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_arrow_function_body_bt_0(p: &mut Parser) -> Result<ArrowFunctionBodyNode, ParseError> {
     let start = p.peek().span.start;
     let single_expression = parse_single_expression(p)?;
@@ -15152,12 +16778,8 @@ fn parse_arrow_function_body(p: &mut Parser) -> Result<ArrowFunctionBodyNode, Pa
     let kind = p.peek_kind();
     if kind matches { TK_LIT_LBRACE | TK_Async | TK_Function_ | TK_Identifier | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Break | TK_Do | TK_Instanceof | TK_Typeof | TK_Case | TK_Else | TK_New | TK_Var | TK_Catch | TK_Finally | TK_Return | TK_Void | TK_Continue | TK_For | TK_Switch | TK_While | TK_Debugger | TK_This | TK_With | TK_Default | TK_If | TK_Throw | TK_Delete | TK_In | TK_Try | TK_Class | TK_Enum | TK_Extends | TK_Super | TK_Const | TK_Export | TK_Import | TK_Implements | TK_Let | TK_Private | TK_Public | TK_Interface | TK_Package | TK_Protected | TK_Static | TK_Await | TK_ReadOnly | TK_Require | TK_Module | TK_NullLiteral | TK_BooleanLiteral | TK_StringLiteral | TK_DecimalLiteral | TK_HexIntegerLiteral | TK_OctalIntegerLiteral | TK_OctalIntegerLiteral2 | TK_BinaryIntegerLiteral | TK_LIT_LBRACKET | TK_LIT_LPAREN | TK_LIT_PLUSPLUS | TK_LIT_MINUSMINUS | TK_LIT_PLUS | TK_LIT_MINUS | TK_LIT_TILDE | TK_LIT_BANG | TK_YieldStar | TK_BackTick | TK_RegularExpressionLiteral | TK_BigDecimalIntegerLiteral | TK_BigHexIntegerLiteral | TK_BigOctalIntegerLiteral | TK_BigBinaryIntegerLiteral | TK_LIT_LT } {
         if p.peek_kind() == TK_LIT_LBRACE {
-            let saved = p.pos;
-            let r_1 = parse_arrow_function_body_bt_1(p);
-            if let Err(_) = r_1 {
-                p.pos = saved;
-            } else {
-                return r_1;
+            if parse_arrow_function_body_scan_1(&p.tokens, p.pos) >= 0 {
+                return parse_arrow_function_body_bt_1(p);
             }
             return parse_arrow_function_body_bt_0(p);
         } else if p.peek_kind() matches { TK_Async | TK_Function_ | TK_Identifier | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Break | TK_Do | TK_Instanceof | TK_Typeof | TK_Case | TK_Else | TK_New | TK_Var | TK_Catch | TK_Finally | TK_Return | TK_Void | TK_Continue | TK_For | TK_Switch | TK_While | TK_Debugger | TK_This | TK_With | TK_Default | TK_If | TK_Throw | TK_Delete | TK_In | TK_Try | TK_Class | TK_Enum | TK_Extends | TK_Super | TK_Const | TK_Export | TK_Import | TK_Implements | TK_Let | TK_Private | TK_Public | TK_Interface | TK_Package | TK_Protected | TK_Static | TK_Await | TK_ReadOnly | TK_Require | TK_Module | TK_NullLiteral | TK_BooleanLiteral | TK_StringLiteral | TK_DecimalLiteral | TK_HexIntegerLiteral | TK_OctalIntegerLiteral | TK_OctalIntegerLiteral2 | TK_BinaryIntegerLiteral | TK_LIT_LBRACKET | TK_LIT_LPAREN | TK_LIT_PLUSPLUS | TK_LIT_MINUSMINUS | TK_LIT_PLUS | TK_LIT_MINUS | TK_LIT_TILDE | TK_LIT_BANG | TK_YieldStar | TK_BackTick | TK_RegularExpressionLiteral | TK_BigDecimalIntegerLiteral | TK_BigHexIntegerLiteral | TK_BigOctalIntegerLiteral | TK_BigBinaryIntegerLiteral | TK_LIT_LT } {
@@ -15497,6 +17119,13 @@ fn parse_identifier_name_bt_0(p: &mut Parser) -> Result<IdentifierNameNode, Pars
     }));
 }
 
+fn parse_identifier_name_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_identifier_name_bt_1(p: &mut Parser) -> Result<IdentifierNameNode, ParseError> {
     let start = p.peek().span.start;
     let reserved_word = parse_reserved_word(p)?;
@@ -15506,6 +17135,13 @@ fn parse_identifier_name_bt_1(p: &mut Parser) -> Result<IdentifierNameNode, Pars
     }));
 }
 
+fn parse_identifier_name_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_reserved_word(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_identifier_name(p: &mut Parser) -> Result<IdentifierNameNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
@@ -15513,12 +17149,8 @@ fn parse_identifier_name(p: &mut Parser) -> Result<IdentifierNameNode, ParseErro
         if p.peek_kind() matches { TK_Identifier | TK_Of | TK_Any | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_Constructor | TK_Namespace | TK_Abstract } {
             return parse_identifier_name_bt_0(p);
         } else if p.peek_kind() matches { TK_Async | TK_As | TK_From | TK_Yield | TK_Number | TK_Boolean | TK_String | TK_TypeAlias } {
-            let saved = p.pos;
-            let r_0 = parse_identifier_name_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_identifier_name_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_identifier_name_bt_0(p);
             }
             return parse_identifier_name_bt_1(p);
         } else if p.peek_kind() matches { TK_Break | TK_Do | TK_Instanceof | TK_Typeof | TK_Case | TK_Else | TK_New | TK_Var | TK_Catch | TK_Finally | TK_Return | TK_Void | TK_Continue | TK_For | TK_Switch | TK_While | TK_Debugger | TK_Function_ | TK_This | TK_With | TK_Default | TK_If | TK_Throw | TK_Delete | TK_In | TK_Try | TK_Class | TK_Enum | TK_Extends | TK_Super | TK_Const | TK_Export | TK_Import | TK_Implements | TK_Let | TK_Private | TK_Public | TK_Interface | TK_Package | TK_Protected | TK_Static | TK_Await | TK_ReadOnly | TK_Require | TK_Module | TK_NullLiteral | TK_BooleanLiteral } {
@@ -15541,6 +17173,13 @@ fn parse_identifier_bt_6(p: &mut Parser) -> Result<IdentifierNode, ParseError> {
     }));
 }
 
+fn parse_identifier_scan_6(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Any { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_identifier_bt_7(p: &mut Parser) -> Result<IdentifierNode, ParseError> {
     let start = p.peek().span.start;
     let any = p.expect(TK_Any)?;
@@ -15548,6 +17187,13 @@ fn parse_identifier_bt_7(p: &mut Parser) -> Result<IdentifierNode, ParseError> {
         span: Span::new(start, p.last_end()),
         any,
     }));
+}
+
+fn parse_identifier_scan_7(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_Any { return -1; }
+    pos += 1;
+    return pos;
 }
 
 fn parse_identifier(p: &mut Parser) -> Result<IdentifierNode, ParseError> {
@@ -15596,12 +17242,8 @@ fn parse_identifier(p: &mut Parser) -> Result<IdentifierNode, ParseError> {
         }));
     }
     if kind == TK_Any {
-        let saved = p.pos;
-        let r_6 = parse_identifier_bt_6(p);
-        if let Err(_) = r_6 {
-            p.pos = saved;
-        } else {
-            return r_6;
+        if parse_identifier_scan_6(&p.tokens, p.pos) >= 0 {
+            return parse_identifier_bt_6(p);
         }
         return parse_identifier_bt_7(p);
     }
@@ -15712,6 +17354,13 @@ fn parse_identifier_or_key_word_bt_0(p: &mut Parser) -> Result<IdentifierOrKeyWo
     }));
 }
 
+fn parse_identifier_or_key_word_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_identifier(tokens, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
 fn parse_identifier_or_key_word_bt_1(p: &mut Parser) -> Result<IdentifierOrKeyWordNode, ParseError> {
     let start = p.peek().span.start;
     let typealias = p.expect(TK_TypeAlias)?;
@@ -15721,17 +17370,20 @@ fn parse_identifier_or_key_word_bt_1(p: &mut Parser) -> Result<IdentifierOrKeyWo
     }));
 }
 
+fn parse_identifier_or_key_word_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_TypeAlias { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn parse_identifier_or_key_word(p: &mut Parser) -> Result<IdentifierOrKeyWordNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind matches { TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract } {
         if p.peek_kind() == TK_TypeAlias {
-            let saved = p.pos;
-            let r_0 = parse_identifier_or_key_word_bt_0(p);
-            if let Err(_) = r_0 {
-                p.pos = saved;
-            } else {
-                return r_0;
+            if parse_identifier_or_key_word_scan_0(&p.tokens, p.pos) >= 0 {
+                return parse_identifier_or_key_word_bt_0(p);
             }
             return parse_identifier_or_key_word_bt_1(p);
         } else if p.peek_kind() matches { TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_Constructor | TK_Namespace | TK_Abstract } {

--- a/package-gale/tests/golden/typescript.wado
+++ b/package-gale/tests/golden/typescript.wado
@@ -12608,8 +12608,14 @@ fn parse_export_statement(p: &mut Parser) -> Result<ExportStatementNode, ParseEr
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_Export {
+        let saved = p.pos;
         if parse_export_statement_scan_0(&p.tokens, p.pos) >= 0 {
-            return parse_export_statement_bt_0(p);
+            let r_0 = parse_export_statement_bt_0(p);
+            if let Err(_) = r_0 {
+                p.pos = saved;
+            } else {
+                return r_0;
+            }
         }
         return parse_export_statement_bt_1(p);
     }
@@ -12876,8 +12882,14 @@ fn parse_variable_statement(p: &mut Parser) -> Result<VariableStatementNode, Par
     let kind = p.peek_kind();
     if kind matches { TK_Public | TK_Private | TK_Protected | TK_Var | TK_Let | TK_Const | TK_ReadOnly | TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Require | TK_LIT_LBRACKET | TK_LIT_LBRACE } {
         if p.peek_kind() matches { TK_LIT_LBRACKET | TK_LIT_LBRACE } {
+            let saved = p.pos;
             if parse_variable_statement_scan_1(&p.tokens, p.pos) >= 0 {
-                return parse_variable_statement_bt_1(p);
+                let r_1 = parse_variable_statement_bt_1(p);
+                if let Err(_) = r_1 {
+                    p.pos = saved;
+                } else {
+                    return r_1;
+                }
             }
             return parse_variable_statement_bt_0(p);
         } else if p.peek_kind() matches { TK_Public | TK_Private | TK_Protected | TK_Var | TK_Let | TK_Const | TK_ReadOnly | TK_Identifier | TK_Async | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Require } {
@@ -13353,20 +13365,46 @@ fn parse_iteration_statement(p: &mut Parser) -> Result<IterationStatementNode, P
         }));
     }
     if kind == TK_For {
+        let saved = p.pos;
         if parse_iteration_statement_scan_3(&p.tokens, p.pos) >= 0 {
-            return parse_iteration_statement_bt_3(p);
+            let r_3 = parse_iteration_statement_bt_3(p);
+            if let Err(_) = r_3 {
+                p.pos = saved;
+            } else {
+                return r_3;
+            }
         }
         if parse_iteration_statement_scan_7(&p.tokens, p.pos) >= 0 {
-            return parse_iteration_statement_bt_7(p);
+            let r_7 = parse_iteration_statement_bt_7(p);
+            if let Err(_) = r_7 {
+                p.pos = saved;
+            } else {
+                return r_7;
+            }
         }
         if parse_iteration_statement_scan_6(&p.tokens, p.pos) >= 0 {
-            return parse_iteration_statement_bt_6(p);
+            let r_6 = parse_iteration_statement_bt_6(p);
+            if let Err(_) = r_6 {
+                p.pos = saved;
+            } else {
+                return r_6;
+            }
         }
         if parse_iteration_statement_scan_2(&p.tokens, p.pos) >= 0 {
-            return parse_iteration_statement_bt_2(p);
+            let r_2 = parse_iteration_statement_bt_2(p);
+            if let Err(_) = r_2 {
+                p.pos = saved;
+            } else {
+                return r_2;
+            }
         }
         if parse_iteration_statement_scan_5(&p.tokens, p.pos) >= 0 {
-            return parse_iteration_statement_bt_5(p);
+            let r_5 = parse_iteration_statement_bt_5(p);
+            if let Err(_) = r_5 {
+                p.pos = saved;
+            } else {
+                return r_5;
+            }
         }
         return parse_iteration_statement_bt_4(p);
     }
@@ -14109,11 +14147,22 @@ fn parse_property_member_declaration(p: &mut Parser) -> Result<PropertyMemberDec
     let kind = p.peek_kind();
     if kind matches { TK_Public | TK_Private | TK_Protected | TK_Async | TK_Static | TK_ReadOnly } {
         if p.peek_kind() matches { TK_Public | TK_Private | TK_Protected | TK_Async | TK_Static | TK_ReadOnly } {
+            let saved = p.pos;
             if parse_property_member_declaration_scan_0(&p.tokens, p.pos) >= 0 {
-                return parse_property_member_declaration_bt_0(p);
+                let r_0 = parse_property_member_declaration_bt_0(p);
+                if let Err(_) = r_0 {
+                    p.pos = saved;
+                } else {
+                    return r_0;
+                }
             }
             if parse_property_member_declaration_scan_1(&p.tokens, p.pos) >= 0 {
-                return parse_property_member_declaration_bt_1(p);
+                let r_1 = parse_property_member_declaration_bt_1(p);
+                if let Err(_) = r_1 {
+                    p.pos = saved;
+                } else {
+                    return r_1;
+                }
             }
             return parse_property_member_declaration_bt_2(p);
         }
@@ -15651,8 +15700,14 @@ fn parse_single_expression_atom(p: &mut Parser) -> Result<SingleExpressionNode, 
             }
             return parse_single_expression_bt_47(p);
         } else if p.peek_kind() == TK_LIT_LPAREN {
+            let saved = p.pos;
             if parse_single_expression_scan_49(&p.tokens, p.pos) >= 0 {
-                return parse_single_expression_bt_49(p);
+                let r_49 = parse_single_expression_bt_49(p);
+                if let Err(_) = r_49 {
+                    p.pos = saved;
+                } else {
+                    return r_49;
+                }
             }
             return parse_single_expression_bt_0(p);
         } else if p.peek_kind() matches { TK_Async | TK_Function_ } {
@@ -16778,8 +16833,14 @@ fn parse_arrow_function_body(p: &mut Parser) -> Result<ArrowFunctionBodyNode, Pa
     let kind = p.peek_kind();
     if kind matches { TK_LIT_LBRACE | TK_Async | TK_Function_ | TK_Identifier | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Break | TK_Do | TK_Instanceof | TK_Typeof | TK_Case | TK_Else | TK_New | TK_Var | TK_Catch | TK_Finally | TK_Return | TK_Void | TK_Continue | TK_For | TK_Switch | TK_While | TK_Debugger | TK_This | TK_With | TK_Default | TK_If | TK_Throw | TK_Delete | TK_In | TK_Try | TK_Class | TK_Enum | TK_Extends | TK_Super | TK_Const | TK_Export | TK_Import | TK_Implements | TK_Let | TK_Private | TK_Public | TK_Interface | TK_Package | TK_Protected | TK_Static | TK_Await | TK_ReadOnly | TK_Require | TK_Module | TK_NullLiteral | TK_BooleanLiteral | TK_StringLiteral | TK_DecimalLiteral | TK_HexIntegerLiteral | TK_OctalIntegerLiteral | TK_OctalIntegerLiteral2 | TK_BinaryIntegerLiteral | TK_LIT_LBRACKET | TK_LIT_LPAREN | TK_LIT_PLUSPLUS | TK_LIT_MINUSMINUS | TK_LIT_PLUS | TK_LIT_MINUS | TK_LIT_TILDE | TK_LIT_BANG | TK_YieldStar | TK_BackTick | TK_RegularExpressionLiteral | TK_BigDecimalIntegerLiteral | TK_BigHexIntegerLiteral | TK_BigOctalIntegerLiteral | TK_BigBinaryIntegerLiteral | TK_LIT_LT } {
         if p.peek_kind() == TK_LIT_LBRACE {
+            let saved = p.pos;
             if parse_arrow_function_body_scan_1(&p.tokens, p.pos) >= 0 {
-                return parse_arrow_function_body_bt_1(p);
+                let r_1 = parse_arrow_function_body_bt_1(p);
+                if let Err(_) = r_1 {
+                    p.pos = saved;
+                } else {
+                    return r_1;
+                }
             }
             return parse_arrow_function_body_bt_0(p);
         } else if p.peek_kind() matches { TK_Async | TK_Function_ | TK_Identifier | TK_As | TK_From | TK_Yield | TK_Of | TK_Any | TK_Number | TK_Boolean | TK_String | TK_Unique | TK_Symbol | TK_Never | TK_Undefined | TK_Object | TK_KeyOf | TK_TypeAlias | TK_Constructor | TK_Namespace | TK_Abstract | TK_Break | TK_Do | TK_Instanceof | TK_Typeof | TK_Case | TK_Else | TK_New | TK_Var | TK_Catch | TK_Finally | TK_Return | TK_Void | TK_Continue | TK_For | TK_Switch | TK_While | TK_Debugger | TK_This | TK_With | TK_Default | TK_If | TK_Throw | TK_Delete | TK_In | TK_Try | TK_Class | TK_Enum | TK_Extends | TK_Super | TK_Const | TK_Export | TK_Import | TK_Implements | TK_Let | TK_Private | TK_Public | TK_Interface | TK_Package | TK_Protected | TK_Static | TK_Await | TK_ReadOnly | TK_Require | TK_Module | TK_NullLiteral | TK_BooleanLiteral | TK_StringLiteral | TK_DecimalLiteral | TK_HexIntegerLiteral | TK_OctalIntegerLiteral | TK_OctalIntegerLiteral2 | TK_BinaryIntegerLiteral | TK_LIT_LBRACKET | TK_LIT_LPAREN | TK_LIT_PLUSPLUS | TK_LIT_MINUSMINUS | TK_LIT_PLUS | TK_LIT_MINUS | TK_LIT_TILDE | TK_LIT_BANG | TK_YieldStar | TK_BackTick | TK_RegularExpressionLiteral | TK_BigDecimalIntegerLiteral | TK_BigHexIntegerLiteral | TK_BigOctalIntegerLiteral | TK_BigBinaryIntegerLiteral | TK_LIT_LT } {


### PR DESCRIPTION
## Summary

- Generate lightweight **scan functions** for each scannable parser rule that check token kinds only (no CST, no error construction), then use them to pick the correct alternative before calling the real parse function exactly once
- Adds scannability analysis (`gen_context.wado`) to identify which rules can be recognized by bounded token scans — left-recursive rules like `expr` are correctly excluded
- Distinguishes **full scans** (all elements scannable → direct dispatch) from **partial scans** (prefix only → save/restore with fallthrough) to avoid false positives
- SQL Parse benchmark ratio vs sqlparser-rs improved from **12.35x → 6.91x** (44% faster)

## Approach

For each `Backtrack` node in the SLL prediction tree, instead of generating save/try/restore code that calls full parse functions speculatively:

```
// Before: try each alternative, backtrack on failure
let saved = p.pos;
let r = parse_rule_bt_1(p);        // full parse: CST + errors
if let Err(_) = r { p.pos = saved; } else { return r; }
return parse_rule_bt_2(p);

// After: scan to pick the right alternative, parse once
if scan_rule_bt_1(&p.tokens, p.pos) >= 0 {
    return parse_rule_bt_1(p);      // parse once, correct alternative
}
return parse_rule_bt_2(p);
```

This is grammar-agnostic — scan functions are generated mechanically from any grammar's rules. The SLL prediction engine is unchanged; only code generation for `Backtrack` nodes is modified.

## Test plan

- [x] All 1,635 Wado tests pass (including 219 Gale driver tests across 11 grammars)
- [x] All 14 golden fixture tests pass
- [x] `mise run on-task-done` passes (format, clippy, golden regen, full test suite)
- [x] `mise run benchmark-sqlite-parse` confirms 6.91x ratio (down from 12.35x)

https://claude.ai/code/session_01AJHKv7nFtp78uT5J7XLcq8