### PR TITLE
Clean up dead code and consolidate walkers in TIR optimizer

### DIFF
--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -1,13 +1,19 @@
 //! Optimization pass for Wado TIR
 //!
-//! This module coordinates various optimization passes:
+//! This module coordinates the following optimization passes:
 //! - Dead Code Elimination (DCE) via `dce` module
 //! - Function inlining via `inline` module
+//! - Labeled block fusion via `labeled_block_fusion` module
 //! - Reference elimination via `ref_elim` module
 //! - Scalar Replacement of Aggregates (SROA) via `sroa` module
 //! - Copy propagation via `copy_prop` module
+//! - Common Subexpression Elimination (CSE) via `cse` module
+//! - Store-to-load forwarding via `store_load_forward` module
 //! - Constant optimizations (propagation, folding, global promotion, branch pruning) via `const_*` modules
 //! - Loop-Invariant Code Motion (LICM) via `licm` module
+//! - Condition implication elimination via `condition_implication` module
+//! - Template buffer hoisting via `tmpl_hoist` module
+//! - Hot Field Scalarization (HFS) via `field_scalarize` module
 //! - Select lowering via `select_lowering` module
 
 mod condition_implication;
@@ -200,13 +206,21 @@ fn run_pass(
 
 /// Run optimization passes with a fixed-point iteration strategy.
 ///
-/// Each iteration runs the full optimization pipeline:
-/// - Function inlining
-/// - Reference elimination
-/// - Scalar Replacement of Aggregates (SROA)
-/// - Copy propagation
-/// - Constant optimizations (propagation → folding → global promotion → branch pruning)
-/// - Loop-invariant code motion (LICM)
+/// Each iteration runs 14 optimization passes in the following order:
+/// 1. Function inlining (`inline`)
+/// 2. Labeled block fusion (`labeled_block_fusion`)
+/// 3. Reference elimination (`ref_elim`)
+/// 4. Scalar Replacement of Aggregates (`sroa`)
+/// 5. Copy propagation (`copy_prop`)
+/// 6. Common Subexpression Elimination (`cse`)
+/// 7. Store-to-load forwarding (`store_load_forward`)
+/// 8. Constant propagation (`const_prop`)
+/// 9. Constant folding (`const_fold`)
+/// 10. Constant global promotion (`const_global_promotion`)
+/// 11. Constant branch pruning (`branch_prune`)
+/// 12. Loop-invariant code motion (`licm`)
+/// 13. Condition implication elimination (`condition_implication`)
+/// 14. Template buffer hoisting (`tmpl_hoist`)
 ///
 /// The `config` parameter controls the number of iterations and inline threshold.
 /// More iterations can find more optimization opportunities but take longer.

--- a/wado-compiler/src/optimize/copy_prop.rs
+++ b/wado-compiler/src/optimize/copy_prop.rs
@@ -30,9 +30,6 @@ struct CopyBinding {
     source: CopySource,
     /// Type of the binding
     type_id: TypeId,
-    /// Whether the target is mutable
-    #[allow(dead_code)]
-    is_mut: bool,
 }
 
 /// Source of a copy binding
@@ -71,9 +68,6 @@ struct LocalUsage {
     is_assigned: bool,
     /// Whether a field of this local is ever assigned (e.g., `x.field = ...`)
     has_field_mutation: bool,
-    /// Whether the local is used in a loop condition (risky to propagate)
-    #[allow(dead_code)]
-    in_loop_condition: bool,
     /// Whether the local has its address taken
     address_taken: bool,
     /// Whether the local is captured by a closure
@@ -84,7 +78,6 @@ struct LocalUsage {
 fn analyze_copy_binding(stmt: &TirStmt) -> Option<CopyBinding> {
     let TirStmtKind::Let {
         local_index,
-        is_mut,
         value,
         skip_value_copy,
         ..
@@ -143,7 +136,6 @@ fn analyze_copy_binding(stmt: &TirStmt) -> Option<CopyBinding> {
         target_local: *local_index,
         source,
         type_id: value.type_id,
-        is_mut: *is_mut,
     })
 }
 
@@ -158,31 +150,31 @@ fn analyze_function_body(body: &TirBlock) -> AnalysisResult {
         bindings: Vec::new(),
         usage: IndexMap::default(),
     };
-    analyze_block(body, &mut result, false);
+    analyze_block(body, &mut result);
     result
 }
 
-fn analyze_block(block: &TirBlock, result: &mut AnalysisResult, in_loop: bool) {
+fn analyze_block(block: &TirBlock, result: &mut AnalysisResult) {
     for stmt in &block.stmts {
         // Check for copy bindings at statement level
         if let Some(binding) = analyze_copy_binding(stmt) {
             result.bindings.push(binding);
         }
-        analyze_stmt(stmt, result, in_loop);
+        analyze_stmt(stmt, result);
     }
 }
 
-fn analyze_stmt(stmt: &TirStmt, result: &mut AnalysisResult, in_loop: bool) {
+fn analyze_stmt(stmt: &TirStmt, result: &mut AnalysisResult) {
     match &stmt.kind {
         TirStmtKind::Let { value, .. } => {
-            analyze_expr(value, result, in_loop, false);
+            analyze_expr(value, result);
         }
         TirStmtKind::Expr(expr) => {
-            analyze_expr(expr, result, in_loop, false);
+            analyze_expr(expr, result);
         }
         TirStmtKind::Return { value } => {
             if let Some(v) = value {
-                analyze_expr(v, result, in_loop, false);
+                analyze_expr(v, result);
             }
         }
         TirStmtKind::If {
@@ -190,17 +182,17 @@ fn analyze_stmt(stmt: &TirStmt, result: &mut AnalysisResult, in_loop: bool) {
             then_block,
             else_block,
         } => {
-            analyze_expr(condition, result, in_loop, false);
-            analyze_block(then_block, result, in_loop);
+            analyze_expr(condition, result);
+            analyze_block(then_block, result);
             if let Some(eb) = else_block {
-                analyze_block(eb, result, in_loop);
+                analyze_block(eb, result);
             }
         }
         TirStmtKind::Loop { body } => {
-            analyze_block(body, result, true);
+            analyze_block(body, result);
         }
         TirStmtKind::LabeledBlock { block, .. } => {
-            analyze_block(block, result, in_loop);
+            analyze_block(block, result);
         }
         TirStmtKind::IfLet {
             scrutinee,
@@ -208,20 +200,20 @@ fn analyze_stmt(stmt: &TirStmt, result: &mut AnalysisResult, in_loop: bool) {
             else_block,
             ..
         } => {
-            analyze_expr(scrutinee, result, in_loop, false);
-            analyze_block(then_block, result, in_loop);
+            analyze_expr(scrutinee, result);
+            analyze_block(then_block, result);
             if let Some(eb) = else_block {
-                analyze_block(eb, result, in_loop);
+                analyze_block(eb, result);
             }
         }
         TirStmtKind::Break { value, .. } => {
             if let Some(v) = value {
-                analyze_expr(v, result, in_loop, false);
+                analyze_expr(v, result);
             }
         }
         TirStmtKind::Continue => {}
         TirStmtKind::LetDestructure { value, .. } => {
-            analyze_expr(value, result, in_loop, false);
+            analyze_expr(value, result);
         }
         TirStmtKind::TaskReturn { .. } => {
             unreachable!("TaskReturn should be eliminated by synthesis before this phase")
@@ -232,14 +224,10 @@ fn analyze_stmt(stmt: &TirStmt, result: &mut AnalysisResult, in_loop: bool) {
     }
 }
 
-fn analyze_expr(expr: &TirExpr, result: &mut AnalysisResult, in_loop: bool, in_condition: bool) {
+fn analyze_expr(expr: &TirExpr, result: &mut AnalysisResult) {
     match &expr.kind {
         TirExprKind::Local { index, .. } => {
-            let entry = result.usage.entry(*index).or_default();
-            entry.read_count += 1;
-            if in_loop && in_condition {
-                entry.in_loop_condition = true;
-            }
+            result.usage.entry(*index).or_default().read_count += 1;
         }
         TirExprKind::Assign { target, value } => {
             if let TirExprKind::Local { index, .. } = &target.kind {
@@ -251,8 +239,8 @@ fn analyze_expr(expr: &TirExpr, result: &mut AnalysisResult, in_loop: bool, in_c
             {
                 result.usage.entry(*index).or_default().has_field_mutation = true;
             }
-            analyze_expr(target, result, in_loop, in_condition);
-            analyze_expr(value, result, in_loop, in_condition);
+            analyze_expr(target, result);
+            analyze_expr(value, result);
         }
         TirExprKind::Unary { op, expr: inner } => {
             if matches!(op, TirUnaryOp::Ref | TirUnaryOp::MutRef)
@@ -260,36 +248,36 @@ fn analyze_expr(expr: &TirExpr, result: &mut AnalysisResult, in_loop: bool, in_c
             {
                 result.usage.entry(*index).or_default().address_taken = true;
             }
-            analyze_expr(inner, result, in_loop, in_condition);
+            analyze_expr(inner, result);
         }
         TirExprKind::Binary { left, right, .. } => {
-            analyze_expr(left, result, in_loop, in_condition);
-            analyze_expr(right, result, in_loop, in_condition);
+            analyze_expr(left, result);
+            analyze_expr(right, result);
         }
         TirExprKind::Call { args, .. } => {
             for arg in args {
-                analyze_expr(&arg.expr, result, in_loop, in_condition);
+                analyze_expr(&arg.expr, result);
             }
         }
         TirExprKind::CmRawCall { args, .. } => {
             for arg in args {
-                analyze_expr(arg, result, in_loop, in_condition);
+                analyze_expr(arg, result);
             }
         }
         TirExprKind::MethodCall { receiver, args, .. } => {
-            analyze_expr(receiver, result, in_loop, in_condition);
+            analyze_expr(receiver, result);
             for arg in args {
-                analyze_expr(&arg.expr, result, in_loop, in_condition);
+                analyze_expr(&arg.expr, result);
             }
         }
         TirExprKind::IndirectCall { callee, args, .. } => {
-            analyze_expr(callee, result, in_loop, in_condition);
+            analyze_expr(callee, result);
             for arg in args {
-                analyze_expr(arg, result, in_loop, in_condition);
+                analyze_expr(arg, result);
             }
         }
         TirExprKind::ClosureToCanonical { functor, .. } => {
-            analyze_expr(functor, result, in_loop, in_condition);
+            analyze_expr(functor, result);
         }
         TirExprKind::FieldAccess { expr: inner, .. }
         | TirExprKind::TupleSpread { expr: inner }
@@ -297,47 +285,47 @@ fn analyze_expr(expr: &TirExpr, result: &mut AnalysisResult, in_loop: bool, in_c
         | TirExprKind::TypePackExpansion {
             call_expr: inner, ..
         } => {
-            analyze_expr(inner, result, in_loop, in_condition);
+            analyze_expr(inner, result);
         }
         TirExprKind::Index {
             expr: inner, index, ..
         } => {
-            analyze_expr(inner, result, in_loop, in_condition);
-            analyze_expr(index, result, in_loop, in_condition);
+            analyze_expr(inner, result);
+            analyze_expr(index, result);
         }
         TirExprKind::Cast { expr: inner, .. } => {
-            analyze_expr(inner, result, in_loop, in_condition);
+            analyze_expr(inner, result);
         }
         TirExprKind::Block(block) => {
-            analyze_block(block, result, in_loop);
+            analyze_block(block, result);
         }
         TirExprKind::LabeledBlock { block, .. } => {
-            analyze_block(block, result, in_loop);
+            analyze_block(block, result);
         }
         TirExprKind::If {
             condition,
             then_branch,
             else_branch,
         } => {
-            analyze_expr(condition, result, in_loop, in_condition);
-            analyze_block(then_branch, result, in_loop);
+            analyze_expr(condition, result);
+            analyze_block(then_branch, result);
             if let Some(eb) = else_branch {
-                analyze_block(eb, result, in_loop);
+                analyze_block(eb, result);
             }
         }
         TirExprKind::StructLiteral { fields, .. } => {
             for field in fields {
-                analyze_expr(&field.value, result, in_loop, in_condition);
+                analyze_expr(&field.value, result);
             }
         }
         TirExprKind::TupleLiteral { elements, .. } => {
             for elem in elements {
-                analyze_expr(elem, result, in_loop, in_condition);
+                analyze_expr(elem, result);
             }
         }
         TirExprKind::VariantConstruct { payload, .. } => {
             if let Some(payload_expr) = payload {
-                analyze_expr(payload_expr, result, in_loop, in_condition);
+                analyze_expr(payload_expr, result);
             }
         }
         TirExprKind::Closure { body, captures, .. } => {
@@ -348,25 +336,25 @@ fn analyze_expr(expr: &TirExpr, result: &mut AnalysisResult, in_loop: bool, in_c
                     .or_default()
                     .is_captured = true;
             }
-            analyze_expr(body, result, in_loop, in_condition);
+            analyze_expr(body, result);
         }
         TirExprKind::Match { expr: inner, arms } => {
-            analyze_expr(inner, result, in_loop, in_condition);
+            analyze_expr(inner, result);
             for arm in arms {
                 if let Some(guard) = &arm.guard {
-                    analyze_expr(guard, result, in_loop, in_condition);
+                    analyze_expr(guard, result);
                 }
-                analyze_expr(&arm.body, result, in_loop, in_condition);
+                analyze_expr(&arm.body, result);
             }
         }
         TirExprKind::GlobalVarSet { value, .. } => {
-            analyze_expr(value, result, in_loop, in_condition);
+            analyze_expr(value, result);
         }
         TirExprKind::VariantTag { expr } | TirExprKind::VariantTest { expr, .. } => {
-            analyze_expr(expr, result, in_loop, in_condition);
+            analyze_expr(expr, result);
         }
         TirExprKind::VariantPayload { expr, .. } => {
-            analyze_expr(expr, result, in_loop, in_condition);
+            analyze_expr(expr, result);
         }
         TirExprKind::Switch {
             scrutinee,
@@ -374,11 +362,11 @@ fn analyze_expr(expr: &TirExpr, result: &mut AnalysisResult, in_loop: bool, in_c
             default,
             ..
         } => {
-            analyze_expr(scrutinee, result, in_loop, in_condition);
+            analyze_expr(scrutinee, result);
             for arm in arms {
-                analyze_block(arm, result, in_loop);
+                analyze_block(arm, result);
             }
-            analyze_block(default, result, in_loop);
+            analyze_block(default, result);
         }
         // Leaf nodes
         TirExprKind::IntLiteral { .. }

--- a/wado-compiler/src/optimize/inline.rs
+++ b/wado-compiler/src/optimize/inline.rs
@@ -11,10 +11,11 @@ use crate::hashmap::IndexMap;
 use crate::hashmap::IndexSet;
 use crate::name::ModuleSource;
 use crate::tir::{
-    CallArg, InlineHint, PrimitiveType, ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction,
-    TirPattern, TirStmt, TirStmtKind, TirUnaryOp, TypeId, TypeTable,
+    CallArg, InlineHint, ResolvedType, TirBlock, TirExpr, TirExprKind, TirFunction, TirPattern,
+    TirStmt, TirStmtKind, TirUnaryOp, TypeId, TypeTable,
 };
 use crate::tir_visitor::block_has_break_to;
+use crate::token::Span;
 
 // The inline threshold is based on expression count, which provides a more
 // accurate measure of function complexity than statement count.
@@ -1008,41 +1009,6 @@ fn inline_calls_in_block(
     block.stmts = new_stmts;
 }
 
-/// Create a default value for a type (for initializing result locals)
-fn create_default_value(type_id: TypeId, type_table: &TypeTable, span: crate::Span) -> TirExpr {
-    let kind = match type_table.get(type_id) {
-        ResolvedType::Primitive(prim) => match prim {
-            PrimitiveType::I8
-            | PrimitiveType::I16
-            | PrimitiveType::I32
-            | PrimitiveType::I64
-            | PrimitiveType::I128
-            | PrimitiveType::U8
-            | PrimitiveType::U16
-            | PrimitiveType::U32
-            | PrimitiveType::U64
-            | PrimitiveType::U128 => TirExprKind::IntLiteral {
-                value: 0,
-                repr: "0".to_string(),
-            },
-            PrimitiveType::F32 | PrimitiveType::F64 => TirExprKind::FloatLiteral {
-                value: 0.0,
-                repr: "0.0".to_string(),
-            },
-            PrimitiveType::Bool => TirExprKind::BoolLiteral(false),
-            PrimitiveType::Char => TirExprKind::CharLiteral('\0'),
-            PrimitiveType::V128 => TirExprKind::IntLiteral {
-                value: 0,
-                repr: "0".to_string(),
-            },
-        },
-        // For all reference types (structs, arrays, options, etc.), use Null
-        // The value will be immediately overwritten, so this is just a placeholder
-        _ => TirExprKind::Null,
-    };
-    TirExpr::new(kind, type_id, span)
-}
-
 /// Look up an inline candidate by module path and function name.
 fn find_inline_candidate<'a>(
     candidates: &'a IndexMap<(ModuleSource, String), TirFunction>,
@@ -1061,31 +1027,46 @@ fn find_inline_candidate<'a>(
     candidates.get(&key).map(|c| (c, key))
 }
 
-/// Try to inline a call expression, returning the inlined expression and key
-fn try_inline_call_expr(
-    expr: &TirExpr,
-    candidates: &IndexMap<(ModuleSource, String), TirFunction>,
-    current_module: &ModuleSource,
+/// Binding for a single parameter during inlining.
+///
+/// Each binding becomes a `Let` statement at the head of the synthesized
+/// labeled block. Fields carry the information needed without requiring the
+/// shared helper to know whether the call site is a free function or a method.
+struct InlineBinding {
+    /// Original callee-side local index of the parameter being bound.
+    /// Used to build the `param_to_local` remapping for the inlined body.
+    callee_local_index: u32,
+    /// Parameter name (used verbatim as the new `let` name for debuggability).
+    name: String,
+    /// Whether the synthesized `let` should be mutable. Free function calls
+    /// preserve the original parameter's `is_mut`; method calls always pass
+    /// `false` (the method body cannot rebind `self` or its arguments).
+    is_mut: bool,
+    /// Type of the value bound to the new local. This may differ from
+    /// `param.type_id` due to monomorphization (arg type differs from param type)
+    /// or `&mut self` wrapping (receiver gets wrapped in a `MutRef` unary).
+    local_type: TypeId,
+    /// The value expression bound to the new local.
+    value: TirExpr,
+}
+
+/// Core inlining routine: builds a labeled block that binds each prepared
+/// parameter value and executes the callee body with locals remapped into the
+/// caller's frame.
+///
+/// Shared by `try_inline_call_expr` and `try_inline_method_call_expr`. The
+/// difference between the two lies entirely in how they prepare `bindings`.
+fn build_inlined_labeled_block(
+    candidate: &TirFunction,
+    body: &TirBlock,
+    func_name: &str,
+    bindings: Vec<InlineBinding>,
+    call_span: Span,
     local_count: &mut u32,
     local_types: &mut Vec<TypeId>,
-    _type_table: &TypeTable,
     inline_counter: &mut u32,
-) -> Option<(TirExpr, (ModuleSource, String))> {
-    let TirExprKind::Call { func, args, .. } = &expr.kind else {
-        return None;
-    };
-
-    let call_module_source = func.module_source.clone();
-    let func_name = func.name.clone();
-
-    // Look up the candidate function.
-    let (candidate, inlined_key) =
-        find_inline_candidate(candidates, &call_module_source, current_module, &func_name)?;
-
-    // Get the function body
-    let body = candidate.body.as_ref()?;
-
-    // Generate unique label for this inline site
+) -> TirExpr {
+    // Generate unique label for this inline site.
     // Sanitize function name for use as label (replace non-alphanumeric with _)
     let sanitized_name: String = func_name
         .chars()
@@ -1100,47 +1081,46 @@ fn try_inline_call_expr(
     let label = format!("__inline_{}_{}", sanitized_name, *inline_counter);
     *inline_counter += 1;
 
-    // Calculate local index offset for remapping
+    // Calculate local index offset for remapping.
     let local_offset = *local_count;
 
     let callee_param_count = candidate.params.len() as u32;
     let callee_local_count = candidate.local_count;
     let new_locals_needed = callee_local_count.saturating_sub(callee_param_count);
 
-    // Create argument bindings as let statements inside a labeled block
     // IMPORTANT: Push param types first to match index assignment order
     // (params get indices local_offset+0, local_offset+1, ..., then non-params follow)
-    let mut block_stmts = Vec::new();
+    let mut block_stmts = Vec::with_capacity(bindings.len() + body.stmts.len());
     let mut param_to_local: IndexMap<u32, u32> = IndexMap::default();
 
-    for (i, (param, arg)) in candidate.params.iter().zip(args.iter()).enumerate() {
+    for (i, binding) in bindings.into_iter().enumerate() {
         let new_local_index = local_offset + i as u32;
-        param_to_local.insert(param.local_index, new_local_index);
+        param_to_local.insert(binding.callee_local_index, new_local_index);
 
-        // Extend local_types for parameter - use argument's type_id to match
-        // the actual value being assigned (handles monomorphization type variance)
-        local_types.push(arg.expr.type_id);
+        // Extend local_types for parameter using the binding's actual local_type
+        // (handles monomorphization type variance and &mut self ref wrapping).
+        local_types.push(binding.local_type);
         *local_count += 1;
 
-        // Use original parameter name (not _inline_ prefix)
+        // Use original parameter name (not _inline_ prefix).
         block_stmts.push(TirStmt::new(
             TirStmtKind::Let {
-                name: param.name.clone(),
+                name: binding.name,
                 local_index: new_local_index,
-                is_mut: param.is_mut, // Preserve mutability from the original parameter
+                is_mut: binding.is_mut,
                 is_reactive: false,
-                type_id: arg.expr.type_id,
-                value: arg.expr.clone(),
+                type_id: binding.local_type,
+                value: binding.value,
                 skip_value_copy: false,
             },
-            expr.span,
+            call_span,
         ));
     }
 
-    // param_offset marks where non-param locals start (after all params)
-    let param_offset = local_offset + candidate.params.len() as u32;
+    // param_offset marks where non-param locals start (after all params).
+    let param_offset = local_offset + callee_param_count;
 
-    // Now extend local_types for the non-parameter locals
+    // Now extend local_types for the non-parameter locals.
     for i in callee_param_count..callee_local_count {
         if let Some(&type_id) = candidate.local_types.get(i as usize) {
             local_types.push(type_id);
@@ -1148,7 +1128,7 @@ fn try_inline_call_expr(
     }
     *local_count += new_locals_needed;
 
-    // Convert the body, transforming `return` into `break label: expr`
+    // Convert the body, transforming `return` into `break label: expr`.
     let remapped_stmts = remap_and_convert_returns(
         body,
         &param_to_local,
@@ -1159,21 +1139,69 @@ fn try_inline_call_expr(
 
     block_stmts.extend(remapped_stmts);
 
-    // Create a labeled block expression that produces the return value
-    let inlined_expr = TirExpr::new(
+    // Create a labeled block expression that produces the return value.
+    TirExpr::new(
         TirExprKind::LabeledBlock {
             label,
-            block: TirBlock::new(block_stmts, expr.span),
+            block: TirBlock::new(block_stmts, call_span),
             result_type: candidate.return_type,
         },
         candidate.return_type,
+        call_span,
+    )
+}
+
+/// Try to inline a free function call expression, returning the inlined
+/// expression and the callee's lookup key.
+fn try_inline_call_expr(
+    expr: &TirExpr,
+    candidates: &IndexMap<(ModuleSource, String), TirFunction>,
+    current_module: &ModuleSource,
+    local_count: &mut u32,
+    local_types: &mut Vec<TypeId>,
+    _type_table: &TypeTable,
+    inline_counter: &mut u32,
+) -> Option<(TirExpr, (ModuleSource, String))> {
+    let TirExprKind::Call { func, args, .. } = &expr.kind else {
+        return None;
+    };
+
+    let func_name = func.name.clone();
+    let (candidate, inlined_key) =
+        find_inline_candidate(candidates, &func.module_source, current_module, &func_name)?;
+    let body = candidate.body.as_ref()?;
+
+    // Use argument's type_id to match the actual value being assigned
+    // (handles monomorphization type variance).
+    let bindings: Vec<InlineBinding> = candidate
+        .params
+        .iter()
+        .zip(args.iter())
+        .map(|(param, arg)| InlineBinding {
+            callee_local_index: param.local_index,
+            name: param.name.clone(),
+            is_mut: param.is_mut,
+            local_type: arg.expr.type_id,
+            value: arg.expr.clone(),
+        })
+        .collect();
+
+    let inlined_expr = build_inlined_labeled_block(
+        candidate,
+        body,
+        &func_name,
+        bindings,
         expr.span,
+        local_count,
+        local_types,
+        inline_counter,
     );
 
     Some((inlined_expr, inlined_key))
 }
 
-/// Try to inline a method call expression, returning the inlined expression and key
+/// Try to inline a method call expression, returning the inlined expression
+/// and the callee's lookup key.
 fn try_inline_method_call_expr(
     expr: &TirExpr,
     candidates: &IndexMap<(ModuleSource, String), TirFunction>,
@@ -1193,43 +1221,12 @@ fn try_inline_method_call_expr(
         return None;
     };
 
-    let call_module_source = func.module_source.clone();
     let func_name = func.name.clone();
-
-    // Look up the candidate function.
     let (candidate, inlined_key) =
-        find_inline_candidate(candidates, &call_module_source, current_module, &func_name)?;
-
-    // Get the function body
+        find_inline_candidate(candidates, &func.module_source, current_module, &func_name)?;
     let body = candidate.body.as_ref()?;
 
-    // Generate unique label for this inline site
-    // Sanitize function name for use as label (replace non-alphanumeric with _)
-    let sanitized_name: String = func_name
-        .chars()
-        .map(|c| {
-            if c.is_alphanumeric() || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    let label = format!("__inline_{}_{}", sanitized_name, *inline_counter);
-    *inline_counter += 1;
-
-    // Calculate local index offset for remapping
-    let local_offset = *local_count;
-
-    let callee_param_count = candidate.params.len() as u32;
-    let callee_local_count = candidate.local_count;
-    let new_locals_needed = callee_local_count.saturating_sub(callee_param_count);
-
-    // Create argument bindings as let statements inside a labeled block
-    // IMPORTANT: Push param types first to match index assignment order
-    // For methods, first param is `self` (receiver), then the rest are args
-    let mut block_stmts = Vec::new();
-    let mut param_to_local: IndexMap<u32, u32> = IndexMap::default();
+    let mut bindings: Vec<InlineBinding> = Vec::with_capacity(candidate.params.len());
 
     // Bind receiver to first parameter (self).
     // For &mut self receivers, wrap in a MutRef expression so that field
@@ -1238,8 +1235,6 @@ fn try_inline_method_call_expr(
     // For &self receivers, a value copy is safe (no mutations) and lets copy
     // propagation simplify `self.field` → `receiver.field` without a ref level.
     let first_param = &candidate.params[0];
-    let self_local_index = local_offset;
-    param_to_local.insert(first_param.local_index, self_local_index);
     let (self_type_id, self_value) =
         if matches!(type_table.get(first_param.type_id), ResolvedType::MutRef(_)) {
             if matches!(type_table.get(receiver.type_id), ResolvedType::MutRef(_)) {
@@ -1261,77 +1256,35 @@ fn try_inline_method_call_expr(
         } else {
             (receiver.type_id, (**receiver).clone())
         };
-    local_types.push(self_type_id);
-    *local_count += 1;
+    bindings.push(InlineBinding {
+        callee_local_index: first_param.local_index,
+        name: first_param.name.clone(),
+        is_mut: false,
+        local_type: self_type_id,
+        value: self_value,
+    });
 
-    // Use original parameter name (not _inline_ prefix)
-    block_stmts.push(TirStmt::new(
-        TirStmtKind::Let {
-            name: first_param.name.clone(),
-            local_index: self_local_index,
+    // Bind remaining args to remaining parameters.
+    // Use argument's type_id to handle monomorphization type variance.
+    for (param, arg) in candidate.params.iter().skip(1).zip(args.iter()) {
+        bindings.push(InlineBinding {
+            callee_local_index: param.local_index,
+            name: param.name.clone(),
             is_mut: false,
-            is_reactive: false,
-            type_id: self_type_id,
-            value: self_value,
-            skip_value_copy: false,
-        },
-        expr.span,
-    ));
-
-    // Bind remaining args to remaining parameters
-    // Use argument's type_id to handle monomorphization type variance
-    for (i, (param, arg)) in candidate.params.iter().skip(1).zip(args.iter()).enumerate() {
-        let new_local_index = local_offset + 1 + i as u32;
-        param_to_local.insert(param.local_index, new_local_index);
-        local_types.push(arg.expr.type_id);
-        *local_count += 1;
-
-        // Use original parameter name (not _inline_ prefix)
-        block_stmts.push(TirStmt::new(
-            TirStmtKind::Let {
-                name: param.name.clone(),
-                local_index: new_local_index,
-                is_mut: false,
-                is_reactive: false,
-                type_id: arg.expr.type_id,
-                value: arg.expr.clone(),
-                skip_value_copy: false,
-            },
-            expr.span,
-        ));
+            local_type: arg.expr.type_id,
+            value: arg.expr.clone(),
+        });
     }
 
-    // param_offset marks where non-param locals start (after all params)
-    let param_offset = local_offset + candidate.params.len() as u32;
-
-    // Now extend local_types for the non-parameter locals
-    for i in callee_param_count..callee_local_count {
-        if let Some(&type_id) = candidate.local_types.get(i as usize) {
-            local_types.push(type_id);
-        }
-    }
-    *local_count += new_locals_needed;
-
-    // Convert the body, transforming `return` into `break label: expr`
-    let remapped_stmts = remap_and_convert_returns(
+    let inlined_expr = build_inlined_labeled_block(
+        candidate,
         body,
-        &param_to_local,
-        param_offset,
-        callee_param_count,
-        &label,
-    );
-
-    block_stmts.extend(remapped_stmts);
-
-    // Create a labeled block expression that produces the return value
-    let inlined_expr = TirExpr::new(
-        TirExprKind::LabeledBlock {
-            label,
-            block: TirBlock::new(block_stmts, expr.span),
-            result_type: candidate.return_type,
-        },
-        candidate.return_type,
+        &func_name,
+        bindings,
         expr.span,
+        local_count,
+        local_types,
+        inline_counter,
     );
 
     Some((inlined_expr, inlined_key))
@@ -2423,11 +2376,4 @@ fn inline_calls_in_expr(
             unreachable!("TemplateString should be expanded before this phase")
         }
     }
-}
-
-// Note: create_default_value is kept but currently unused since we use labeled block expressions
-// which don't need a default value initialization. It may be useful for future optimizations.
-#[allow(dead_code)]
-fn _create_default_value(type_id: TypeId, type_table: &TypeTable, span: crate::Span) -> TirExpr {
-    create_default_value(type_id, type_table, span)
 }

--- a/wado-compiler/src/optimize/licm.rs
+++ b/wado-compiler/src/optimize/licm.rs
@@ -660,50 +660,6 @@ fn collect_modified_vars_in_expr(
     }
 }
 
-/// Check if an expression is loop-invariant given the set of modified variables.
-/// An expression is loop-invariant if:
-/// 1. It's a constant/literal
-/// 2. It's a local variable not in the modified set
-/// 3. It's a field access on a loop-invariant expression
-#[allow(dead_code)]
-fn is_loop_invariant(expr: &TirExpr, modified_vars: &IndexSet<u32>) -> bool {
-    match &expr.kind {
-        // Constants are always invariant
-        TirExprKind::IntLiteral { .. }
-        | TirExprKind::FloatLiteral { .. }
-        | TirExprKind::BoolLiteral(_)
-        | TirExprKind::CharLiteral(_)
-        | TirExprKind::StringLiteral(_)
-        | TirExprKind::BytesLiteral(_)
-        | TirExprKind::Null
-        | TirExprKind::Unit
-        | TirExprKind::FuncRef { .. } => true,
-
-        // Local variable is invariant if not modified in the loop
-        TirExprKind::Local { index, .. } => !modified_vars.contains(index),
-
-        // Field access is invariant if the base expression is invariant
-        TirExprKind::FieldAccess { expr, .. }
-        | TirExprKind::TupleSpread { expr }
-        | TirExprKind::TupleZip { expr }
-        | TirExprKind::TypePackExpansion {
-            call_expr: expr, ..
-        } => is_loop_invariant(expr, modified_vars),
-
-        // Pure binary ops are invariant if operands are invariant
-        // (Assignments are handled separately via TirExprKind::Assign, not as binary ops)
-        TirExprKind::Binary { left, right, .. } => {
-            is_loop_invariant(left, modified_vars) && is_loop_invariant(right, modified_vars)
-        }
-        TirExprKind::Unary { expr, .. } => is_loop_invariant(expr, modified_vars),
-        TirExprKind::Cast { expr, .. } => is_loop_invariant(expr, modified_vars),
-
-        // Everything else is considered not invariant (conservative)
-        // This includes: calls, method calls, index access (could have side effects), etc.
-        _ => false,
-    }
-}
-
 /// Information about an immutable reference binding: `let ref_var: &T = &source_var`
 #[derive(Debug, Clone)]
 struct LicmRefBinding {

--- a/wado-compiler/src/optimize/sroa.rs
+++ b/wado-compiler/src/optimize/sroa.rs
@@ -31,6 +31,7 @@ use crate::tir::{
     FunctionRef, TirBlock, TirExpr, TirExprKind, TirFunction, TirStmt, TirStmtKind, TirStructField,
     TirUnaryOp, TypeId, TypeTable,
 };
+use crate::tir_visitor::TirRefVisitor;
 use crate::token::Span;
 
 /// Maps (`module_source`, `func_name`) → set of parameter indices that have `stores` declared.
@@ -622,268 +623,102 @@ fn collect_candidates_in_expr(
 /// Escape analysis: find all candidate locals that escape (used in non-field-access positions).
 fn find_escaped_locals(body: &TirBlock, candidates: &[SroaCandidate]) -> IndexSet<u32> {
     let candidate_set: IndexSet<u32> = candidates.iter().map(|c| c.local_index).collect();
-    let mut escaped = IndexSet::default();
-    check_escape_in_block(body, &candidate_set, &mut escaped);
-    escaped
+    let mut checker = EscapeChecker {
+        candidates: &candidate_set,
+        escaped: IndexSet::default(),
+    };
+    checker.visit_block(body);
+    checker.escaped
 }
 
-fn check_escape_in_block(
-    block: &TirBlock,
-    candidates: &IndexSet<u32>,
-    escaped: &mut IndexSet<u32>,
-) {
-    for stmt in &block.stmts {
-        check_escape_in_stmt(stmt, candidates, escaped);
-    }
-}
-
-fn check_escape_in_stmt(stmt: &TirStmt, candidates: &IndexSet<u32>, escaped: &mut IndexSet<u32>) {
-    match &stmt.kind {
-        TirStmtKind::Let { value, .. } => {
-            check_escape_in_expr(value, candidates, escaped);
-        }
-        TirStmtKind::Expr(expr) => {
-            check_escape_in_expr(expr, candidates, escaped);
-        }
-        TirStmtKind::Return { value } => {
-            if let Some(v) = value {
-                check_escape_in_expr(v, candidates, escaped);
-            }
-        }
-        TirStmtKind::If {
-            condition,
-            then_block,
-            else_block,
-        } => {
-            check_escape_in_expr(condition, candidates, escaped);
-            check_escape_in_block(then_block, candidates, escaped);
-            if let Some(eb) = else_block {
-                check_escape_in_block(eb, candidates, escaped);
-            }
-        }
-        TirStmtKind::Loop { body } => {
-            check_escape_in_block(body, candidates, escaped);
-        }
-        TirStmtKind::LabeledBlock { block, .. } => {
-            check_escape_in_block(block, candidates, escaped);
-        }
-        TirStmtKind::IfLet {
-            scrutinee,
-            then_block,
-            else_block,
-            ..
-        } => {
-            check_escape_in_expr(scrutinee, candidates, escaped);
-            check_escape_in_block(then_block, candidates, escaped);
-            if let Some(eb) = else_block {
-                check_escape_in_block(eb, candidates, escaped);
-            }
-        }
-        TirStmtKind::Break { value, .. } => {
-            if let Some(v) = value {
-                check_escape_in_expr(v, candidates, escaped);
-            }
-        }
-        TirStmtKind::Continue => {}
-        TirStmtKind::LetDestructure { value, .. } => {
-            check_escape_in_expr(value, candidates, escaped);
-        }
-        TirStmtKind::TaskReturn { .. } => {
-            unreachable!("TaskReturn should be eliminated by synthesis before this phase")
-        }
-        TirStmtKind::VariadicForOf { .. } => {
-            unreachable!("VariadicForOf should be expanded during monomorphization")
-        }
-    }
-}
-
-/// Check if an expression causes any candidate locals to escape.
+/// Visitor that marks candidate locals as escaped if they appear outside of
+/// field-access positions.
 ///
 /// A local is "safe" (non-escaping) if it only appears as:
 /// - `FieldAccess { expr: Local { index: candidate }, .. }` (field read)
-/// - `FieldAccess { expr: Move { expr: Local { index: candidate } }, .. }` (field read through move)
 /// - `Assign { target: FieldAccess { expr: Local { .. }, .. }, .. }` (field write)
 ///
-/// Any other use of the local (passed to function, returned, address taken, etc.) is an escape.
-fn check_escape_in_expr(expr: &TirExpr, candidates: &IndexSet<u32>, escaped: &mut IndexSet<u32>) {
-    match &expr.kind {
-        // FieldAccess on a candidate local is safe — don't mark the base local as escaped.
-        // But do recurse into the non-base subexpressions.
-        TirExprKind::FieldAccess { expr: inner, .. }
-        | TirExprKind::TupleSpread { expr: inner }
-        | TirExprKind::TupleZip { expr: inner }
-        | TirExprKind::TypePackExpansion {
-            call_expr: inner, ..
-        } => {
-            if is_candidate_local(inner, candidates).is_some() {
-                // Safe: field read on candidate. Don't recurse into inner (it's the local itself).
-                return;
-            }
-            // Not a candidate — recurse normally
-            check_escape_in_expr(inner, candidates, escaped);
-        }
+/// Any other use of the local (passed to function, returned, address taken,
+/// captured by a closure, etc.) is an escape.
+struct EscapeChecker<'a> {
+    candidates: &'a IndexSet<u32>,
+    escaped: IndexSet<u32>,
+}
 
-        // Assign to a field of a candidate is safe for the target side.
-        TirExprKind::Assign { target, value } => {
-            if let TirExprKind::FieldAccess { expr: inner, .. }
+impl TirRefVisitor for EscapeChecker<'_> {
+    fn visit_stmt(&mut self, stmt: &TirStmt) {
+        match &stmt.kind {
+            TirStmtKind::TaskReturn { .. } => {
+                unreachable!("TaskReturn should be eliminated by synthesis before this phase")
+            }
+            TirStmtKind::VariadicForOf { .. } => {
+                unreachable!("VariadicForOf should be expanded during monomorphization")
+            }
+            _ => self.walk_stmt(stmt),
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &TirExpr) {
+        match &expr.kind {
+            // FieldAccess on a candidate local is safe — don't mark the base local as
+            // escaped and don't recurse into the base (which is the local itself).
+            TirExprKind::FieldAccess { expr: inner, .. }
             | TirExprKind::TupleSpread { expr: inner }
             | TirExprKind::TupleZip { expr: inner }
             | TirExprKind::TypePackExpansion {
                 call_expr: inner, ..
-            } = &target.kind
-                && is_candidate_local(inner, candidates).is_some()
-            {
-                // Safe: field write. Only recurse into value, not target.
-                check_escape_in_expr(value, candidates, escaped);
-                return;
+            } => {
+                if is_candidate_local(inner, self.candidates).is_some() {
+                    return;
+                }
+                self.visit_expr(inner);
             }
-            // Assign to a candidate local as a whole → escape
-            check_escape_in_expr(target, candidates, escaped);
-            check_escape_in_expr(value, candidates, escaped);
-        }
-
-        // A bare Local reference to a candidate in any other position → escape
-        TirExprKind::Local { index, .. } => {
-            if candidates.contains(index) {
-                escaped.insert(*index);
+            // Assign to a field of a candidate is safe for the target side.
+            TirExprKind::Assign { target, value } => {
+                if let TirExprKind::FieldAccess { expr: inner, .. }
+                | TirExprKind::TupleSpread { expr: inner }
+                | TirExprKind::TupleZip { expr: inner }
+                | TirExprKind::TypePackExpansion {
+                    call_expr: inner, ..
+                } = &target.kind
+                    && is_candidate_local(inner, self.candidates).is_some()
+                {
+                    self.visit_expr(value);
+                    return;
+                }
+                self.visit_expr(target);
+                self.visit_expr(value);
             }
-        }
-
-        // Address taken → definitely escape
-        TirExprKind::Unary { op, expr: inner } => {
-            if matches!(op, TirUnaryOp::Ref | TirUnaryOp::MutRef)
-                && let TirExprKind::Local { index, .. } = &inner.kind
-                && candidates.contains(index)
-            {
-                escaped.insert(*index);
-                return;
-            }
-            check_escape_in_expr(inner, candidates, escaped);
-        }
-
-        // Closure captures → escape
-        TirExprKind::Closure { body, captures, .. } => {
-            for capture in captures {
-                if candidates.contains(&capture.outer_index) {
-                    escaped.insert(capture.outer_index);
+            // A bare Local reference to a candidate in any other position → escape.
+            TirExprKind::Local { index, .. } => {
+                if self.candidates.contains(index) {
+                    self.escaped.insert(*index);
                 }
             }
-            check_escape_in_expr(body, candidates, escaped);
-        }
-
-        // Recurse into all other expression kinds
-        TirExprKind::Binary { left, right, .. } => {
-            check_escape_in_expr(left, candidates, escaped);
-            check_escape_in_expr(right, candidates, escaped);
-        }
-        TirExprKind::Call { args, .. } => {
-            for arg in args {
-                check_escape_in_expr(&arg.expr, candidates, escaped);
-            }
-        }
-        TirExprKind::CmRawCall { args, .. } => {
-            for arg in args {
-                check_escape_in_expr(arg, candidates, escaped);
-            }
-        }
-        TirExprKind::MethodCall { receiver, args, .. } => {
-            check_escape_in_expr(receiver, candidates, escaped);
-            for arg in args {
-                check_escape_in_expr(&arg.expr, candidates, escaped);
-            }
-        }
-        TirExprKind::IndirectCall { callee, args, .. } => {
-            check_escape_in_expr(callee, candidates, escaped);
-            for arg in args {
-                check_escape_in_expr(arg, candidates, escaped);
-            }
-        }
-        TirExprKind::ClosureToCanonical { functor, .. } => {
-            check_escape_in_expr(functor, candidates, escaped);
-        }
-        TirExprKind::Cast { expr: inner, .. } => {
-            check_escape_in_expr(inner, candidates, escaped);
-        }
-        TirExprKind::Index {
-            expr: inner, index, ..
-        } => {
-            check_escape_in_expr(inner, candidates, escaped);
-            check_escape_in_expr(index, candidates, escaped);
-        }
-        TirExprKind::Block(block) | TirExprKind::LabeledBlock { block, .. } => {
-            check_escape_in_block(block, candidates, escaped);
-        }
-        TirExprKind::If {
-            condition,
-            then_branch,
-            else_branch,
-        } => {
-            check_escape_in_expr(condition, candidates, escaped);
-            check_escape_in_block(then_branch, candidates, escaped);
-            if let Some(eb) = else_branch {
-                check_escape_in_block(eb, candidates, escaped);
-            }
-        }
-        TirExprKind::Match { expr: inner, arms } => {
-            check_escape_in_expr(inner, candidates, escaped);
-            for arm in arms {
-                if let Some(guard) = &arm.guard {
-                    check_escape_in_expr(guard, candidates, escaped);
+            // Address taken → definitely escape.
+            TirExprKind::Unary { op, expr: inner } => {
+                if matches!(op, TirUnaryOp::Ref | TirUnaryOp::MutRef)
+                    && let TirExprKind::Local { index, .. } = &inner.kind
+                    && self.candidates.contains(index)
+                {
+                    self.escaped.insert(*index);
+                    return;
                 }
-                check_escape_in_expr(&arm.body, candidates, escaped);
+                self.visit_expr(inner);
             }
-        }
-        TirExprKind::StructLiteral { fields, .. } => {
-            for field in fields {
-                check_escape_in_expr(&field.value, candidates, escaped);
+            // Closure captures → escape.
+            TirExprKind::Closure { body, captures, .. } => {
+                for capture in captures {
+                    if self.candidates.contains(&capture.outer_index) {
+                        self.escaped.insert(capture.outer_index);
+                    }
+                }
+                self.visit_expr(body);
             }
-        }
-        TirExprKind::TupleLiteral { elements, .. } => {
-            for elem in elements {
-                check_escape_in_expr(elem, candidates, escaped);
+            TirExprKind::TemplateString { .. } => {
+                unreachable!("TemplateString should be expanded before this phase")
             }
-        }
-        TirExprKind::VariantConstruct { payload, .. } => {
-            if let Some(p) = payload {
-                check_escape_in_expr(p, candidates, escaped);
-            }
-        }
-        TirExprKind::GlobalVarSet { value, .. } => {
-            check_escape_in_expr(value, candidates, escaped);
-        }
-        TirExprKind::VariantTag { expr } | TirExprKind::VariantTest { expr, .. } => {
-            check_escape_in_expr(expr, candidates, escaped);
-        }
-        TirExprKind::VariantPayload { expr, .. } => {
-            check_escape_in_expr(expr, candidates, escaped);
-        }
-        TirExprKind::Switch {
-            scrutinee,
-            arms,
-            default,
-            ..
-        } => {
-            check_escape_in_expr(scrutinee, candidates, escaped);
-            for arm in arms {
-                check_escape_in_block(arm, candidates, escaped);
-            }
-            check_escape_in_block(default, candidates, escaped);
-        }
-        // Leaf nodes — no locals to check
-        TirExprKind::IntLiteral { .. }
-        | TirExprKind::FloatLiteral { .. }
-        | TirExprKind::BoolLiteral(_)
-        | TirExprKind::CharLiteral(_)
-        | TirExprKind::StringLiteral(_)
-        | TirExprKind::BytesLiteral(_)
-        | TirExprKind::Null
-        | TirExprKind::Unit
-        | TirExprKind::FuncRef { .. }
-        | TirExprKind::GlobalVarGet { .. }
-        | TirExprKind::Capture { .. }
-        | TirExprKind::EnumConstruct { .. } => {}
-        TirExprKind::TemplateString { .. } => {
-            unreachable!("TemplateString should be expanded before this phase")
+            _ => self.walk_expr(expr),
         }
     }
 }
@@ -913,19 +748,29 @@ fn find_soft_escaped_locals(
         return IndexSet::default();
     }
 
-    // Check: does every non-field-access use of this candidate appear as a call arg or return?
-    let mut hard_escaped = IndexSet::default();
-    check_soft_escape_in_block(
-        body,
-        &escaped_candidates,
-        &mut hard_escaped,
-        stores_lookup,
-        current_module,
-    );
+    // Does every non-field-access use of this candidate appear in a soft position
+    // (return value, break value, or immutable ref to a non-stores callee)?
+    let hard_escaped = {
+        let mut checker = SoftEscapeChecker {
+            candidates: &escaped_candidates,
+            hard_escaped: IndexSet::default(),
+            stores_lookup,
+            current_module,
+            soft_allowed: false,
+        };
+        checker.visit_block(body);
+        checker.hard_escaped
+    };
 
-    // Soft-escaped = escaped but NOT hard-escaped, AND has at least one field access
-    let mut has_field_access = IndexSet::default();
-    check_has_field_access(body, &escaped_candidates, &mut has_field_access);
+    // Soft-escaped = escaped but NOT hard-escaped, AND has at least one field access.
+    let has_field_access = {
+        let mut checker = FieldAccessChecker {
+            candidates: &escaped_candidates,
+            has_access: IndexSet::default(),
+        };
+        checker.visit_block(body);
+        checker.has_access
+    };
 
     escaped_candidates
         .into_iter()
@@ -933,523 +778,214 @@ fn find_soft_escaped_locals(
         .collect()
 }
 
-/// Check if a block contains any field accesses on the given candidates.
-fn check_has_field_access(
-    block: &TirBlock,
-    candidates: &IndexSet<u32>,
-    has_access: &mut IndexSet<u32>,
-) {
-    for stmt in &block.stmts {
-        check_has_field_access_stmt(stmt, candidates, has_access);
-    }
+/// Visitor that records which escaped candidates have at least one field-access use.
+/// Used to filter out candidates whose only uses are in call arguments or return
+/// values — SROA would not help those, since there are no loads/stores to eliminate.
+struct FieldAccessChecker<'a> {
+    candidates: &'a IndexSet<u32>,
+    has_access: IndexSet<u32>,
 }
 
-fn check_has_field_access_stmt(
-    stmt: &TirStmt,
-    candidates: &IndexSet<u32>,
-    has_access: &mut IndexSet<u32>,
-) {
-    match &stmt.kind {
-        TirStmtKind::Let { value, .. } => {
-            check_has_field_access_expr(value, candidates, has_access);
+impl TirRefVisitor for FieldAccessChecker<'_> {
+    fn visit_stmt(&mut self, stmt: &TirStmt) {
+        match &stmt.kind {
+            // The original walker ignored these stmt kinds entirely — preserve.
+            TirStmtKind::LetDestructure { .. }
+            | TirStmtKind::TaskReturn { .. }
+            | TirStmtKind::VariadicForOf { .. } => {}
+            _ => self.walk_stmt(stmt),
         }
-        TirStmtKind::Expr(expr) => {
-            check_has_field_access_expr(expr, candidates, has_access);
-        }
-        TirStmtKind::Return { value } => {
-            if let Some(v) = value {
-                check_has_field_access_expr(v, candidates, has_access);
-            }
-        }
-        TirStmtKind::If {
-            condition,
-            then_block,
-            else_block,
-        } => {
-            check_has_field_access_expr(condition, candidates, has_access);
-            check_has_field_access(then_block, candidates, has_access);
-            if let Some(eb) = else_block {
-                check_has_field_access(eb, candidates, has_access);
-            }
-        }
-        TirStmtKind::Loop { body } | TirStmtKind::LabeledBlock { block: body, .. } => {
-            check_has_field_access(body, candidates, has_access);
-        }
-        TirStmtKind::IfLet {
-            scrutinee,
-            then_block,
-            else_block,
-            ..
-        } => {
-            check_has_field_access_expr(scrutinee, candidates, has_access);
-            check_has_field_access(then_block, candidates, has_access);
-            if let Some(eb) = else_block {
-                check_has_field_access(eb, candidates, has_access);
-            }
-        }
-        TirStmtKind::Break { value, .. } => {
-            if let Some(v) = value {
-                check_has_field_access_expr(v, candidates, has_access);
-            }
-        }
-        TirStmtKind::Continue
-        | TirStmtKind::LetDestructure { .. }
-        | TirStmtKind::TaskReturn { .. }
-        | TirStmtKind::VariadicForOf { .. } => {}
     }
-}
 
-fn check_has_field_access_expr(
-    expr: &TirExpr,
-    candidates: &IndexSet<u32>,
-    has_access: &mut IndexSet<u32>,
-) {
-    match &expr.kind {
-        TirExprKind::FieldAccess { expr: inner, .. }
-        | TirExprKind::TupleSpread { expr: inner }
-        | TirExprKind::TupleZip { expr: inner }
-        | TirExprKind::TypePackExpansion {
-            call_expr: inner, ..
-        } => {
-            if let Some(idx) = is_candidate_local_ref(inner, candidates) {
-                has_access.insert(idx);
-                return;
-            }
-            check_has_field_access_expr(inner, candidates, has_access);
-        }
-        TirExprKind::Assign { target, value } => {
-            if let TirExprKind::FieldAccess { expr: inner, .. }
+    fn visit_expr(&mut self, expr: &TirExpr) {
+        match &expr.kind {
+            TirExprKind::FieldAccess { expr: inner, .. }
             | TirExprKind::TupleSpread { expr: inner }
             | TirExprKind::TupleZip { expr: inner }
             | TirExprKind::TypePackExpansion {
                 call_expr: inner, ..
-            } = &target.kind
-                && let Some(idx) = is_candidate_local_ref(inner, candidates)
-            {
-                has_access.insert(idx);
-                check_has_field_access_expr(value, candidates, has_access);
-                return;
-            }
-            check_has_field_access_expr(target, candidates, has_access);
-            check_has_field_access_expr(value, candidates, has_access);
-        }
-        TirExprKind::Binary { left, right, .. } => {
-            check_has_field_access_expr(left, candidates, has_access);
-            check_has_field_access_expr(right, candidates, has_access);
-        }
-        TirExprKind::Block(block) | TirExprKind::LabeledBlock { block, .. } => {
-            check_has_field_access(block, candidates, has_access);
-        }
-        TirExprKind::If {
-            condition,
-            then_branch,
-            else_branch,
-        } => {
-            check_has_field_access_expr(condition, candidates, has_access);
-            check_has_field_access(then_branch, candidates, has_access);
-            if let Some(eb) = else_branch {
-                check_has_field_access(eb, candidates, has_access);
-            }
-        }
-        TirExprKind::Match { expr: inner, arms } => {
-            check_has_field_access_expr(inner, candidates, has_access);
-            for arm in arms {
-                if let Some(guard) = &arm.guard {
-                    check_has_field_access_expr(guard, candidates, has_access);
+            } => {
+                if let Some(idx) = is_candidate_local(inner, self.candidates) {
+                    self.has_access.insert(idx);
+                    return;
                 }
-                check_has_field_access_expr(&arm.body, candidates, has_access);
+                self.visit_expr(inner);
             }
-        }
-        TirExprKind::Switch {
-            scrutinee,
-            arms,
-            default,
-            ..
-        } => {
-            check_has_field_access_expr(scrutinee, candidates, has_access);
-            for arm in arms {
-                check_has_field_access(arm, candidates, has_access);
+            TirExprKind::Assign { target, value } => {
+                if let TirExprKind::FieldAccess { expr: inner, .. }
+                | TirExprKind::TupleSpread { expr: inner }
+                | TirExprKind::TupleZip { expr: inner }
+                | TirExprKind::TypePackExpansion {
+                    call_expr: inner, ..
+                } = &target.kind
+                    && let Some(idx) = is_candidate_local(inner, self.candidates)
+                {
+                    self.has_access.insert(idx);
+                    self.visit_expr(value);
+                    return;
+                }
+                self.visit_expr(target);
+                self.visit_expr(value);
             }
-            check_has_field_access(default, candidates, has_access);
-        }
-        TirExprKind::Unary { expr: inner, .. }
-        | TirExprKind::Cast { expr: inner, .. }
-        | TirExprKind::VariantTag { expr: inner }
-        | TirExprKind::VariantTest { expr: inner, .. }
-        | TirExprKind::VariantPayload { expr: inner, .. }
-        | TirExprKind::ClosureToCanonical { functor: inner, .. } => {
-            check_has_field_access_expr(inner, candidates, has_access);
-        }
-        TirExprKind::Index { expr: inner, index } => {
-            check_has_field_access_expr(inner, candidates, has_access);
-            check_has_field_access_expr(index, candidates, has_access);
-        }
-        TirExprKind::Call { args, .. } => {
-            for arg in args {
-                check_has_field_access_expr(&arg.expr, candidates, has_access);
+            TirExprKind::TemplateString { .. } => {
+                unreachable!("TemplateString should be expanded before this phase")
             }
-        }
-        TirExprKind::CmRawCall { args, .. } => {
-            for arg in args {
-                check_has_field_access_expr(arg, candidates, has_access);
-            }
-        }
-        TirExprKind::MethodCall { receiver, args, .. } => {
-            check_has_field_access_expr(receiver, candidates, has_access);
-            for arg in args {
-                check_has_field_access_expr(&arg.expr, candidates, has_access);
-            }
-        }
-        TirExprKind::IndirectCall { callee, args } => {
-            check_has_field_access_expr(callee, candidates, has_access);
-            for arg in args {
-                check_has_field_access_expr(arg, candidates, has_access);
-            }
-        }
-        TirExprKind::StructLiteral { fields, .. } => {
-            for field in fields {
-                check_has_field_access_expr(&field.value, candidates, has_access);
-            }
-        }
-        TirExprKind::TupleLiteral { elements } => {
-            for elem in elements {
-                check_has_field_access_expr(elem, candidates, has_access);
-            }
-        }
-        TirExprKind::VariantConstruct { payload, .. } => {
-            if let Some(p) = payload {
-                check_has_field_access_expr(p, candidates, has_access);
-            }
-        }
-        TirExprKind::Closure { body, .. } => {
-            check_has_field_access_expr(body, candidates, has_access);
-        }
-        TirExprKind::GlobalVarSet { value, .. } => {
-            check_has_field_access_expr(value, candidates, has_access);
-        }
-        // Leaf nodes
-        TirExprKind::Local { .. }
-        | TirExprKind::FuncRef { .. }
-        | TirExprKind::GlobalVarGet { .. }
-        | TirExprKind::Capture { .. }
-        | TirExprKind::IntLiteral { .. }
-        | TirExprKind::FloatLiteral { .. }
-        | TirExprKind::StringLiteral(_)
-        | TirExprKind::BytesLiteral(_)
-        | TirExprKind::BoolLiteral(_)
-        | TirExprKind::CharLiteral(_)
-        | TirExprKind::Null
-        | TirExprKind::Unit
-        | TirExprKind::EnumConstruct { .. } => {}
-        TirExprKind::TemplateString { .. } => {
-            unreachable!("TemplateString should be expanded before this phase")
+            _ => self.walk_expr(expr),
         }
     }
 }
 
-/// Check if all non-field-access uses of escaped candidates are "soft" (reconstructible).
-/// Marks candidates as "hard escaped" if any use is non-reconstructible.
-fn check_soft_escape_in_block(
-    block: &TirBlock,
-    candidates: &IndexSet<u32>,
-    hard_escaped: &mut IndexSet<u32>,
-    stores_lookup: &StoresLookup,
-    current_module: &ModuleSource,
-) {
-    for stmt in &block.stmts {
-        check_soft_escape_in_stmt(
-            stmt,
-            candidates,
-            hard_escaped,
-            stores_lookup,
-            current_module,
-        );
-    }
+/// Visitor that checks escaped candidates for "hard" escapes (non-reconstructible).
+/// A candidate is marked hard-escaped if any use is non-reconstructible.
+///
+/// `soft_allowed` is set by `visit_stmt` when visiting a Return/Break value and
+/// consumed by the first call to `visit_expr` on the top-level expression only,
+/// so that only a bare `Local` at the very top of a Return/Break value is treated
+/// as a "soft" escape.  Call arguments are NOT soft: in Wasm GC, structs are
+/// heap-allocated and passed by reference, so a callee receiving a reconstructed
+/// (new) object would modify that fresh copy instead of the original — losing the
+/// mutation.  The exception is `&candidate` passed to a callee that does not
+/// declare `stores` for that parameter, which is always safe.
+struct SoftEscapeChecker<'a> {
+    candidates: &'a IndexSet<u32>,
+    hard_escaped: IndexSet<u32>,
+    stores_lookup: &'a StoresLookup,
+    current_module: &'a ModuleSource,
+    soft_allowed: bool,
 }
 
-fn check_soft_escape_in_stmt(
-    stmt: &TirStmt,
-    candidates: &IndexSet<u32>,
-    hard_escaped: &mut IndexSet<u32>,
-    stores_lookup: &StoresLookup,
-    current_module: &ModuleSource,
-) {
-    let sl = stores_lookup;
-    let cm = current_module;
-    match &stmt.kind {
-        TirStmtKind::Let { value, .. } => {
-            check_soft_escape_in_expr(value, candidates, hard_escaped, false, sl, cm);
-        }
-        TirStmtKind::Expr(expr) => {
-            check_soft_escape_in_expr(expr, candidates, hard_escaped, false, sl, cm);
-        }
-        TirStmtKind::Return { value } => {
-            if let Some(v) = value {
-                check_soft_escape_in_expr(v, candidates, hard_escaped, true, sl, cm);
+impl TirRefVisitor for SoftEscapeChecker<'_> {
+    fn visit_stmt(&mut self, stmt: &TirStmt) {
+        match &stmt.kind {
+            TirStmtKind::Return { value: Some(v) } | TirStmtKind::Break { value: Some(v), .. } => {
+                self.soft_allowed = true;
+                self.visit_expr(v);
+                self.soft_allowed = false;
             }
-        }
-        TirStmtKind::If {
-            condition,
-            then_block,
-            else_block,
-        } => {
-            check_soft_escape_in_expr(condition, candidates, hard_escaped, false, sl, cm);
-            check_soft_escape_in_block(then_block, candidates, hard_escaped, sl, cm);
-            if let Some(eb) = else_block {
-                check_soft_escape_in_block(eb, candidates, hard_escaped, sl, cm);
+            TirStmtKind::TaskReturn { .. } => {
+                unreachable!("TaskReturn should be eliminated by synthesis before this phase")
             }
-        }
-        TirStmtKind::Loop { body } | TirStmtKind::LabeledBlock { block: body, .. } => {
-            check_soft_escape_in_block(body, candidates, hard_escaped, sl, cm);
-        }
-        TirStmtKind::IfLet {
-            scrutinee,
-            then_block,
-            else_block,
-            ..
-        } => {
-            check_soft_escape_in_expr(scrutinee, candidates, hard_escaped, false, sl, cm);
-            check_soft_escape_in_block(then_block, candidates, hard_escaped, sl, cm);
-            if let Some(eb) = else_block {
-                check_soft_escape_in_block(eb, candidates, hard_escaped, sl, cm);
+            TirStmtKind::VariadicForOf { .. } => {
+                unreachable!("VariadicForOf should be expanded during monomorphization")
             }
-        }
-        TirStmtKind::Break { value, .. } => {
-            if let Some(v) = value {
-                check_soft_escape_in_expr(v, candidates, hard_escaped, true, sl, cm);
-            }
-        }
-        TirStmtKind::Continue => {}
-        TirStmtKind::LetDestructure { value, .. } => {
-            check_soft_escape_in_expr(value, candidates, hard_escaped, false, sl, cm);
-        }
-        TirStmtKind::TaskReturn { .. } => {
-            unreachable!("TaskReturn should be eliminated by synthesis before this phase")
-        }
-        TirStmtKind::VariadicForOf { .. } => {
-            unreachable!("VariadicForOf should be expanded during monomorphization")
+            _ => self.walk_stmt(stmt),
         }
     }
-}
 
-/// Check if an expression's use of candidates is soft-escapable.
-/// `in_soft_context` is true when the expression result is in a reconstructible position
-/// where the caller will never observe the original object again (e.g., return value,
-/// break value).  Call arguments are NOT soft: in Wasm GC, structs are heap-allocated
-/// and passed by reference, so a callee receiving a reconstructed (new) object would
-/// modify that fresh copy instead of the original — losing the mutation.
-fn check_soft_escape_in_expr(
-    expr: &TirExpr,
-    candidates: &IndexSet<u32>,
-    hard_escaped: &mut IndexSet<u32>,
-    in_soft_context: bool,
-    stores_lookup: &StoresLookup,
-    current_module: &ModuleSource,
-) {
-    let sl = stores_lookup;
-    let cm = current_module;
-    match &expr.kind {
-        // FieldAccess on candidate is always safe — skip
-        TirExprKind::FieldAccess { expr: inner, .. }
-        | TirExprKind::TupleSpread { expr: inner }
-        | TirExprKind::TupleZip { expr: inner }
-        | TirExprKind::TypePackExpansion {
-            call_expr: inner, ..
-        } => {
-            if is_candidate_local_ref(inner, candidates).is_some() {
-                return;
-            }
-            check_soft_escape_in_expr(inner, candidates, hard_escaped, false, sl, cm);
-        }
-
-        // Assign to field of candidate is safe
-        TirExprKind::Assign { target, value } => {
-            if let TirExprKind::FieldAccess { expr: inner, .. }
+    fn visit_expr(&mut self, expr: &TirExpr) {
+        // Consume the soft-context flag at the top of the first visit only.
+        // All recursive visits see soft=false, mirroring the original walker's
+        // `in_soft_context=false` for non-top-level children.
+        let soft = std::mem::replace(&mut self.soft_allowed, false);
+        match &expr.kind {
+            // FieldAccess on candidate is always safe — skip recursion into the base.
+            TirExprKind::FieldAccess { expr: inner, .. }
             | TirExprKind::TupleSpread { expr: inner }
             | TirExprKind::TupleZip { expr: inner }
             | TirExprKind::TypePackExpansion {
                 call_expr: inner, ..
-            } = &target.kind
-                && is_candidate_local_ref(inner, candidates).is_some()
-            {
-                check_soft_escape_in_expr(value, candidates, hard_escaped, false, sl, cm);
-                return;
-            }
-            // Assign to the whole candidate (not a field) → hard escape
-            check_soft_escape_in_expr(target, candidates, hard_escaped, false, sl, cm);
-            check_soft_escape_in_expr(value, candidates, hard_escaped, false, sl, cm);
-        }
-
-        // Bare Local in a soft context (return, call arg) → soft escape (OK)
-        // Bare Local in a non-soft context → hard escape
-        TirExprKind::Local { index, .. } => {
-            if candidates.contains(index) && !in_soft_context {
-                hard_escaped.insert(*index);
-            }
-        }
-
-        // Address taken → hard escape unless in a non-stores call context
-        // (handled by Call/MethodCall arms below for &candidate args)
-        TirExprKind::Unary { op, expr: inner } => {
-            if matches!(op, TirUnaryOp::Ref | TirUnaryOp::MutRef)
-                && let TirExprKind::Local { index, .. } = &inner.kind
-                && candidates.contains(index)
-            {
-                hard_escaped.insert(*index);
-                return;
-            }
-            check_soft_escape_in_expr(inner, candidates, hard_escaped, false, sl, cm);
-        }
-
-        // Closure captures → hard escape
-        TirExprKind::Closure { body, captures, .. } => {
-            for capture in captures {
-                if candidates.contains(&capture.outer_index) {
-                    hard_escaped.insert(capture.outer_index);
+            } => {
+                if is_candidate_local(inner, self.candidates).is_some() {
+                    return;
                 }
+                self.visit_expr(inner);
             }
-            check_soft_escape_in_expr(body, candidates, hard_escaped, false, sl, cm);
-        }
-
-        // Function call args: in Wasm GC, structs are heap-allocated and passed
-        // by reference.  A callee receiving a reconstructed struct would modify
-        // a fresh copy, not the SROA'd scalars, so bare candidates as call args
-        // are hard escapes (in_soft_context = false).
-        // Exception: &candidate to non-stores callee is always safe (skip).
-        TirExprKind::Call { func, args, .. } => {
-            for (i, arg) in args.iter().enumerate() {
-                if is_immut_ref_to_candidate(&arg.expr, candidates)
-                    && !callee_stores_param_at(func, i, cm, sl)
+            // Assign to field of candidate is safe — only recurse into value.
+            TirExprKind::Assign { target, value } => {
+                if let TirExprKind::FieldAccess { expr: inner, .. }
+                | TirExprKind::TupleSpread { expr: inner }
+                | TirExprKind::TupleZip { expr: inner }
+                | TirExprKind::TypePackExpansion {
+                    call_expr: inner, ..
+                } = &target.kind
+                    && is_candidate_local(inner, self.candidates).is_some()
                 {
-                    continue;
+                    self.visit_expr(value);
+                    return;
                 }
-                check_soft_escape_in_expr(&arg.expr, candidates, hard_escaped, false, sl, cm);
+                self.visit_expr(target);
+                self.visit_expr(value);
             }
-        }
-        TirExprKind::CmRawCall { args, .. } => {
-            for arg in args {
-                check_soft_escape_in_expr(arg, candidates, hard_escaped, false, sl, cm);
+            // Bare Local in a soft context (return/break value) is OK.
+            // Bare Local anywhere else → hard escape.
+            TirExprKind::Local { index, .. } => {
+                if self.candidates.contains(index) && !soft {
+                    self.hard_escaped.insert(*index);
+                }
             }
-        }
-        TirExprKind::MethodCall {
-            receiver,
-            func,
-            args,
-            ..
-        } => {
-            if is_immut_ref_to_candidate(receiver, candidates)
-                && !callee_stores_param_at(func, 0, cm, sl)
-            {
-                // &self on non-stores method → safe, skip
-            } else {
-                check_soft_escape_in_expr(receiver, candidates, hard_escaped, false, sl, cm);
-            }
-            for (i, arg) in args.iter().enumerate() {
-                if is_immut_ref_to_candidate(&arg.expr, candidates)
-                    && !callee_stores_param_at(func, i + 1, cm, sl)
+            // Address taken → hard escape.  The `&candidate` as a non-stores call
+            // argument exception is handled by the Call/MethodCall arms below,
+            // which skip visiting such args entirely.
+            TirExprKind::Unary { op, expr: inner } => {
+                if matches!(op, TirUnaryOp::Ref | TirUnaryOp::MutRef)
+                    && let TirExprKind::Local { index, .. } = &inner.kind
+                    && self.candidates.contains(index)
                 {
-                    continue;
+                    self.hard_escaped.insert(*index);
+                    return;
                 }
-                check_soft_escape_in_expr(&arg.expr, candidates, hard_escaped, false, sl, cm);
+                self.visit_expr(inner);
             }
-        }
-        TirExprKind::IndirectCall { callee, args, .. } => {
-            check_soft_escape_in_expr(callee, candidates, hard_escaped, false, sl, cm);
-            for arg in args {
-                check_soft_escape_in_expr(arg, candidates, hard_escaped, false, sl, cm);
-            }
-        }
-
-        // Recurse into children
-        TirExprKind::Binary { left, right, .. } => {
-            check_soft_escape_in_expr(left, candidates, hard_escaped, false, sl, cm);
-            check_soft_escape_in_expr(right, candidates, hard_escaped, false, sl, cm);
-        }
-        TirExprKind::ClosureToCanonical { functor, .. } => {
-            check_soft_escape_in_expr(functor, candidates, hard_escaped, false, sl, cm);
-        }
-        TirExprKind::Cast { expr: inner, .. } => {
-            check_soft_escape_in_expr(inner, candidates, hard_escaped, false, sl, cm);
-        }
-        TirExprKind::Index {
-            expr: inner, index, ..
-        } => {
-            check_soft_escape_in_expr(inner, candidates, hard_escaped, false, sl, cm);
-            check_soft_escape_in_expr(index, candidates, hard_escaped, false, sl, cm);
-        }
-        TirExprKind::Block(block) | TirExprKind::LabeledBlock { block, .. } => {
-            check_soft_escape_in_block(block, candidates, hard_escaped, sl, cm);
-        }
-        TirExprKind::If {
-            condition,
-            then_branch,
-            else_branch,
-        } => {
-            check_soft_escape_in_expr(condition, candidates, hard_escaped, false, sl, cm);
-            check_soft_escape_in_block(then_branch, candidates, hard_escaped, sl, cm);
-            if let Some(eb) = else_branch {
-                check_soft_escape_in_block(eb, candidates, hard_escaped, sl, cm);
-            }
-        }
-        TirExprKind::Match { expr: inner, arms } => {
-            check_soft_escape_in_expr(inner, candidates, hard_escaped, false, sl, cm);
-            for arm in arms {
-                if let Some(guard) = &arm.guard {
-                    check_soft_escape_in_expr(guard, candidates, hard_escaped, false, sl, cm);
+            // Closure captures → hard escape.
+            TirExprKind::Closure { body, captures, .. } => {
+                for capture in captures {
+                    if self.candidates.contains(&capture.outer_index) {
+                        self.hard_escaped.insert(capture.outer_index);
+                    }
                 }
-                check_soft_escape_in_expr(&arm.body, candidates, hard_escaped, false, sl, cm);
+                self.visit_expr(body);
             }
-        }
-        TirExprKind::StructLiteral { fields, .. } => {
-            for field in fields {
-                check_soft_escape_in_expr(&field.value, candidates, hard_escaped, false, sl, cm);
+            // Call / MethodCall: skip `&candidate` args to non-stores callees.
+            TirExprKind::Call { func, args, .. } => {
+                for (i, arg) in args.iter().enumerate() {
+                    if is_immut_ref_to_candidate(&arg.expr, self.candidates)
+                        && !callee_stores_param_at(
+                            func,
+                            i,
+                            self.current_module,
+                            self.stores_lookup,
+                        )
+                    {
+                        continue;
+                    }
+                    self.visit_expr(&arg.expr);
+                }
             }
-        }
-        TirExprKind::TupleLiteral { elements, .. } => {
-            for elem in elements {
-                check_soft_escape_in_expr(elem, candidates, hard_escaped, false, sl, cm);
+            TirExprKind::MethodCall {
+                receiver,
+                func,
+                args,
+                ..
+            } => {
+                // &self on non-stores method → safe, skip receiver.
+                if !is_immut_ref_to_candidate(receiver, self.candidates)
+                    || callee_stores_param_at(
+                        func,
+                        0,
+                        self.current_module,
+                        self.stores_lookup,
+                    )
+                {
+                    self.visit_expr(receiver);
+                }
+                for (i, arg) in args.iter().enumerate() {
+                    if is_immut_ref_to_candidate(&arg.expr, self.candidates)
+                        && !callee_stores_param_at(
+                            func,
+                            i + 1,
+                            self.current_module,
+                            self.stores_lookup,
+                        )
+                    {
+                        continue;
+                    }
+                    self.visit_expr(&arg.expr);
+                }
             }
-        }
-        TirExprKind::VariantConstruct { payload, .. } => {
-            if let Some(p) = payload {
-                check_soft_escape_in_expr(p, candidates, hard_escaped, false, sl, cm);
+            TirExprKind::TemplateString { .. } => {
+                unreachable!("TemplateString should be expanded before this phase")
             }
-        }
-        TirExprKind::GlobalVarSet { value, .. } => {
-            check_soft_escape_in_expr(value, candidates, hard_escaped, false, sl, cm);
-        }
-        TirExprKind::VariantTag { expr: inner }
-        | TirExprKind::VariantTest { expr: inner, .. }
-        | TirExprKind::VariantPayload { expr: inner, .. } => {
-            check_soft_escape_in_expr(inner, candidates, hard_escaped, false, sl, cm);
-        }
-        TirExprKind::Switch {
-            scrutinee,
-            arms,
-            default,
-            ..
-        } => {
-            check_soft_escape_in_expr(scrutinee, candidates, hard_escaped, false, sl, cm);
-            for arm in arms {
-                check_soft_escape_in_block(arm, candidates, hard_escaped, sl, cm);
-            }
-            check_soft_escape_in_block(default, candidates, hard_escaped, sl, cm);
-        }
-        // Leaf nodes
-        TirExprKind::IntLiteral { .. }
-        | TirExprKind::FloatLiteral { .. }
-        | TirExprKind::BoolLiteral(_)
-        | TirExprKind::CharLiteral(_)
-        | TirExprKind::StringLiteral(_)
-        | TirExprKind::BytesLiteral(_)
-        | TirExprKind::Null
-        | TirExprKind::Unit
-        | TirExprKind::FuncRef { .. }
-        | TirExprKind::GlobalVarGet { .. }
-        | TirExprKind::Capture { .. }
-        | TirExprKind::EnumConstruct { .. } => {}
-        TirExprKind::TemplateString { .. } => {
-            unreachable!("TemplateString should be expanded before this phase")
+            _ => self.walk_expr(expr),
         }
     }
 }
@@ -1484,16 +1020,6 @@ fn callee_stores_param_at(
         Some(stored_indices) => stored_indices.contains(&param_index as &usize),
         None => false, // No stores declaration → param is not stored
     }
-}
-
-/// Check if an expression is a `Local` node referencing a candidate (non-consuming check).
-fn is_candidate_local_ref(expr: &TirExpr, candidates: &IndexSet<u32>) -> Option<u32> {
-    if let TirExprKind::Local { index, .. } = &expr.kind
-        && candidates.contains(index)
-    {
-        return Some(*index);
-    }
-    None
 }
 
 /// Check if an expression is a `Local` node referencing a candidate.

--- a/wado-compiler/src/optimize/sroa.rs
+++ b/wado-compiler/src/optimize/sroa.rs
@@ -939,12 +939,7 @@ impl TirRefVisitor for SoftEscapeChecker<'_> {
             TirExprKind::Call { func, args, .. } => {
                 for (i, arg) in args.iter().enumerate() {
                     if is_immut_ref_to_candidate(&arg.expr, self.candidates)
-                        && !callee_stores_param_at(
-                            func,
-                            i,
-                            self.current_module,
-                            self.stores_lookup,
-                        )
+                        && !callee_stores_param_at(func, i, self.current_module, self.stores_lookup)
                     {
                         continue;
                     }
@@ -959,12 +954,7 @@ impl TirRefVisitor for SoftEscapeChecker<'_> {
             } => {
                 // &self on non-stores method → safe, skip receiver.
                 if !is_immut_ref_to_candidate(receiver, self.candidates)
-                    || callee_stores_param_at(
-                        func,
-                        0,
-                        self.current_module,
-                        self.stores_lookup,
-                    )
+                    || callee_stores_param_at(func, 0, self.current_module, self.stores_lookup)
                 {
                     self.visit_expr(receiver);
                 }


### PR DESCRIPTION
## Summary

Audit and clean-up of the TIR optimizer. No behavior changes — purely structural refactoring driven by an audit that flagged dead helpers, missing documentation, and walker duplication.

### P0 — Dead code & documentation

- **`optimize.rs`**: Module doc and `run_optimization_passes` doc only listed about half of the actual passes. Updated to enumerate all 14 passes that run in the fixed-point loop, plus HFS that runs once after convergence.
- **`licm.rs`**: Removed the unused `is_loop_invariant` helper (it was already marked `#[allow(dead_code)]` and had no call sites).
- **`copy_prop.rs`**: Dropped unused fields `CopyBinding::is_mut` and `LocalUsage::in_loop_condition`, and the `in_loop` / `in_condition` analyzer parameters that fed them. Both were dead since an earlier refactor.

### P1 — Targeted refactors

- **`inline.rs`**: Extracted `build_inlined_labeled_block` helper shared by `try_inline_call_expr` and `try_inline_method_call_expr`. The two sites previously duplicated ~130 lines of label generation, local allocation, let-binding synthesis, and body remapping. They now differ only in how they prepare an `InlineBinding` vector — free functions preserve `param.is_mut`, while methods always pass `false` and wrap `&mut self` in a `MutRef` unary.

- **`sroa.rs`**: Replaced three hand-written walker trios (`check_escape_in_*`, `check_has_field_access*`, `check_soft_escape_in_*`) with `TirRefVisitor`-based structs (`EscapeChecker`, `FieldAccessChecker`, `SoftEscapeChecker`). Each visitor overrides only the arms with non-default semantics and defers the rest to the default `walk_stmt` / `walk_expr`.

  The soft-escape checker threads the "value is the direct child of a Return/Break stmt" context via a `soft_allowed: bool` field that `visit_stmt` sets before visiting the value and `visit_expr` consumes at the top of each visit, preserving the original "one-shot top-level only" semantics exactly.

  Also deleted the dead `is_candidate_local_ref` duplicate of `is_candidate_local`.

### Stats

| File | Before | After | Δ |
|---|---:|---:|---:|
| `sroa.rs` | 2291 | 1825 | −466 |
| `inline.rs` | 2391 | 2379 | −12 |

Net: +479 / −1049 (−570 lines).

The visitor refactor saved less than initially estimated because SROA's escape analysis has many "special" arms (FieldAccess, Assign, Local, Unary, Closure, Call/MethodCall) that cannot defer to the default walker. The bigger long-term win is that **adding a new `TirExprKind` no longer requires updating three walkers** — the default `walk_expr` will handle it automatically.

## Test plan

- [x] `cargo clippy -p wado-compiler --lib -- -D warnings` clean
- [x] `cargo test -p wado-compiler --lib` — 319/319 pass
- [x] `cargo test -p wado-compiler --test e2e` — 5020/5020 pass (270s)
- [ ] `mise run on-task-done` — running

https://claude.ai/code/session_01LcJ9f4dMLWVgRPqYDQ7x83