### PR TITLE
WEP: Default Arguments for functions and struct fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ PLAN.md
 profile.json
 *.jitdump
 jit-*.dump
+
+# npm
+node_modules/

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -97,3 +97,4 @@ It may include TODOs on WIP.
 - [WebIDL Binding Generator (`wado-from-idl`)](./wep-2026-04-01-tide.md)
 - [Reactive Signals](./wep-2026-04-04-reactive-signals.md)
 - [URL Standard Library (`core:url`)](./wep-2026-04-10-url-stdlib.md)
+- [Default Arguments](./wep-2026-04-11-default-arguments.md)

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -260,19 +260,6 @@ struct Box<T> {
     value: T,
 }
 
-// Field defaults
-struct Config {
-    host: String,              // required (no default)
-    port: i32 = 8080,          // optional (has default)
-    debug: bool = false,
-}
-
-let c = Config { host: "localhost" };
-// → Config { host: "localhost", port: 8080, debug: false }
-
-let c = Config { host: "localhost", port: 3000 };
-// → Config { host: "localhost", port: 3000, debug: false }
-
 // Field visibility
 pub struct Config {
     pub name: String,   // accessible from other modules
@@ -621,16 +608,6 @@ fn add(a: i32, b: i32) -> i32 {
     return a + b;
 }
 
-// Default arguments (trailing parameters only)
-fn connect(host: String, port: i32 = 8080, timeout: i32 = 30) { ... }
-connect("localhost");              // → connect("localhost", 8080, 30)
-connect("localhost", 3000);        // → connect("localhost", 3000, 30)
-connect("localhost", 3000, 60);
-
-// Default expressions: any pure expression (no effects)
-fn make_rect(width: f64, height: f64 = width) -> Rect { ... }
-make_rect(10.0);                   // → make_rect(10.0, 10.0)
-
 // With effects
 fn greet(name: String) with Stdout {
     println(`Hello, {name}!`);
@@ -646,8 +623,6 @@ export fn run() { ... }
 ```
 
 A function must have `return` if it returns a value. See Visibility for `pub` and `export` details.
-
-Default arguments are desugared at the call site (zero overhead). Default expressions must be pure (no effects). Defaults are not part of function types — assigning to `fn(A, B) -> C` erases defaults.
 
 ### Methods
 
@@ -692,10 +667,6 @@ let compute = |x: i32| {
 
 // Struct literal return
 let make_point = |x: i32, y: i32| Point { x, y };
-
-// Default parameters in closures
-let greet = |name: String, greeting: String = "Hello"| `{greeting}, {name}!`;
-greet("Alice");        // → greet("Alice", "Hello")
 
 // Capturing outer variables (value semantics - copy)
 let multiplier = 10;
@@ -846,18 +817,6 @@ trait Summary {
         return `Title: {self.title()}`;
     }
 }
-
-// Default arguments in trait methods (only trait defines defaults, not impl)
-trait Drawable {
-    fn draw(&self, opacity: f64 = 1.0);
-}
-
-impl Drawable for Circle {
-    fn draw(&self, opacity: f64) { ... }  // impl receives all params
-}
-
-circle.draw();      // → circle.draw(1.0)
-circle.draw(0.5);
 
 // Associated type
 trait Container {

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -260,6 +260,19 @@ struct Box<T> {
     value: T,
 }
 
+// Field defaults
+struct Config {
+    host: String,              // required (no default)
+    port: i32 = 8080,          // optional (has default)
+    debug: bool = false,
+}
+
+let c = Config { host: "localhost" };
+// → Config { host: "localhost", port: 8080, debug: false }
+
+let c = Config { host: "localhost", port: 3000 };
+// → Config { host: "localhost", port: 3000, debug: false }
+
 // Field visibility
 pub struct Config {
     pub name: String,   // accessible from other modules
@@ -608,6 +621,16 @@ fn add(a: i32, b: i32) -> i32 {
     return a + b;
 }
 
+// Default arguments (trailing parameters only)
+fn connect(host: String, port: i32 = 8080, timeout: i32 = 30) { ... }
+connect("localhost");              // → connect("localhost", 8080, 30)
+connect("localhost", 3000);        // → connect("localhost", 3000, 30)
+connect("localhost", 3000, 60);
+
+// Default expressions: any pure expression (no effects)
+fn make_rect(width: f64, height: f64 = width) -> Rect { ... }
+make_rect(10.0);                   // → make_rect(10.0, 10.0)
+
 // With effects
 fn greet(name: String) with Stdout {
     println(`Hello, {name}!`);
@@ -623,6 +646,8 @@ export fn run() { ... }
 ```
 
 A function must have `return` if it returns a value. See Visibility for `pub` and `export` details.
+
+Default arguments are desugared at the call site (zero overhead). Default expressions must be pure (no effects). Defaults are not part of function types — assigning to `fn(A, B) -> C` erases defaults.
 
 ### Methods
 
@@ -667,6 +692,10 @@ let compute = |x: i32| {
 
 // Struct literal return
 let make_point = |x: i32, y: i32| Point { x, y };
+
+// Default parameters in closures
+let greet = |name: String, greeting: String = "Hello"| `{greeting}, {name}!`;
+greet("Alice");        // → greet("Alice", "Hello")
 
 // Capturing outer variables (value semantics - copy)
 let multiplier = 10;
@@ -817,6 +846,18 @@ trait Summary {
         return `Title: {self.title()}`;
     }
 }
+
+// Default arguments in trait methods (only trait defines defaults, not impl)
+trait Drawable {
+    fn draw(&self, opacity: f64 = 1.0);
+}
+
+impl Drawable for Circle {
+    fn draw(&self, opacity: f64) { ... }  // impl receives all params
+}
+
+circle.draw();      // → circle.draw(1.0)
+circle.draw(0.5);
 
 // Associated type
 trait Container {

--- a/docs/wep-2026-04-01-tide.md
+++ b/docs/wep-2026-04-01-tide.md
@@ -63,6 +63,12 @@ Wado eliminates several root causes of these pain points:
 
 `wado-from-idl` uses the [`@webref/idl`](https://www.npmjs.com/package/@webref/idl) npm package as its source of truth. This package provides curated, validated WebIDL definitions scraped from W3C and WHATWG specifications, updated weekly. All definitions are guaranteed to parse and be internally consistent.
 
+```sh
+npm install @webref/idl
+```
+
+The package's `parseAll()` API (powered by `webidl2`) produces parsed AST nodes with structured `default` fields for optional parameters and dictionary members. Default value types: `boolean`, `number`, `string`, `null`, `dictionary` (`= {}`), `sequence` (`= []`). When no default is specified, the `default` field is `null`.
+
 ### Tool Implementation
 
 `wado-from-idl` (renamed from `wado-from-wit`) already provides a type-safe IR (`WadoModule`, `WadoResource`, `WadoStruct`, `WadoEffect`, etc.) and a `WadoCodeGenerator` that emits clean Wado source. The concepts map directly: WIT interfaces and WebIDL interfaces both produce resources, structs, enums, and effects.

--- a/docs/wep-2026-04-01-tide.md
+++ b/docs/wep-2026-04-01-tide.md
@@ -324,11 +324,11 @@ pub resource EventTarget {
 
     #[cm("web:dom#EventTarget.addEventListener")]
     fn add_event_listener(&self, type: String, callback: Option<fn(Event)>,
-                          options: Option<AddEventListenerOptions> = null);
+                          options: AddEventListenerOptions = AddEventListenerOptions {});
 
     #[cm("web:dom#EventTarget.removeEventListener")]
     fn remove_event_listener(&self, type: String, callback: Option<fn(Event)>,
-                             options: Option<EventListenerOptions> = null);
+                             options: EventListenerOptions = EventListenerOptions {});
 
     #[cm("web:dom#EventTarget.dispatchEvent")]
     fn dispatch_event(&self, event: Event) -> bool;
@@ -658,7 +658,7 @@ Generated Wado:
 
 ```wado
 pub struct RequestInit {
-    pub method: String = "GET",
+    pub method: Option<String> = null,
     pub headers: Option<Headers> = null,
     pub body: Option<String> = null,
     pub mode: Option<RequestMode> = null,
@@ -728,7 +728,7 @@ fn load_data(url: String) with Fetch {
 
 fn post_json(url: String, body: String) with Fetch {
     let init: RequestInit = {
-        method: "POST",
+        method: Option::Some("POST"),
         body: Option::Some(body),
         mode: Option::Some(RequestMode::Cors),
     };

--- a/docs/wep-2026-04-01-tide.md
+++ b/docs/wep-2026-04-01-tide.md
@@ -182,7 +182,7 @@ This applies only to `resource` (opaque handle types), not to `struct` (value ty
 | `interface`       | `resource`             | Opaque handle with methods       |
 | `interface X : Y` | `resource X extends Y` | Single inheritance               |
 | `interface mixin` | `trait`                | Shared behavior across resources |
-| `dictionary`      | `struct`               | Data with optional fields        |
+| `dictionary`      | `struct`               | Data with field defaults         |
 | `enum`            | `enum`                 | String enum → Wado enum          |
 | `callback`        | `fn(...)`              | Closure type                     |
 | `typedef`         | `type`                 | Newtype alias                    |
@@ -224,19 +224,29 @@ fn app() with Dom, Fetch {
 
 ### Method Overload Strategy
 
-WebIDL allows method overloading (same name, different signatures). `wado-from-idl` resolves these using `Option<T>` for optional parameters:
+WebIDL allows method overloading (same name, different signatures) and optional parameters with default values. `wado-from-idl` resolves these using [default arguments](./wep-2026-04-11-default-arguments.md):
 
 ```webidl
-// WebIDL: addEventListener has optional third argument
+// WebIDL: optional parameter with default
+Node cloneNode(optional boolean deep = false);
+// WebIDL: optional parameter without default
+undefined fillText(DOMString text, double x, double y, optional double maxWidth);
+// WebIDL: nullable callback with optional third argument
 undefined addEventListener(DOMString type, EventListener? callback,
                            optional (AddEventListenerOptions or boolean) options);
 ```
 
 ```wado
-// Generated Wado: optional param becomes Option<T>
+// Generated Wado: optional params with known defaults use the actual type
+fn clone_node(&self, deep: bool = false) -> Node;
+// Optional params without a WebIDL default use Option<T> with = null
+fn fill_text(&self, text: String, x: f64, y: f64, max_width: Option<f64> = null);
+// Nullable params remain Option<T>; optional params get defaults
 fn add_event_listener(&self, type: String, callback: Option<fn(Event)>,
-                      options: Option<AddEventListenerOptions>);
+                      options: Option<AddEventListenerOptions> = null);
 ```
+
+Default arguments are desugared at the call site with zero overhead — see [WEP: Default Arguments](./wep-2026-04-11-default-arguments.md).
 
 For true type overloads (different types at the same position), `wado-from-idl` generates a variant:
 
@@ -246,8 +256,6 @@ variant CanvasImageSourceOrPath {
     Path(Path2d),
 }
 ```
-
-Future Wado language extensions (default arguments, named parameters) will further improve this.
 
 ### Concrete Examples
 
@@ -293,14 +301,14 @@ Generated Wado:
 #![generated]
 
 pub struct EventListenerOptions {
-    pub capture: Option<bool>,
+    pub capture: bool = false,
 }
 
 pub struct AddEventListenerOptions {
-    pub capture: Option<bool>,
-    pub passive: Option<bool>,
-    pub once: Option<bool>,
-    pub signal: Option<AbortSignal>,
+    pub capture: bool = false,
+    pub passive: Option<bool> = null,
+    pub once: bool = false,
+    pub signal: Option<AbortSignal> = null,
 }
 
 #[cm("web:dom#EventTarget")]
@@ -310,11 +318,11 @@ pub resource EventTarget {
 
     #[cm("web:dom#EventTarget.addEventListener")]
     fn add_event_listener(&self, type: String, callback: Option<fn(Event)>,
-                          options: Option<AddEventListenerOptions>);
+                          options: Option<AddEventListenerOptions> = null);
 
     #[cm("web:dom#EventTarget.removeEventListener")]
     fn remove_event_listener(&self, type: String, callback: Option<fn(Event)>,
-                             options: Option<EventListenerOptions>);
+                             options: Option<EventListenerOptions> = null);
 
     #[cm("web:dom#EventTarget.dispatchEvent")]
     fn dispatch_event(&self, event: Event) -> bool;
@@ -347,7 +355,7 @@ pub resource Node extends EventTarget {
     fn remove_child(&self, child: &Node) -> Node;
 
     #[cm("web:dom#Node.cloneNode")]
-    fn clone_node(&self, deep: Option<bool>) -> Node;
+    fn clone_node(&self, deep: bool = false) -> Node;
 }
 
 #[cm("web:dom#Element")]
@@ -383,10 +391,10 @@ pub resource Element extends Node {
 
 Key design points:
 
-- Dictionary inheritance is flattened (`AddEventListenerOptions` includes `capture` from `EventListenerOptions`).
+- Dictionary inheritance is flattened (`AddEventListenerOptions` includes `capture` from `EventListenerOptions`). Dictionary fields use struct field defaults.
 - `(AddEventListenerOptions or boolean)` union is simplified to `Option<AddEventListenerOptions>`. The `boolean` shorthand (`{capture: true}`) is a JS convenience that the host runtime can handle.
 - `callback EventListener = undefined (Event event)` becomes `fn(Event)` directly — Wado closures are GC-managed, no wrapping needed.
-- `optional boolean deep = false` becomes `Option<bool>` — default values are applied by the host.
+- `optional boolean deep = false` becomes `deep: bool = false` — default arguments are desugared at the call site with zero overhead.
 
 #### Document and the Dom Effect
 
@@ -434,7 +442,7 @@ fn setup_page() with Dom {
     let doc = Dom::document();
     let el = doc.create_element("div");
     el.set_id("app");
-    el.set_text_content(Option::<String>::Some("Hello, Wado!"));
+    el.set_text_content(Option::Some("Hello, Wado!"));
     if let Some(body) = doc.body() {
         body.append_child(&el);  // append_child from Node, available via extends
     }
@@ -533,7 +541,7 @@ fn setup_form() with Dom {
             input.add_event_listener("input", Option::Some(|e: Event| {
                 // Closures just work — no Closure::wrap, no .forget()
                 log_stdout(`input changed`);
-            }), null);
+            }));  // options defaults to null
         }
     }
 }
@@ -611,7 +619,7 @@ fn setup_search() with Dom {
                     // ... perform search
                 }
             }
-        }), null);
+        }));  // options defaults to null
     }
 }
 ```
@@ -644,11 +652,11 @@ Generated Wado:
 
 ```wado
 pub struct RequestInit {
-    pub method: Option<String>,
-    pub headers: Option<Headers>,
-    pub body: Option<String>,
-    pub mode: Option<RequestMode>,
-    pub credentials: Option<RequestCredentials>,
+    pub method: String = "GET",
+    pub headers: Option<Headers> = null,
+    pub body: Option<String> = null,
+    pub mode: Option<RequestMode> = null,
+    pub credentials: Option<RequestCredentials> = null,
 }
 
 pub enum RequestMode {
@@ -691,7 +699,7 @@ pub resource Response {
 #[cm("web:fetch")]
 pub effect Fetch {
     #[cm("web:fetch#fetch")]
-    fn fetch(input: String, init: Option<RequestInit>) -> Future<Response>;
+    fn fetch(input: String, init: RequestInit = RequestInit {}) -> Future<Response>;
 }
 ```
 
@@ -701,7 +709,7 @@ User code:
 use { Fetch, Response, RequestInit, RequestMode } from "web:fetch";
 
 fn load_data(url: String) with Fetch {
-    let resp = Fetch::fetch(url, null).read();
+    let resp = Fetch::fetch(url).read();  // init defaults to RequestInit {}
     if let Some(r) = resp {
         if r.ok() {
             let body = r.text().read();
@@ -713,14 +721,12 @@ fn load_data(url: String) with Fetch {
 }
 
 fn post_json(url: String, body: String) with Fetch {
-    let init = RequestInit {
-        method: Option::<String>::Some("POST"),
-        body: Option::<String>::Some(body),
-        headers: null,
-        mode: Option::<RequestMode>::Some(RequestMode::Cors),
-        credentials: null,
+    let init: RequestInit = {
+        method: "POST",
+        body: Option::Some(body),
+        mode: Option::Some(RequestMode::Cors),
     };
-    let resp = Fetch::fetch(url, Option::Some(init)).read();
+    let resp = Fetch::fetch(url, init).read();
 }
 ```
 
@@ -774,7 +780,7 @@ pub resource CanvasRenderingContext2d {
     fn move_to(&self, x: f64, y: f64);
     fn line_to(&self, x: f64, y: f64);
     fn arc(&self, x: f64, y: f64, radius: f64,
-           start_angle: f64, end_angle: f64, anticlockwise: Option<bool>);
+           start_angle: f64, end_angle: f64, anticlockwise: bool = false);
     fn fill(&self);
     fn stroke(&self);
 
@@ -793,7 +799,7 @@ pub resource CanvasRenderingContext2d {
     #[cm("web:canvas#CanvasRenderingContext2D.lineWidth", setter)]
     fn set_line_width(&self, value: f64);
 
-    fn fill_text(&self, text: String, x: f64, y: f64, max_width: Option<f64>);
+    fn fill_text(&self, text: String, x: f64, y: f64, max_width: Option<f64> = null);
 
     #[cm("web:canvas#CanvasRenderingContext2D.font", getter)]
     fn font(&self) -> String;
@@ -817,12 +823,12 @@ fn draw() with Dom {
                 ctx.fill_rect(10.0, 10.0, 100.0, 50.0);
 
                 ctx.begin_path();
-                ctx.arc(75.0, 75.0, 50.0, 0.0, f64::PI * 2.0, null);
+                ctx.arc(75.0, 75.0, 50.0, 0.0, f64::PI * 2.0);  // anticlockwise defaults to false
                 ctx.set_fill_style("blue");
                 ctx.fill();
 
                 ctx.set_font("24px serif");
-                ctx.fill_text("Hello Wado!", 50.0, 150.0, null);
+                ctx.fill_text("Hello Wado!", 50.0, 150.0);  // max_width defaults to null
             }
         }
     }
@@ -917,7 +923,7 @@ Organized by W3C/WHATWG specification, mirroring how `wasi/` is organized by WAS
 | Type casting        | `el.dyn_into::<HtmlInputElement>()?`    | `el.downcast::<HtmlInputElement>()` → `Option` |
 | Closure boilerplate | `Closure::wrap(Box::new(...)).forget()` | `\|e: Event\| { ... }` — native GC closures    |
 | Untyped promises    | `JsFuture → JsValue` (untyped)          | `Future<Response>` (typed)                     |
-| Overload naming     | `fetch_with_str_and_init()`             | `fetch(url, Option::Some(init))`               |
+| Overload naming     | `fetch_with_str_and_init()`             | `fetch(url)` or `fetch(url, init)`             |
 | Feature flags       | `features = ["Element", "Node", ...]`   | None needed                                    |
 | Inheritance         | `Deref` chain (anti-pattern)            | `resource extends` (first-class)               |
 | Effect tracking     | None (side effects implicit)            | `with Dom`, `with Fetch` (explicit)            |
@@ -942,4 +948,4 @@ Organized by W3C/WHATWG specification, mirroring how `wasi/` is organized by WAS
 - Hand-tuned high-level APIs (e.g., ergonomic DOM builder DSL) — may come later as a separate library on top of the generated bindings.
 - Web Components / Custom Elements support.
 - Service Workers / Web Workers API design.
-- Default parameters and named parameters — separate Wado language WEPs.
+- Named parameters — a separate Wado language WEP.

--- a/docs/wep-2026-04-11-default-arguments.md
+++ b/docs/wep-2026-04-11-default-arguments.md
@@ -1,0 +1,438 @@
+# WEP: Default Arguments
+
+## Context
+
+Wado currently requires all function arguments and all struct fields to be specified explicitly at every call site and construction site. This creates verbosity in two major areas.
+
+### WebIDL Bindings
+
+The [WebIDL Binding Generator](./wep-2026-04-01-tide.md) generates Wado bindings for browser APIs. WebIDL makes heavy use of optional parameters with default values:
+
+```webidl
+Node cloneNode(optional boolean deep = false);
+undefined addEventListener(DOMString type, EventListener? callback,
+                           optional AddEventListenerOptions options);
+undefined fillText(DOMString text, double x, double y, optional double maxWidth);
+```
+
+Without default arguments, these map to `Option<T>` parameters, which is verbose and introduces runtime overhead (Option wrapping/unwrapping):
+
+```wado
+// Current: Option<T> mapping
+fn clone_node(&self, deep: Option<bool>) -> Node;
+fn fill_text(&self, text: String, x: f64, y: f64, max_width: Option<f64>);
+
+node.clone_node(Option::<bool>::Some(false));
+ctx.fill_text("Hello", 50.0, 150.0, null);
+```
+
+WebIDL dictionaries have the same problem. All dictionary members are optional:
+
+```webidl
+dictionary RequestInit {
+  ByteString method;
+  BodyInit? body;
+  RequestMode mode;
+};
+```
+
+```wado
+// Current: all fields are Option<T>
+let init = RequestInit {
+    method: Option::<String>::Some("POST"),
+    body: Option::<String>::Some(data),
+    headers: null,
+    mode: null,
+    credentials: null,
+};
+```
+
+### General Ergonomics
+
+Beyond WebIDL, many APIs have parameters with natural default values:
+
+```wado
+// Without defaults: multiple function names or Option wrapping
+fn connect(host: String, port: i32, timeout: i32) { ... }
+fn connect_default(host: String) { connect(host, 8080, 30); }
+```
+
+### Design Requirements
+
+- Zero overhead: a call with defaults omitted must produce the same Wasm as a call with all arguments explicit.
+- Simple, uniform rules for both function parameters and struct fields.
+
+### Cross-Language Survey
+
+| Language | Approach               | Evaluation          | Named Args       |
+| -------- | ---------------------- | ------------------- | ---------------- |
+| Swift    | Inline defaults        | Call-site           | Yes (labels)     |
+| Kotlin   | Inline defaults        | Call-site (bitmask) | Yes              |
+| Zig      | Struct field defaults  | Construction-site   | No (field names) |
+| Python   | Inline defaults        | Definition-time     | Yes              |
+| C++      | Inline defaults        | Call-site           | No               |
+| Rust     | None (builder pattern) | —                   | No               |
+
+Key lessons:
+
+- Call-site evaluation avoids Python's mutable-default pitfall.
+- Named fields/arguments make implicit omission safe (Zig, Swift, Kotlin).
+- Keeping defaults out of trait/protocol requirements avoids dispatch complexity (Swift).
+- Kotlin's bitmask approach is ABI-stable but has runtime overhead.
+- Zig's struct-field-default pattern is zero overhead and works without named arguments.
+
+## Decision
+
+### Function Parameter Defaults
+
+Trailing parameters may have default values:
+
+```wado
+fn connect(host: String, port: i32 = 8080, timeout: i32 = 30) { ... }
+
+connect("localhost");           // → connect("localhost", 8080, 30)
+connect("localhost", 3000);     // → connect("localhost", 3000, 30)
+connect("localhost", 3000, 60); // no desugaring
+```
+
+#### Syntax
+
+```
+fn name(param: Type, param: Type = expr, ...) -> ReturnType { ... }
+```
+
+Parameters with defaults must come after all parameters without defaults. This is enforced at parse time.
+
+```wado
+fn foo(a: i32 = 0, b: i32) { ... }  // compile error: non-default param after default
+```
+
+The `self` parameter cannot have a default.
+
+#### Semantics: Call-Site Expansion
+
+The compiler inserts default values at the call site as a desugaring pass. This is purely a compile-time transformation — no runtime cost.
+
+```wado
+fn greet(name: String, greeting: String = "Hello") -> String {
+    return `{greeting}, {name}!`;
+}
+
+// Source:
+greet("Alice");
+// After desugaring (identical Wasm):
+greet("Alice", "Hello");
+```
+
+#### Default Expressions
+
+Any expression without effects is allowed as a default:
+
+```wado
+fn foo(
+    x: i32 = 0,                      // literal
+    y: f64 = f64::PI,                 // associated constant
+    z: String = `default`,            // template string
+    w: Option<Config> = null,         // null (coerces to Option::None)
+    v: Color = Color::Red,            // enum variant
+    u: i32 = i32::max(1, 2),          // pure function call
+) { ... }
+
+// Error: effectful expression in default
+fn bar(path: String = read_env("PATH")) { ... }  // compile error: requires effects
+```
+
+The restriction is enforced by the effect system: default expressions must have an empty effect set.
+
+Default expressions may reference earlier parameters in the same function:
+
+```wado
+fn make_rect(width: f64, height: f64 = width) -> Rect { ... }
+
+make_rect(10.0);        // → make_rect(10.0, 10.0)
+make_rect(10.0, 20.0);
+```
+
+#### Interaction with Function Types
+
+Function types do not carry default information. Assigning a function with defaults to a function type erases the defaults:
+
+```wado
+fn connect(host: String, port: i32 = 8080) { ... }
+
+let f: fn(String, i32) = connect;  // OK: full signature
+f("localhost", 3000);              // OK
+f("localhost");                    // compile error: expected 2 arguments, found 1
+
+// The arity is part of the type — no defaults in fn types
+let g: fn(String) = connect;      // compile error: type mismatch
+```
+
+This is a direct consequence of zero overhead: function types represent the actual call signature at the Wasm level.
+
+#### Interaction with Closures
+
+Closures support default parameters with the same rules:
+
+```wado
+let greet = |name: String, greeting: String = "Hello"| `{greeting}, {name}!`;
+greet("Alice");        // → greet("Alice", "Hello")
+```
+
+When a closure is assigned to a function type, defaults are erased, same as for named functions.
+
+#### Interaction with Trait Methods
+
+Only the trait definition may specify default arguments. Implementations cannot add, remove, or change defaults:
+
+```wado
+trait Drawable {
+    fn draw(&self, opacity: f64 = 1.0);
+}
+
+impl Drawable for Circle {
+    fn draw(&self, opacity: f64) {
+        // impl receives all parameters — no default syntax here
+    }
+}
+
+let c = Circle { radius: 5.0 };
+c.draw();      // → c.draw(1.0)   — trait's default applied at call site
+c.draw(0.5);
+```
+
+Rationale: the caller sees the trait's interface, so the trait owns the defaults. This avoids ambiguity about which defaults apply when calling through a trait reference, and prevents implementations from silently changing call-site behavior.
+
+If a method is not part of a trait (a direct `impl` method), it may freely define defaults:
+
+```wado
+impl Circle {
+    fn scale(&mut self, factor: f64 = 2.0) {
+        self.radius = self.radius * factor;
+    }
+}
+```
+
+#### Interaction with Component Model Exports
+
+`export fn` may have default parameters. Defaults apply only to Wado-side calls. At the CM boundary, the host must provide all arguments (CM ABI requires all parameters):
+
+```wado
+export fn configure(name: String, debug: bool = false) { ... }
+
+// From Wado code:
+configure("app");         // → configure("app", false)
+
+// From the host (CM boundary): both arguments always required
+```
+
+### Struct Field Defaults
+
+Struct fields may have default values:
+
+```wado
+struct Config {
+    host: String,
+    port: i32 = 8080,
+    timeout: i32 = 30,
+    debug: bool = false,
+}
+```
+
+#### Implicit Omission
+
+Fields with defaults may be omitted in struct construction. Fields without defaults are required:
+
+```wado
+let c = Config { host: "localhost" };
+// Desugars to: Config { host: "localhost", port: 8080, timeout: 30, debug: false }
+
+let c = Config { host: "localhost", port: 3000 };
+// Desugars to: Config { host: "localhost", port: 3000, timeout: 30, debug: false }
+
+Config { port: 3000 };  // compile error: missing required field 'host'
+```
+
+No special syntax marker (such as `..`) is needed. This follows the same model as Zig, Swift, Kotlin, Dart, and Scala.
+
+Omission is safe because struct construction uses named fields — the compiler checks that all provided field names are valid and all required fields are present.
+
+#### Default Expressions
+
+Same rules as function parameter defaults: any expression without effects.
+
+```wado
+struct Circle {
+    center: Point = Point { x: 0, y: 0 },
+    radius: f64 = 1.0,
+}
+
+let unit_circle = Circle {};  // center at origin, radius 1.0
+```
+
+Unlike function parameter defaults, struct field default expressions cannot reference other fields.
+
+#### Interaction with Shorthand Construction
+
+Field shorthand (variable name matches field name) works with defaults:
+
+```wado
+let host = "localhost";
+let c = Config { host };
+// Desugars to: Config { host: host, port: 8080, timeout: 30, debug: false }
+```
+
+#### Interaction with Destructuring
+
+Defaults do not affect destructuring. When destructuring, all fields are available:
+
+```wado
+let Config { host, port, timeout, debug } = config;  // all fields accessible
+let Config { host, .. } = config;                     // ignore rest
+```
+
+#### Interaction with Default Trait
+
+A struct where all fields have defaults automatically implements `Default`:
+
+```wado
+struct Config {
+    host: String = "localhost",
+    port: i32 = 8080,
+}
+
+// Auto-derived (the compiler synthesizes this):
+// impl Default for Config {
+//     fn default() -> Config {
+//         return Config { host: "localhost", port: 8080 };
+//     }
+// }
+
+let c = Config::default();
+```
+
+A struct with any required field (no default) does not auto-derive `Default`.
+
+#### Interaction with Serde
+
+The `#[serde(default)]` attribute on a struct field currently uses `Default` trait for the field's type. With struct field defaults, `#[serde(default)]` uses the field's declared default value instead:
+
+```wado
+struct Config {
+    #[serde(default)]
+    port: i32 = 8080,  // serde uses 8080 when field is missing from JSON
+}
+```
+
+### WebIDL Mapping Improvement
+
+With default arguments, WebIDL optional parameters map to their actual types instead of `Option<T>`:
+
+```wado
+// Before (Option wrapping):
+fn clone_node(&self, deep: Option<bool>) -> Node;
+fn arc(&self, x: f64, y: f64, radius: f64,
+       start_angle: f64, end_angle: f64, anticlockwise: Option<bool>);
+
+// After (defaults):
+fn clone_node(&self, deep: bool = false) -> Node;
+fn arc(&self, x: f64, y: f64, radius: f64,
+       start_angle: f64, end_angle: f64, anticlockwise: bool = false);
+```
+
+WebIDL optional parameters without explicit defaults map to `Option<T>` with `= null`:
+
+```wado
+// WebIDL: undefined fillText(DOMString text, double x, double y, optional double maxWidth);
+fn fill_text(&self, text: String, x: f64, y: f64, max_width: Option<f64> = null);
+```
+
+WebIDL dictionaries map to structs with field defaults:
+
+```wado
+// Before:
+pub struct RequestInit {
+    pub method: Option<String>,
+    pub body: Option<String>,
+    pub mode: Option<RequestMode>,
+}
+
+// After:
+pub struct RequestInit {
+    pub method: String = "GET",
+    pub body: Option<String> = null,
+    pub mode: Option<RequestMode> = null,
+}
+```
+
+User code becomes significantly cleaner:
+
+```wado
+// Before:
+let init = RequestInit {
+    method: Option::<String>::Some("POST"),
+    body: Option::<String>::Some(data),
+    mode: null,
+};
+let resp = Fetch::fetch(url, Option::Some(init)).read();
+
+// After:
+let init: RequestInit = { method: "POST", body: Option::Some(data) };
+let resp = Fetch::fetch(url, init).read();
+```
+
+## Consequences
+
+### Benefits
+
+- Zero runtime overhead — defaults are a compile-time desugaring.
+- WebIDL bindings become ergonomic: `Option<T>` wrapping eliminated for parameters with known defaults.
+- Simple rule: "has default → optional, no default → required" applies uniformly to function parameters and struct fields.
+- Trait defaults are owned by the trait definition, avoiding ambiguity.
+
+### Trade-offs
+
+- Default value changes require recompilation of callers. This is a non-issue for Wado's whole-program compilation model.
+- Defaults are not part of function types. Code that stores functions as `fn(...)` values loses access to defaults. This is intentional (zero overhead).
+- No named arguments: without named arguments, only trailing parameters can have defaults. Middle parameters cannot be skipped. This limits flexibility compared to Swift/Kotlin but keeps the language simpler.
+
+### Interaction with Existing Features
+
+| Feature          | Interaction                                         |
+| ---------------- | --------------------------------------------------- |
+| Effect system    | Default expressions must be pure (no effects)       |
+| Traits           | Only trait definition specifies defaults            |
+| Function types   | Defaults erased — arity fixed                       |
+| Closures         | Defaults supported, same rules as functions         |
+| `export fn` (CM) | Defaults apply to Wado-side calls only              |
+| Default trait    | Auto-derived for all-defaulted structs              |
+| Serde            | `#[serde(default)]` uses field default value        |
+| Generics         | Default expressions are monomorphized per call site |
+
+### Not in Scope
+
+- Named arguments — a separate feature that would complement defaults by allowing middle-parameter skipping.
+- Struct update syntax (`{ field: value, ..other }`) — copying fields from another instance is orthogonal to field defaults.
+
+## Implementation Roadmap
+
+- [ ] AST: add `default: Option<Expr>` to `Param`
+- [ ] AST: add `default: Option<Expr>` to struct `Field`
+- [ ] Parser: parse `= expr` after parameter type and after struct field type
+- [ ] Parser: validate default parameters are trailing
+- [ ] Resolver: validate default expressions are pure (no effects)
+- [ ] Resolver: adjust argument count checking to allow fewer arguments
+- [ ] Resolver: insert default expressions at call sites during resolution
+- [ ] Resolver: insert default field values at struct construction sites
+- [ ] TIR: add `default_expr: Option<TirExpr>` to `TirParam` and `TirField`
+- [ ] Trait resolution: propagate trait method defaults to call sites
+- [ ] Trait resolution: reject defaults in `impl` blocks for trait methods
+- [ ] Auto-derive `Default` for all-defaulted structs
+- [ ] Update `wado-from-idl` WebIDL mapping to emit defaults instead of `Option<T>`
+- [ ] Update `wado-from-idl` dictionary mapping to emit struct field defaults
+
+## See Also
+
+- [Default Trait](./wep-2026-03-04-default-trait.md) — the `Default` trait that interacts with struct field defaults
+- [WebIDL Binding Generator](./wep-2026-04-01-tide.md) — the primary motivation for this feature
+- [Effect System Design](./wep-2026-01-27-effect-system-design.md) — enforces purity of default expressions

--- a/docs/wep-2026-04-11-default-arguments.md
+++ b/docs/wep-2026-04-11-default-arguments.md
@@ -326,16 +326,16 @@ struct Config {
 
 ### WebIDL Mapping Improvement
 
-With default arguments, WebIDL optional parameters map to their actual types instead of `Option<T>`:
+With default arguments, WebIDL optional parameters with explicit defaults map to their actual types instead of `Option<T>`:
 
 ```wado
+// WebIDL: optional boolean subtree = false
 // Before (Option wrapping):
 fn clone_node(&self, deep: Option<bool>) -> Node;
-fn arc(&self, x: f64, y: f64, radius: f64,
-       start_angle: f64, end_angle: f64, anticlockwise: Option<bool>);
-
-// After (defaults):
+// After (default value from IDL):
 fn clone_node(&self, deep: bool = false) -> Node;
+
+// WebIDL: optional boolean counterclockwise = false
 fn arc(&self, x: f64, y: f64, radius: f64,
        start_angle: f64, end_angle: f64, anticlockwise: bool = false);
 ```
@@ -343,13 +343,31 @@ fn arc(&self, x: f64, y: f64, radius: f64,
 WebIDL optional parameters without explicit defaults map to `Option<T>` with `= null`:
 
 ```wado
-// WebIDL: undefined fillText(DOMString text, double x, double y, optional double maxWidth);
+// WebIDL: optional double maxWidth (no default in IDL)
 fn fill_text(&self, text: String, x: f64, y: f64, max_width: Option<f64> = null);
 ```
 
-WebIDL dictionaries map to structs with field defaults:
+WebIDL optional parameters with `= {}` (empty dictionary default) map to struct type with struct default:
 
 ```wado
+// WebIDL: optional RequestInit init = {}
+fn fetch(input: String, init: RequestInit = RequestInit {}) -> Future<Response>;
+
+// WebIDL: optional AddEventListenerOptions options = {}
+fn add_event_listener(&self, type: String, callback: Option<fn(Event)>,
+                      options: AddEventListenerOptions = AddEventListenerOptions {});
+```
+
+WebIDL dictionaries map to structs with field defaults. Members with explicit defaults use the declared default; members without defaults use `Option<T> = null`:
+
+```wado
+// WebIDL:
+// dictionary RequestInit {
+//   ByteString method;          ← no default in IDL
+//   BodyInit? body;             ← no default in IDL
+//   RequestMode mode;           ← no default in IDL
+// };
+
 // Before:
 pub struct RequestInit {
     pub method: Option<String>,
@@ -357,11 +375,23 @@ pub struct RequestInit {
     pub mode: Option<RequestMode>,
 }
 
-// After:
+// After: all fields Option<T> = null (no IDL defaults to use)
 pub struct RequestInit {
-    pub method: String = "GET",
+    pub method: Option<String> = null,
     pub body: Option<String> = null,
     pub mode: Option<RequestMode> = null,
+}
+
+// Dictionary WITH explicit defaults:
+// dictionary ResponseInit {
+//   unsigned short status = 200;    ← default in IDL
+//   ByteString statusText = "";     ← default in IDL
+//   HeadersInit headers;            ← no default
+// };
+pub struct ResponseInit {
+    pub status: u16 = 200,
+    pub status_text: String = "",
+    pub headers: Option<Headers> = null,
 }
 ```
 
@@ -376,8 +406,8 @@ let init = RequestInit {
 };
 let resp = Fetch::fetch(url, Option::Some(init)).read();
 
-// After:
-let init: RequestInit = { method: "POST", body: Option::Some(data) };
+// After: struct field defaults eliminate boilerplate, fetch default is {}
+let init: RequestInit = { method: Option::Some("POST"), body: Option::Some(data) };
 let resp = Fetch::fetch(url, init).read();
 ```
 


### PR DESCRIPTION
## Summary

- Add WEP for default arguments: zero-overhead call-site expansion for function parameters and struct field defaults
- Update WebIDL WEP to use default arguments instead of `Option<T>` wrapping, aligned with actual `@webref/idl` data
- Add `node_modules/` to `.gitignore` for `@webref/idl` npm dependency

## Design Decisions

- **Zero overhead**: defaults are desugared at the call site — identical Wasm output
- **Function params**: trailing parameters may have `= expr` defaults (pure expressions only, no effects)
- **Struct fields**: fields with defaults can be omitted in construction (implicit, no `..` needed)
- **Traits**: only the trait definition specifies defaults; impl cannot override
- **Function types**: `fn(A, B) -> C` erases defaults — arity is fixed
- **WebIDL mapping**: `optional T x = value` → `x: T = value`; `optional T x` (no default) → `x: Option<T> = null`; `optional Dict x = {}` → `x: Dict = Dict {}`

## Test plan

- [ ] Review WEP design for completeness
- [ ] Verify WebIDL examples match `@webref/idl` data

https://claude.ai/code/session_01AvgZBwwRDvo24BWchhPYLc