### PR TITLE
Clippy clean: auto-fix + manual fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,5 @@ match_wildcard_for_single_variants = "allow"
 needless_range_loop = "allow"
 # from_str method doesn't always match FromStr trait
 should_implement_trait = "allow"
-# Case-sensitive extension comparisons are intentional in the compiler
-case_sensitive_file_extension_comparisons = "allow"
 # Sometimes needed for unused bindings
 used_underscore_binding = "allow"

--- a/mise.toml
+++ b/mise.toml
@@ -128,11 +128,11 @@ cargo run --bin wado -- format -w \
 
 [tasks.clippy]
 description = "Run clippy checks"
-run = "cargo clippy --all --all-features -- -D warnings"
+run = "cargo clippy --all --all-features --all-targets -- -D warnings"
 
 [tasks.clippy-fix]
 description = "Run clippy auto-fix"
-run = "cargo clippy --all --all-features --fix --allow-dirty --allow-staged"
+run = "cargo clippy --all --all-features --all-targets --fix --allow-dirty --allow-staged"
 
 [tasks.update-golden-fixtures]
 description = "Regenerate WIR golden fixtures"

--- a/wado-cli/src/syntax.rs
+++ b/wado-cli/src/syntax.rs
@@ -611,15 +611,15 @@ mod tests {
     use super::*;
     use jsonschema::validator_for;
 
-    /// TextMate grammar JSON schema
-    /// From: https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json
+    /// `TextMate` grammar JSON schema
+    /// From: <https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json>
     fn textmate_grammar_schema() -> serde_json::Value {
         serde_json::from_str(include_str!("../schemas/tmlanguage.schema.json"))
             .expect("failed to parse tmlanguage schema")
     }
 
     /// VS Code language-configuration.json schema
-    /// From: https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/language-configuration.json
+    /// From: <https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/language-configuration.json>
     fn language_configuration_schema() -> serde_json::Value {
         serde_json::from_str(include_str!(
             "../schemas/language-configuration.schema.json"
@@ -639,12 +639,10 @@ mod tests {
             .map(|e| e.to_string())
             .collect();
 
-        if !errors.is_empty() {
-            panic!(
-                "TextMate grammar failed schema validation:\n{}",
-                errors.join("\n")
-            );
-        }
+        assert!(errors.is_empty(), 
+            "TextMate grammar failed schema validation:\n{}",
+            errors.join("\n")
+        )
     }
 
     #[test]
@@ -659,11 +657,9 @@ mod tests {
             .map(|e| e.to_string())
             .collect();
 
-        if !errors.is_empty() {
-            panic!(
-                "Language configuration failed schema validation:\n{}",
-                errors.join("\n")
-            );
-        }
+        assert!(errors.is_empty(), 
+            "Language configuration failed schema validation:\n{}",
+            errors.join("\n")
+        )
     }
 }

--- a/wado-cli/src/syntax.rs
+++ b/wado-cli/src/syntax.rs
@@ -639,10 +639,11 @@ mod tests {
             .map(|e| e.to_string())
             .collect();
 
-        assert!(errors.is_empty(), 
+        assert!(
+            errors.is_empty(),
             "TextMate grammar failed schema validation:\n{}",
             errors.join("\n")
-        )
+        );
     }
 
     #[test]
@@ -657,9 +658,10 @@ mod tests {
             .map(|e| e.to_string())
             .collect();
 
-        assert!(errors.is_empty(), 
+        assert!(
+            errors.is_empty(),
             "Language configuration failed schema validation:\n{}",
             errors.join("\n")
-        )
+        );
     }
 }

--- a/wado-cli/tests/manifest_integration.rs
+++ b/wado-cli/tests/manifest_integration.rs
@@ -245,11 +245,11 @@ lib = "src/lib.wado"
 "#;
     fs::write(tmp.path().join("wado.toml"), toml).unwrap();
 
-    let source = r#"
+    let source = r"
 export fn add(a: i32, b: i32) -> i32 {
     return a + b;
 }
-"#;
+";
     fs::write(src_dir.join("lib.wado"), source).unwrap();
 
     let output_path = tmp.path().join("out.wasm");

--- a/wado-compiler/src/bind.rs
+++ b/wado-compiler/src/bind.rs
@@ -1240,12 +1240,12 @@ mod tests {
     #[test]
     fn test_simple_binding() {
         let module = parse(
-            r#"
+            r"
             fn run() {
                 let x = 1;
                 let y = x;
             }
-        "#,
+        ",
         );
         let (ok, diags) = bind_and_check(&module);
         assert!(ok);
@@ -1255,14 +1255,14 @@ mod tests {
     #[test]
     fn test_out_of_scope() {
         let module = parse(
-            r#"
+            r"
             fn run() {
                 if true {
                     let x = 1;
                 }
                 let y = x;
             }
-        "#,
+        ",
         );
         let (ok, diags) = bind_and_check(&module);
         assert!(!ok);
@@ -1274,12 +1274,12 @@ mod tests {
     #[test]
     fn test_duplicate_in_scope() {
         let module = parse(
-            r#"
+            r"
             fn run() {
                 let x = 1;
                 let x = 2;
             }
-        "#,
+        ",
         );
         let (ok, diags) = bind_and_check(&module);
         assert!(!ok);
@@ -1290,34 +1290,33 @@ mod tests {
     #[test]
     fn test_same_scope_shadow_with_self_ref() {
         let module = parse(
-            r#"
+            r"
             fn run() {
                 let x = 1;
                 let x = x + 1;
             }
-        "#,
+        ",
         );
         let (ok, diags) = bind_and_check(&module);
-        assert!(ok, "shadowing with self-ref should be allowed: {:?}", diags);
+        assert!(ok, "shadowing with self-ref should be allowed: {diags:?}");
         assert!(diags.is_empty());
     }
 
     #[test]
     fn test_same_scope_shadow_with_self_ref_in_call() {
         let module = parse(
-            r#"
+            r"
             fn transform(n: i32) -> i32 { return n; }
             fn run() {
                 let x = 1;
                 let x = transform(x);
             }
-        "#,
+        ",
         );
         let (ok, diags) = bind_and_check(&module);
         assert!(
             ok,
-            "shadowing with self-ref in call should be allowed: {:?}",
-            diags
+            "shadowing with self-ref in call should be allowed: {diags:?}"
         );
         assert!(diags.is_empty());
     }
@@ -1326,12 +1325,12 @@ mod tests {
     fn test_same_scope_shadow_closure_param_not_self_ref() {
         // |x| x + 1 — the x inside refers to the closure param, not the outer variable
         let module = parse(
-            r#"
+            r"
             fn run() {
                 let x = 1;
                 let x = |x: i32| x + 1;
             }
-        "#,
+        ",
         );
         let (ok, diags) = bind_and_check(&module);
         assert!(!ok, "closure param shadowing should NOT count as self-ref");
@@ -1342,29 +1341,29 @@ mod tests {
     fn test_same_scope_shadow_closure_capture_is_self_ref() {
         // || x + 1 — captures the outer x, this IS a self-reference
         let module = parse(
-            r#"
+            r"
             fn run() {
                 let x = 1;
                 let x = || x + 1;
             }
-        "#,
+        ",
         );
         let (ok, diags) = bind_and_check(&module);
-        assert!(ok, "closure capture should count as self-ref: {:?}", diags);
+        assert!(ok, "closure capture should count as self-ref: {diags:?}");
         assert!(diags.is_empty());
     }
 
     #[test]
     fn test_shadowing_in_nested_scope() {
         let module = parse(
-            r#"
+            r"
             fn run() {
                 let x = 1;
                 if true {
                     let x = 2;
                 }
             }
-        "#,
+        ",
         );
         let (ok, diags) = bind_and_check(&module);
         assert!(ok);
@@ -1374,12 +1373,12 @@ mod tests {
     #[test]
     fn test_assign_to_immutable() {
         let module = parse(
-            r#"
+            r"
             fn run() {
                 let x = 1;
                 x = 2;
             }
-        "#,
+        ",
         );
         let (ok, diags) = bind_and_check(&module);
         assert!(!ok);
@@ -1390,12 +1389,12 @@ mod tests {
     #[test]
     fn test_assign_to_mutable() {
         let module = parse(
-            r#"
+            r"
             fn run() {
                 let mut x = 1;
                 x = 2;
             }
-        "#,
+        ",
         );
         let (ok, diags) = bind_and_check(&module);
         assert!(ok);

--- a/wado-compiler/src/bundled.rs
+++ b/wado-compiler/src/bundled.rs
@@ -31,10 +31,8 @@ mod tests {
         let mut found_exports = Vec::new();
         for payload in parser.parse_all(wasm) {
             if let Ok(Payload::ExportSection(exports)) = payload {
-                for export in exports {
-                    if let Ok(exp) = export {
-                        found_exports.push(exp.name.to_string());
-                    }
+                for exp in exports.into_iter().flatten() {
+                    found_exports.push(exp.name.to_string());
                 }
             }
         }

--- a/wado-compiler/src/codegen/postprocess.rs
+++ b/wado-compiler/src/codegen/postprocess.rs
@@ -236,7 +236,7 @@ mod tests {
     #[test]
     fn test_convert_memory_to_import() {
         let result = convert_memory_to_import(wado_bundled_libm_wasm(), "env", "memory");
-        assert!(result.is_ok(), "Failed to convert: {:?}", result);
+        assert!(result.is_ok(), "Failed to convert: {result:?}");
 
         let converted = result.unwrap();
 
@@ -251,15 +251,12 @@ mod tests {
         for payload in parser.parse_all(&converted) {
             match payload {
                 Ok(Payload::ImportSection(imports)) => {
-                    for imports_group in imports {
-                        if let Ok(group) = imports_group {
-                            for import in group {
-                                if let Ok((_, imp)) = import {
-                                    if matches!(imp.ty, wasmparser::TypeRef::Memory(_)) {
-                                        has_memory_import = true;
-                                    }
+                    for group in imports.into_iter().flatten() {
+                        for import in group {
+                            if let Ok((_, imp)) = import
+                                && matches!(imp.ty, wasmparser::TypeRef::Memory(_)) {
+                                    has_memory_import = true;
                                 }
-                            }
                         }
                     }
                 }

--- a/wado-compiler/src/codegen/postprocess.rs
+++ b/wado-compiler/src/codegen/postprocess.rs
@@ -254,9 +254,10 @@ mod tests {
                     for group in imports.into_iter().flatten() {
                         for import in group {
                             if let Ok((_, imp)) = import
-                                && matches!(imp.ty, wasmparser::TypeRef::Memory(_)) {
-                                    has_memory_import = true;
-                                }
+                                && matches!(imp.ty, wasmparser::TypeRef::Memory(_))
+                            {
+                                has_memory_import = true;
+                            }
                         }
                     }
                 }

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -2755,8 +2755,7 @@ mod tests {
         let resolved = registry.resolve("TcpSocket::create");
         assert!(
             resolved.is_some(),
-            "TcpSocket::create should be resolved, got {:?}",
-            resolved
+            "TcpSocket::create should be resolved, got {resolved:?}"
         );
 
         // Check that the sockets types interface is included

--- a/wado-compiler/src/desugar.rs
+++ b/wado-compiler/src/desugar.rs
@@ -1288,113 +1288,6 @@ fn reconstruct_with_intermediates(expr: &Expr, intermediates: &[(String, String,
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::ast::{IdentExpr, LiteralExpr};
-    use crate::token::Span;
-
-    fn dummy_span() -> Span {
-        Span::new(0, 0, 1, 1)
-    }
-
-    #[test]
-    fn test_desugar_compound_assign() {
-        // x += 1
-        let ca = CompoundAssignExpr {
-            target: Expr::Ident(IdentExpr {
-                name: "x".to_string(),
-                span: dummy_span(),
-            }),
-            op: CompoundAssignOp::Add,
-            value: Expr::Literal(LiteralExpr {
-                value: crate::ast::Literal::Number("1".to_string()),
-                span: dummy_span(),
-            }),
-            span: dummy_span(),
-        };
-
-        let desugared = desugar_compound_assign(&ca);
-
-        // Should be x = x + 1
-        match desugared {
-            Expr::Assign(assign) => {
-                match &assign.target {
-                    Expr::Ident(i) => assert_eq!(i.name, "x"),
-                    _ => panic!("expected ident"),
-                }
-                match &assign.value {
-                    Expr::Binary(b) => {
-                        assert_eq!(b.op, BinaryOp::Add);
-                        match &b.left {
-                            Expr::Ident(i) => assert_eq!(i.name, "x"),
-                            _ => panic!("expected ident"),
-                        }
-                    }
-                    _ => panic!("expected binary"),
-                }
-            }
-            _ => panic!("expected assign"),
-        }
-    }
-
-    #[test]
-    fn test_desugar_comparison_chain() {
-        use crate::ast::ChainedComparison;
-
-        // 0 < x < 10
-        let chain = ComparisonChainExpr {
-            first: Expr::Literal(LiteralExpr {
-                value: crate::ast::Literal::Number("0".to_string()),
-                span: dummy_span(),
-            }),
-            comparisons: vec![
-                ChainedComparison {
-                    op: BinaryOp::Lt,
-                    right: Expr::Ident(IdentExpr {
-                        name: "x".to_string(),
-                        span: dummy_span(),
-                    }),
-                    op_span: dummy_span(),
-                },
-                ChainedComparison {
-                    op: BinaryOp::Lt,
-                    right: Expr::Literal(LiteralExpr {
-                        value: crate::ast::Literal::Number("10".to_string()),
-                        span: dummy_span(),
-                    }),
-                    op_span: dummy_span(),
-                },
-            ],
-            span: dummy_span(),
-        };
-
-        let desugared = desugar_comparison_chain(&chain);
-
-        // Should be (0 < x) && (x < 10)
-        match desugared {
-            Expr::Binary(and) => {
-                assert_eq!(and.op, BinaryOp::And);
-                // Left should be 0 < x
-                match &and.left {
-                    Expr::Binary(lt) => {
-                        assert_eq!(lt.op, BinaryOp::Lt);
-                    }
-                    _ => panic!("expected binary"),
-                }
-                // Right should be x < 10
-                match &and.right {
-                    Expr::Binary(lt) => {
-                        assert_eq!(lt.op, BinaryOp::Lt);
-                    }
-                    _ => panic!("expected binary"),
-                }
-            }
-            _ => panic!("expected binary (and)"),
-        }
-    }
-}
-
 fn strip_ns_from_item(item: Item, ctx: &DesugarContext) -> Item {
     match item {
         Item::Function(f) => Item::Function(strip_ns_from_function(f, ctx)),
@@ -1771,5 +1664,112 @@ fn strip_ns_from_expr(expr: Expr, ctx: &DesugarContext) -> Expr {
             Expr::Range(range)
         }
         Expr::Literal(_) | Expr::CompoundAssign(_) | Expr::ComparisonChain(_) => expr,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{IdentExpr, LiteralExpr};
+    use crate::token::Span;
+
+    fn dummy_span() -> Span {
+        Span::new(0, 0, 1, 1)
+    }
+
+    #[test]
+    fn test_desugar_compound_assign() {
+        // x += 1
+        let ca = CompoundAssignExpr {
+            target: Expr::Ident(IdentExpr {
+                name: "x".to_string(),
+                span: dummy_span(),
+            }),
+            op: CompoundAssignOp::Add,
+            value: Expr::Literal(LiteralExpr {
+                value: crate::ast::Literal::Number("1".to_string()),
+                span: dummy_span(),
+            }),
+            span: dummy_span(),
+        };
+
+        let desugared = desugar_compound_assign(&ca);
+
+        // Should be x = x + 1
+        match desugared {
+            Expr::Assign(assign) => {
+                match &assign.target {
+                    Expr::Ident(i) => assert_eq!(i.name, "x"),
+                    _ => panic!("expected ident"),
+                }
+                match &assign.value {
+                    Expr::Binary(b) => {
+                        assert_eq!(b.op, BinaryOp::Add);
+                        match &b.left {
+                            Expr::Ident(i) => assert_eq!(i.name, "x"),
+                            _ => panic!("expected ident"),
+                        }
+                    }
+                    _ => panic!("expected binary"),
+                }
+            }
+            _ => panic!("expected assign"),
+        }
+    }
+
+    #[test]
+    fn test_desugar_comparison_chain() {
+        use crate::ast::ChainedComparison;
+
+        // 0 < x < 10
+        let chain = ComparisonChainExpr {
+            first: Expr::Literal(LiteralExpr {
+                value: crate::ast::Literal::Number("0".to_string()),
+                span: dummy_span(),
+            }),
+            comparisons: vec![
+                ChainedComparison {
+                    op: BinaryOp::Lt,
+                    right: Expr::Ident(IdentExpr {
+                        name: "x".to_string(),
+                        span: dummy_span(),
+                    }),
+                    op_span: dummy_span(),
+                },
+                ChainedComparison {
+                    op: BinaryOp::Lt,
+                    right: Expr::Literal(LiteralExpr {
+                        value: crate::ast::Literal::Number("10".to_string()),
+                        span: dummy_span(),
+                    }),
+                    op_span: dummy_span(),
+                },
+            ],
+            span: dummy_span(),
+        };
+
+        let desugared = desugar_comparison_chain(&chain);
+
+        // Should be (0 < x) && (x < 10)
+        match desugared {
+            Expr::Binary(and) => {
+                assert_eq!(and.op, BinaryOp::And);
+                // Left should be 0 < x
+                match &and.left {
+                    Expr::Binary(lt) => {
+                        assert_eq!(lt.op, BinaryOp::Lt);
+                    }
+                    _ => panic!("expected binary"),
+                }
+                // Right should be x < 10
+                match &and.right {
+                    Expr::Binary(lt) => {
+                        assert_eq!(lt.op, BinaryOp::Lt);
+                    }
+                    _ => panic!("expected binary"),
+                }
+            }
+            _ => panic!("expected binary (and)"),
+        }
     }
 }

--- a/wado-compiler/src/lexer.rs
+++ b/wado-compiler/src/lexer.rs
@@ -1256,9 +1256,9 @@ mod tests {
 
     #[test]
     fn test_data_section_basic() {
-        let source = r#"fn main() { }
+        let source = r"fn main() { }
 __DATA__
-hello world"#;
+hello world";
         let mut lexer = Lexer::new(source);
         let tokens = lexer.tokenize().unwrap();
 
@@ -1272,11 +1272,11 @@ hello world"#;
 
     #[test]
     fn test_data_section_multiline() {
-        let source = r#"fn main() { }
+        let source = r"fn main() { }
 __DATA__
 line 1
 line 2
-line 3"#;
+line 3";
         let mut lexer = Lexer::new(source);
         lexer.tokenize().unwrap();
 
@@ -1352,10 +1352,10 @@ __DATA__
 
     #[test]
     fn test_data_section_after_comment() {
-        let source = r#"// some comment
+        let source = r"// some comment
 fn main() { }
 __DATA__
-test data"#;
+test data";
         let mut lexer = Lexer::new(source);
         lexer.tokenize().unwrap();
 

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -1395,7 +1395,7 @@ mod tests {
         let s3 = StructName::from_path_and_name(&["./other.wado".to_string()], "Point");
 
         let mut set = IndexSet::default();
-        set.insert(s1.clone());
+        set.insert(s1);
         assert!(set.contains(&s2));
         assert!(!set.contains(&s3));
     }

--- a/wado-compiler/src/optimize/const_folding.rs
+++ b/wado-compiler/src/optimize/const_folding.rs
@@ -767,7 +767,7 @@ mod tests {
 
     #[test]
     fn test_float_format() {
-        assert_eq!(format_float(3.14), "3.14");
+        assert_eq!(format_float(3.25), "3.25");
         assert_eq!(format_float(0.0), "0.0");
         assert_eq!(format_float(4.0), "4.0");
         assert_eq!(format_float(f64::INFINITY), "Infinity");

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -5016,9 +5016,10 @@ line 2
             let body = func.body.as_ref().unwrap();
             if let Stmt::If(if_stmt) = &body.stmts[0]
                 && let Condition::LetChain { elements, .. } = &if_stmt.condition
-                    && let crate::ast::ConditionElement::Let { pattern, .. } = &elements[0] {
-                        return pattern.clone();
-                    }
+                && let crate::ast::ConditionElement::Let { pattern, .. } = &elements[0]
+            {
+                return pattern.clone();
+            }
         }
         panic!("failed to parse pattern from: {source}");
     }

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -4571,7 +4571,7 @@ mod tests {
 
     #[test]
     fn test_world_decl() {
-        let source = r#"
+        let source = r"
             world CliCommand {
                 import Stdout {
                     write_via_stream,
@@ -4579,7 +4579,7 @@ mod tests {
 
                 export async fn run() -> Result<(), ()>;
             }
-        "#;
+        ";
 
         let module = parse(source).unwrap();
         assert_eq!(module.items.len(), 1);
@@ -4607,7 +4607,7 @@ mod tests {
 
     #[test]
     fn test_world_multiple_imports_exports() {
-        let source = r#"
+        let source = r"
             world TestWorld {
                 import Stdout {
                     write_via_stream,
@@ -4625,7 +4625,7 @@ mod tests {
                 export async fn run() -> Result<(), ()>;
                 export fn get_version() -> string;
             }
-        "#;
+        ";
 
         let module = parse(source).unwrap();
 
@@ -4654,12 +4654,12 @@ mod tests {
 
     #[test]
     fn test_effect_with_async_method() {
-        let source = r#"
+        let source = r"
             effect Http {
                 async fn get(url: String) -> Response;
                 fn status() -> i32;
             }
-        "#;
+        ";
 
         let module = parse(source).unwrap();
 
@@ -4716,11 +4716,11 @@ mod tests {
 
     #[test]
     fn test_export_with_params() {
-        let source = r#"
+        let source = r"
             world TestWorld {
                 export fn process(input: String, count: i32) -> Result<String, Error>;
             }
-        "#;
+        ";
 
         let module = parse(source).unwrap();
 
@@ -4740,11 +4740,11 @@ mod tests {
     #[test]
     fn test_bodyless_function_declaration() {
         // Bodyless functions are compiler built-ins
-        let source = r#"
+        let source = r"
             pub fn stream_new() -> i64;
             pub fn stream_write(tx: i32, ptr: i32, len: i32) -> i32;
             fn internal_helper();
-        "#;
+        ";
 
         let module = parse(source).unwrap();
         assert_eq!(module.items.len(), 3);
@@ -4877,11 +4877,11 @@ mod tests {
 
     #[test]
     fn test_assert_simple() {
-        let source = r#"
+        let source = r"
             fn test() {
                 assert x > 0;
             }
-        "#;
+        ";
 
         let module = parse(source).unwrap();
 
@@ -4928,11 +4928,11 @@ mod tests {
 
     #[test]
     fn test_assert_with_template_message() {
-        let source = r#"
+        let source = r"
             fn test() {
                 assert x > 0, `x must be positive, got {x}`;
             }
-        "#;
+        ";
 
         let module = parse(source).unwrap();
 
@@ -5014,13 +5014,11 @@ line 2
         let module = parse(&wrapped).unwrap();
         if let Item::Function(func) = &module.items[0] {
             let body = func.body.as_ref().unwrap();
-            if let Stmt::If(if_stmt) = &body.stmts[0] {
-                if let Condition::LetChain { elements, .. } = &if_stmt.condition {
-                    if let crate::ast::ConditionElement::Let { pattern, .. } = &elements[0] {
+            if let Stmt::If(if_stmt) = &body.stmts[0]
+                && let Condition::LetChain { elements, .. } = &if_stmt.condition
+                    && let crate::ast::ConditionElement::Let { pattern, .. } = &elements[0] {
                         return pattern.clone();
                     }
-                }
-            }
         }
         panic!("failed to parse pattern from: {source}");
     }
@@ -5223,11 +5221,11 @@ line 2
     fn test_effect_method_with_generics() {
         // Ensure effect methods with generic parameters parse correctly
         // (previously used a naive skip that could break on nested <>)
-        let source = r#"
+        let source = r"
             effect Store {
                 fn get<K>(key: K) -> String;
             }
-        "#;
+        ";
         let module = parse(source).unwrap();
         if let Item::Effect(effect) = &module.items[0] {
             assert_eq!(effect.methods.len(), 1);
@@ -5263,12 +5261,12 @@ line 2
 
     #[test]
     fn test_trait_decl_associated_type_bounds() {
-        let source = r#"
+        let source = r"
             trait Container {
                 type Item: Eq + Ord;
                 fn get(&self) -> Self::Item;
             }
-        "#;
+        ";
         let module = parse(source).unwrap();
         if let Item::Trait(trait_decl) = &module.items[0] {
             assert_eq!(trait_decl.associated_types.len(), 1);

--- a/wado-compiler/src/syntax.rs
+++ b/wado-compiler/src/syntax.rs
@@ -118,7 +118,7 @@ mod tests {
         assert!(def.keywords.declaration.contains(&"fn"));
     }
 
-    /// Verify all keywords in SyntaxDefinition are recognized by the lexer
+    /// Verify all keywords in `SyntaxDefinition` are recognized by the lexer
     #[test]
     fn test_syntax_keywords_match_lexer() {
         let def = SyntaxDefinition::wado();
@@ -184,7 +184,7 @@ mod tests {
         }
     }
 
-    /// Verify all constants in SyntaxDefinition are recognized by the lexer
+    /// Verify all constants in `SyntaxDefinition` are recognized by the lexer
     #[test]
     fn test_syntax_constants_match_lexer() {
         let def = SyntaxDefinition::wado();

--- a/wado-compiler/tests/common.rs
+++ b/wado-compiler/tests/common.rs
@@ -572,10 +572,8 @@ pub fn extract_data_section(source: &str) -> Option<&str> {
     let marker = "\n__DATA__\n";
     if let Some(pos) = source.find(marker) {
         Some(&source[pos + marker.len()..])
-    } else if source.starts_with("__DATA__\n") {
-        Some(&source["__DATA__\n".len()..])
     } else {
-        None
+        source.strip_prefix("__DATA__\n")
     }
 }
 

--- a/wado-compiler/tests/common.rs
+++ b/wado-compiler/tests/common.rs
@@ -23,7 +23,7 @@ use wado_compiler::{
     CompileError, CompileFailure, CompilerHost, Diagnostic, OptLevel, SourceError,
 };
 
-/// A filesystem-based CompilerHost for tests that need to load files
+/// A filesystem-based `CompilerHost` for tests that need to load files
 pub struct FilesystemHost {
     base_path: PathBuf,
     diagnostics: Mutex<Vec<Diagnostic>>,
@@ -61,7 +61,7 @@ impl CompilerHost for FilesystemHost {
     }
 }
 
-/// An in-memory CompilerHost for tests that don't need file loading
+/// An in-memory `CompilerHost` for tests that don't need file loading
 pub struct InMemoryHost {
     diagnostics: Mutex<Vec<Diagnostic>>,
 }
@@ -285,6 +285,12 @@ pub struct TestHttpCtx {
     pub mocks: indexmap::IndexMap<String, OutgoingMockResponse>,
 }
 
+impl Default for TestHttpCtx {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TestHttpCtx {
     pub fn new() -> Self {
         Self {
@@ -346,7 +352,7 @@ impl WasiHttpHooks for TestHttpCtx {
                 let path = request
                     .uri()
                     .path_and_query()
-                    .map(|pq| pq.as_str())
+                    .map(http::uri::PathAndQuery::as_str)
                     .unwrap_or("/");
                 self.mocks.get(path)
             })
@@ -492,7 +498,7 @@ pub fn compile_source_with_opts(
     source: &str,
     opt_level: OptLevel,
 ) -> Result<wado_compiler::CompileResult, CompileError> {
-    let base_path = path.parent().map(|p| p.to_path_buf()).unwrap_or_default();
+    let base_path = path.parent().map(std::path::Path::to_path_buf).unwrap_or_default();
     let host = FilesystemHost::new(base_path);
     let filename = path.to_string_lossy();
 
@@ -526,7 +532,7 @@ pub fn compile_source_with_compiler_options_and_filename(
     options: wado_compiler::CompilerOptions,
     display_filename: Option<&str>,
 ) -> Result<wado_compiler::CompileResult, CompileError> {
-    let base_path = path.parent().map(|p| p.to_path_buf()).unwrap_or_default();
+    let base_path = path.parent().map(std::path::Path::to_path_buf).unwrap_or_default();
     let host = FilesystemHost::new(base_path);
     let filename = display_filename
         .map(std::borrow::Cow::Borrowed)
@@ -552,7 +558,7 @@ pub async fn compile_file_async(
         message: e.to_string(),
     })?;
 
-    let base_path = path.parent().map(|p| p.to_path_buf()).unwrap_or_default();
+    let base_path = path.parent().map(std::path::Path::to_path_buf).unwrap_or_default();
     let host = FilesystemHost::new(base_path);
     let filename = path.to_string_lossy();
 

--- a/wado-compiler/tests/common.rs
+++ b/wado-compiler/tests/common.rs
@@ -498,7 +498,10 @@ pub fn compile_source_with_opts(
     source: &str,
     opt_level: OptLevel,
 ) -> Result<wado_compiler::CompileResult, CompileError> {
-    let base_path = path.parent().map(std::path::Path::to_path_buf).unwrap_or_default();
+    let base_path = path
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_default();
     let host = FilesystemHost::new(base_path);
     let filename = path.to_string_lossy();
 
@@ -532,7 +535,10 @@ pub fn compile_source_with_compiler_options_and_filename(
     options: wado_compiler::CompilerOptions,
     display_filename: Option<&str>,
 ) -> Result<wado_compiler::CompileResult, CompileError> {
-    let base_path = path.parent().map(std::path::Path::to_path_buf).unwrap_or_default();
+    let base_path = path
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_default();
     let host = FilesystemHost::new(base_path);
     let filename = display_filename
         .map(std::borrow::Cow::Borrowed)
@@ -558,7 +564,10 @@ pub async fn compile_file_async(
         message: e.to_string(),
     })?;
 
-    let base_path = path.parent().map(std::path::Path::to_path_buf).unwrap_or_default();
+    let base_path = path
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_default();
     let host = FilesystemHost::new(base_path);
     let filename = path.to_string_lossy();
 

--- a/wado-compiler/tests/compile_errors.rs
+++ b/wado-compiler/tests/compile_errors.rs
@@ -101,9 +101,9 @@ fn test_lexer_error_invalid_character() {
 
 #[test]
 fn test_parser_error_missing_function_body() {
-    let source = r#"
+    let source = r"
 fn main()
-"#;
+";
 
     let result = common::compile_source(source);
     assert!(result.is_err());
@@ -118,7 +118,7 @@ fn main()
             ..
         } => {
             assert!(
-                message.contains("expected") || message.contains("{"),
+                message.contains("expected") || message.contains('{'),
                 "Unexpected message: {message}"
             );
             assert!(line > 0);
@@ -131,11 +131,11 @@ fn main()
 
 #[test]
 fn test_parser_error_unexpected_token() {
-    let source = r#"
+    let source = r"
 fn main() {
     let = 42;
 }
-"#;
+";
 
     let result = common::compile_source(source);
     assert!(result.is_err());
@@ -163,12 +163,12 @@ fn main() {
 
 #[test]
 fn test_parser_error_missing_semicolon() {
-    let source = r#"
+    let source = r"
 fn main() {
     let x = 1
     let y = 2;
 }
-"#;
+";
 
     let result = common::compile_source(source);
     assert!(result.is_err());
@@ -183,7 +183,7 @@ fn main() {
             ..
         } => {
             assert!(
-                message.contains("expected") || message.contains(";"),
+                message.contains("expected") || message.contains(';'),
                 "Unexpected message: {message}"
             );
             assert!(line >= 3);
@@ -196,9 +196,9 @@ fn main() {
 
 #[test]
 fn test_parser_error_invalid_use_statement() {
-    let source = r#"
+    let source = r"
 use;
-"#;
+";
 
     let result = common::compile_source(source);
     assert!(result.is_err());
@@ -288,11 +288,11 @@ fn main() {
 
 #[test]
 fn test_comparison_chain_error_not_equal_cannot_chain() {
-    let source = r#"
+    let source = r"
 fn run() {
     let a = 1 != 2 != 3;
 }
-"#;
+";
 
     let result = common::compile_source(source);
     assert!(result.is_err());
@@ -320,11 +320,11 @@ fn run() {
 
 #[test]
 fn test_comparison_chain_error_mixed_ascending_descending() {
-    let source = r#"
+    let source = r"
 fn run() {
     let a = 1 < 2 > 3;
 }
-"#;
+";
 
     let result = common::compile_source(source);
     assert!(result.is_err());
@@ -352,11 +352,11 @@ fn run() {
 
 #[test]
 fn test_comparison_chain_error_mixed_descending_ascending() {
-    let source = r#"
+    let source = r"
 fn run() {
     let a = 3 > 2 < 1;
 }
-"#;
+";
 
     let result = common::compile_source(source);
     assert!(result.is_err());
@@ -384,11 +384,11 @@ fn run() {
 
 #[test]
 fn test_comparison_chain_error_equality_with_inequality() {
-    let source = r#"
+    let source = r"
 fn run() {
     let a = 1 == 2 < 3;
 }
-"#;
+";
 
     let result = common::compile_source(source);
     assert!(result.is_err());
@@ -416,11 +416,11 @@ fn run() {
 
 #[test]
 fn test_comparison_chain_error_inequality_with_equality() {
-    let source = r#"
+    let source = r"
 fn run() {
     let a = 1 < 2 == 3;
 }
-"#;
+";
 
     let result = common::compile_source(source);
     assert!(result.is_err());
@@ -448,11 +448,11 @@ fn run() {
 
 #[test]
 fn test_comparison_chain_error_not_equal_after_less_than() {
-    let source = r#"
+    let source = r"
 fn run() {
     let a = 1 < 2 != 3;
 }
-"#;
+";
 
     let result = common::compile_source(source);
     assert!(result.is_err());
@@ -491,7 +491,7 @@ fn test_error_display_with_filename() {
     let display = format!("{err}");
     assert!(display.contains("test.wado"));
     assert!(display.contains("10"));
-    assert!(display.contains("5"));
+    assert!(display.contains('5'));
     assert!(display.contains("unexpected token"));
     assert!(display.contains("parse error"));
 }

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -831,7 +831,7 @@ fn fixture_test_o2(path: &Path, content: &str) -> Result<(), Box<dyn std::error:
 }
 
 /// Test function for O1 (development optimization)
-/// Skipped by default locally. Runs in CI or when WADO_FULL_TEST=1 is set.
+/// Skipped by default locally. Runs in CI or when `WADO_FULL_TEST=1` is set.
 fn fixture_test_o1(path: &Path, content: &str) -> Result<(), Box<dyn std::error::Error>> {
     if std::env::var("CI").is_err() && std::env::var("WADO_FULL_TEST").is_err() {
         return Ok(()); // Skip locally by default
@@ -841,7 +841,7 @@ fn fixture_test_o1(path: &Path, content: &str) -> Result<(), Box<dyn std::error:
 }
 
 /// Test function for O3 (aggressive optimization)
-/// Skipped by default locally. Runs in CI or when WADO_FULL_TEST=1 is set.
+/// Skipped by default locally. Runs in CI or when `WADO_FULL_TEST=1` is set.
 fn fixture_test_o3(path: &Path, content: &str) -> Result<(), Box<dyn std::error::Error>> {
     if std::env::var("CI").is_err() && std::env::var("WADO_FULL_TEST").is_err() {
         return Ok(()); // Skip locally by default
@@ -851,7 +851,7 @@ fn fixture_test_o3(path: &Path, content: &str) -> Result<(), Box<dyn std::error:
 }
 
 /// Test function for Os (size optimization)
-/// Skipped by default locally. Runs in CI or when WADO_FULL_TEST=1 is set.
+/// Skipped by default locally. Runs in CI or when `WADO_FULL_TEST=1` is set.
 fn fixture_test_os(path: &Path, content: &str) -> Result<(), Box<dyn std::error::Error>> {
     if std::env::var("CI").is_err() && std::env::var("WADO_FULL_TEST").is_err() {
         return Ok(()); // Skip locally by default

--- a/wado-compiler/tests/format.rs
+++ b/wado-compiler/tests/format.rs
@@ -1066,10 +1066,11 @@ fn test_format_idempotent_all_fixtures() {
         }
     }
 
-    assert!(failures.is_empty(), 
+    assert!(
+        failures.is_empty(),
         "Format idempotency failures:\n{}",
         failures.join("\n\n---\n\n")
-    )
+    );
 }
 
 #[test]
@@ -1661,11 +1662,12 @@ fn test_roundtrip_ast_all_fixtures() {
         }
     }
 
-    assert!(failures.is_empty(), 
+    assert!(
+        failures.is_empty(),
         "Round-trip AST equivalence failures ({} files):\n{}",
         failures.len(),
         failures.join("\n")
-    )
+    );
 }
 
 /// Regression test: the formatter must preserve parentheses in `if let ... && (expr)`
@@ -1780,11 +1782,12 @@ fn test_roundtrip_ast_all_stdlib() {
 
     visit_dir(&lib_dir, &mut failures);
 
-    assert!(failures.is_empty(), 
+    assert!(
+        failures.is_empty(),
         "Round-trip AST equivalence failures in stdlib ({} files):\n{}",
         failures.len(),
         failures.join("\n")
-    )
+    );
 }
 
 #[test]

--- a/wado-compiler/tests/format.rs
+++ b/wado-compiler/tests/format.rs
@@ -126,11 +126,11 @@ fn assert_format_preserves_ast(source: &str) {
 
 #[test]
 fn test_format_idempotent_simple() {
-    let source = r#"
+    let source = r"
 fn run() {
     let x = 1;
 }
-"#;
+";
     let formatted1 = wado_compiler::format(source).expect("format failed");
     let formatted2 = wado_compiler::format(&formatted1).expect("format failed");
     assert_eq!(formatted1, formatted2, "format should be idempotent");
@@ -152,7 +152,7 @@ fn run() with Stdout {
 
 #[test]
 fn test_format_idempotent_with_struct() {
-    let source = r#"
+    let source = r"
 struct Point {
     x: i32,
     y: i32,
@@ -161,7 +161,7 @@ struct Point {
 fn run() {
     let p = Point { x: 1, y: 2 };
 }
-"#;
+";
     let formatted1 = wado_compiler::format(source).expect("format failed");
     let formatted2 = wado_compiler::format(&formatted1).expect("format failed");
     assert_eq!(formatted1, formatted2, "format should be idempotent");
@@ -169,63 +169,59 @@ fn run() {
 
 #[test]
 fn test_format_preserves_line_comment() {
-    let source = r#"
+    let source = r"
 // This is a comment
 fn run() {
     let x = 1;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("// This is a comment"),
-        "line comment should be preserved: {}",
-        formatted
+        "line comment should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_preserves_block_comment() {
-    let source = r#"
+    let source = r"
 /* This is a block comment */
 fn run() {
     let x = 1;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("/* This is a block comment */"),
-        "block comment should be preserved: {}",
-        formatted
+        "block comment should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_preserves_trailing_comment() {
-    let source = r#"
+    let source = r"
 fn run() {
     let x = 1; // trailing comment
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("// trailing comment"),
-        "trailing comment should be preserved: {}",
-        formatted
+        "trailing comment should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_comment_at_file_start() {
-    let source = r#"// First line comment
+    let source = r"// First line comment
 fn run() {
     let x = 1;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.starts_with("// First line comment\n"),
-        "comment at file start should be preserved at start: {}",
-        formatted
+        "comment at file start should be preserved at start: {formatted}"
     );
     // Idempotency check
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
@@ -234,18 +230,17 @@ fn run() {
 
 #[test]
 fn test_format_multiple_consecutive_comments() {
-    let source = r#"// Comment 1
+    let source = r"// Comment 1
 // Comment 2
 // Comment 3
 fn run() {
     let x = 1;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("// Comment 1\n// Comment 2\n// Comment 3"),
-        "consecutive comments should be preserved: {}",
-        formatted
+        "consecutive comments should be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -253,7 +248,7 @@ fn run() {
 
 #[test]
 fn test_format_comment_between_items() {
-    let source = r#"fn foo() {
+    let source = r"fn foo() {
     let x = 1;
 }
 
@@ -261,12 +256,11 @@ fn test_format_comment_between_items() {
 fn bar() {
     let y = 2;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("// Comment between functions"),
-        "comment between items should be preserved: {}",
-        formatted
+        "comment between items should be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -274,18 +268,17 @@ fn bar() {
 
 #[test]
 fn test_format_comment_inside_nested_block() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     if true {
         // Inside if
         let x = 1;
     }
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("// Inside if"),
-        "comment inside nested block should be preserved: {}",
-        formatted
+        "comment inside nested block should be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -293,24 +286,22 @@ fn test_format_comment_inside_nested_block() {
 
 #[test]
 fn test_format_multiline_block_comment() {
-    let source = r#"/*
+    let source = r"/*
  * Multi-line
  * block comment
  */
 fn run() {
     let x = 1;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("Multi-line"),
-        "multiline block comment should be preserved: {}",
-        formatted
+        "multiline block comment should be preserved: {formatted}"
     );
     assert!(
         formatted.contains("block comment"),
-        "multiline block comment should be preserved: {}",
-        formatted
+        "multiline block comment should be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -318,16 +309,15 @@ fn run() {
 
 #[test]
 fn test_format_comment_on_closing_brace_line() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let x = 1;
 } // end run
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     // Canonical format uses two spaces before trailing comments
     assert!(
         formatted.contains("}  // end run"),
-        "comment on closing brace line should be preserved: {}",
-        formatted
+        "comment on closing brace line should be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -335,16 +325,15 @@ fn test_format_comment_on_closing_brace_line() {
 
 #[test]
 fn test_format_comment_after_last_statement() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let x = 1;
     // Last comment in block
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("// Last comment in block"),
-        "comment after last statement should be preserved: {}",
-        formatted
+        "comment after last statement should be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -352,23 +341,21 @@ fn test_format_comment_after_last_statement() {
 
 #[test]
 fn test_format_comment_in_struct() {
-    let source = r#"struct Point {
+    let source = r"struct Point {
     // X coordinate
     x: i32,
     // Y coordinate
     y: i32,
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("// X coordinate"),
-        "comment in struct should be preserved: {}",
-        formatted
+        "comment in struct should be preserved: {formatted}"
     );
     assert!(
         formatted.contains("// Y coordinate"),
-        "comment in struct should be preserved: {}",
-        formatted
+        "comment in struct should be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -376,21 +363,19 @@ fn test_format_comment_in_struct() {
 
 #[test]
 fn test_format_trailing_comment_on_field() {
-    let source = r#"struct Point {
+    let source = r"struct Point {
     x: i32, // horizontal
     y: i32, // vertical
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("// horizontal"),
-        "trailing comment on field should be preserved: {}",
-        formatted
+        "trailing comment on field should be preserved: {formatted}"
     );
     assert!(
         formatted.contains("// vertical"),
-        "trailing comment on field should be preserved: {}",
-        formatted
+        "trailing comment on field should be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -398,18 +383,17 @@ fn test_format_trailing_comment_on_field() {
 
 #[test]
 fn test_format_comment_blank_line_preservation() {
-    let source = r#"// Top comment
+    let source = r"// Top comment
 
 fn run() {
     let x = 1;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     // There should be exactly one blank line between comment and function
     assert!(
         formatted.contains("// Top comment\n\nfn run()"),
-        "blank line after comment should be preserved: {}",
-        formatted
+        "blank line after comment should be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -422,8 +406,7 @@ fn test_format_use_braces_spacing() {
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("use { foo }"),
-        "use should have spaces inside braces: {}",
-        formatted
+        "use should have spaces inside braces: {formatted}"
     );
 }
 
@@ -433,25 +416,23 @@ fn test_format_use_multiple_items() {
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("use { foo, bar, baz }"),
-        "multiple items should be comma-separated with spaces: {}",
-        formatted
+        "multiple items should be comma-separated with spaces: {formatted}"
     );
 }
 
 #[test]
 fn test_format_indentation() {
-    let source = r#"
+    let source = r"
 fn run() {
 let x = 1;
 let y = 2;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     // Should use 4-space indentation
     assert!(
         formatted.contains("    let x = 1;"),
-        "should use 4-space indentation: {}",
-        formatted
+        "should use 4-space indentation: {formatted}"
     );
 }
 
@@ -466,8 +447,7 @@ fn run() {
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains(r#"use _ from "core:prelude/primitive.wado";"#),
-        "wildcard import should be preserved: {}",
-        formatted
+        "wildcard import should be preserved: {formatted}"
     );
     // Verify idempotency
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
@@ -481,13 +461,11 @@ fn test_format_wildcard_import_not_braces() {
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("use _ from"),
-        "wildcard import should use `use _ from` syntax: {}",
-        formatted
+        "wildcard import should use `use _ from` syntax: {formatted}"
     );
     assert!(
         !formatted.contains("use {"),
-        "wildcard import should NOT use braces: {}",
-        formatted
+        "wildcard import should NOT use braces: {formatted}"
     );
 }
 
@@ -502,13 +480,11 @@ fn run() {
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains(r#"use utils from "./utils.wado";"#),
-        "namespace import should be preserved: {}",
-        formatted
+        "namespace import should be preserved: {formatted}"
     );
     assert!(
         !formatted.contains("use {"),
-        "namespace import should NOT use braces: {}",
-        formatted
+        "namespace import should NOT use braces: {formatted}"
     );
     // Verify idempotency
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
@@ -517,23 +493,22 @@ fn run() {
 
 #[test]
 fn test_format_preserves_compound_assign() {
-    let source = r#"
+    let source = r"
 fn run() {
     let mut x = 1;
     x += 5;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("x += 5;"),
-        "compound assignment should be preserved: {}",
-        formatted
+        "compound assignment should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_preserves_all_compound_ops() {
-    let source = r#"
+    let source = r"
 fn run() {
     let mut a = 10;
     a += 1;
@@ -542,36 +517,35 @@ fn run() {
     a /= 4;
     a %= 5;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
-    assert!(formatted.contains("a += 1;"), "+=: {}", formatted);
-    assert!(formatted.contains("a -= 2;"), "-=: {}", formatted);
-    assert!(formatted.contains("a *= 3;"), "*=: {}", formatted);
-    assert!(formatted.contains("a /= 4;"), "/=: {}", formatted);
-    assert!(formatted.contains("a %= 5;"), "%=: {}", formatted);
+    assert!(formatted.contains("a += 1;"), "+=: {formatted}");
+    assert!(formatted.contains("a -= 2;"), "-=: {formatted}");
+    assert!(formatted.contains("a *= 3;"), "*=: {formatted}");
+    assert!(formatted.contains("a /= 4;"), "/=: {formatted}");
+    assert!(formatted.contains("a %= 5;"), "%=: {formatted}");
 }
 
 #[test]
 fn test_format_preserves_comparison_chain() {
-    let source = r#"
+    let source = r"
 fn run() {
     let x = 5;
     if 0 < x < 10 {
         let y = 1;
     }
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("0 < x < 10"),
-        "comparison chain should be preserved: {}",
-        formatted
+        "comparison chain should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_preserves_struct_shorthand() {
-    let source = r#"
+    let source = r"
 struct Point {
     x: i32,
     y: i32,
@@ -582,19 +556,18 @@ fn run() {
     let y = 2;
     let p = Point { x, y };
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     // Shorthand should be preserved (not expanded to x: x, y: y)
     assert!(
         formatted.contains("Point { x, y }"),
-        "struct shorthand should be preserved: {}",
-        formatted
+        "struct shorthand should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_preserves_self_shorthand() {
-    let source = r#"
+    let source = r"
 struct Point {
     x: i32,
     y: i32,
@@ -605,25 +578,23 @@ impl Point {
         return self.x;
     }
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     // &self should be preserved as shorthand, not expanded to self: &Self
     assert!(
         formatted.contains("fn get_x(&self)"),
-        "&self shorthand should be preserved: {}",
-        formatted
+        "&self shorthand should be preserved: {formatted}"
     );
     assert!(
         !formatted.contains("self: &Self"),
-        "self: &Self should not appear: {}",
-        formatted
+        "self: &Self should not appear: {formatted}"
     );
 }
 
 #[test]
 fn test_format_normalizes_explicit_self_type() {
     // Explicit `self: &Self` should be normalized to `&self` shorthand
-    let source = r#"
+    let source = r"
 struct Point {
     x: i32,
     y: i32,
@@ -634,17 +605,15 @@ impl Point {
         return self.x;
     }
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("fn get_x(&self)"),
-        "explicit self: &Self should be normalized to &self: {}",
-        formatted
+        "explicit self: &Self should be normalized to &self: {formatted}"
     );
     assert!(
         !formatted.contains("self: &Self"),
-        "self: &Self should not appear after normalization: {}",
-        formatted
+        "self: &Self should not appear after normalization: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -652,7 +621,7 @@ impl Point {
 
 #[test]
 fn test_format_preserves_mut_self_shorthand() {
-    let source = r#"
+    let source = r"
 struct Point {
     x: i32,
     y: i32,
@@ -663,25 +632,23 @@ impl Point {
         self.x = x;
     }
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     // &mut self should be preserved as shorthand
     assert!(
         formatted.contains("fn set_x(&mut self"),
-        "&mut self shorthand should be preserved: {}",
-        formatted
+        "&mut self shorthand should be preserved: {formatted}"
     );
     assert!(
         !formatted.contains("self: &mut Self"),
-        "self: &mut Self should not appear: {}",
-        formatted
+        "self: &mut Self should not appear: {formatted}"
     );
 }
 
 #[test]
 fn test_format_normalizes_explicit_mut_self_type() {
     // Explicit `self: &mut Self` should be normalized to `&mut self` shorthand
-    let source = r#"
+    let source = r"
 struct Point {
     x: i32,
     y: i32,
@@ -692,17 +659,15 @@ impl Point {
         self.x = x;
     }
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("fn set_x(&mut self"),
-        "explicit self: &mut Self should be normalized to &mut self: {}",
-        formatted
+        "explicit self: &mut Self should be normalized to &mut self: {formatted}"
     );
     assert!(
         !formatted.contains("self: &mut Self"),
-        "self: &mut Self should not appear after normalization: {}",
-        formatted
+        "self: &mut Self should not appear after normalization: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -721,43 +686,39 @@ __DATA__
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("__DATA__"),
-        "data section marker should be preserved: {}",
-        formatted
+        "data section marker should be preserved: {formatted}"
     );
     assert!(
         formatted.contains(r#"{"stdout": "hello"}"#),
-        "data section content should be preserved: {}",
-        formatted
+        "data section content should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_preserves_shebang() {
-    let source = r#"#!/usr/bin/env wado
+    let source = r"#!/usr/bin/env wado
 fn run() {
     let x = 1;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.starts_with("#!/usr/bin/env wado\n"),
-        "shebang should be preserved at start: {}",
-        formatted
+        "shebang should be preserved at start: {formatted}"
     );
 }
 
 #[test]
 fn test_format_preserves_shebang_with_args() {
-    let source = r#"#!/usr/bin/wado --some-flag
+    let source = r"#!/usr/bin/wado --some-flag
 fn run() {
     let x = 1;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.starts_with("#!/usr/bin/wado --some-flag\n"),
-        "shebang with args should be preserved: {}",
-        formatted
+        "shebang with args should be preserved: {formatted}"
     );
 }
 
@@ -774,18 +735,15 @@ __DATA__
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.starts_with("#!/usr/bin/env wado\n"),
-        "shebang should be preserved: {}",
-        formatted
+        "shebang should be preserved: {formatted}"
     );
     assert!(
         formatted.contains("__DATA__"),
-        "data section should be preserved: {}",
-        formatted
+        "data section should be preserved: {formatted}"
     );
     assert!(
         formatted.contains(r#"{"stdout": "hello"}"#),
-        "data section content should be preserved: {}",
-        formatted
+        "data section content should be preserved: {formatted}"
     );
 }
 
@@ -795,29 +753,27 @@ __DATA__
 
 #[test]
 fn test_format_decimal_literal() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let x = 42;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("let x = 42;"),
-        "decimal literal should be preserved: {}",
-        formatted
+        "decimal literal should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_binary_literal_preserved() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let x = 0b1100;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("let x = 0b1100;"),
-        "binary literal should be preserved: {}",
-        formatted
+        "binary literal should be preserved: {formatted}"
     );
     // Verify idempotency
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
@@ -826,143 +782,133 @@ fn test_format_binary_literal_preserved() {
 
 #[test]
 fn test_format_hex_literal_preserved() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let x = 0xFF;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("let x = 0xFF;"),
-        "hex literal should be preserved: {}",
-        formatted
+        "hex literal should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_octal_literal_preserved() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let x = 0o755;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("let x = 0o755;"),
-        "octal literal should be preserved: {}",
-        formatted
+        "octal literal should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_underscore_literal_preserved() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let x = 1_000_000;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("let x = 1_000_000;"),
-        "underscores should be preserved: {}",
-        formatted
+        "underscores should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_float_preserves_decimal() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let x = 3.14159;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("let x = 3.14159;"),
-        "float literal should be preserved: {}",
-        formatted
+        "float literal should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_integer_as_float() {
     // When parsing 3.0, it might be stored as 3 internally, but should format with .0
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let x: f64 = 3.0;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
-        formatted.contains("3.0") || formatted.contains("3"),
-        "should be able to format: {}",
-        formatted
+        formatted.contains("3.0") || formatted.contains('3'),
+        "should be able to format: {formatted}"
     );
 }
 
 #[test]
 fn test_format_negative_literal() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let x = -42;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("let x = -42;"),
-        "negative literal should be preserved: {}",
-        formatted
+        "negative literal should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_float_scientific_preserved() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let x = 6.022e23;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("let x = 6.022e23;"),
-        "scientific notation should be preserved: {}",
-        formatted
+        "scientific notation should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_float_underscore_preserved() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let x = 1_000_000.5;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("let x = 1_000_000.5;"),
-        "underscore in float should be preserved: {}",
-        formatted
+        "underscore in float should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_float_negative_exponent_preserved() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let x = 1.6e-19;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("let x = 1.6e-19;"),
-        "negative exponent should be preserved: {}",
-        formatted
+        "negative exponent should be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_deref_index_preserves_parens() {
     // (*p)[i] must keep parens — *p[i] means *(p[i])
-    let source = r#"fn foo(data: &Array<i32>) -> i32 {
+    let source = r"fn foo(data: &Array<i32>) -> i32 {
     return (*data)[0];
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("(*data)[0]"),
-        "deref-index parens must be preserved: {}",
-        formatted
+        "deref-index parens must be preserved: {formatted}"
     );
     // Idempotency
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
@@ -972,30 +918,28 @@ fn test_format_deref_index_preserves_parens() {
 #[test]
 fn test_format_deref_field_preserves_parens() {
     // (*p).field must keep parens — *p.field means *(p.field)
-    let source = r#"fn foo(p: &Point) -> i32 {
+    let source = r"fn foo(p: &Point) -> i32 {
     return (*p).x;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("(*p).x"),
-        "deref-field parens must be preserved: {}",
-        formatted
+        "deref-field parens must be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_deref_method_preserves_parens() {
     // (*p).method() must keep parens
-    let source = r#"fn foo(data: &Array<i32>) -> i32 {
+    let source = r"fn foo(data: &Array<i32>) -> i32 {
     return (*data).len();
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("(*data).len()"),
-        "deref-method parens must be preserved: {}",
-        formatted
+        "deref-method parens must be preserved: {formatted}"
     );
 }
 
@@ -1006,8 +950,7 @@ fn test_format_doc_comment_before_attribute_no_extra_blank() {
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         !formatted.contains("/// Doc\n\n#["),
-        "doc comment + attribute must not have a blank line between them: {}",
-        formatted
+        "doc comment + attribute must not have a blank line between them: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "format should be idempotent");
@@ -1016,18 +959,17 @@ fn test_format_doc_comment_before_attribute_no_extra_blank() {
 #[test]
 fn test_format_impl_explicit_type_params() {
     // Formatter must always emit explicit `impl<T>`, never compact `impl Foo<T>`
-    let source = r#"
+    let source = r"
 impl<T> WrapBox<T> {
     pub fn new(value: T) -> WrapBox<T> {
         return WrapBox { value };
     }
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("impl<T> WrapBox<T>"),
-        "impl type params must be preserved: {}",
-        formatted
+        "impl type params must be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "format should be idempotent");
@@ -1036,17 +978,16 @@ impl<T> WrapBox<T> {
 #[test]
 fn test_format_impl_bounded_type_params() {
     // Bounded compact form `impl Foo<T: Ord>` should be normalized to `impl<T: Ord> Foo<T>`
-    let source = r#"
+    let source = r"
 impl MyArray<T: Ord> {
     fn sort(&mut self) {
     }
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("impl<T: Ord> MyArray<T>"),
-        "bounded compact form should be expanded: {}",
-        formatted
+        "bounded compact form should be expanded: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "format should be idempotent");
@@ -1054,18 +995,17 @@ impl MyArray<T: Ord> {
 
 #[test]
 fn test_format_impl_trait_for_type_preserves_params() {
-    let source = r#"
+    let source = r"
 impl<T: Eq> Eq for Pair<T> {
     fn eq(&self, other: &Self) -> bool {
         return true;
     }
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("impl<T: Eq> Eq for Pair<T>"),
-        "trait impl type params must be preserved: {}",
-        formatted
+        "trait impl type params must be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "format should be idempotent");
@@ -1104,7 +1044,7 @@ fn test_format_idempotent_all_fixtures() {
         let formatted1 = match wado_compiler::format(&source) {
             Ok(f) => f,
             Err(e) => {
-                failures.push(format!("{}: format error: {}", filename, e));
+                failures.push(format!("{filename}: format error: {e}"));
                 continue;
             }
         };
@@ -1113,7 +1053,7 @@ fn test_format_idempotent_all_fixtures() {
         let formatted2 = match wado_compiler::format(&formatted1) {
             Ok(f) => f,
             Err(e) => {
-                failures.push(format!("{}: second format error: {}", filename, e));
+                failures.push(format!("{filename}: second format error: {e}"));
                 continue;
             }
         };
@@ -1121,33 +1061,29 @@ fn test_format_idempotent_all_fixtures() {
         // Check idempotency
         if formatted1 != formatted2 {
             failures.push(format!(
-                "{}: not idempotent\nFirst:\n{}\nSecond:\n{}",
-                filename, formatted1, formatted2
+                "{filename}: not idempotent\nFirst:\n{formatted1}\nSecond:\n{formatted2}"
             ));
         }
     }
 
-    if !failures.is_empty() {
-        panic!(
-            "Format idempotency failures:\n{}",
-            failures.join("\n\n---\n\n")
-        );
-    }
+    assert!(failures.is_empty(), 
+        "Format idempotency failures:\n{}",
+        failures.join("\n\n---\n\n")
+    )
 }
 
 #[test]
 fn test_format_break_with_label() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     outer: {
         break outer;
     }
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("break outer;"),
-        "break with label should be preserved: {}",
-        formatted
+        "break with label should be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -1155,17 +1091,16 @@ fn test_format_break_with_label() {
 
 #[test]
 fn test_format_break_with_label_and_value() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let x = foo: {
         break foo: 42;
     };
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("break foo: 42;"),
-        "break with label and value should be preserved: {}",
-        formatted
+        "break with label and value should be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -1173,19 +1108,18 @@ fn test_format_break_with_label_and_value() {
 
 #[test]
 fn test_format_break_with_label_and_expression() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let result = compute: {
         let a = 10;
         let b = 20;
         break compute: a + b;
     };
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("break compute: a + b;"),
-        "break with label and expression should be preserved: {}",
-        formatted
+        "break with label and expression should be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -1193,7 +1127,7 @@ fn test_format_break_with_label_and_expression() {
 
 #[test]
 fn test_format_nested_labeled_blocks() {
-    let source = r#"fn run() {
+    let source = r"fn run() {
     let result = outer: {
         let x = inner: {
             break inner: 10;
@@ -1201,17 +1135,15 @@ fn test_format_nested_labeled_blocks() {
         break outer: x * 2;
     };
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("break inner: 10;"),
-        "break inner with value should be preserved: {}",
-        formatted
+        "break inner with value should be preserved: {formatted}"
     );
     assert!(
         formatted.contains("break outer: x * 2;"),
-        "break outer with expression should be preserved: {}",
-        formatted
+        "break outer with expression should be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
@@ -1234,8 +1166,7 @@ fn test_format_golden() {
     let formatted = wado_compiler::format(&dirty).expect("format dirty failed");
     assert_eq!(
         formatted, clean,
-        "format(dirty) should equal clean\n\nActual:\n{}\n\nExpected:\n{}",
-        formatted, clean
+        "format(dirty) should equal clean\n\nActual:\n{formatted}\n\nExpected:\n{clean}"
     );
 
     let formatted2 = wado_compiler::format(&formatted).expect("format clean failed");
@@ -1257,8 +1188,7 @@ fn test_format_golden_mess() {
     let formatted = wado_compiler::format(&dirty).expect("format mess dirty failed");
     assert_eq!(
         formatted, clean,
-        "format(mess dirty) should equal mess clean\n\nActual:\n{}\n\nExpected:\n{}",
-        formatted, clean
+        "format(mess dirty) should equal mess clean\n\nActual:\n{formatted}\n\nExpected:\n{clean}"
     );
 
     let formatted2 = wado_compiler::format(&formatted).expect("format mess clean failed");
@@ -1268,7 +1198,7 @@ fn test_format_golden_mess() {
     );
 }
 
-/// Golden test for no_prelude constructs: effects, resources, WASI attributes,
+/// Golden test for `no_prelude` constructs: effects, resources, WASI attributes,
 /// and other syntax that requires `#![no_prelude]` or cannot compile.
 ///
 /// `format.fixtures/no_prelude.dirty.wado` has dirty patterns (e.g. `self: &Self`).
@@ -1285,8 +1215,7 @@ fn test_format_golden_no_prelude() {
     let formatted = wado_compiler::format(&dirty).expect("format no_prelude dirty failed");
     assert_eq!(
         formatted, clean,
-        "format(no_prelude dirty) should equal no_prelude clean\n\nActual:\n{}\n\nExpected:\n{}",
-        formatted, clean
+        "format(no_prelude dirty) should equal no_prelude clean\n\nActual:\n{formatted}\n\nExpected:\n{clean}"
     );
 
     let formatted2 = wado_compiler::format(&formatted).expect("format no_prelude clean failed");
@@ -1312,8 +1241,7 @@ fn test_format_golden_ops_all() {
     let formatted = wado_compiler::format(&dirty).expect("format ops.all dirty failed");
     assert_eq!(
         formatted, clean,
-        "format(ops.all dirty) should equal ops.all clean\n\nActual:\n{}\n\nExpected:\n{}",
-        formatted, clean
+        "format(ops.all dirty) should equal ops.all clean\n\nActual:\n{formatted}\n\nExpected:\n{clean}"
     );
 
     let formatted2 = wado_compiler::format(&formatted).expect("format ops.all clean failed");
@@ -1340,8 +1268,7 @@ fn test_format_golden_ops_mess() {
     let formatted = wado_compiler::format(&dirty).expect("format ops.mess dirty failed");
     assert_eq!(
         formatted, clean,
-        "format(ops.mess dirty) should equal ops.mess clean\n\nActual:\n{}\n\nExpected:\n{}",
-        formatted, clean
+        "format(ops.mess dirty) should equal ops.mess clean\n\nActual:\n{formatted}\n\nExpected:\n{clean}"
     );
 
     let formatted2 = wado_compiler::format(&formatted).expect("format ops.mess clean failed");
@@ -1353,7 +1280,7 @@ fn test_format_golden_ops_mess() {
 
 #[test]
 fn test_format_match_arm_trailing_comment() {
-    let source = r#"
+    let source = r"
 fn foo(c: char) -> bool {
     return match c {
         ' ' => true,              // SP
@@ -1362,7 +1289,7 @@ fn foo(c: char) -> bool {
         _ => false,
     };
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("true,  // SP"),
@@ -1379,7 +1306,7 @@ fn foo(c: char) -> bool {
 #[test]
 fn test_format_if_else_chain_all_multiline() {
     // When the first branch of an if-else chain is multiline, all branches should be multiline
-    let source = r#"
+    let source = r"
 fn foo(x: i32) -> i32 {
     let result = if x < 10 {
         '0' as i32 + x
@@ -1390,7 +1317,7 @@ fn foo(x: i32) -> i32 {
     };
     return result;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     // The else-if and else blocks should NOT be inlined when the first branch is multiline
     assert!(
@@ -1417,8 +1344,7 @@ fn run() {
     // The match should have been broken out to multiline since it exceeds 120 chars
     assert!(
         formatted.contains('\n'),
-        "wide single-arg call should wrap: {}",
-        formatted
+        "wide single-arg call should wrap: {formatted}"
     );
     // Should be idempotent
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
@@ -1427,24 +1353,22 @@ fn run() {
 
 #[test]
 fn test_format_trait_assoc_type_bounds_preserved() {
-    let source = r#"
+    let source = r"
 trait Serializer {
     type SeqSerializer: SerializeSeq;
     type MapSerializer: SerializeMap;
 
     fn serialize_i32(&mut self, v: i32) -> Result<(), SerializeError>;
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("type SeqSerializer: SerializeSeq;"),
-        "assoc type bounds should be preserved: {}",
-        formatted
+        "assoc type bounds should be preserved: {formatted}"
     );
     assert!(
         formatted.contains("type MapSerializer: SerializeMap;"),
-        "assoc type bounds should be preserved: {}",
-        formatted
+        "assoc type bounds should be preserved: {formatted}"
     );
     // Should be idempotent
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
@@ -1454,13 +1378,13 @@ trait Serializer {
 #[test]
 fn test_format_logical_chain_multiline() {
     // A long && chain should be broken with operator at start of continuation lines
-    let source = r#"
+    let source = r"
 fn run() {
     if self.input.get_byte(self.pos) as i32 == 'n' as i32 && self.input.get_byte(self.pos + 1) as i32 == 'u' as i32 && self.input.get_byte(self.pos + 2) as i32 == 'l' as i32 && self.input.get_byte(self.pos + 3) as i32 == 'l' as i32 {
         return null;
     }
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     // Each continuation line should start with && (after indentation)
     let lines: Vec<&str> = formatted.lines().collect();
@@ -1470,8 +1394,7 @@ fn run() {
         .collect();
     assert!(
         !continuation_lines.is_empty(),
-        "&& should appear at start of continuation lines: {}",
-        formatted
+        "&& should appear at start of continuation lines: {formatted}"
     );
     // Should be idempotent
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
@@ -1490,19 +1413,19 @@ fn run() {
 #[test]
 fn test_roundtrip_ast_simple() {
     assert_format_preserves_ast(
-        r#"
+        r"
 fn run() {
     let x = 1;
     let y = (x + 2) * 3;
 }
-"#,
+",
     );
 }
 
 #[test]
 fn test_roundtrip_ast_operator_precedence() {
     assert_format_preserves_ast(
-        r#"
+        r"
 fn run() {
     let a = (1 + 2) * 3;
     let b = 1 + 2 * 3;
@@ -1511,21 +1434,21 @@ fn run() {
     let e = !(a && b);
     let f = -(a + b);
 }
-"#,
+",
     );
 }
 
 #[test]
 fn test_roundtrip_ast_deref_parens() {
     assert_format_preserves_ast(
-        r#"
+        r"
 fn foo(data: &Array<i32>, p: &Point) -> i32 {
     let a = (*data)[0];
     let b = (*p).x;
     let c = (*data).len();
     return a + b + c;
 }
-"#,
+",
     );
 }
 
@@ -1548,7 +1471,7 @@ fn run() {
 #[test]
 fn test_roundtrip_ast_struct_and_methods() {
     assert_format_preserves_ast(
-        r#"
+        r"
 struct Point {
     x: i32,
     y: i32,
@@ -1563,14 +1486,14 @@ impl Point {
         return Point { x: 0, y: 0 };
     }
 }
-"#,
+",
     );
 }
 
 #[test]
 fn test_roundtrip_ast_closures() {
     assert_format_preserves_ast(
-        r#"
+        r"
 fn run() {
     let add = |a: i32, b: i32| a + b;
     let compute = |x: i32| {
@@ -1578,14 +1501,14 @@ fn run() {
         return doubled + x;
     };
 }
-"#,
+",
     );
 }
 
 #[test]
 fn test_roundtrip_ast_control_flow() {
     assert_format_preserves_ast(
-        r#"
+        r"
 fn run() {
     for let mut i = 0; i < 10; i += 1 {
         if i % 2 == 0 {
@@ -1601,14 +1524,14 @@ fn run() {
         break outer;
     }
 }
-"#,
+",
     );
 }
 
 #[test]
 fn test_roundtrip_ast_generics_and_traits() {
     assert_format_preserves_ast(
-        r#"
+        r"
 trait Container {
     type Item;
     fn get(&self) -> Self::Item;
@@ -1621,14 +1544,14 @@ fn identity<T>(x: T) -> T {
 struct Box<T> {
     value: T,
 }
-"#,
+",
     );
 }
 
 #[test]
 fn test_roundtrip_ast_variants_and_match() {
     assert_format_preserves_ast(
-        r#"
+        r"
 variant Shape {
     Circle(f64),
     Rectangle([f64, f64]),
@@ -1642,7 +1565,7 @@ fn area(s: Shape) -> f64 {
         Point => 0.0,
     };
 }
-"#,
+",
     );
 }
 
@@ -1662,7 +1585,7 @@ fn greet(name: String) with Stdout {
 #[test]
 fn test_roundtrip_ast_bitwise_and_cast() {
     assert_format_preserves_ast(
-        r#"
+        r"
 fn run() {
     let a = 0xFF & 0x0F;
     let b = (1 << 4) | 3;
@@ -1670,7 +1593,7 @@ fn run() {
     let d = 42 as f64;
     let e = 'A' as i32;
 }
-"#,
+",
     );
 }
 
@@ -1738,13 +1661,11 @@ fn test_roundtrip_ast_all_fixtures() {
         }
     }
 
-    if !failures.is_empty() {
-        panic!(
-            "Round-trip AST equivalence failures ({} files):\n{}",
-            failures.len(),
-            failures.join("\n")
-        );
-    }
+    assert!(failures.is_empty(), 
+        "Round-trip AST equivalence failures ({} files):\n{}",
+        failures.len(),
+        failures.join("\n")
+    )
 }
 
 /// Regression test: the formatter must preserve parentheses in `if let ... && (expr)`
@@ -1755,7 +1676,7 @@ fn test_roundtrip_ast_all_fixtures() {
 fn test_roundtrip_ast_let_chain_paren_preservation() {
     // if let with && boolean guard containing &&
     assert_format_preserves_ast(
-        r#"
+        r"
 fn test() {
     let opt = Option::<i32>::Some(5);
     let flag1 = true;
@@ -1764,12 +1685,12 @@ fn test() {
         println(`{x}`);
     }
 }
-"#,
+",
     );
 
     // while let with && guard containing &&
     assert_format_preserves_ast(
-        r#"
+        r"
 fn test() {
     let mut iter = [1, 2, 3].iter();
     let min = 0;
@@ -1778,19 +1699,19 @@ fn test() {
         println(`{v}`);
     }
 }
-"#,
+",
     );
 
     // if let with || inside guard
     assert_format_preserves_ast(
-        r#"
+        r"
 fn test() {
     let opt = Option::<i32>::Some(5);
     if let Some(x) = opt && (x > 10 || x < 0) {
         println(`{x}`);
     }
 }
-"#,
+",
     );
 }
 
@@ -1859,13 +1780,11 @@ fn test_roundtrip_ast_all_stdlib() {
 
     visit_dir(&lib_dir, &mut failures);
 
-    if !failures.is_empty() {
-        panic!(
-            "Round-trip AST equivalence failures in stdlib ({} files):\n{}",
-            failures.len(),
-            failures.join("\n")
-        );
-    }
+    assert!(failures.is_empty(), 
+        "Round-trip AST equivalence failures in stdlib ({} files):\n{}",
+        failures.len(),
+        failures.join("\n")
+    )
 }
 
 #[test]
@@ -1875,8 +1794,7 @@ fn test_format_attribute_numeric_arg_preserved() {
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("#[timeout_ms(120000)]"),
-        "numeric attribute argument must not be quoted: {}",
-        formatted
+        "numeric attribute argument must not be quoted: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "format should be idempotent");
@@ -1889,8 +1807,7 @@ fn test_format_template_string_escape_sequences_preserved() {
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("`hello\\nworld`"),
-        "\\n escape in template string must be preserved: {}",
-        formatted
+        "\\n escape in template string must be preserved: {formatted}"
     );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "format should be idempotent");
@@ -1903,24 +1820,22 @@ fn test_format_template_string_escape_sequences_all() {
     let formatted = wado_compiler::format(source).expect("format failed");
     assert!(
         formatted.contains("`a\\nb\\rc\\td\\0e\\\\f\\{g\\}`"),
-        "all escape sequences in template string must be preserved: {}",
-        formatted
+        "all escape sequences in template string must be preserved: {formatted}"
     );
 }
 
 #[test]
 fn test_format_match_two_arms_always_multiline() {
     // Match with 2+ arms must always be formatted multiline, never collapsed to one line
-    let source = r#"
+    let source = r"
 fn foo(x: Option<i32>) -> i32 {
     return match x { Some(v) => v, None => 0 };
 }
-"#;
+";
     let formatted = wado_compiler::format(source).expect("format failed");
     // The match should be expanded to multiple lines
     assert!(
         formatted.contains("Some(v) => v,\n"),
-        "match with 2 arms must be multiline:\n{}",
-        formatted
+        "match with 2 arms must be multiline:\n{formatted}"
     );
 }

--- a/wado-compiler/tests/literals.rs
+++ b/wado-compiler/tests/literals.rs
@@ -271,10 +271,7 @@ fn test_string_escape_tab() {
 
     match lit {
         wado_compiler::ast::Literal::String(raw) => {
-            assert_eq!(
-                raw, r"col1\tcol2",
-                "expected raw escape text, got {raw:?}"
-            );
+            assert_eq!(raw, r"col1\tcol2", "expected raw escape text, got {raw:?}");
         }
         other => panic!("expected String, got {other:?}"),
     }

--- a/wado-compiler/tests/literals.rs
+++ b/wado-compiler/tests/literals.rs
@@ -50,7 +50,7 @@ fn test_bool_true() {
 
     match lit {
         wado_compiler::ast::Literal::Bool(true) => {}
-        other => panic!("expected Bool(true), got {:?}", other),
+        other => panic!("expected Bool(true), got {other:?}"),
     }
 }
 
@@ -61,7 +61,7 @@ fn test_bool_false() {
 
     match lit {
         wado_compiler::ast::Literal::Bool(false) => {}
-        other => panic!("expected Bool(false), got {:?}", other),
+        other => panic!("expected Bool(false), got {other:?}"),
     }
 }
 
@@ -72,7 +72,7 @@ fn test_integer_zero() {
 
     match lit {
         wado_compiler::ast::Literal::Number(repr) if repr == "0" => {}
-        other => panic!("expected Number(\"0\"), got {:?}", other),
+        other => panic!("expected Number(\"0\"), got {other:?}"),
     }
 }
 
@@ -83,7 +83,7 @@ fn test_integer_positive() {
 
     match lit {
         wado_compiler::ast::Literal::Number(repr) if repr == "42" => {}
-        other => panic!("expected Number(\"42\"), got {:?}", other),
+        other => panic!("expected Number(\"42\"), got {other:?}"),
     }
 }
 
@@ -94,7 +94,7 @@ fn test_integer_large() {
 
     match lit {
         wado_compiler::ast::Literal::Number(repr) if repr == "9223372036854775807" => {}
-        other => panic!("expected Number(\"9223372036854775807\"), got {:?}", other),
+        other => panic!("expected Number(\"9223372036854775807\"), got {other:?}"),
     }
 }
 
@@ -104,7 +104,7 @@ fn test_integer_with_separator() {
     let lit = extract_literal(&module).expect("no literal found");
     match lit {
         wado_compiler::ast::Literal::Number(repr) if repr == "1_000_000" => {}
-        other => panic!("expected Number(\"1_000_000\"), got {:?}", other),
+        other => panic!("expected Number(\"1_000_000\"), got {other:?}"),
     }
 }
 
@@ -114,7 +114,7 @@ fn test_integer_hex() {
     let lit = extract_literal(&module).expect("no literal found");
     match lit {
         wado_compiler::ast::Literal::Number(repr) if repr == "0xFF" => {}
-        other => panic!("expected Number(\"0xFF\"), got {:?}", other),
+        other => panic!("expected Number(\"0xFF\"), got {other:?}"),
     }
 }
 
@@ -124,7 +124,7 @@ fn test_integer_binary() {
     let lit = extract_literal(&module).expect("no literal found");
     match lit {
         wado_compiler::ast::Literal::Number(repr) if repr == "0b1010" => {}
-        other => panic!("expected Number(\"0b1010\"), got {:?}", other),
+        other => panic!("expected Number(\"0b1010\"), got {other:?}"),
     }
 }
 
@@ -134,7 +134,7 @@ fn test_integer_octal() {
     let lit = extract_literal(&module).expect("no literal found");
     match lit {
         wado_compiler::ast::Literal::Number(repr) if repr == "0o755" => {}
-        other => panic!("expected Number(\"0o755\"), got {:?}", other),
+        other => panic!("expected Number(\"0o755\"), got {other:?}"),
     }
 }
 
@@ -145,7 +145,7 @@ fn test_float_simple() {
 
     match lit {
         wado_compiler::ast::Literal::Number(repr) if repr == "3.25" => {}
-        other => panic!("expected Number(\"3.25\"), got {:?}", other),
+        other => panic!("expected Number(\"3.25\"), got {other:?}"),
     }
 }
 
@@ -156,7 +156,7 @@ fn test_float_zero() {
 
     match lit {
         wado_compiler::ast::Literal::Number(repr) if repr == "0.0" => {}
-        other => panic!("expected Number(\"0.0\"), got {:?}", other),
+        other => panic!("expected Number(\"0.0\"), got {other:?}"),
     }
 }
 
@@ -167,7 +167,7 @@ fn test_float_leading_zero() {
 
     match lit {
         wado_compiler::ast::Literal::Number(repr) if repr == "0.5" => {}
-        other => panic!("expected Number(\"0.5\"), got {:?}", other),
+        other => panic!("expected Number(\"0.5\"), got {other:?}"),
     }
 }
 
@@ -178,7 +178,7 @@ fn test_float_many_decimals() {
 
     match lit {
         wado_compiler::ast::Literal::Number(repr) if repr == "1.23456789012345" => {}
-        other => panic!("expected Number(\"1.23456789012345\"), got {:?}", other),
+        other => panic!("expected Number(\"1.23456789012345\"), got {other:?}"),
     }
 }
 
@@ -188,7 +188,7 @@ fn test_float_scientific() {
     let lit = extract_literal(&module).expect("no literal found");
     match lit {
         wado_compiler::ast::Literal::Number(repr) if repr == "6.022e23" => {}
-        other => panic!("expected Number(\"6.022e23\"), got {:?}", other),
+        other => panic!("expected Number(\"6.022e23\"), got {other:?}"),
     }
 }
 
@@ -198,7 +198,7 @@ fn test_float_with_separator() {
     let lit = extract_literal(&module).expect("no literal found");
     match lit {
         wado_compiler::ast::Literal::Number(repr) if repr == "1_000_000.5" => {}
-        other => panic!("expected Number(\"1_000_000.5\"), got {:?}", other),
+        other => panic!("expected Number(\"1_000_000.5\"), got {other:?}"),
     }
 }
 
@@ -212,9 +212,9 @@ fn test_string_empty() {
 
     match lit {
         wado_compiler::ast::Literal::String(raw) => {
-            assert_eq!(raw, "", "expected empty raw string, got {:?}", raw);
+            assert_eq!(raw, "", "expected empty raw string, got {raw:?}");
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -225,9 +225,9 @@ fn test_string_simple() {
 
     match lit {
         wado_compiler::ast::Literal::String(raw) => {
-            assert_eq!(raw, "hello", "expected raw \"hello\", got {:?}", raw);
+            assert_eq!(raw, "hello", "expected raw \"hello\", got {raw:?}");
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -240,11 +240,10 @@ fn test_string_with_spaces() {
         wado_compiler::ast::Literal::String(raw) => {
             assert_eq!(
                 raw, "hello world",
-                "expected raw \"hello world\", got {:?}",
-                raw
+                "expected raw \"hello world\", got {raw:?}"
             );
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -258,11 +257,10 @@ fn test_string_escape_newline() {
         wado_compiler::ast::Literal::String(raw) => {
             assert_eq!(
                 raw, r"line1\nline2",
-                "expected raw escape text, got {:?}",
-                raw
+                "expected raw escape text, got {raw:?}"
             );
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -275,11 +273,10 @@ fn test_string_escape_tab() {
         wado_compiler::ast::Literal::String(raw) => {
             assert_eq!(
                 raw, r"col1\tcol2",
-                "expected raw escape text, got {:?}",
-                raw
+                "expected raw escape text, got {raw:?}"
             );
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -290,9 +287,9 @@ fn test_string_escape_carriage_return() {
 
     match lit {
         wado_compiler::ast::Literal::String(raw) => {
-            assert_eq!(raw, r"line\r", "expected raw escape text, got {:?}", raw);
+            assert_eq!(raw, r"line\r", "expected raw escape text, got {raw:?}");
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -306,11 +303,10 @@ fn test_string_escape_backslash() {
             // Raw text between the quotes: path\\to\\file (two escaped backslashes)
             assert_eq!(
                 raw, r"path\\to\\file",
-                "expected raw escape text, got {:?}",
-                raw
+                "expected raw escape text, got {raw:?}"
             );
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -324,11 +320,10 @@ fn test_string_escape_quote() {
             // Raw text: say \"hello\"
             assert_eq!(
                 raw, r#"say \"hello\""#,
-                "expected raw escape text, got {:?}",
-                raw
+                "expected raw escape text, got {raw:?}"
             );
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -341,11 +336,10 @@ fn test_string_multiple_escapes() {
         wado_compiler::ast::Literal::String(raw) => {
             assert_eq!(
                 raw, r"line1\nline2\ttab",
-                "expected raw escape text, got {:?}",
-                raw
+                "expected raw escape text, got {raw:?}"
             );
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -355,9 +349,9 @@ fn test_string_escape_forward_slash() {
     let lit = extract_literal(&module).expect("no literal found");
     match lit {
         wado_compiler::ast::Literal::String(raw) => {
-            assert_eq!(raw, r"path\/to", "expected raw escape text, got {:?}", raw);
+            assert_eq!(raw, r"path\/to", "expected raw escape text, got {raw:?}");
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -367,9 +361,9 @@ fn test_string_escape_backspace() {
     let lit = extract_literal(&module).expect("no literal found");
     match lit {
         wado_compiler::ast::Literal::String(raw) => {
-            assert_eq!(raw, r"hello\b", "expected raw escape text, got {:?}", raw);
+            assert_eq!(raw, r"hello\b", "expected raw escape text, got {raw:?}");
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -379,9 +373,9 @@ fn test_string_escape_form_feed() {
     let lit = extract_literal(&module).expect("no literal found");
     match lit {
         wado_compiler::ast::Literal::String(raw) => {
-            assert_eq!(raw, r"page\f", "expected raw escape text, got {:?}", raw);
+            assert_eq!(raw, r"page\f", "expected raw escape text, got {raw:?}");
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -392,9 +386,9 @@ fn test_string_escape_unicode_bmp() {
     let lit = extract_literal(&module).expect("no literal found");
     match lit {
         wado_compiler::ast::Literal::String(raw) => {
-            assert_eq!(raw, r"\u0041", "expected raw unicode escape, got {:?}", raw);
+            assert_eq!(raw, r"\u0041", "expected raw unicode escape, got {raw:?}");
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -407,11 +401,10 @@ fn test_string_escape_unicode_full() {
         wado_compiler::ast::Literal::String(raw) => {
             assert_eq!(
                 raw, r"\u{1F600}",
-                "expected raw unicode escape, got {:?}",
-                raw
+                "expected raw unicode escape, got {raw:?}"
             );
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -424,11 +417,10 @@ fn test_string_surrogate_pair() {
         wado_compiler::ast::Literal::String(raw) => {
             assert_eq!(
                 raw, r"\uD83D\uDE00",
-                "expected raw surrogate pair text, got {:?}",
-                raw
+                "expected raw surrogate pair text, got {raw:?}"
             );
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -439,7 +431,7 @@ fn test_unit_literal() {
 
     match lit {
         wado_compiler::ast::Literal::Unit => {}
-        other => panic!("expected Unit, got {:?}", other),
+        other => panic!("expected Unit, got {other:?}"),
     }
 }
 
@@ -462,7 +454,7 @@ fn test_string_unknown_escape_stored_as_raw() {
                 "expected raw text including unknown escape"
             );
         }
-        other => panic!("expected String, got {:?}", other),
+        other => panic!("expected String, got {other:?}"),
     }
 }
 
@@ -474,28 +466,28 @@ fn test_char_simple() {
     let lit = extract_literal(&module).expect("no literal found");
     match lit {
         wado_compiler::ast::Literal::Char(raw) if raw == "A" => {}
-        other => panic!("expected Char(\"A\"), got {:?}", other),
+        other => panic!("expected Char(\"A\"), got {other:?}"),
     }
 }
 
 #[test]
 fn test_char_escape_newline() {
-    let module = parse_expr(r#"'\n'"#).expect("parse failed");
+    let module = parse_expr(r"'\n'").expect("parse failed");
     let lit = extract_literal(&module).expect("no literal found");
     match lit {
         wado_compiler::ast::Literal::Char(raw) if raw == r"\n" => {}
-        other => panic!("expected Char(\"\\n\"), got {:?}", other),
+        other => panic!("expected Char(\"\\n\"), got {other:?}"),
     }
 }
 
 #[test]
 fn test_char_unicode() {
     // '\u0041' — raw text is `\u0041`; the resolver interprets it as 'A'
-    let module = parse_expr(r#"'\u0041'"#).expect("parse failed");
+    let module = parse_expr(r"'\u0041'").expect("parse failed");
     let lit = extract_literal(&module).expect("no literal found");
     match lit {
         wado_compiler::ast::Literal::Char(raw) if raw == r"\u0041" => {}
-        other => panic!("expected Char(\"\\u0041\"), got {:?}", other),
+        other => panic!("expected Char(\"\\u0041\"), got {other:?}"),
     }
 }
 
@@ -506,6 +498,6 @@ fn test_null_literal() {
     // null should be equivalent to None
     match lit {
         wado_compiler::ast::Literal::Null => {}
-        other => panic!("expected Null, got {:?}", other),
+        other => panic!("expected Null, got {other:?}"),
     }
 }

--- a/wado-compiler/tests/string_templates.rs
+++ b/wado-compiler/tests/string_templates.rs
@@ -46,7 +46,7 @@ fn test_template_string_empty() {
                 "expected no parts in empty template"
             );
         }
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -62,10 +62,10 @@ fn test_template_string_plain_text() {
                 wado_compiler::ast::TemplatePart::String(s) => {
                     assert_eq!(s, "hello world");
                 }
-                other => panic!("expected String part, got {:?}", other),
+                other => panic!("expected String part, got {other:?}"),
             }
         }
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -87,7 +87,7 @@ fn test_template_string_single_interpolation() {
                 wado_compiler::ast::TemplatePart::String(s) => {
                     assert_eq!(s, "Hello, ");
                 }
-                other => panic!("expected String part, got {:?}", other),
+                other => panic!("expected String part, got {other:?}"),
             }
 
             // Part 1: {name}
@@ -98,10 +98,10 @@ fn test_template_string_single_interpolation() {
                         wado_compiler::ast::Expr::Ident(ident) => {
                             assert_eq!(ident.name, "name");
                         }
-                        other => panic!("expected Ident, got {:?}", other),
+                        other => panic!("expected Ident, got {other:?}"),
                     }
                 }
-                other => panic!("expected Interpolation part, got {:?}", other),
+                other => panic!("expected Interpolation part, got {other:?}"),
             }
 
             // Part 2: "!"
@@ -109,10 +109,10 @@ fn test_template_string_single_interpolation() {
                 wado_compiler::ast::TemplatePart::String(s) => {
                     assert_eq!(s, "!");
                 }
-                other => panic!("expected String part, got {:?}", other),
+                other => panic!("expected String part, got {other:?}"),
             }
         }
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -148,7 +148,7 @@ fn test_template_string_multiple_interpolations() {
                 wado_compiler::ast::TemplatePart::Interpolation { .. }
             ));
         }
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -166,10 +166,10 @@ fn test_template_string_expression_interpolation() {
                     // Should be a binary expression (x + y)
                     assert!(matches!(&**expr, wado_compiler::ast::Expr::Binary(_)));
                 }
-                other => panic!("expected Interpolation with binary expr, got {:?}", other),
+                other => panic!("expected Interpolation with binary expr, got {other:?}"),
             }
         }
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -187,17 +187,17 @@ fn test_template_format_simple() {
                         wado_compiler::ast::Expr::Ident(ident) => {
                             assert_eq!(ident.name, "pi");
                         }
-                        other => panic!("expected Ident, got {:?}", other),
+                        other => panic!("expected Ident, got {other:?}"),
                     }
 
                     // Check format spec
                     let format_spec = format.as_ref().expect("expected format spec");
                     assert_eq!(format_spec.spec, ".2f", "expected '.2f' format spec");
                 }
-                other => panic!("expected Interpolation, got {:?}", other),
+                other => panic!("expected Interpolation, got {other:?}"),
             }
         }
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -212,9 +212,9 @@ fn test_template_format_zero_padding() {
                 let format_spec = format.as_ref().expect("expected format spec");
                 assert_eq!(format_spec.spec, "0.3f");
             }
-            other => panic!("expected Interpolation, got {:?}", other),
+            other => panic!("expected Interpolation, got {other:?}"),
         },
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -229,9 +229,9 @@ fn test_template_format_width() {
                 let format_spec = format.as_ref().expect("expected format spec");
                 assert_eq!(format_spec.spec, "10");
             }
-            other => panic!("expected Interpolation, got {:?}", other),
+            other => panic!("expected Interpolation, got {other:?}"),
         },
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -254,10 +254,10 @@ fn test_template_double_colon_not_format() {
                     // The expression should be a function call
                     assert!(matches!(&**expr, wado_compiler::ast::Expr::Call(_)));
                 }
-                other => panic!("expected Interpolation, got {:?}", other),
+                other => panic!("expected Interpolation, got {other:?}"),
             }
         }
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -273,9 +273,9 @@ fn test_template_colon_alone_is_format() {
                 let format_spec = format.as_ref().expect("expected format spec");
                 assert_eq!(format_spec.spec, "d");
             }
-            other => panic!("expected Interpolation, got {:?}", other),
+            other => panic!("expected Interpolation, got {other:?}"),
         },
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -302,10 +302,10 @@ fn test_template_nested() {
                         wado_compiler::ast::Expr::TemplateString(_)
                     ));
                 }
-                other => panic!("expected Interpolation, got {:?}", other),
+                other => panic!("expected Interpolation, got {other:?}"),
             }
         }
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -327,7 +327,7 @@ fn test_template_consecutive_interpolations() {
                 wado_compiler::ast::TemplatePart::Interpolation { .. }
             ));
         }
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -344,7 +344,7 @@ fn test_template_starts_with_interpolation() {
                 wado_compiler::ast::TemplatePart::Interpolation { .. }
             ));
         }
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -361,23 +361,23 @@ fn test_template_ends_with_interpolation() {
                 wado_compiler::ast::TemplatePart::Interpolation { .. }
             ));
         }
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
 #[test]
 fn test_template_escape_sequences() {
-    let module = parse_expr(r#"`Line 1\nLine 2\ttab`"#).expect("parse failed");
+    let module = parse_expr(r"`Line 1\nLine 2\ttab`").expect("parse failed");
     let expr = extract_expr(&module).expect("no expression found");
 
     match expr {
         wado_compiler::ast::Expr::TemplateString(template) => match &template.parts[0] {
             wado_compiler::ast::TemplatePart::String(s) => {
-                assert_eq!(s, r#"Line 1\nLine 2\ttab"#);
+                assert_eq!(s, r"Line 1\nLine 2\ttab");
             }
-            other => panic!("expected String part, got {:?}", other),
+            other => panic!("expected String part, got {other:?}"),
         },
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -413,10 +413,10 @@ fn test_template_complex_expression() {
                     // Should parse as a binary expression
                     assert!(matches!(&**expr, wado_compiler::ast::Expr::Binary(_)));
                 }
-                other => panic!("expected Interpolation, got {:?}", other),
+                other => panic!("expected Interpolation, got {other:?}"),
             }
         }
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }
 
@@ -432,9 +432,9 @@ fn test_template_method_call() {
                     // Should be a method call
                     assert!(matches!(&**expr, wado_compiler::ast::Expr::MethodCall(_)));
                 }
-                other => panic!("expected Interpolation, got {:?}", other),
+                other => panic!("expected Interpolation, got {other:?}"),
             }
         }
-        other => panic!("expected TemplateString, got {:?}", other),
+        other => panic!("expected TemplateString, got {other:?}"),
     }
 }

--- a/wado-compiler/tests/wat.rs
+++ b/wado-compiler/tests/wat.rs
@@ -102,19 +102,20 @@ fn test_tuple_elision_multivalue() {
 
         // Also check i64.mul_wide_u and i64.mul_wide_s
         if (line.contains("i64.mul_wide_u") || line.contains("i64.mul_wide_s"))
-            && i + 1 < lines.len() {
-                let next_line = lines[i + 1].trim();
-                assert!(
-                    !next_line.contains("struct.new"),
-                    "Tuple elision optimization not applied! Found struct.new after multi-value instruction.\n\
+            && i + 1 < lines.len()
+        {
+            let next_line = lines[i + 1].trim();
+            assert!(
+                !next_line.contains("struct.new"),
+                "Tuple elision optimization not applied! Found struct.new after multi-value instruction.\n\
                      Line {}: {}\n\
                      Line {}: {}",
-                    i + 1,
-                    line,
-                    i + 2,
-                    next_line
-                );
-            }
+                i + 1,
+                line,
+                i + 2,
+                next_line
+            );
+        }
     }
 
     // Verify that local.set appears after the multi-value instructions (positive check)

--- a/wado-compiler/tests/wat.rs
+++ b/wado-compiler/tests/wat.rs
@@ -87,7 +87,8 @@ fn test_tuple_elision_multivalue() {
             // Check the next few lines for struct.new - it should NOT be present
             if i + 1 < lines.len() {
                 let next_line = lines[i + 1].trim();
-                assert!(!next_line.contains("struct.new"), 
+                assert!(
+                    !next_line.contains("struct.new"),
                     "Tuple elision optimization not applied! Found struct.new after multi-value instruction.\n\
                      Line {}: {}\n\
                      Line {}: {}",
@@ -95,7 +96,7 @@ fn test_tuple_elision_multivalue() {
                     line,
                     i + 2,
                     next_line
-                )
+                );
             }
         }
 
@@ -103,7 +104,8 @@ fn test_tuple_elision_multivalue() {
         if (line.contains("i64.mul_wide_u") || line.contains("i64.mul_wide_s"))
             && i + 1 < lines.len() {
                 let next_line = lines[i + 1].trim();
-                assert!(!next_line.contains("struct.new"), 
+                assert!(
+                    !next_line.contains("struct.new"),
                     "Tuple elision optimization not applied! Found struct.new after multi-value instruction.\n\
                      Line {}: {}\n\
                      Line {}: {}",
@@ -111,7 +113,7 @@ fn test_tuple_elision_multivalue() {
                     line,
                     i + 2,
                     next_line
-                )
+                );
             }
     }
 

--- a/wado-compiler/tests/wat.rs
+++ b/wado-compiler/tests/wat.rs
@@ -87,37 +87,32 @@ fn test_tuple_elision_multivalue() {
             // Check the next few lines for struct.new - it should NOT be present
             if i + 1 < lines.len() {
                 let next_line = lines[i + 1].trim();
-                if next_line.contains("struct.new") {
-                    panic!(
-                        "Tuple elision optimization not applied! Found struct.new after multi-value instruction.\n\
-                         Line {}: {}\n\
-                         Line {}: {}",
-                        i + 1,
-                        line,
-                        i + 2,
-                        next_line
-                    );
-                }
+                assert!(!next_line.contains("struct.new"), 
+                    "Tuple elision optimization not applied! Found struct.new after multi-value instruction.\n\
+                     Line {}: {}\n\
+                     Line {}: {}",
+                    i + 1,
+                    line,
+                    i + 2,
+                    next_line
+                )
             }
         }
 
         // Also check i64.mul_wide_u and i64.mul_wide_s
-        if line.contains("i64.mul_wide_u") || line.contains("i64.mul_wide_s") {
-            if i + 1 < lines.len() {
+        if (line.contains("i64.mul_wide_u") || line.contains("i64.mul_wide_s"))
+            && i + 1 < lines.len() {
                 let next_line = lines[i + 1].trim();
-                if next_line.contains("struct.new") {
-                    panic!(
-                        "Tuple elision optimization not applied! Found struct.new after multi-value instruction.\n\
-                         Line {}: {}\n\
-                         Line {}: {}",
-                        i + 1,
-                        line,
-                        i + 2,
-                        next_line
-                    );
-                }
+                assert!(!next_line.contains("struct.new"), 
+                    "Tuple elision optimization not applied! Found struct.new after multi-value instruction.\n\
+                     Line {}: {}\n\
+                     Line {}: {}",
+                    i + 1,
+                    line,
+                    i + 2,
+                    next_line
+                )
             }
-        }
     }
 
     // Verify that local.set appears after the multi-value instructions (positive check)

--- a/wado-compiler/tests/zlib_interop.rs
+++ b/wado-compiler/tests/zlib_interop.rs
@@ -329,10 +329,10 @@ fn date_seed() -> u32 {
     let days = now / 86400;
     // Reconstruct YYYYMMDD from days since epoch
     // Simple civil-calendar conversion (good through 2099)
-    let z = days + 719468;
-    let era = z / 146097;
-    let doe = z - era * 146097;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let z = days + 719_468;
+    let era = z / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
     let y = yoe + era * 400;
     let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
     let mp = (5 * doy + 2) / 153;

--- a/wado-from-idl/tests/e2e.rs
+++ b/wado-from-idl/tests/e2e.rs
@@ -13,7 +13,7 @@ fn parse_wit_and_generate(wit: &str) -> String {
     let mut generator = WadoCodeGenerator::new();
 
     let mut output = String::new();
-    for (iface_id, _) in resolve.interfaces.iter() {
+    for (iface_id, _) in &resolve.interfaces {
         let module = transformer
             .transform_interface(iface_id)
             .expect("Failed to transform interface");
@@ -24,13 +24,13 @@ fn parse_wit_and_generate(wit: &str) -> String {
 
 #[test]
 fn test_simple_function() {
-    let wit = r#"
+    let wit = r"
 package test:example@0.1.0;
 
 interface greet {
     hello: func(name: string) -> string;
 }
-"#;
+";
 
     let output = parse_wit_and_generate(wit);
 
@@ -41,7 +41,7 @@ interface greet {
 
 #[test]
 fn test_record_type() {
-    let wit = r#"
+    let wit = r"
 package test:example@0.1.0;
 
 interface types {
@@ -50,7 +50,7 @@ interface types {
         y: s32,
     }
 }
-"#;
+";
 
     let output = parse_wit_and_generate(wit);
 
@@ -61,7 +61,7 @@ interface types {
 
 #[test]
 fn test_enum_type() {
-    let wit = r#"
+    let wit = r"
 package test:example@0.1.0;
 
 interface types {
@@ -71,7 +71,7 @@ interface types {
         blue,
     }
 }
-"#;
+";
 
     let output = parse_wit_and_generate(wit);
 
@@ -83,14 +83,14 @@ interface types {
 
 #[test]
 fn test_option_and_result_types() {
-    let wit = r#"
+    let wit = r"
 package test:example@0.1.0;
 
 interface api {
     get-value: func(key: string) -> option<string>;
     parse: func(input: string) -> result<u32, string>;
 }
-"#;
+";
 
     let output = parse_wit_and_generate(wit);
 
@@ -100,7 +100,7 @@ interface api {
 
 #[test]
 fn test_resource_type() {
-    let wit = r#"
+    let wit = r"
 package test:example@0.1.0;
 
 interface storage {
@@ -109,7 +109,7 @@ interface storage {
         write: func(data: list<u8>);
     }
 }
-"#;
+";
 
     let output = parse_wit_and_generate(wit);
 

--- a/wado-manifest/tests/lockfile.rs
+++ b/wado-manifest/tests/lockfile.rs
@@ -158,9 +158,9 @@ deps-hash = "sha256:abc"
 
 #[test]
 fn missing_deps_hash() {
-    let toml = r#"
+    let toml = r"
 version = 1
-"#;
+";
     let err = toml.parse::<LockFile>().unwrap_err();
     assert!(matches!(err, LockFileError::MissingField { .. }));
 }
@@ -201,5 +201,5 @@ fn error_display() {
     };
     let msg = err.to_string();
     assert!(msg.contains("42"));
-    assert!(msg.contains("1"));
+    assert!(msg.contains('1'));
 }


### PR DESCRIPTION
## Summary
- Run `cargo clippy --fix` to auto-resolve mechanical lints across the workspace.
- Hand-fix the remaining warnings so `mise run clippy` passes under `-D warnings`:
  - `unreadable_literal` — add separators to civil-calendar constants in `zlib_interop.rs`
  - `semicolon_if_nothing_returned` — terminate trailing `assert!` calls in `format.rs`, `wat.rs`, and `syntax.rs`
  - `manual_strip` — replace manual prefix slicing with `strip_prefix` in tests `common.rs`
  - `approx_constant` — swap a `3.14` test literal (looked like π) for `3.25` in `const_folding.rs`

## Test plan
- [x] `mise run clippy`