### PR TITLE
Gale: close TODO gaps (sections A, C, D, F)

### DIFF
--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -10,74 +10,6 @@ exception). The remaining work is mostly about **propagating** parsed
 information into the IR and **using** it in the code generator so that
 generated parsers are semantically correct, not just syntactically accepted.
 
-## A. Parser accepts but IR drops information
-
-Constructs the parser recognizes correctly, but whose payload is currently
-discarded so downstream stages cannot see them. Each item should grow an IR
-field plus targeted parser tests.
-
-- **Grammar / rule / element / block options** (`options { caseInsensitive=true; ... }`,
-  `<assoc=right, fail='msg'>`). Every option block is currently consumed and
-  thrown away. Need at minimum a `Map<String, String>` on `Grammar`,
-  `ParserRule`, `LexerRule`, and on the relevant elements. ANTLR4 spec:
-  `vendor/antlr4/doc/options.md`.
-- **Grammar-level options** like `superClass`, `tokenVocab`, `language`,
-  `caseInsensitive`. Same as above — currently invisible to the rest of
-  the pipeline.
-- **Rule visibility modifiers** (`public`, `private`, `protected`).
-  Accepted by `parse_grammar` but not stored on `ParserRule`.
-- **`channels { ERROR, USER_CHAN }` block.** Names are accepted but
-  discarded, so `channel(USER_CHAN)` cannot be resolved at codegen time.
-  Add `Grammar.channels: Array<String>` and resolve named channel
-  references in `parse_lexer_actions`.
-- **`tokens { VIRTUAL_TOK }` block.** Virtual lexer rules are created,
-  but the fact that a token came from a `tokens{}` block (vs. a real
-  rule) is lost. Tag those entries so generators can emit the right
-  token-id constants.
-- **Named actions** (`@header { ... }`, `@parser::members { ... }`).
-  Action bodies are intentionally skipped per the compatibility
-  principle, **but their _presence_ and _position_ should still be
-  recorded** in the IR. AGENTS.md states this explicitly ("preserve their
-  _presence_ and _position_"); the implementation does not yet match.
-
-## C. IR has the field but the code generator ignores it
-
-These constructs are parsed and stored on the IR, but the parser /
-lexer code generator never reads them. As a result the parser-level
-"compat" is misleading: the grammar parses, but the generated parser
-behaves incorrectly. **This is the most user-visible gap.**
-
-| IR field                               | Generator status                                                                          |
-| -------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `Element::Wildcard` (`.`)              | Not handled in `parser_gen.wado` / `gen_util.wado`. Likely produces wrong code or panics. |
-| `Element::Not` (parser-side `~`)       | Only `LexerNotElement` (lexer-side) is wired. Parser-side `~ TOK` is unhandled.           |
-| `LabelElement.list` (`+=`)             | Treated identically to single `=`. Should append to an `Array<T>` field.                  |
-| `LexerRule.set_mode` (`mode(X)`)       | Unread. Generated lexer never switches the current mode.                                  |
-| `LexerRule.more`                       | Unread. `more` semantics (collect more text without emitting) is not implemented.         |
-| `LexerRule.type_override` (`type(X)`)  | Unread. Token type rewriting is not applied.                                              |
-| `LexerRule.channel` (integer or named) | Unread. Tokens always go to channel 0 (or are skipped, in the HIDDEN approximation).      |
-
-Each row needs:
-
-1. A unit test in `lexer_gen_test.wado` / `parser_gen_test.wado` that
-   exercises a minimal grammar using the construct and asserts the
-   generated code does the right thing.
-2. Codegen support in the relevant `*_gen.wado` file.
-3. A driver test under `tests/grammars/` (or extending one of the
-   existing real-world grammars) that proves end-to-end parsing of
-   real input works after the change.
-
-## D. Semantic approximations to revisit
-
-- **`channel(HIDDEN)` is treated as `skip`.** ANTLR4 actually emits
-  HIDDEN tokens on a separate channel; they are not discarded. This is
-  a pre-existing approximation that the new lexer-command parser
-  preserves. To remove the approximation, the runtime needs proper
-  channel routing (`Token.channel`, channel-aware parser lookups).
-- **HIDDEN channel id is hard-coded to 1.** Matches ANTLR4
-  (`Token.HIDDEN_CHANNEL = 1`) but the value should come from a named
-  constant once channels become first class.
-
 ## E. Test density / regression safety
 
 - **Integration tests for most real grammars are loose.** Most tests in
@@ -95,17 +27,6 @@ Each row needs:
   generation for the largest grammars. Investigate which generator
   pass is the bottleneck (likely SLL prediction or string building)
   and fix it instead of widening the timeout further.
-
-## F. Edge cases not yet exercised
-
-These are corners of ANTLR4 syntax that no current test grammar uses, so
-the parser may or may not handle them correctly. Each should get a
-dedicated unit test before the next compatibility-related change.
-
-- `~` applied to a block, not just a single token: `~( 'a' | 'b' )`.
-- Block label syntax: `lbl=( a | b )` and `lbl+=( a | b )`.
-- ARG_ACTION with only whitespace: `returns []`.
-- ANTLR3-style numbered token assignment: `tokens { A=1, B=2 }`.
 
 ## Performance: sqlite-parse Benchmark
 

--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -10,6 +10,106 @@ exception). The remaining work is mostly about **propagating** parsed
 information into the IR and **using** it in the code generator so that
 generated parsers are semantically correct, not just syntactically accepted.
 
+## A. Remaining IR gaps (partial from the previous sweep)
+
+The previous TODO cleanup wired grammar-level and rule-level options into
+the IR, but two sub-kinds of the same feature were left unhandled:
+
+- **Element-level options** (`ID<assoc=right, fail='msg'>`, `'lit'<p=3>`).
+  Currently consumed and dropped by `skip_angle_block`. `assoc=right`
+  affects left-recursion handling semantically, so this cannot stay
+  invisible. Needs a field on `Element` / `LabelElement` / `TokenRef` or a
+  wrapper variant.
+- **Block-level options** (`( options { assoc = right; } : a | b )`).
+  Currently consumed by `skip_block_prequel`. Same story as above —
+  need a dedicated slot on `Element::Group` (or a wrapping struct).
+
+## B. IR → pipeline wiring (preserve what's stored)
+
+The previous sweep populated the IR but the code generator still ignores
+most of the new fields. "Parsed and stored" is not "used":
+
+- `Grammar.options.caseInsensitive = true` — generated lexer is still
+  case-sensitive. Needs a pass over lexer-gen to fold `tolower` into
+  literal matching (or switch to case-insensitive char comparisons).
+- `Grammar.options.superClass` / `tokenVocab` / `language` — completely
+  ignored. `tokenVocab` in particular is non-trivial: it implies loading
+  another grammar's token ids.
+- `Grammar.named_actions` — stored for presence/position but not
+  surfaced anywhere. At minimum, generated output could include a
+  comment marker so downstream tooling can see where actions used to be.
+- `ParserRule.visibility` / `LexerRule.visibility` — stored but unused.
+  ANTLR4 itself ignores these at codegen, so matching ANTLR4's behavior
+  is fine, but a lint or doc comment in the generated output would make
+  the information observable.
+- `LexerRule.is_virtual` — stored but not emitted differently from real
+  lexer rules. Generated lexers happily produce try_<name> functions for
+  virtual tokens that should never match. Should be gated.
+
+## C. Representation quality of stored options
+
+- **`GrammarOption.value` is a lossy raw String.** Option values in
+  ANTLR4 can be identifier / qualified.name / string literal / integer
+  literal / **action block (`{ ... }`)**. The current implementation
+  stores identifiers and integers verbatim, wraps string literals in
+  single quotes, and collapses action-block values to the placeholder
+  `"{}"`. Round-trip from IR to surface syntax is therefore impossible
+  for action-block values.
+- Consider switching to a `variant OptionValue { Ident(String),
+  Qualified(Array<String>), Str(String), Int(i64), Action(String) }`
+  so consumers can branch without re-parsing the string.
+
+## D. Driver-level verification (gaps from the previous sweep)
+
+The previous sweep added unit tests and golden tests for new features,
+but several semantic changes have no runtime verification in the driver
+tests (`package-gale/tests/driver_*_test.wado`). Each of the following
+should grow a dedicated driver assertion:
+
+- **HIDDEN channel routing.** `HTMLLexer.g4` declares
+  `TAG_WHITESPACE -> channel(HIDDEN)`. The driver test should tokenize
+  a tag like `<p class="x">`, assert that whitespace tokens do **not**
+  appear in the `tokens` array, and assert that they do appear in the
+  following token's `leading_trivia` with `channel == 1`.
+- **Parser-side `~TOK` / `~(block)`.** Find a driver test whose grammar
+  exercises a parser-level complement and assert the generated parser
+  accepts a representative input and rejects the complemented token.
+- **List labels `+=`.** SQLite and several other grammars collect
+  expression lists with `+=`. A driver test should parse a compound
+  input and assert the resulting `Array<_>` field has the expected
+  length and element values.
+- **`mode(X)` semantics (set_mode).** The Rust lexer uses `mode()`
+  alongside `pushMode` / `popMode`. Driver test should feed input that
+  exercises `mode()`-style transitions and assert the token stream
+  matches expectations.
+- **`more` semantics.** HTMLLexer / TypeScriptLexer use `more` to
+  concatenate multi-part tokens. Driver test should feed input that
+  would split without `more` and assert a single combined token.
+- **`type(X)` override.** Find a grammar that uses `type(X)` to rewrite
+  the emitted kind and assert the driver output reflects the overridden
+  kind, not the source rule name.
+
+## E. Negative tests
+
+The parser test suite is overwhelmingly positive — it verifies that
+well-formed input parses. There are almost no negative tests that pin
+down the parser's **rejection** behavior. Add fixtures for:
+
+- Duplicate rule names (`foo : ID ; foo : NUM ;`).
+- References to undefined rules.
+- `mode X;` inside a parser grammar (already covered by one test — use
+  it as a template for the rest).
+- Malformed `channels { }` / `tokens { }` blocks (unclosed brace,
+  trailing junk, etc.).
+- `~` applied to something that isn't a set (ANTLR4 rejects
+  `~ruleref`, only tokens / lexer atoms / blocks are allowed).
+- Left-recursion with `assoc` conflicts.
+- Lexer commands with unknown names (`foo : 'x' -> totallymadeup ;`).
+
+Each fixture should assert `parse(input) matches { Err(_) }` with a
+useful error message (not just "unexpected token"). This guards against
+regressions where the parser silently accepts garbage.
+
 ## Performance: sqlite-parse Benchmark
 
 ### Remaining Bottleneck: `Parser::last_end` (11.7%)

--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -59,35 +59,48 @@ most of the new fields. "Parsed and stored" is not "used":
   Qualified(Array<String>), Str(String), Int(i64), Action(String) }`
   so consumers can branch without re-parsing the string.
 
-## D. Driver-level verification (gaps from the previous sweep)
+## D. Driver-level verification (remaining gaps)
 
-The previous sweep added unit tests and golden tests for new features,
-but several semantic changes have no runtime verification in the driver
-tests (`package-gale/tests/driver_*_test.wado`). Each of the following
-should grow a dedicated driver assertion:
+The previous sweep added unit tests, golden tests, and driver tests for
+the most critical semantic changes. The following driver coverage was
+added in this branch:
 
-- **HIDDEN channel routing.** `HTMLLexer.g4` declares
-  `TAG_WHITESPACE -> channel(HIDDEN)`. The driver test should tokenize
-  a tag like `<p class="x">`, assert that whitespace tokens do **not**
-  appear in the `tokens` array, and assert that they do appear in the
-  following token's `leading_trivia` with `channel == 1`.
-- **Parser-side `~TOK` / `~(block)`.** Find a driver test whose grammar
-  exercises a parser-level complement and assert the generated parser
-  accepts a representative input and rejects the complemented token.
-- **List labels `+=`.** SQLite and several other grammars collect
-  expression lists with `+=`. A driver test should parse a compound
-  input and assert the resulting `Array<_>` field has the expected
-  length and element values.
-- **`mode(X)` semantics (set_mode).** The Rust lexer uses `mode()`
-  alongside `pushMode` / `popMode`. Driver test should feed input that
-  exercises `mode()`-style transitions and assert the token stream
-  matches expectations.
-- **`more` semantics.** HTMLLexer / TypeScriptLexer use `more` to
-  concatenate multi-part tokens. Driver test should feed input that
-  would split without `more` and assert a single combined token.
-- **`type(X)` override.** Find a grammar that uses `type(X)` to rewrite
-  the emitted kind and assert the driver output reflects the overridden
-  kind, not the source rule name.
+- **HIDDEN channel routing** — `driver_html_test.wado` tokenizes
+  `<p class="x">`, asserts TAG_WHITESPACE is absent from the main token
+  stream, and asserts it appears as leading trivia on the next TAG_NAME
+  with `channel == 1`. An additional end-to-end assertion confirms the
+  parser successfully accepts whitespace-separated attributes.
+- **HIDDEN channel (TypeScript)** — `driver_typescript_test.wado`
+  verifies `WhiteSpaces` routes to trivia with `channel == 1` around
+  `let x`.
+- **User-defined channel routing** — `driver_antlr4_test.wado` exercises
+  `channel(COMMENT)` (the second user channel beyond DEFAULT/HIDDEN),
+  asserting both `//` LINE_COMMENT and `/* */` BLOCK_COMMENT appear as
+  trivia with `channel == 3`.
+- **`type(X)` override** — `driver_typescript_test.wado` tokenizes
+  `` `hi` `` and asserts both backticks emit as `TK_BackTick`, never
+  `TK_BackTickInside`, confirming the type-override rewrite.
+
+Still missing driver-level coverage (deferred because no existing test
+grammar exercises the feature end-to-end):
+
+- **Parser-side `~TOK` / `~(block)`.** No driver-test grammar currently
+  uses a parser-level complement. Either add a minimal new grammar, or
+  extend `sexpression.g4` to exercise `~TOK`.
+- **List labels `+=`.** None of the existing test grammars use list
+  labels in the label sense — all `+=` matches are literal `'+='`
+  operator tokens. Add a minimal new grammar or extend an existing one
+  (a `list : items += item (',' items += item)*` pattern).
+- **`mode(X)` semantics (set_mode).** No existing test grammar uses the
+  bare `mode(X)` command — everything uses `pushMode` / `popMode`. Need
+  a new fixture that actually calls `mode(X)`.
+- **`more` semantics.** `ANTLRv4Lexer.LexerCharSet` mode uses `more`,
+  but that mode is only entered from an action block (which Gale
+  skips), so the rule is never actually triggered end-to-end. Need a
+  fixture that enters a `more`-bearing mode via a lexer-command-only
+  `pushMode`.
+- **Wildcard `.` at parser level.** Only lexer-level `.` is exercised
+  today. A parser rule like `any : . ;` has no driver-level test.
 
 ## E. Negative tests
 

--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -10,24 +10,6 @@ exception). The remaining work is mostly about **propagating** parsed
 information into the IR and **using** it in the code generator so that
 generated parsers are semantically correct, not just syntactically accepted.
 
-## E. Test density / regression safety
-
-- **Integration tests for most real grammars are loose.** Most tests in
-  `g4/integration_test.wado` only assert `parser_rules.len() > N` and
-  similar shape checks. After Batch 5 the HTMLLexer / TypeScriptLexer
-  / css3Lexer tests verify specific lexer-command fields, but the
-  Rust, SQLite, ANTLRv4, and HTMLParser tests still need similar
-  tightening.
-- **No negative test cases.** No fixtures for malformed `.g4` input
-  (syntax errors, missing rules, duplicate rule names) — robustness
-  regressions are easy to miss.
-- **Golden test timeouts were bumped, not fixed.** `generate_typescript_golden`,
-  `generate_rust_golden`, and `generate_css3_golden` are right at the
-  edge of their (now 120 s) timeouts. The root cause is slow code
-  generation for the largest grammars. Investigate which generator
-  pass is the bottleneck (likely SLL prediction or string building)
-  and fix it instead of widening the timeout further.
-
 ## Performance: sqlite-parse Benchmark
 
 ### Remaining Bottleneck: `Parser::last_end` (11.7%)

--- a/package-gale/src/g4/integration_test.wado
+++ b/package-gale/src/g4/integration_test.wado
@@ -143,8 +143,10 @@ test "parse HTMLLexer.g4" {
         }
         if rule.name == "TAG_WHITESPACE" {
             // -> channel(HIDDEN) sets channel to 1 (HIDDEN's predefined id).
+            // ANTLR4 routes HIDDEN tokens to a separate channel without
+            // discarding them, so `skip` must remain false.
             assert rule.channel == 1;
-            assert rule.skip == true;
+            assert rule.skip == false;
             found_tag_whitespace = true;
         }
     }

--- a/package-gale/src/g4/parser.wado
+++ b/package-gale/src/g4/parser.wado
@@ -1,6 +1,8 @@
 use { Span, Token, ParseError } from "../runtime.wado";
 use {
     Grammar,
+    GrammarOption,
+    NamedAction,
     ParserRule,
     Alternative,
     Element,
@@ -15,8 +17,11 @@ use {
     LexerNotElement,
     CharClass,
     CharRange,
+    Visibility,
     DEFAULT_MODE,
     NO_MODE,
+    DEFAULT_CHANNEL,
+    HIDDEN_CHANNEL,
 } from "../ir.wado";
 use { G4Token, make_token } from "./token.wado";
 use { tokenize } from "./lexer.wado";
@@ -30,6 +35,17 @@ pub struct G4Parser {
     /// host-language code.
     chars: Array<char>,
     pos: i32,
+    /// User-defined channel names collected from `channels { }` blocks.
+    /// Lexer command `channel(X)` with an identifier argument is resolved
+    /// against this list; matching names map to id `index + 2` (0=DEFAULT,
+    /// 1=HIDDEN are predefined).
+    channels: Array<String>,
+    /// Grammar-level options collected from the grammar prequel
+    /// `options { ... }` blocks. Later blocks append to earlier ones.
+    options: Array<GrammarOption>,
+    /// Grammar-level `@name { ... }` named actions collected from the
+    /// prequel. Action bodies are discarded; only the name/scope is kept.
+    named_actions: Array<NamedAction>,
 }
 
 /// Accumulator for lexer commands parsed from `-> cmd, cmd, ...`.
@@ -72,7 +88,14 @@ fn is_lexer_rule_name(name: &String) -> bool {
 
 impl G4Parser {
     pub fn new(tokens: Array<Token>, chars: Array<char>) -> G4Parser {
-        return G4Parser { tokens, chars, pos: 0 };
+        return G4Parser {
+            tokens,
+            chars,
+            pos: 0,
+            channels: [],
+            options: [],
+            named_actions: [],
+        };
     }
 
     fn peek(&self) -> &Token {
@@ -163,9 +186,11 @@ impl G4Parser {
             }
 
             // Optional rule modifiers: `public`, `private`, `protected`, `fragment`.
-            // ANTLR4 allows multiple modifiers; we just consume and discard the
-            // visibility modifiers and remember `fragment` for the lexer-rule branch.
+            // ANTLR4 allows multiple visibility modifiers before `fragment`;
+            // Gale records the last visibility seen and whether `fragment` was
+            // present (only meaningful for the lexer-rule branch).
             let mut is_frag = false;
+            let mut visibility = Visibility::Default;
             loop {
                 if self.is_kind(G4Token::Fragment) {
                     is_frag = true;
@@ -174,9 +199,18 @@ impl G4Parser {
                 }
                 if self.is_kind(G4Token::Identifier) {
                     let text = &self.peek().text;
-                    if LexerSlice::eq_str(&"public", text)
-                        || LexerSlice::eq_str(&"private", text)
-                        || LexerSlice::eq_str(&"protected", text) {
+                    if LexerSlice::eq_str(&"public", text) {
+                        visibility = Visibility::Public;
+                        self.advance();
+                        continue;
+                    }
+                    if LexerSlice::eq_str(&"private", text) {
+                        visibility = Visibility::Private;
+                        self.advance();
+                        continue;
+                    }
+                    if LexerSlice::eq_str(&"protected", text) {
+                        visibility = Visibility::Protected;
                         self.advance();
                         continue;
                     }
@@ -188,10 +222,12 @@ impl G4Parser {
             let rule_name = rule_name_tok.text.to_string();
 
             if is_lexer_grammar || is_frag || is_lexer_rule_name(&rule_name) {
-                let rule = self.parse_lexer_rule(rule_name, is_frag, current_mode, &mut mode_names)?;
+                let mut rule = self.parse_lexer_rule(rule_name, is_frag, current_mode, &mut mode_names)?;
+                rule.visibility = visibility;
                 lexer_rules.push(rule);
             } else {
-                let rule = self.parse_parser_rule(rule_name)?;
+                let mut rule = self.parse_parser_rule(rule_name)?;
+                rule.visibility = visibility;
                 parser_rules.push(rule);
             }
             // Optional exception group: catch* finally? (parser rules only,
@@ -209,11 +245,24 @@ impl G4Parser {
                 }
             }
             if !found {
-                lexer_rules.push(LexerRule::new(vt, false, false, []));
+                lexer_rules.push(LexerRule::virtual_token(vt));
             }
         }
 
-        return Result::<Grammar, ParseError>::Ok(Grammar { name, parser_rules, lexer_rules, mode_names });
+        let channels = self.channels;
+        let options = self.options;
+        let named_actions = self.named_actions;
+        return Result::<Grammar, ParseError>::Ok(
+            Grammar {
+                name,
+                parser_rules,
+                lexer_rules,
+                mode_names,
+                channels,
+                options,
+                named_actions,
+            },
+        );
     }
 
     fn skip_preamble_blocks(&mut self, virtual_tokens: &mut Array<String>) {
@@ -231,9 +280,17 @@ impl G4Parser {
                     self.parse_tokens_block(virtual_tokens);
                     continue;
                 }
-                if LexerSlice::eq_str(&"channels", text) || LexerSlice::eq_str(&"options", text) {
+                if LexerSlice::eq_str(&"channels", text) {
                     self.advance();
-                    self.skip_braced_block();
+                    self.parse_channels_block();
+                    continue;
+                }
+                if LexerSlice::eq_str(&"options", text) {
+                    self.advance();
+                    let opts = self.parse_options_block();
+                    for let o of opts {
+                        self.options.push(o);
+                    }
                     continue;
                 }
                 if LexerSlice::eq_str(&"import", text) {
@@ -243,10 +300,42 @@ impl G4Parser {
                 }
             }
             if self.is_kind(G4Token::At) {
-                self.parse_named_action();
+                let act = self.parse_named_action();
+                self.named_actions.push(act);
                 continue;
             }
             break;
+        }
+    }
+
+    /// Parse `channels { NAME, NAME, ... }` and collect channel names into
+    /// `self.channels`. Duplicate declarations collapse silently — ANTLR4
+    /// also tolerates repeated channels blocks; the name list is the union.
+    fn parse_channels_block(&mut self) {
+        if !self.is_kind(G4Token::LBrace) {
+            return;
+        }
+        self.advance();  // skip '{'
+        while !self.at_eof() && !self.is_kind(G4Token::RBrace) {
+            if self.is_kind(G4Token::Identifier) {
+                let name = self.peek().text.to_string();
+                let mut dup = false;
+                for let existing of &self.channels {
+                    if *existing == name {
+                        dup = true;
+                    }
+                }
+                if !dup {
+                    self.channels.push(name);
+                }
+                self.advance();
+            }
+            if self.is_kind(G4Token::Comma) {
+                self.advance();
+            }
+        }
+        if self.is_kind(G4Token::RBrace) {
+            self.advance();
         }
     }
 
@@ -275,25 +364,125 @@ impl G4Parser {
         }
     }
 
-    /// Parse `@ id ('::' id)? '{' ... '}'`. The action body is discarded —
-    /// it would be host-language code that Gale cannot transpile.
-    fn parse_named_action(&mut self) {
-        self.expect(G4Token::At).unwrap();
+    /// Parse `options { name = value ; ... }` and return the entries.
+    /// Each option value is stored as the raw source text with no further
+    /// interpretation: bare identifiers, qualified `a.b.c` names, quoted
+    /// string literals (re-quoted with single quotes), integer literals,
+    /// and action-style `{ ... }` bodies (kept as `{ ... }` placeholder so
+    /// that downstream stages can tell an action value apart from an
+    /// identifier). Malformed entries are silently tolerated to match the
+    /// rest of the parser's recovery posture.
+    fn parse_options_block(&mut self) -> Array<GrammarOption> {
+        let mut out: Array<GrammarOption> = [];
+        if !self.is_kind(G4Token::LBrace) {
+            return out;
+        }
+        self.advance();  // '{'
+        while !self.at_eof() && !self.is_kind(G4Token::RBrace) {
+            if !self.is_kind(G4Token::Identifier) {
+                // Resync: skip unexpected tokens until `;` or `}`.
+                self.advance();
+                continue;
+            }
+            let name = self.peek().text.to_string();
+            self.advance();
+            if !self.is_kind(G4Token::Assign) {
+                // No `=`; best-effort recover by swallowing until `;`/`}`.
+                while !self.at_eof()
+                    && !self.is_kind(G4Token::Semicolon)
+                    && !self.is_kind(G4Token::RBrace) {
+                    self.advance();
+                }
+                if self.is_kind(G4Token::Semicolon) {
+                    self.advance();
+                }
+                continue;
+            }
+            self.advance();  // '='
+            let value = self.parse_option_value();
+            out.push(GrammarOption { name, value });
+            if self.is_kind(G4Token::Semicolon) {
+                self.advance();
+            }
+        }
+        if self.is_kind(G4Token::RBrace) {
+            self.advance();
+        }
+        return out;
+    }
+
+    /// Parse a single option value. See `parse_options_block` for the
+    /// accepted value shapes.
+    fn parse_option_value(&mut self) -> String {
+        if self.is_kind(G4Token::StringLit) {
+            let mut out = String::with_capacity(2);
+            out.push('\'');
+            out.push_str(self.peek().text.to_string());
+            out.push('\'');
+            self.advance();
+            return out;
+        }
+        if self.is_kind(G4Token::IntLit) {
+            let out = self.peek().text.to_string();
+            self.advance();
+            return out;
+        }
+        if self.is_kind(G4Token::LBrace) {
+            // Action value: discard body but preserve a textual marker so
+            // downstream tooling can distinguish it from an identifier.
+            self.skip_braced_block();
+            return "{}";
+        }
         if self.is_kind(G4Token::Identifier) {
+            let mut out = self.peek().text.to_string();
+            self.advance();
+            // Dotted qualified id: `java.util.List`.
+            while self.is_kind(G4Token::Dot)
+                && self.peek_kind_at(1) == G4Token::Identifier as i32 {
+                self.advance();
+                out.push('.');
+                out.push_str(self.peek().text.to_string());
+                self.advance();
+            }
+            return out;
+        }
+        return "";
+    }
+
+    /// Parse `@ id ('::' id)? '{' ... '}'`. The action body is discarded —
+    /// it would be host-language code that Gale cannot transpile — but we
+    /// return the `NamedAction` record so callers can preserve presence
+    /// and position.
+    fn parse_named_action(&mut self) -> NamedAction {
+        self.expect(G4Token::At).unwrap();
+        let mut scope: Option<String> = null;
+        let mut name = String::with_capacity(8);
+        if self.is_kind(G4Token::Identifier) {
+            name = self.peek().text.to_string();
             self.advance();
         }
         if self.is_kind(G4Token::ColonColon) {
             self.advance();
+            // The previously-parsed id was the scope; read the real name.
+            scope = Option::<String>::Some(name);
+            name = String::with_capacity(8);
             if self.is_kind(G4Token::Identifier) {
+                name = self.peek().text.to_string();
                 self.advance();
             }
         }
         if self.is_kind(G4Token::LBrace) {
             self.skip_braced_block();
         }
+        return NamedAction { scope, name };
     }
 
     /// Parse `tokens { NAME, NAME, ... }` and collect token names.
+    ///
+    /// Accepts ANTLR3-style numbered assignments `NAME = INT` too for
+    /// permissive parsing of legacy `.g4` files ported without cleanup.
+    /// The assigned integer is discarded — Gale assigns token ids based on
+    /// declaration order internally.
     fn parse_tokens_block(&mut self, virtual_tokens: &mut Array<String>) {
         if !self.is_kind(G4Token::LBrace) {
             return;
@@ -302,6 +491,19 @@ impl G4Parser {
         while !self.at_eof() && !self.is_kind(G4Token::RBrace) {
             if self.is_kind(G4Token::Identifier) {
                 virtual_tokens.push(self.peek().text.to_string());
+                self.advance();
+                // Tolerate ANTLR3-style `= INT` assignments.
+                if self.is_kind(G4Token::Assign) {
+                    self.advance();
+                    if self.is_kind(G4Token::IntLit) {
+                        self.advance();
+                    }
+                }
+            } else {
+                // Unknown token — advance to avoid infinite loop on malformed
+                // input. The compatibility principle prefers permissive
+                // parsing, and `tokens { }` bodies are not semantically
+                // meaningful to Gale beyond the names.
                 self.advance();
             }
             // Skip commas between token names
@@ -360,11 +562,16 @@ impl G4Parser {
     }
 
     fn parse_parser_rule(&mut self, name: String) -> Result<ParserRule, ParseError> {
-        self.skip_rule_prequel();
+        let options = self.skip_rule_prequel();
         self.expect(G4Token::Colon)?;
         let alternatives = self.parse_alternatives()?;
         self.expect(G4Token::Semicolon)?;
-        return Result::<ParserRule, ParseError>::Ok(ParserRule { name, alternatives });
+        return Result::<ParserRule, ParseError>::Ok(ParserRule {
+            name,
+            visibility: Visibility::Default,
+            options,
+            alternatives,
+        });
     }
 
     /// Consume the optional rule prequel:
@@ -373,8 +580,9 @@ impl G4Parser {
     /// where rulePrequel is `optionsSpec` or `'@' id ACTION` (e.g. `@init`,
     /// `@after`). ANTLR4 fixes the order of args/returns/throws/locals before
     /// the repeated `options{}`/`@id{}` block, but we accept any order here
-    /// for resilience.
-    fn skip_rule_prequel(&mut self) {
+    /// for resilience. Returns the union of any `options { ... }` entries.
+    fn skip_rule_prequel(&mut self) -> Array<GrammarOption> {
+        let mut options: Array<GrammarOption> = [];
         loop {
             if self.is_kind(G4Token::CharClass) {
                 // Bare ARG_ACTION right after the rule name → rule arguments.
@@ -397,18 +605,23 @@ impl G4Parser {
                 }
                 if LexerSlice::eq_str(&"options", text) {
                     self.advance();
-                    if self.is_kind(G4Token::LBrace) {
-                        self.skip_braced_block();
+                    let opts = self.parse_options_block();
+                    for let o of opts {
+                        options.push(o);
                     }
                     continue;
                 }
             }
             if self.is_kind(G4Token::At) {
-                self.parse_named_action();
+                // Rule-level prequel actions (`@init`/`@after`) are not
+                // grammar-scoped and have no dedicated IR slot yet; we
+                // still parse them so the bodies are correctly skipped.
+                let _ = self.parse_named_action();
                 continue;
             }
             break;
         }
+        return options;
     }
 
     fn skip_qualified_id_list(&mut self) {
@@ -649,7 +862,7 @@ impl G4Parser {
     fn parse_lexer_rule(&mut self, name: String, is_fragment: bool, mode: i32, mode_names: &mut Array<String>) -> Result<LexerRule, ParseError> {
         // Lexer rules in ANTLR4 also accept the rule prequel (rare but legal,
         // most commonly `locals [int n]`).
-        self.skip_rule_prequel();
+        let options = self.skip_rule_prequel();
         self.expect(G4Token::Colon)?;
         let body = self.parse_lexer_alternatives()?;
 
@@ -663,6 +876,7 @@ impl G4Parser {
         return Result::<LexerRule, ParseError>::Ok(
             LexerRule {
                 name,
+                visibility: Visibility::Default,
                 is_fragment,
                 skip: actions.skip,
                 more: actions.more,
@@ -672,6 +886,8 @@ impl G4Parser {
                 set_mode: actions.set_mode,
                 push_mode: actions.push_mode,
                 pop_mode: actions.pop_mode,
+                is_virtual: false,
+                options,
                 body,
             },
         );
@@ -702,19 +918,29 @@ impl G4Parser {
                 self.expect(G4Token::LParen).unwrap();
                 let arg = self.advance();
                 self.expect(G4Token::RParen).unwrap();
-                if LexerSlice::eq_str(&"HIDDEN", &arg.text) {
+                if LexerSlice::eq_str(&"DEFAULT_TOKEN_CHANNEL", &arg.text) {
+                    // ANTLR4's predefined name for channel 0.
+                    actions.channel = DEFAULT_CHANNEL;
+                } else if LexerSlice::eq_str(&"HIDDEN", &arg.text) {
                     // HIDDEN is the predefined hidden channel (id 1).
-                    actions.channel = 1;
-                    // Treat HIDDEN as effectively skipped for codegen until
-                    // proper channel routing is implemented.
-                    actions.skip = true;
+                    // ANTLR4 emits HIDDEN tokens on a separate channel —
+                    // they are NOT discarded.
+                    actions.channel = HIDDEN_CHANNEL;
                 } else if arg.kind == G4Token::IntLit as i32 {
                     actions.channel = parse_int_literal(&arg.text.to_string());
                 } else {
-                    // User-defined channel name. Resolution against the
-                    // grammar's channels{} block is left to the code
-                    // generator; the parser only records the presence.
-                    actions.channel = 0;
+                    // User-defined channel name: look up in the grammar's
+                    // channels { } block. Unknown names default to 0 so
+                    // generation still emits a well-formed lexer — the
+                    // compatibility principle prefers permissive parsing.
+                    let name = arg.text.to_string();
+                    let mut resolved = 0;
+                    for let mut i = 0; i < self.channels.len(); i += 1 {
+                        if self.channels[i] == name {
+                            resolved = i + 2;
+                        }
+                    }
+                    actions.channel = resolved;
                 }
             } else if LexerSlice::eq_str(&"type", action_text) {
                 self.expect(G4Token::LParen).unwrap();

--- a/package-gale/src/g4/parser_test.wado
+++ b/package-gale/src/g4/parser_test.wado
@@ -12,6 +12,7 @@ use {
     LexerElement,
     CharClass,
     CharRange,
+    Visibility,
 } from "../ir.wado";
 use { parse } from "./parser.wado";
 
@@ -355,6 +356,30 @@ channels { CHAN_A, CHAN_B }
 rule : ID ;";
     let g = parse(input).unwrap();
     assert g.parser_rules.len() == 1;
+    assert g.channels.len() == 2;
+    assert g.channels[0] == "CHAN_A";
+    assert g.channels[1] == "CHAN_B";
+}
+
+test "lexer rule with named channel resolves to user channel id" {
+    // ANTLR4 reserves channel 0 (DEFAULT) and 1 (HIDDEN); user channels
+    // declared via `channels { }` start at id 2. The parser should assign
+    // sequential ids based on the declaration order in the preamble.
+    let input = "lexer grammar Test;
+channels { COMMENTS, DOCS }
+COMMENT : '//' -> channel(COMMENTS) ;
+DOC : '///' -> channel(DOCS) ;";
+    let g = parse(input).unwrap();
+    assert g.lexer_rules.len() == 2;
+    // COMMENTS -> 2, DOCS -> 3
+    for let r of &g.lexer_rules {
+        if r.name == "COMMENT" {
+            assert r.channel == 2, `COMMENT channel {r.channel}`;
+        }
+        if r.name == "DOC" {
+            assert r.channel == 3, `DOC channel {r.channel}`;
+        }
+    }
 }
 
 test "grammar with tokens block declares virtual tokens" {
@@ -363,19 +388,37 @@ tokens { VIRTUAL_A, VIRTUAL_B }
 rule : ID ;";
     let g = parse(input).unwrap();
     assert g.parser_rules.len() == 1;
-    // Both virtual tokens become entries in lexer_rules with empty body.
+    // Both virtual tokens become entries in lexer_rules with empty body and
+    // are flagged with `is_virtual` so generators can distinguish them from
+    // real lexer rules.
     let mut found_a = false;
     let mut found_b = false;
     for let r of &g.lexer_rules {
         if r.name == "VIRTUAL_A" {
             found_a = true;
+            assert r.is_virtual, "VIRTUAL_A must be tagged as virtual";
+            assert r.body.is_empty();
         }
         if r.name == "VIRTUAL_B" {
             found_b = true;
+            assert r.is_virtual, "VIRTUAL_B must be tagged as virtual";
         }
     }
     assert found_a, "VIRTUAL_A must be declared";
     assert found_b, "VIRTUAL_B must be declared";
+}
+
+test "tokens block does not flag existing lexer rule as virtual" {
+    // If both `tokens { X }` and `X : ... ;` are present, X must NOT be
+    // treated as virtual — the real body wins. ANTLR4 accepts this shape
+    // and uses the explicit rule.
+    let input = "lexer grammar Test;
+tokens { ID }
+ID : [a-z]+ ;";
+    let g = parse(input).unwrap();
+    assert g.lexer_rules.len() == 1;
+    assert g.lexer_rules[0].name == "ID";
+    assert !g.lexer_rules[0].is_virtual;
 }
 
 test "grammar with prequel any order" {
@@ -475,9 +518,128 @@ test "private rule modifier" {
     let input = "grammar Test;
 public expr : ID ;
 private nested : ID ;
-protected helper : ID ;";
+protected helper : ID ;
+plain : ID ;";
     let g = parse(input).unwrap();
-    assert g.parser_rules.len() == 3;
+    assert g.parser_rules.len() == 4;
+    // Visibility should be preserved on the rule.
+    assert g.parser_rules[0].name == "expr";
+    if let Public = g.parser_rules[0].visibility {
+        // ok
+    } else {
+        panic("expected Public visibility on expr");
+    }
+    assert g.parser_rules[1].name == "nested";
+    if let Private = g.parser_rules[1].visibility {
+        // ok
+    } else {
+        panic("expected Private visibility on nested");
+    }
+    assert g.parser_rules[2].name == "helper";
+    if let Protected = g.parser_rules[2].visibility {
+        // ok
+    } else {
+        panic("expected Protected visibility on helper");
+    }
+    assert g.parser_rules[3].name == "plain";
+    if let Default = g.parser_rules[3].visibility {
+        // ok
+    } else {
+        panic("expected Default visibility on plain");
+    }
+}
+
+test "grammar-level options block stored in ir" {
+    let input = "grammar Test;
+options {
+    caseInsensitive = true;
+    language = Python;
+    superClass = my.pkg.BaseParser;
+}
+rule : ID ;";
+    let g = parse(input).unwrap();
+    assert g.options.len() == 3, `got {g.options.len()} options`;
+    assert g.options[0].name == "caseInsensitive";
+    assert g.options[0].value == "true";
+    assert g.options[1].name == "language";
+    assert g.options[1].value == "Python";
+    assert g.options[2].name == "superClass";
+    assert g.options[2].value == "my.pkg.BaseParser";
+}
+
+test "grammar options with string literal value" {
+    let input = "grammar Test;
+options { tokenVocab = 'foo.g4'; }
+rule : ID ;";
+    let g = parse(input).unwrap();
+    assert g.options.len() == 1;
+    assert g.options[0].name == "tokenVocab";
+    assert g.options[0].value == "'foo.g4'";
+}
+
+test "parser rule options block stored in ir" {
+    let input = "grammar Test;
+rule options { foo = bar; } : ID ;";
+    let g = parse(input).unwrap();
+    assert g.parser_rules.len() == 1;
+    assert g.parser_rules[0].options.len() == 1;
+    assert g.parser_rules[0].options[0].name == "foo";
+    assert g.parser_rules[0].options[0].value == "bar";
+}
+
+test "lexer rule options block stored in ir" {
+    let input = "lexer grammar Test;
+ID options { caseInsensitive = false; } : [a-z]+ ;";
+    let g = parse(input).unwrap();
+    assert g.lexer_rules.len() == 1;
+    assert g.lexer_rules[0].options.len() == 1;
+    assert g.lexer_rules[0].options[0].name == "caseInsensitive";
+    assert g.lexer_rules[0].options[0].value == "false";
+}
+
+test "grammar level named actions recorded" {
+    let input = "grammar Test;
+@header { package foo; }
+@members { private int x; }
+@parser::members { /* parser-specific */ }
+rule : ID ;";
+    let g = parse(input).unwrap();
+    assert g.named_actions.len() == 3, `got {g.named_actions.len()} actions`;
+    // @header has no scope.
+    assert g.named_actions[0].name == "header";
+    if let Some(_) = g.named_actions[0].scope {
+        panic("@header should have no scope");
+    }
+    // @members has no scope.
+    assert g.named_actions[1].name == "members";
+    if let Some(_) = g.named_actions[1].scope {
+        panic("@members should have no scope");
+    }
+    // @parser::members has scope "parser".
+    assert g.named_actions[2].name == "members";
+    if let Some(scope) = g.named_actions[2].scope {
+        assert scope == "parser";
+    } else {
+        panic("expected scope 'parser'");
+    }
+}
+
+test "lexer rule visibility modifiers" {
+    let input = "lexer grammar Test;
+public ID : [a-z]+ ;
+private HELPER : [A-Z]+ ;";
+    let g = parse(input).unwrap();
+    assert g.lexer_rules.len() == 2;
+    if let Public = g.lexer_rules[0].visibility {
+        // ok
+    } else {
+        panic("expected Public visibility on ID");
+    }
+    if let Private = g.lexer_rules[1].visibility {
+        // ok
+    } else {
+        panic("expected Private visibility on HELPER");
+    }
 }
 
 test "parser rule with plus_assign list label" {
@@ -632,8 +794,11 @@ test "lexer command channel with HIDDEN" {
 WS : [ \\t]+ -> channel(HIDDEN) ;";
     let g = parse(input).unwrap();
     assert g.lexer_rules.len() == 1;
-    // HIDDEN is the predefined channel id 1.
+    // HIDDEN is the predefined channel id 1. ANTLR4 emits HIDDEN tokens on
+    // a separate channel — they are NOT discarded, so `skip` must remain
+    // false.
     assert g.lexer_rules[0].channel == 1;
+    assert g.lexer_rules[0].skip == false;
 }
 
 test "lexer command type override" {
@@ -769,4 +934,136 @@ mode FOO;
 expr : ID ;";
     let result = parse(input);
     assert result matches { Err(_) }, "expected mode in parser grammar to be rejected";
+}
+
+test "parser rule tilde applied to block" {
+    // ANTLR4 allows `~` on a set expressed as a block of alternatives, not
+    // just a single token reference: `~( 'a' | 'b' | 'c' )`.
+    // Spec: vendor/antlr4/doc/parser-rules.md (set complement).
+    let input = "grammar Test;
+noise : ~( 'a' | 'b' | 'c' ) ;";
+    let g = parse(input).unwrap();
+    assert g.parser_rules.len() == 1;
+    let elems = &g.parser_rules[0].alternatives[0].elements;
+    assert elems.len() == 1;
+    if let Not(n) = &elems[0] {
+        if let Group(alts) = &n.element {
+            assert alts.len() == 3;
+        } else {
+            panic("expected Group inside Not");
+        }
+    } else {
+        panic("expected Not element");
+    }
+}
+
+test "lexer rule tilde applied to block" {
+    // Same as the parser case, but for lexer rules where `~` may wrap a set
+    // of char classes / literals: `~( 'a' | [0-9] )`.
+    let input = "lexer grammar Test;
+NON_AB : ~( 'a' | 'b' ) ;";
+    let g = parse(input).unwrap();
+    assert g.lexer_rules.len() == 1;
+    let rule = &g.lexer_rules[0];
+    let elems = &rule.body[0].elements;
+    assert elems.len() == 1;
+    if let Not(n) = &elems[0] {
+        if let Group(_) = &n.element {
+            // ok
+        } else {
+            panic("expected Group inside LexerElement::Not");
+        }
+    } else {
+        panic("expected LexerElement::Not");
+    }
+}
+
+test "block label single-value" {
+    // ANTLR4 allows labels on blocks, not just single atoms:
+    //   lbl = ( 'a' | 'b' )
+    let input = "grammar Test;
+expr : op = ( '+' | '-' ) ;";
+    let g = parse(input).unwrap();
+    let elems = &g.parser_rules[0].alternatives[0].elements;
+    assert elems.len() == 1;
+    if let Label(l) = &elems[0] {
+        assert l.name == "op";
+        assert l.list == false;
+        if let Group(_) = &l.element {
+            // ok
+        } else {
+            panic("expected Group inside Label");
+        }
+    } else {
+        panic("expected Label element");
+    }
+}
+
+test "block label list" {
+    // `+=` form of block label: collect each match into an Array.
+    let input = "grammar Test;
+expr : ops += ( '+' | '-' )* ;";
+    let g = parse(input).unwrap();
+    let elems = &g.parser_rules[0].alternatives[0].elements;
+    assert elems.len() == 1;
+    // The top-level element is a Repeat (because of the `*`) whose inner
+    // element is the Label.
+    if let Repeat(r) = &elems[0] {
+        if let Label(l) = &r.element {
+            assert l.name == "ops";
+            assert l.list == true;
+            if let Group(_) = &l.element {
+                // ok
+            } else {
+                panic("expected Group inside Label");
+            }
+        } else {
+            panic("expected Label inside Repeat");
+        }
+    } else {
+        panic("expected Repeat at top level");
+    }
+}
+
+test "arg action with only whitespace" {
+    // ANTLR4 accepts an empty/whitespace-only ARG_ACTION: `returns [ ]`.
+    // Gale discards the body, but the surrounding structure must still
+    // parse.
+    let input = "grammar Test;
+expr returns [ ] : ID ;";
+    let g = parse(input).unwrap();
+    assert g.parser_rules.len() == 1;
+    assert g.parser_rules[0].name == "expr";
+}
+
+test "empty arg action on rule arguments" {
+    // Same for bare rule arguments: `rule[] : ...`.
+    let input = "grammar Test;
+expr [ ] : ID ;";
+    let g = parse(input).unwrap();
+    assert g.parser_rules.len() == 1;
+    assert g.parser_rules[0].name == "expr";
+}
+
+test "tokens block with numbered assignments" {
+    // ANTLR3 allowed `tokens { NAME = 1, OTHER = 2 }`. ANTLR4's grammar
+    // rejects the assignment syntax, but real-world `.g4` files that were
+    // ported without cleanup still contain it. Gale's compatibility
+    // principle is lenient — we accept (and ignore) the `= INT` suffix so
+    // the rest of the grammar still parses, rather than erroring out.
+    let input = "grammar Test;
+tokens { FOO = 1, BAR = 2 }
+expr : ID ;";
+    let g = parse(input).unwrap();
+    assert g.parser_rules.len() == 1;
+    // Both virtual tokens must still be registered on the lexer side, with
+    // their original names.
+    let mut saw_foo = false;
+    let mut saw_bar = false;
+    for let r of &g.lexer_rules {
+        if r.name == "FOO" && r.is_virtual { saw_foo = true; }
+        if r.name == "BAR" && r.is_virtual { saw_bar = true; }
+    }
+    assert saw_foo, "tokens{} block must still register FOO as virtual token";
+    assert saw_bar, "tokens{} block must still register BAR as virtual token";
 }

--- a/package-gale/src/gen_context.wado
+++ b/package-gale/src/gen_context.wado
@@ -102,7 +102,13 @@ impl GenContext {
             },
             Repeat(rep) => self.first_of_element(&rep.element, visiting),
             Label(lab) => self.first_of_element(&lab.element, visiting),
-            _ => [],
+            // Wildcard and Not match an open-ended set of tokens; we cannot
+            // enumerate FIRST statically. Returning [] disables static prediction
+            // for alternatives starting with them — such alternatives must either
+            // be in a single-alt rule, used as a fallback, or be distinguished
+            // from their siblings by later elements.
+            Wildcard => [],
+            Not(_) => [],
         };
     }
 
@@ -292,6 +298,12 @@ impl GenContext {
                 }
                 return true;
             },
+            // Wildcard advances by exactly one token (unless at EOF).
+            Wildcard => true,
+            // `~ X` advances by one token when the current token is not in
+            // the complement set. The inner element is required to be a
+            // terminal or a simple terminal set, both of which are scannable.
+            Not(_) => true,
         };
     }
 

--- a/package-gale/src/gen_util.wado
+++ b/package-gale/src/gen_util.wado
@@ -171,6 +171,19 @@ fn symbol_char_names(c: char) -> Option<[String, String]> {
     };
 }
 
+/// Field base name for a parser-side `~ X` (set complement). The inner element
+/// is typically a terminal (TokenRef / Literal) or a simple terminal set; we
+/// derive a readable name from it so multi-element alternatives can dedup.
+pub fn not_element_field_name(inner: &Element) -> String {
+    if let TokenRef(name) = inner {
+        return `not_{to_lower(name)}`;
+    }
+    if let Literal(text) = inner {
+        return `not_{literal_field_name(text)}`;
+    }
+    return "not_set";
+}
+
 pub fn literal_field_name(text: &String) -> String {
     let chars: Array<char> = text.chars().collect();
     if chars.len() == 1 {

--- a/package-gale/src/generator.wado
+++ b/package-gale/src/generator.wado
@@ -1,4 +1,4 @@
-use { Grammar, ParserRule, Alternative, Element, RepeatElement, LabelElement, RepeatKind, LexerRule } from "./ir.wado";
+use { Grammar, ParserRule, Alternative, Element, RepeatElement, LabelElement, NotElement, RepeatKind, LexerRule } from "./ir.wado";
 use {
     to_pascal_case,
     to_snake_case,
@@ -6,6 +6,7 @@ use {
     escape_ident,
     rule_type_name,
     literal_field_name,
+    not_element_field_name,
     strip_suffix,
     case_names_for_rule,
     is_simple_cst_group,
@@ -362,7 +363,27 @@ fn element_to_field(elem: &Element, rule_name: &String, group_counter: &mut i32)
             type_str: "Token",
         });
     }
+    if let Wildcard = elem {
+        return Option::<Field>::Some(Field {
+            name: "wildcard",
+            type_str: "Token",
+        });
+    }
+    if let Not(ne) = elem {
+        return Option::<Field>::Some(Field {
+            name: not_element_field_name(&ne.element),
+            type_str: "Token",
+        });
+    }
     if let Repeat(rep) = elem {
+        // List labels are already Array-typed — return them as-is without
+        // re-wrapping. `(items+=item)*` and `items+=item*` both produce a
+        // single `items: Array<ItemNode>` field.
+        if let Label(lab) = &rep.element {
+            if lab.list {
+                return element_to_field(&rep.element, rule_name, group_counter);
+            }
+        }
         let inner_field = repeat_inner_field(&rep.element, rule_name, group_counter);
         if let Some(inner) = inner_field {
             let field = match rep.kind {
@@ -381,6 +402,14 @@ fn element_to_field(elem: &Element, rule_name: &String, group_counter: &mut i32)
     }
     if let Label(lab) = elem {
         if let Some(inner) = element_to_field(&lab.element, rule_name, group_counter) {
+            if lab.list {
+                // `items+=item` — the field is an Array<ItemNode>, regardless
+                // of whether this Label is wrapped in a Repeat.
+                return Option::<Field>::Some(Field {
+                    name: escape_ident(&to_snake_case(&lab.name)),
+                    type_str: `Array<{inner.type_str}>`,
+                });
+            }
             return Option::<Field>::Some(Field {
                 name: escape_ident(&to_snake_case(&lab.name)),
                 type_str: inner.type_str,

--- a/package-gale/src/generator_test.wado
+++ b/package-gale/src/generator_test.wado
@@ -5,9 +5,12 @@ use {
     Element,
     RepeatElement,
     LabelElement,
+    NotElement,
     RepeatKind,
     LexerRule,
     LexerAlt,
+    LexerElement,
+    Visibility,
     merge_grammars,
 } from "./ir.wado";
 use { generate, GenerateOptions } from "./generator.wado";
@@ -21,6 +24,9 @@ test "generate header" {
         parser_rules: [],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
     assert output.len() > 0;
@@ -40,6 +46,9 @@ test "generate token kind" {
             LexerRule::new("WS", false, true, []),
         ],
         mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
     assert str_contains(&output, "pub enum TokenKind {");
@@ -56,6 +65,8 @@ test "generate single-alt struct" {
         parser_rules: [
             ParserRule {
                 name: "json",
+                visibility: Visibility::Default,
+                options: [],
                 alternatives: [
                     Alternative {
                         label: null,
@@ -66,6 +77,9 @@ test "generate single-alt struct" {
         ],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
     assert str_contains(&output, "pub struct JsonNode {");
@@ -80,6 +94,8 @@ test "generate multi-alt variant with labels" {
         parser_rules: [
             ParserRule {
                 name: "expr",
+                visibility: Visibility::Default,
+                options: [],
                 alternatives: [
                     Alternative {
                         label: Option::<String>::Some("BinOp"),
@@ -94,6 +110,9 @@ test "generate multi-alt variant with labels" {
         ],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
     assert str_contains(&output, "pub variant ExprNode {");
@@ -112,6 +131,8 @@ test "generate multi-alt variant without labels" {
         parser_rules: [
             ParserRule {
                 name: "item",
+                visibility: Visibility::Default,
+                options: [],
                 alternatives: [
                     Alternative {
                         label: null,
@@ -126,6 +147,9 @@ test "generate multi-alt variant without labels" {
         ],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
     assert str_contains(&output, "pub variant ItemNode {");
@@ -141,6 +165,8 @@ test "generate repeat fields" {
         parser_rules: [
             ParserRule {
                 name: "list",
+                visibility: Visibility::Default,
+                options: [],
                 alternatives: [
                     Alternative {
                         label: null,
@@ -162,6 +188,9 @@ test "generate repeat fields" {
         ],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
     assert str_contains(&output, "    pub item_list: Array<ItemNode>,");
@@ -174,6 +203,8 @@ test "generate duplicate field names" {
         parser_rules: [
             ParserRule {
                 name: "pair",
+                visibility: Visibility::Default,
+                options: [],
                 alternatives: [
                     Alternative {
                         label: null,
@@ -184,6 +215,9 @@ test "generate duplicate field names" {
         ],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
     assert str_contains(&output, "    pub item: ItemNode,");
@@ -196,6 +230,8 @@ test "generate group variant type for repeated group" {
         parser_rules: [
             ParserRule {
                 name: "parse",
+                visibility: Visibility::Default,
+                options: [],
                 alternatives: [
                     Alternative {
                         label: null,
@@ -216,6 +252,9 @@ test "generate group variant type for repeated group" {
         ],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
     assert str_contains(&output, "pub variant StmtOrErrorGroup {");
@@ -224,12 +263,110 @@ test "generate group variant type for repeated group" {
     assert str_contains(&output, "    pub stmt_or_error_list: Array<StmtOrErrorGroup>,");
 }
 
+test "generate wildcard element" {
+    let grammar = Grammar {
+        name: "Test",
+        parser_rules: [
+            ParserRule {
+                name: "any",
+                visibility: Visibility::Default,
+                options: [],
+                alternatives: [
+                    Alternative {
+                        label: null,
+                        elements: [Element::Wildcard, Element::TokenRef("EOF")],
+                    },
+                ],
+            },
+        ],
+        lexer_rules: [],
+        mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
+    };
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    assert str_contains(&output, "pub struct AnyNode {");
+    assert str_contains(&output, "    pub wildcard: Token,");
+    assert str_contains(&output, "let wildcard = p.match_any()?;");
+}
+
+test "generate parser not element" {
+    let grammar = Grammar {
+        name: "Test",
+        parser_rules: [
+            ParserRule {
+                name: "except_comma",
+                visibility: Visibility::Default,
+                options: [],
+                alternatives: [
+                    Alternative {
+                        label: null,
+                        elements: [
+                            Element::Not(NotElement { element: Element::TokenRef("COMMA") }),
+                            Element::TokenRef("EOF"),
+                        ],
+                    },
+                ],
+            },
+        ],
+        lexer_rules: [],
+        mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
+    };
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    assert str_contains(&output, "pub struct ExceptCommaNode {");
+    assert str_contains(&output, "    pub not_comma: Token,");
+    assert str_contains(&output, "let not_comma = p.match_not(&[TK_COMMA])?;");
+}
+
+test "generate list label field" {
+    let grammar = Grammar {
+        name: "Test",
+        parser_rules: [
+            ParserRule {
+                name: "list",
+                visibility: Visibility::Default,
+                options: [],
+                alternatives: [
+                    Alternative {
+                        label: null,
+                        elements: [
+                            Element::Repeat(RepeatElement {
+                                kind: RepeatKind::Star,
+                                element: Element::Label(LabelElement {
+                                    name: "items",
+                                    list: true,
+                                    element: Element::RuleRef("item"),
+                                }),
+                                non_greedy: false,
+                            }),
+                            Element::TokenRef("EOF"),
+                        ],
+                    },
+                ],
+            },
+        ],
+        lexer_rules: [],
+        mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
+    };
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    assert str_contains(&output, "    pub items: Array<ItemNode>,");
+}
+
 test "generate standalone group as optional field" {
     let grammar = Grammar {
         name: "Test",
         parser_rules: [
             ParserRule {
                 name: "cmd",
+                visibility: Visibility::Default,
+                options: [],
                 alternatives: [
                     Alternative {
                         label: null,
@@ -246,12 +383,207 @@ test "generate standalone group as optional field" {
         ],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
     assert str_contains(&output, "pub variant FooOrBarGroup {");
     assert str_contains(&output, "    Foo(FooNode),");
     assert str_contains(&output, "    Bar(BarNode),");
     assert str_contains(&output, "    pub foo_or_bar: Option<FooOrBarGroup>,");
+}
+
+test "generate lexer set_mode" {
+    let grammar = Grammar {
+        name: "Test",
+        parser_rules: [],
+        lexer_rules: [
+            LexerRule {
+                name: "OPEN_TAG",
+                visibility: Visibility::Default,
+                is_fragment: false,
+                skip: false,
+                more: false,
+                type_override: null,
+                channel: 0,
+                mode: 0,
+                set_mode: 1,
+                push_mode: -1,
+                pop_mode: false,
+                is_virtual: false,
+                options: [],
+                body: [LexerAlt { elements: [LexerElement::Literal("<")] }],
+            },
+            LexerRule {
+                name: "TAG_NAME",
+                visibility: Visibility::Default,
+                is_fragment: false,
+                skip: false,
+                more: false,
+                type_override: null,
+                channel: 0,
+                mode: 1,
+                set_mode: -1,
+                push_mode: -1,
+                pop_mode: false,
+                is_virtual: false,
+                options: [],
+                body: [LexerAlt { elements: [LexerElement::Literal("a")] }],
+            },
+        ],
+        mode_names: ["DEFAULT_MODE", "TAG_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
+    };
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    assert str_contains(&output, "best_set_mode");
+    assert str_contains(&output, "best_set_mode = 1");
+    assert str_contains(&output, "current_mode = best_set_mode");
+}
+
+test "generate lexer more" {
+    let grammar = Grammar {
+        name: "Test",
+        parser_rules: [],
+        lexer_rules: [
+            LexerRule {
+                name: "STRING_PART",
+                visibility: Visibility::Default,
+                is_fragment: false,
+                skip: false,
+                more: true,
+                type_override: null,
+                channel: 0,
+                mode: 0,
+                set_mode: -1,
+                push_mode: -1,
+                pop_mode: false,
+                is_virtual: false,
+                options: [],
+                body: [LexerAlt { elements: [LexerElement::Literal("a")] }],
+            },
+        ],
+        mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
+    };
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    assert str_contains(&output, "best_more");
+    assert str_contains(&output, "more_start");
+    assert str_contains(&output, "best_more = true");
+}
+
+test "generate lexer type_override" {
+    let grammar = Grammar {
+        name: "Test",
+        parser_rules: [],
+        lexer_rules: [
+            LexerRule {
+                name: "ID",
+                visibility: Visibility::Default,
+                is_fragment: false,
+                skip: false,
+                more: false,
+                type_override: null,
+                channel: 0,
+                mode: 0,
+                set_mode: -1,
+                push_mode: -1,
+                pop_mode: false,
+                is_virtual: false,
+                options: [],
+                body: [LexerAlt { elements: [LexerElement::Literal("x")] }],
+            },
+            LexerRule {
+                name: "IF",
+                visibility: Visibility::Default,
+                is_fragment: false,
+                skip: false,
+                more: false,
+                type_override: Option::<String>::Some("ID"),
+                channel: 0,
+                mode: 0,
+                set_mode: -1,
+                push_mode: -1,
+                pop_mode: false,
+                is_virtual: false,
+                options: [],
+                body: [LexerAlt { elements: [LexerElement::Literal("if")] }],
+            },
+        ],
+        mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
+    };
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    // IF rule should produce tokens tagged as TK_ID (not TK_IF).
+    assert str_contains(&output, "best_kind = TK_ID");
+    // TK_IF should still exist as a token kind (not renamed), because
+    // type_override only rewrites emission, not the rule identifier.
+    assert str_contains(&output, "    IF,");
+}
+
+test "generate lexer channel" {
+    let grammar = Grammar {
+        name: "Test",
+        parser_rules: [],
+        lexer_rules: [
+            LexerRule {
+                name: "COMMENT",
+                visibility: Visibility::Default,
+                is_fragment: false,
+                skip: false,
+                more: false,
+                type_override: null,
+                channel: 2,
+                mode: 0,
+                set_mode: -1,
+                push_mode: -1,
+                pop_mode: false,
+                is_virtual: false,
+                options: [],
+                body: [LexerAlt { elements: [LexerElement::Literal("#")] }],
+            },
+        ],
+        mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
+    };
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    assert str_contains(&output, "best_channel");
+    assert str_contains(&output, "best_channel = 2");
+    // Non-default channels must be routed to trivia, not tokens — ANTLR4
+    // hides channels other than DEFAULT from parser rules.
+    assert str_contains(&output, "else if best_channel != 0");
+    assert str_contains(&output, "Token::with_channel");
+}
+
+test "generate lexer hidden channel routes to trivia" {
+    // `channel(HIDDEN)` must not set `skip`, and tokens matching the rule
+    // must be routed to trivia (not the tokens stream) so the parser does
+    // not see them.
+    let input = "lexer grammar Test;
+WS : [ \\t]+ -> channel(HIDDEN) ;
+ID : [a-z]+ ;";
+    let grammar = parse_grammar(input);
+    // Parser-side contract: HIDDEN channel must not degrade to skip.
+    for let r of &grammar.lexer_rules {
+        if r.name == "WS" {
+            assert r.skip == false, "HIDDEN must not collapse to skip";
+            assert r.channel == 1, "HIDDEN must resolve to channel id 1";
+        }
+    }
+    // Generator-side contract: the emitted dispatch must route `best_channel
+    // != 0` matches to trivia via `Token::with_channel`, not to the tokens
+    // stream.
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    assert str_contains(&output, "else if best_channel != 0");
+    assert str_contains(&output, "trivia.push(Token::with_channel(");
 }
 
 fn parse_grammar(input: String) -> Grammar {

--- a/package-gale/src/ir.wado
+++ b/package-gale/src/ir.wado
@@ -1,17 +1,69 @@
+/// GrammarOption is a single `key = value ;` entry from an ANTLR4
+/// `options { ... }` block. Gale records the raw textual value so the full
+/// surface syntax (bare identifiers, qualified names, string literals,
+/// integer literals) round-trips without loss. ANTLR4 spec:
+/// `vendor/antlr4/doc/options.md`.
+pub struct GrammarOption {
+    pub name: String,
+    pub value: String,
+}
+
+/// NamedAction records the presence and position of a grammar-level
+/// `@name { ... }` or `@scope::name { ... }` prequel action. The action body
+/// itself is always discarded (it would be host-language code Gale cannot
+/// transpile), but downstream stages still need to know which actions were
+/// declared and on what scope. ANTLR4 spec: `vendor/antlr4/doc/actions.md`.
+pub struct NamedAction {
+    /// Optional scope qualifier (`parser` in `@parser::members`). `None`
+    /// for a bare `@name { ... }` action.
+    pub scope: Option<String>,
+    pub name: String,
+}
+
 /// Grammar is the top-level IR representing a parsed .g4 file.
 pub struct Grammar {
     pub name: String,
     pub parser_rules: Array<ParserRule>,
     pub lexer_rules: Array<LexerRule>,
     pub mode_names: Array<String>,
+    /// User-defined channel names from `channels { }` blocks, in declaration
+    /// order. Predefined channels (DEFAULT=0, HIDDEN=1) are NOT included —
+    /// user channels receive sequential ids starting at 2.
+    pub channels: Array<String>,
+    /// Grammar-level options from `options { ... }` prequel blocks
+    /// (`caseInsensitive`, `language`, `tokenVocab`, `superClass`, ...).
+    pub options: Array<GrammarOption>,
+    /// Grammar-level `@name { ... }` / `@scope::name { ... }` actions,
+    /// in declaration order. Action bodies themselves are discarded.
+    pub named_actions: Array<NamedAction>,
 }
 
 pub global DEFAULT_MODE: i32 = 0;
 pub global NO_MODE: i32 = -1;
 
+/// Predefined ANTLR4 channel ids. User channels declared via
+/// `channels { }` start at 2.
+pub global DEFAULT_CHANNEL: i32 = 0;
+pub global HIDDEN_CHANNEL: i32 = 1;
+
+/// Visibility of a rule (`public`/`private`/`protected` modifiers in ANTLR4).
+///
+/// ANTLR4 accepts these modifiers at the rule level but ignores them during
+/// code generation — every rule is effectively public in the generated code.
+/// Gale preserves the value on the IR so downstream tooling can observe it.
+pub enum Visibility {
+    Default,
+    Public,
+    Private,
+    Protected,
+}
+
 /// ParserRule represents a parser rule (lowercase name in .g4).
 pub struct ParserRule {
     pub name: String,
+    pub visibility: Visibility,
+    /// Rule-level options from `options { ... }` prequel blocks.
+    pub options: Array<GrammarOption>,
     pub alternatives: Array<Alternative>,
 }
 
@@ -79,6 +131,7 @@ pub enum RepeatKind {
 ///   `channels {}` block are looked up later by the code generator.
 pub struct LexerRule {
     pub name: String,
+    pub visibility: Visibility,
     pub is_fragment: bool,
     pub skip: bool,
     pub more: bool,
@@ -88,6 +141,13 @@ pub struct LexerRule {
     pub set_mode: i32,
     pub push_mode: i32,
     pub pop_mode: bool,
+    /// True when this entry originates from a `tokens { }` block and has no
+    /// matching lexer rule body. Generators should still emit a token-id
+    /// constant for it, but the tokenizer cannot produce it directly — only
+    /// grammar actions or `type(X)` rewrites can.
+    pub is_virtual: bool,
+    /// Rule-level options from `options { ... }` prequel blocks.
+    pub options: Array<GrammarOption>,
     pub body: Array<LexerAlt>,
 }
 
@@ -95,6 +155,7 @@ impl LexerRule {
     pub fn new(name: String, is_fragment: bool, skip: bool, body: Array<LexerAlt>) -> LexerRule {
         return LexerRule {
             name,
+            visibility: Visibility::Default,
             is_fragment,
             skip,
             more: false,
@@ -104,8 +165,17 @@ impl LexerRule {
             set_mode: NO_MODE,
             push_mode: NO_MODE,
             pop_mode: false,
+            is_virtual: false,
+            options: [],
             body,
         };
+    }
+
+    /// Construct a virtual lexer rule entry from a `tokens { }` declaration.
+    pub fn virtual_token(name: String) -> LexerRule {
+        let mut rule = LexerRule::new(name, false, false, []);
+        rule.is_virtual = true;
+        return rule;
     }
 }
 
@@ -166,12 +236,43 @@ pub fn merge_grammars(grammars: Array<Grammar>) -> Grammar {
     let mut parser_rules: Array<ParserRule> = [];
     let mut lexer_rules: Array<LexerRule> = [];
     let mut mode_names: Array<String> = ["DEFAULT_MODE"];
+    let mut channels: Array<String> = [];
+    let mut options: Array<GrammarOption> = [];
+    let mut named_actions: Array<NamedAction> = [];
     for let g of grammars {
+        // Preserve grammar-level options from every split. Later splits
+        // override earlier ones on collision — ANTLR4 leaves conflict
+        // resolution to the tool, but keeping the last value is a sensible
+        // default for Gale's merge.
+        for let opt of &g.options {
+            let mut found = false;
+            for let mut i = 0; i < options.len(); i += 1 {
+                if options[i].name == opt.name {
+                    options[i] = *opt;
+                    found = true;
+                }
+            }
+            if !found {
+                options.push(*opt);
+            }
+        }
+        // Named actions are concatenated — they are position-bearing markers,
+        // not key/value pairs, so duplicates are preserved.
+        for let act of &g.named_actions {
+            named_actions.push(*act);
+        }
         // Build mode index remapping table for this grammar
         let mut remap: Array<i32> = [];
         for let mn of g.mode_names {
             let idx = find_or_add_mode(&mut mode_names, &mn);
             remap.push(idx);
+        }
+        // Build channel id remapping table. User channels start at id 2
+        // (0=DEFAULT, 1=HIDDEN). Preserve existing ids when names line up.
+        let mut chan_remap: Array<i32> = [];
+        for let cn of &g.channels {
+            let id = find_or_add_channel(&mut channels, cn);
+            chan_remap.push(id);
         }
         for let r of g.parser_rules {
             parser_rules.push(r);
@@ -184,6 +285,13 @@ pub fn merge_grammars(grammars: Array<Grammar>) -> Grammar {
             }
             if r.set_mode >= 0 {
                 r.set_mode = remap[r.set_mode];
+            }
+            // Remap user-defined channel ids (>= 2). 0 and 1 are predefined.
+            if r.channel >= 2 {
+                let src_idx = r.channel - 2;
+                if src_idx < chan_remap.len() {
+                    r.channel = chan_remap[src_idx];
+                }
             }
             lexer_rules.push(r);
         }
@@ -219,7 +327,7 @@ pub fn merge_grammars(grammars: Array<Grammar>) -> Grammar {
             }
         }
     }
-    return Grammar { name, parser_rules, lexer_rules, mode_names };
+    return Grammar { name, parser_rules, lexer_rules, mode_names, channels, options, named_actions };
 }
 
 fn find_or_add_mode(modes: &mut Array<String>, name: &String) -> i32 {
@@ -230,4 +338,16 @@ fn find_or_add_mode(modes: &mut Array<String>, name: &String) -> i32 {
     }
     modes.push(*name);
     return modes.len() - 1;
+}
+
+/// Allocate a channel id for `name`. User channel ids start at 2
+/// (0=DEFAULT, 1=HIDDEN are predefined by ANTLR4).
+fn find_or_add_channel(channels: &mut Array<String>, name: &String) -> i32 {
+    for let mut i = 0; i < channels.len(); i += 1 {
+        if channels[i] == *name {
+            return i + 2;
+        }
+    }
+    channels.push(*name);
+    return channels.len() - 1 + 2;
 }

--- a/package-gale/src/ir_test.wado
+++ b/package-gale/src/ir_test.wado
@@ -11,6 +11,7 @@ use {
     LexerElement,
     CharClass,
     CharRange,
+    Visibility,
 } from "./ir.wado";
 
 test "Grammar construction" {
@@ -19,16 +20,24 @@ test "Grammar construction" {
         parser_rules: [],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
     };
     assert g.name == "JSON";
     assert g.parser_rules.is_empty();
     assert g.lexer_rules.is_empty();
     assert g.mode_names.len() == 1;
+    assert g.channels.is_empty();
+    assert g.options.is_empty();
+    assert g.named_actions.is_empty();
 }
 
 test "ParserRule with alternatives" {
     let rule = ParserRule {
         name: "value",
+        visibility: Visibility::Default,
+        options: [],
         alternatives: [
             Alternative { label: Option::<String>::Some("Str"), elements: [Element::TokenRef("STRING")] },
             Alternative { label: Option::<String>::Some("Num"), elements: [Element::TokenRef("NUMBER")] },
@@ -79,6 +88,7 @@ test "Element variants" {
 test "LexerRule construction" {
     let rule = LexerRule {
         name: "WS",
+        visibility: Visibility::Default,
         is_fragment: false,
         skip: true,
         more: false,
@@ -88,6 +98,8 @@ test "LexerRule construction" {
         set_mode: -1,
         push_mode: -1,
         pop_mode: false,
+        is_virtual: false,
+        options: [],
         body: [
             LexerAlt {
                 elements: [

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -508,6 +508,19 @@ fn try_extract_keyword_info(rule: &LexerRule, all_rules: &Array<LexerRule>) -> O
     if rule.is_fragment || rule.body.len() != 1 {
         return null;
     }
+    // Rules carrying lexer commands (more, channel, type(X), mode(X)/pushMode/popMode, skip)
+    // cannot be shortcut via keyword dispatch — the keyword classifier only rewrites
+    // `best_kind`, it does not propagate the command state to the tokenize loop.
+    if rule.skip
+        || rule.more
+        || rule.channel != 0
+        || rule.type_override matches { Some(_) }
+        || rule.mode != 0
+        || rule.set_mode >= 0
+        || rule.push_mode >= 0
+        || rule.pop_mode {
+        return null;
+    }
     let alt = &rule.body[0];
     if alt.elements.is_empty() {
         return null;
@@ -753,6 +766,33 @@ fn has_modes(mode_names: &Array<String>) -> bool {
     return mode_names.len() > 1;
 }
 
+fn has_set_mode(rules: &Array<LexerRule>) -> bool {
+    for let r of rules {
+        if r.set_mode >= 0 {
+            return true;
+        }
+    }
+    return false;
+}
+
+fn has_more(rules: &Array<LexerRule>) -> bool {
+    for let r of rules {
+        if r.more {
+            return true;
+        }
+    }
+    return false;
+}
+
+fn has_channel(rules: &Array<LexerRule>) -> bool {
+    for let r of rules {
+        if r.channel != 0 {
+            return true;
+        }
+    }
+    return false;
+}
+
 // --- First-character dispatch ---
 
 struct TryCall {
@@ -765,18 +805,84 @@ struct TryCall {
     match_length: i32,
 }
 
-/// Compute the first-char set for a lexer rule body's first element.
-fn compute_first_chars(rule: &LexerRule, all_rules: &Array<LexerRule>) -> TryCall {
-    let fn_name = `try_{to_lower(&rule.name)}`;
-    let token_kind = `TK_{rule.name}`;
-    let mut extra = String::with_capacity(64);
-    if rule.push_mode >= 0 {
-        extra.push_str(` best_push_mode = {rule.push_mode};`);
-    } else if rule.push_mode == -1 {
-        // only add if modes are used (caller will check)
+/// Build the default "reset" extras for state variables that exist in the
+/// current lexer shape. Used for literal-token calls that have no rule flags
+/// of their own — they still need to reset the state written by the previous
+/// best match.
+fn default_extras(
+    use_modes: bool,
+    has_set_mode_rules: bool,
+    has_more_rules: bool,
+    has_channel_rules: bool,
+) -> String {
+    let mut extras = String::with_capacity(64);
+    if use_modes {
+        extras.push_str(" best_push_mode = -1; best_pop_mode = false;");
     }
-    if rule.pop_mode {
-        extra.push_str(" best_pop_mode = true;");
+    if has_set_mode_rules {
+        extras.push_str(" best_set_mode = -1;");
+    }
+    if has_more_rules {
+        extras.push_str(" best_more = false;");
+    }
+    if has_channel_rules {
+        extras.push_str(" best_channel = 0;");
+    }
+    return extras;
+}
+
+/// Compute the first-char set for a lexer rule body's first element.
+fn compute_first_chars(
+    rule: &LexerRule,
+    all_rules: &Array<LexerRule>,
+    use_modes: bool,
+    has_set_mode_rules: bool,
+    has_more_rules: bool,
+    has_channel_rules: bool,
+) -> TryCall {
+    let fn_name = `try_{to_lower(&rule.name)}`;
+    // `type(X)` rewrites the kind used when emitting the token. Use the
+    // override kind at emit time so downstream code (parser, token_kind_name)
+    // sees the renamed type. The rule itself still has its own TK_<name>
+    // constant; the override only affects emission.
+    let token_kind = if let Some(override_name) = rule.type_override {
+        `TK_{override_name}`;
+    } else {
+        `TK_{rule.name}`;
+    };
+    let mut extra = String::with_capacity(64);
+    if use_modes {
+        if rule.push_mode >= 0 {
+            extra.push_str(` best_push_mode = {rule.push_mode};`);
+        } else {
+            extra.push_str(" best_push_mode = -1;");
+        }
+        if rule.pop_mode {
+            extra.push_str(" best_pop_mode = true;");
+        } else {
+            extra.push_str(" best_pop_mode = false;");
+        }
+    }
+    if has_set_mode_rules {
+        if rule.set_mode >= 0 {
+            extra.push_str(` best_set_mode = {rule.set_mode};`);
+        } else {
+            extra.push_str(" best_set_mode = -1;");
+        }
+    }
+    if has_more_rules {
+        if rule.more {
+            extra.push_str(" best_more = true;");
+        } else {
+            extra.push_str(" best_more = false;");
+        }
+    }
+    if has_channel_rules {
+        if rule.channel != 0 {
+            extra.push_str(` best_channel = {rule.channel};`);
+        } else {
+            extra.push_str(" best_channel = 0;");
+        }
     }
     let mut chars: Array<[char, char]> = [];
     let is_wc = compute_elem_first_chars(&rule.body, all_rules, &mut chars);
@@ -1034,10 +1140,10 @@ fn build_dispatch_groups(calls: &Array<TryCall>) -> Array<DispatchGroup> {
     return groups;
 }
 
-fn emit_dispatch_groups(w: &mut CodeWriter, calls: &Array<TryCall>, groups: &Array<DispatchGroup>, use_modes: bool) {
+fn emit_dispatch_groups(w: &mut CodeWriter, calls: &Array<TryCall>, groups: &Array<DispatchGroup>, needs_extras: bool) {
     // If only a wildcard group exists, emit calls directly without dispatch
     if groups.len() == 1 && groups[0].guard == "true" {
-        emit_group_calls(w, calls, &groups[0].calls, use_modes, true);
+        emit_group_calls(w, calls, &groups[0].calls, needs_extras, true);
         return;
     }
     let mut first_group = true;
@@ -1045,7 +1151,7 @@ fn emit_dispatch_groups(w: &mut CodeWriter, calls: &Array<TryCall>, groups: &Arr
         let is_wc = g.guard == "true";
         if is_wc {
             if first_group {
-                emit_group_calls(w, calls, &g.calls, use_modes, true);
+                emit_group_calls(w, calls, &g.calls, needs_extras, true);
                 continue;
             }
             w.else_begin("else");
@@ -1055,38 +1161,30 @@ fn emit_dispatch_groups(w: &mut CodeWriter, calls: &Array<TryCall>, groups: &Arr
             w.else_begin(`else if {g.guard}`);
         }
         first_group = false;
-        emit_group_calls(w, calls, &g.calls, use_modes, is_wc);
+        emit_group_calls(w, calls, &g.calls, needs_extras, is_wc);
     }
     if !first_group {
         w.end();
     }
 }
 
-fn emit_group_calls(w: &mut CodeWriter, calls: &Array<TryCall>, indices: &Array<i32>, use_modes: bool, is_wildcard_group: bool) {
+fn emit_group_calls(w: &mut CodeWriter, calls: &Array<TryCall>, indices: &Array<i32>, needs_extras: bool, is_wildcard_group: bool) {
     for let ci of indices {
         let call = &calls[*ci];
         // In specific dispatch branches, single-char literals are guaranteed to match
         // (the dispatch already confirmed the character). Inline the result
         // instead of calling the try_* function.
         if !is_wildcard_group && call.match_length == 1 {
-            if use_modes {
-                let mut extra = String::from(call.extra);
-                if extra.is_empty() {
-                    extra = String::from(" best_push_mode = -1; best_pop_mode = false;");
-                }
-                w.line(`if start + 1 > best_end \{ best_end = start + 1; best_kind = {call.token_kind};{extra} \}`);
+            if needs_extras {
+                w.line(`if start + 1 > best_end \{ best_end = start + 1; best_kind = {call.token_kind};{call.extra} \}`);
             } else {
                 w.line(`if start + 1 > best_end \{ best_end = start + 1; best_kind = {call.token_kind}; \}`);
             }
             continue;
         }
         w.line(`end = {call.fn_name}(&lexer.chars, start);`);
-        if use_modes {
-            let mut extra = String::from(call.extra);
-            if extra.is_empty() {
-                extra = String::from(" best_push_mode = -1; best_pop_mode = false;");
-            }
-            w.line(`if end > best_end \{ best_end = end; best_kind = {call.token_kind};{extra} \}`);
+        if needs_extras {
+            w.line(`if end > best_end \{ best_end = end; best_kind = {call.token_kind};{call.extra} \}`);
         } else {
             w.line(`if end > best_end \{ best_end = end; best_kind = {call.token_kind}; \}`);
         }
@@ -1107,6 +1205,9 @@ fn arrays_equal(a: &Array<i32>, b: &Array<i32>) -> bool {
 
 fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_tokens: &Array<LitToken>, mode_names: &Array<String>, keywords: &Array<KeywordInfo>) {
     let use_modes = has_modes(mode_names);
+    let has_set_mode_rules = has_set_mode(lexer_rules);
+    let has_more_rules = has_more(lexer_rules);
+    let has_channel_rules = has_channel(lexer_rules);
 
     let mut f = FnSpec::new("tokenize");
     f.set_pub();
@@ -1116,6 +1217,14 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
     w.line("let mut lexer = Lexer::new(input);");
     w.line("let mut tokens: Array<Token> = [];");
     w.line("let mut trivia: Array<Token> = [];");
+
+    if has_more_rules {
+        // Tracks the start position of a pending `more` sequence; -1 means
+        // no pending `more` data. When a non-`more` rule emits, it uses
+        // `more_start` as the token start so the emitted text includes
+        // all previously-`more`'d characters.
+        w.line("let mut more_start: i32 = -1;");
+    }
 
     if use_modes {
         w.line("let mut mode_stack: Array<i32> = [];");
@@ -1133,6 +1242,15 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
         w.line("let mut best_push_mode: i32 = -1;");
         w.line("let mut best_pop_mode = false;");
     }
+    if has_set_mode_rules {
+        w.line("let mut best_set_mode: i32 = -1;");
+    }
+    if has_more_rules {
+        w.line("let mut best_more = false;");
+    }
+    if has_channel_rules {
+        w.line("let mut best_channel: i32 = 0;");
+    }
 
     if use_modes {
         // Generate mode dispatch
@@ -1147,8 +1265,18 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
                 for let lit of lit_tokens {
                     let fn_name = lit_try_fn_name(&lit.const_name);
                     w.line(`end = {fn_name}(&lexer.chars, start);`);
+                    let mut lit_reset = String::from(" best_push_mode = -1; best_pop_mode = false;");
+                    if has_set_mode_rules {
+                        lit_reset.push_str(" best_set_mode = -1;");
+                    }
+                    if has_more_rules {
+                        lit_reset.push_str(" best_more = false;");
+                    }
+                    if has_channel_rules {
+                        lit_reset.push_str(" best_channel = 0;");
+                    }
                     w.line(
-                        `if end > best_end \{ best_end = end; best_kind = {lit.const_name}; best_push_mode = -1; best_pop_mode = false; \}`,
+                        `if end > best_end \{ best_end = end; best_kind = {lit.const_name};{lit_reset} \}`,
                     );
                 }
             }
@@ -1171,13 +1299,44 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
                     } else {
                         extra.push_str(" best_pop_mode = false;");
                     }
-                    w.line(`if end > best_end \{ best_end = end; best_kind = TK_{rule.name};{extra} \}`);
+                    if has_set_mode_rules {
+                        if rule.set_mode >= 0 {
+                            extra.push_str(` best_set_mode = {rule.set_mode};`);
+                        } else {
+                            extra.push_str(" best_set_mode = -1;");
+                        }
+                    }
+                    if has_more_rules {
+                        if rule.more {
+                            extra.push_str(" best_more = true;");
+                        } else {
+                            extra.push_str(" best_more = false;");
+                        }
+                    }
+                    if has_channel_rules {
+                        if rule.channel != 0 {
+                            extra.push_str(` best_channel = {rule.channel};`);
+                        } else {
+                            extra.push_str(" best_channel = 0;");
+                        }
+                    }
+                    // `type(X)` rewrites the emitted kind. The rule still has
+                    // its own TK_<name> constant; the override only affects
+                    // the emitted token.
+                    let emit_kind = if let Some(override_name) = rule.type_override {
+                        `TK_{override_name}`;
+                    } else {
+                        `TK_{rule.name}`;
+                    };
+                    w.line(`if end > best_end \{ best_end = end; best_kind = {emit_kind};{extra} \}`);
                 }
             }
         }
         w.end();  // mode dispatch
     } else {
         // No modes — first-character dispatch
+        let needs_extras = has_set_mode_rules || has_more_rules || has_channel_rules;
+        let lit_extras = default_extras(false, has_set_mode_rules, has_more_rules, has_channel_rules);
         let mut all_calls: Array<TryCall> = [];
         for let lit of lit_tokens {
             let fn_name = lit_try_fn_name(&lit.const_name);
@@ -1189,7 +1348,7 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
             all_calls.push(TryCall {
                 fn_name,
                 token_kind: tk,
-                extra: String::from(""),
+                extra: lit_extras,
                 first_chars: fc,
                 is_wildcard: false,
                 is_catch_all: false,
@@ -1201,11 +1360,18 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
                 && !rule.body.is_empty()
                 && !is_keyword_rule_name(&rule.name, keywords)
                 && !is_literal_duplicate(rule, lit_tokens) {
-                all_calls.push(compute_first_chars(rule, lexer_rules));
+                all_calls.push(compute_first_chars(
+                    rule,
+                    lexer_rules,
+                    false,
+                    has_set_mode_rules,
+                    has_more_rules,
+                    has_channel_rules,
+                ));
             }
         }
         let groups = build_dispatch_groups(&all_calls);
-        emit_dispatch_groups(w, &all_calls, &groups, false);
+        emit_dispatch_groups(w, &all_calls, &groups, needs_extras);
     }
 
     // Keyword reclassification: check if the matched text is actually a keyword.
@@ -1226,6 +1392,15 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
     w.line("lexer.pos = start + 1;");
     w.else_begin("else");
 
+    // `more` rules accumulate text into the next emitted token. `tok_start`
+    // is the earliest start position of the current pending `more` chain,
+    // or `start` if no `more` is pending.
+    if has_more_rules {
+        w.line("let tok_start = if more_start >= 0 { more_start } else { start };");
+    } else {
+        w.line("let tok_start = start;");
+    }
+
     let mut skip_names: Array<String> = [];
     for let rule of lexer_rules {
         if rule.skip {
@@ -1245,13 +1420,44 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
         w.write(" };\n");
     }
 
-    w.begin("if is_skip");
-    w.line("trivia.push(Token::new(best_kind, lexer.slice(start, best_end), Span::new(start, best_end)));");
-    w.else_begin("else");
-    w.line("let tok = Token::with_trivia(best_kind, lexer.slice(start, best_end), Span::new(start, best_end), trivia);");
-    w.line("tokens.push(tok);");
-    w.line("trivia = [];");
-    w.end();
+    if has_more_rules {
+        // A `more` match suppresses emission and remembers the starting
+        // position so the next non-`more` match covers the full span.
+        w.begin("if best_more");
+        w.line("if more_start < 0 { more_start = start; }");
+        w.else_begin("else if is_skip");
+        w.line("trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));");
+        w.line("more_start = -1;");
+        if has_channel_rules {
+            // Non-default channels are invisible to the parser — route to
+            // trivia with the channel id preserved. ANTLR4 treats any
+            // non-DEFAULT channel the same way at the parser boundary.
+            w.else_begin("else if best_channel != 0");
+            w.line("trivia.push(Token::with_channel(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), [], best_channel));");
+            w.line("more_start = -1;");
+        }
+        w.else_begin("else");
+        w.line("let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);");
+        w.line("tokens.push(tok);");
+        w.line("trivia = [];");
+        w.line("more_start = -1;");
+        w.end();
+    } else {
+        w.begin("if is_skip");
+        w.line("trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));");
+        if has_channel_rules {
+            // Non-default channels are invisible to the parser — route to
+            // trivia with the channel id preserved. ANTLR4 treats any
+            // non-DEFAULT channel the same way at the parser boundary.
+            w.else_begin("else if best_channel != 0");
+            w.line("trivia.push(Token::with_channel(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), [], best_channel));");
+        }
+        w.else_begin("else");
+        w.line("let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);");
+        w.line("tokens.push(tok);");
+        w.line("trivia = [];");
+        w.end();
+    }
 
     if use_modes {
         w.begin("if best_push_mode >= 0");
@@ -1268,6 +1474,13 @@ fn gen_tokenize_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, lit_token
         w.end();
         w.line("best_pop_mode = false;");
         w.end();
+        if has_set_mode_rules {
+            // `mode(X)` replaces the current mode directly — no stack push.
+            w.begin("if best_set_mode >= 0");
+            w.line("current_mode = best_set_mode;");
+            w.line("best_set_mode = -1;");
+            w.end();
+        }
     }
 
     w.line("lexer.pos = best_end;");

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -1,4 +1,4 @@
-use { Grammar, ParserRule, Alternative, Element, RepeatElement, RepeatKind, LabelElement } from "./ir.wado";
+use { Grammar, ParserRule, Alternative, Element, RepeatElement, RepeatKind, LabelElement, NotElement } from "./ir.wado";
 use {
     to_lower,
     to_snake_case,
@@ -6,6 +6,7 @@ use {
     escape_ident,
     rule_type_name,
     literal_field_name,
+    not_element_field_name,
     strip_suffix,
     escape_string,
     literal_const_name,
@@ -1129,6 +1130,58 @@ fn gen_parser_struct(w: &mut CodeWriter) {
     w.dedent();
     w.line("));");
     w.end();
+    w.blank();
+
+    // `p.match_any()` — consumes one token of any kind (for `.` wildcard).
+    // Fails at EOF.
+    let mut f9 = FnSpec::new("match_any");
+    f9.set_receiver("&mut self");
+    f9.set_return_type("Result<Token, ParseError>");
+    f9.emit_begin(w);
+    w.begin("if self.tokens[self.pos].kind != TK_EOF");
+    w.line("return Result::<Token, ParseError>::Ok(self.advance());");
+    w.end();
+    w.line("let tok = &self.tokens[self.pos];");
+    w.line("return Result::<Token, ParseError>::Err(ParseError::new(");
+    w.indent();
+    w.line("`expected any token, got \"{tok.text}\"`,");
+    w.line("tok.span,");
+    w.line("[\"any token\"],");
+    w.dedent();
+    w.line("));");
+    w.end();
+    w.blank();
+
+    // `p.match_not(&[TK_A, TK_B, ...])` — consumes one token whose kind is
+    // not in the exclusion set (for parser-side `~ X`). Fails at EOF or when
+    // the current token is in the exclusion set.
+    let mut f10 = FnSpec::new("match_not");
+    f10.set_receiver("&mut self");
+    f10.add_param("excluded", "&Array<i32>");
+    f10.set_return_type("Result<Token, ParseError>");
+    f10.emit_begin(w);
+    w.line("let k = self.tokens[self.pos].kind;");
+    w.begin("if k != TK_EOF");
+    w.line("let mut blocked = false;");
+    w.begin("for let x of excluded");
+    w.begin("if *x == k");
+    w.line("blocked = true;");
+    w.line("break;");
+    w.end();
+    w.end();
+    w.begin("if !blocked");
+    w.line("return Result::<Token, ParseError>::Ok(self.advance());");
+    w.end();
+    w.end();
+    w.line("let tok = &self.tokens[self.pos];");
+    w.line("return Result::<Token, ParseError>::Err(ParseError::new(");
+    w.indent();
+    w.line("`unexpected token \"{tok.text}\"`,");
+    w.line("tok.span,");
+    w.line("[\"set complement\"],");
+    w.dedent();
+    w.line("));");
+    w.end();
 
     w.end();  // impl
     w.blank();
@@ -1283,6 +1336,17 @@ fn gen_scan_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext) {
         w.line("if pos < 0 { return -1; }");
         return;
     }
+    if let Wildcard = elem {
+        w.line("if pos >= tokens.len() || tokens[pos].kind == TK_EOF { return -1; }");
+        w.line("pos += 1;");
+        return;
+    }
+    if let Not(ne) = elem {
+        let check = not_scan_check(&ne.element);
+        w.line(`if pos >= tokens.len() || tokens[pos].kind == TK_EOF || {check} \{ return -1; \}`);
+        w.line("pos += 1;");
+        return;
+    }
     if let Repeat(rep) = elem {
         gen_scan_repeat(w, rep, ctx);
         return;
@@ -1316,6 +1380,17 @@ fn gen_scan_element_in_block(w: &mut CodeWriter, elem: &Element, ctx: &mut GenCo
         let fn_name = `scan_{to_snake_case(name)}`;
         w.line(`pos = {fn_name}(tokens, pos);`);
         w.line(`if pos < 0 \{ break {*label}; \}`);
+        return;
+    }
+    if let Wildcard = elem {
+        w.line(`if pos >= tokens.len() || tokens[pos].kind == TK_EOF \{ break {*label}; \}`);
+        w.line("pos += 1;");
+        return;
+    }
+    if let Not(ne) = elem {
+        let check = not_scan_check(&ne.element);
+        w.line(`if pos >= tokens.len() || tokens[pos].kind == TK_EOF || {check} \{ break {*label}; \}`);
+        w.line("pos += 1;");
         return;
     }
     if let Repeat(rep) = elem {
@@ -1383,6 +1458,15 @@ fn gen_scan_element_assign(w: &mut CodeWriter, elem: &Element, ctx: &mut GenCont
         w.line(`pos = {fn_name}(tokens, pos);`);
         return;
     }
+    if let Wildcard = elem {
+        w.line("if pos >= tokens.len() || tokens[pos].kind == TK_EOF { pos = -1; } else { pos += 1; }");
+        return;
+    }
+    if let Not(ne) = elem {
+        let check = not_scan_check(&ne.element);
+        w.line(`if pos >= tokens.len() || tokens[pos].kind == TK_EOF || {check} \{ pos = -1; \} else \{ pos += 1; \}`);
+        return;
+    }
     if let Group(alts) = elem {
         gen_scan_group(w, alts, ctx);
         return;
@@ -1391,6 +1475,36 @@ fn gen_scan_element_assign(w: &mut CodeWriter, elem: &Element, ctx: &mut GenCont
         gen_scan_repeat(w, rep, ctx);
         return;
     }
+}
+
+/// Build a scan-time check expression for `~ X`. Returns "tokens[pos].kind == TK_X"
+/// or "(tokens[pos].kind == TK_A || tokens[pos].kind == TK_B)" for a set.
+fn not_scan_check(inner: &Element) -> String {
+    if let TokenRef(name) = inner {
+        let const_name = `TK_{name}`;
+        return `tokens[pos].kind == {const_name}`;
+    }
+    if let Literal(text) = inner {
+        let const_name = literal_const_name(text);
+        return `tokens[pos].kind == {const_name}`;
+    }
+    if let Group(alts) = inner {
+        let mut kinds: Array<String> = [];
+        if collect_not_set_tokens(alts, &mut kinds) {
+            let mut out = String::with_capacity(64);
+            out.push('(');
+            for let mut i = 0; i < kinds.len(); i += 1 {
+                if i > 0 {
+                    out.push_str(" || ");
+                }
+                out.push_str(`tokens[pos].kind == {kinds[i]}`);
+            }
+            out.push(')');
+            return out;
+        }
+    }
+    panic("not_scan_check: unsupported inner element for parser-side ~");
+    return "";
 }
 
 global mut SCAN_GROUP_COUNTER: i32 = 0;
@@ -1781,6 +1895,17 @@ fn gen_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, name_co
         w.line(`let {field_name} = {fn_name}(p)?;`);
         return;
     }
+    if let Wildcard = elem {
+        let field_name = dedup_name(&"wildcard", name_counts);
+        w.line(`let {field_name} = p.match_any()?;`);
+        return;
+    }
+    if let Not(ne) = elem {
+        let field_name = dedup_name(&not_element_field_name(&ne.element), name_counts);
+        let check = not_match_call(&ne.element);
+        w.line(`let {field_name} = {check}?;`);
+        return;
+    }
     if let Repeat(rep) = elem {
         gen_repeat(w, rep, ctx, name_counts);
         return;
@@ -1800,6 +1925,17 @@ fn gen_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, name_co
         return;
     }
     if let Label(lab) = elem {
+        if lab.list {
+            // Bare list label: allocate the array, parse the inner element
+            // once, and push. Repeats wrap this via gen_repeat below.
+            let inner_info = element_field_info(&lab.element, ctx);
+            let lab_name = dedup_name(&escape_ident(&to_snake_case(&lab.name)), name_counts);
+            w.line(`let mut {lab_name}: Array<{inner_info.1}> = [];`);
+            let mut nc: Array<[String, i32]> = [];
+            gen_element(w, &lab.element, ctx, &mut nc);
+            w.line(`{lab_name}.push({inner_info.0});`);
+            return;
+        }
         gen_element(w, &lab.element, ctx, name_counts);
         return;
     }
@@ -1809,6 +1945,42 @@ fn gen_repeat(w: &mut CodeWriter, rep: &RepeatElement, ctx: &mut GenContext, nam
     let inner = &rep.element;
     let mut visiting: Array<String> = [];
     let first = ctx.first_of_element(inner, &mut visiting);
+
+    // `(items+=item)*` / `items+=item+` / `items+=item?` — the list label
+    // already implies Array, so use the label name directly and push the
+    // inner element on each iteration.
+    if is_list_label(inner) {
+        if let Label(lab) = inner {
+            let inner_info = element_field_info(&lab.element, ctx);
+            let lab_name = dedup_name(&escape_ident(&to_snake_case(&lab.name)), name_counts);
+            w.line(`let mut {lab_name}: Array<{inner_info.1}> = [];`);
+            if let Star = rep.kind {
+                w.begin(`while {first_check_str(&first)}`);
+                let mut nc: Array<[String, i32]> = [];
+                gen_element(w, &lab.element, ctx, &mut nc);
+                w.line(`{lab_name}.push({inner_info.0});`);
+                w.end();
+            }
+            if let Plus = rep.kind {
+                let plus_flag = dedup_name(&"_plus_first", name_counts);
+                w.line(`let mut {plus_flag} = true;`);
+                w.begin(`while {plus_flag} || {first_check_str(&first)}`);
+                w.line(`{plus_flag} = false;`);
+                let mut nc: Array<[String, i32]> = [];
+                gen_element(w, &lab.element, ctx, &mut nc);
+                w.line(`{lab_name}.push({inner_info.0});`);
+                w.end();
+            }
+            if let Optional = rep.kind {
+                w.begin(`if {first_check_str(&first)}`);
+                let mut nc: Array<[String, i32]> = [];
+                gen_element(w, &lab.element, ctx, &mut nc);
+                w.line(`{lab_name}.push({inner_info.0});`);
+                w.end();
+            }
+            return;
+        }
+    }
 
     if has_field(inner) {
         // Save counter before element_field_info, which may increment it for
@@ -2355,6 +2527,19 @@ fn gen_element_failable(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext
         w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
         return;
     }
+    if let Wildcard = elem {
+        let r_var = dedup_name(&"opt_r", name_counts);
+        w.line(`let {r_var} = p.match_any();`);
+        w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
+        return;
+    }
+    if let Not(ne) = elem {
+        let r_var = dedup_name(&"opt_r", name_counts);
+        let call = not_match_call(&ne.element);
+        w.line(`let {r_var} = {call};`);
+        w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
+        return;
+    }
     if let Repeat(rep) = elem {
         gen_repeat(w, rep, ctx, name_counts);
         return;
@@ -2495,6 +2680,12 @@ fn gen_storable_optional_with_lookahead(w: &mut CodeWriter, inner: &Element, ctx
 fn gen_absent_optional_field(w: &mut CodeWriter, elem: &Element, name_counts: &mut Array<[String, i32]>, ctx: &mut GenContext) {
     if let Repeat(rep) = elem {
         if has_field(&rep.element) {
+            if is_list_label(&rep.element) {
+                let info = element_field_info(&rep.element, ctx);
+                let list_field = dedup_name(&info.0, name_counts);
+                w.line(`let mut {list_field}: {info.1} = [];`);
+                return;
+            }
             let info = element_field_info(&rep.element, ctx);
             if let Optional = rep.kind {
                 let opt_field = dedup_name(&info.0, name_counts);
@@ -2508,6 +2699,12 @@ fn gen_absent_optional_field(w: &mut CodeWriter, elem: &Element, name_counts: &m
         return;
     }
     if let Label(lab) = elem {
+        if lab.list {
+            let info = element_field_info(elem, ctx);
+            let list_field = dedup_name(&info.0, name_counts);
+            w.line(`let mut {list_field}: {info.1} = [];`);
+            return;
+        }
         gen_absent_optional_field(w, &lab.element, name_counts, ctx);
         return;
     }
@@ -2613,6 +2810,23 @@ fn gen_element_failable_named(w: &mut CodeWriter, elem: &Element, ctx: &mut GenC
         w.line(`let {field_name} = {r_var}.unwrap();`);
         return;
     }
+    if let Wildcard = elem {
+        let field_name = dedup_name(&"wildcard", name_counts);
+        let r_var = dedup_name(&"_bt_r", name_counts);
+        w.line(`let {r_var} = p.match_any();`);
+        w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
+        w.line(`let {field_name} = {r_var}.unwrap();`);
+        return;
+    }
+    if let Not(ne) = elem {
+        let field_name = dedup_name(&not_element_field_name(&ne.element), name_counts);
+        let r_var = dedup_name(&"_bt_r", name_counts);
+        let call = not_match_call(&ne.element);
+        w.line(`let {r_var} = {call};`);
+        w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
+        w.line(`let {field_name} = {r_var}.unwrap();`);
+        return;
+    }
     if let Repeat(rep) = elem {
         gen_repeat(w, rep, ctx, name_counts);
         return;
@@ -2637,6 +2851,53 @@ fn gen_element_failable_named(w: &mut CodeWriter, elem: &Element, ctx: &mut GenC
     }
 }
 
+/// Emit the Parser call expression for `~ X` (set complement). Returns a
+/// `Result<Token, ParseError>` at runtime.
+fn not_match_call(inner: &Element) -> String {
+    if let TokenRef(name) = inner {
+        let const_name = `TK_{name}`;
+        return `p.match_not(&[{const_name}])`;
+    }
+    if let Literal(text) = inner {
+        let const_name = literal_const_name(text);
+        return `p.match_not(&[{const_name}])`;
+    }
+    if let Group(alts) = inner {
+        let mut kinds: Array<String> = [];
+        if collect_not_set_tokens(alts, &mut kinds) {
+            let mut list = String::with_capacity(32);
+            for let mut i = 0; i < kinds.len(); i += 1 {
+                if i > 0 {
+                    list.push_str(", ");
+                }
+                list.push_str(kinds[i]);
+            }
+            return `p.match_not(&[{list}])`;
+        }
+    }
+    panic("not_match_call: unsupported inner element for parser-side ~");
+    return "";
+}
+
+/// Collect terminal token constants from a `~ ( ... )` group's alternatives.
+/// Returns false if any alternative is not a simple terminal (unsupported).
+fn collect_not_set_tokens(alts: &Array<Alternative>, out: &mut Array<String>) -> bool {
+    for let alt of alts {
+        if alt.elements.len() != 1 {
+            return false;
+        }
+        let e = &alt.elements[0];
+        if let TokenRef(name) = e {
+            out.push(`TK_{name}`);
+        } else if let Literal(text) = e {
+            out.push(literal_const_name(text));
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
+
 fn is_group_with_store(elem: &Element) -> bool {
     if let Group(alts) = elem {
         return is_storable_group(alts);
@@ -2648,6 +2909,12 @@ fn has_field(elem: &Element) -> bool {
     if let TokenRef(_) | Literal(_) | RuleRef(_) = elem {
         return true;
     }
+    if let Wildcard = elem {
+        return true;
+    }
+    if let Not(_) = elem {
+        return true;
+    }
     if let Label(lab) = elem {
         return has_field(&lab.element);
     }
@@ -2655,6 +2922,32 @@ fn has_field(elem: &Element) -> bool {
         return is_storable_group(alts);
     }
     return false;
+}
+
+/// Returns true if `elem` is a list-label (`items+=X`). List labels store
+/// matches in an `Array<InnerType>` named by `lab.name`.
+fn is_list_label(elem: &Element) -> bool {
+    if let Label(lab) = elem {
+        return lab.list;
+    }
+    return false;
+}
+
+/// For a list-label element, returns [label_field_name, array_type_str,
+/// inner_type_str, inner_field_name]. Returns null for non-list-labels.
+fn list_label_info(elem: &Element, ctx: &mut GenContext) -> Option<[String, String, String, String]> {
+    if let Label(lab) = elem {
+        if lab.list {
+            let inner = element_field_info(&lab.element, ctx);
+            return Option::<[String, String, String, String]>::Some([
+                escape_ident(&to_snake_case(&lab.name)),
+                `Array<{inner.1}>`,
+                inner.1,
+                inner.0,
+            ]);
+        }
+    }
+    return null;
 }
 
 fn element_field_info(elem: &Element, ctx: &mut GenContext) -> [String, String] {
@@ -2667,7 +2960,17 @@ fn element_field_info(elem: &Element, ctx: &mut GenContext) -> [String, String] 
     if let RuleRef(name) = elem {
         return [escape_ident(&to_snake_case(name)), rule_type_name(name)];
     }
+    if let Wildcard = elem {
+        return ["wildcard", "Token"];
+    }
+    if let Not(ne) = elem {
+        return [not_element_field_name(&ne.element), "Token"];
+    }
     if let Label(lab) = elem {
+        if lab.list {
+            let inner = element_field_info(&lab.element, ctx);
+            return [escape_ident(&to_snake_case(&lab.name)), `Array<{inner.1}>`];
+        }
         return element_field_info(&lab.element, ctx);
     }
     if let Group(alts) = elem {
@@ -2714,8 +3017,26 @@ fn gen_field_assignment(w: &mut CodeWriter, elem: &Element, name_counts: &mut Ar
         w.line(`{field_name},`);
         return;
     }
+    if let Wildcard = elem {
+        let field_name = dedup_name(&"wildcard", name_counts);
+        w.line(`{field_name},`);
+        return;
+    }
+    if let Not(ne) = elem {
+        let field_name = dedup_name(&not_element_field_name(&ne.element), name_counts);
+        w.line(`{field_name},`);
+        return;
+    }
     if let Repeat(rep) = elem {
         if has_field(&rep.element) {
+            // A list label inside a repeat still uses the label name directly
+            // (no `_list` suffix), because the label IS the array.
+            if is_list_label(&rep.element) {
+                let info = element_field_info(&rep.element, ctx);
+                let field_name = dedup_name(&info.0, name_counts);
+                w.line(`{field_name},`);
+                return;
+            }
             let info = element_field_info(&rep.element, ctx);
             if let Star | Plus = rep.kind {
                 let field_name = dedup_name(&`{info.0}_list`, name_counts);
@@ -2774,8 +3095,21 @@ fn replay_element_names(elem: &Element, name_counts: &mut Array<[String, i32]>, 
         dedup_name(&escape_ident(&to_snake_case(name)), name_counts);
         return;
     }
+    if let Wildcard = elem {
+        dedup_name(&"wildcard", name_counts);
+        return;
+    }
+    if let Not(ne) = elem {
+        dedup_name(&not_element_field_name(&ne.element), name_counts);
+        return;
+    }
     if let Repeat(rep) = elem {
         if has_field(&rep.element) {
+            if is_list_label(&rep.element) {
+                let info = element_field_info(&rep.element, ctx);
+                dedup_name(&info.0, name_counts);
+                return;
+            }
             let info = element_field_info(&rep.element, ctx);
             if let Star | Plus = rep.kind {
                 dedup_name(&`{info.0}_list`, name_counts);

--- a/package-gale/src/runtime.wado
+++ b/package-gale/src/runtime.wado
@@ -114,20 +114,27 @@ impl Eq for LexerSlice {
 
 /// Token represents a lexed token with its kind, text, and position.
 /// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
 pub struct Token {
     pub kind: i32,
     pub text: LexerSlice,
     pub span: Span,
     pub leading_trivia: Array<Token>,
+    pub channel: i32,
 }
 
 impl Token {
     pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
-        return Token { kind, text, span, leading_trivia: [] };
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
     }
 
     pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
-        return Token { kind, text, span, leading_trivia };
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
     }
 }
 

--- a/package-gale/tests/driver_antlr4_test.wado
+++ b/package-gale/tests/driver_antlr4_test.wado
@@ -5,6 +5,7 @@
 /// These tests verify tokenization, basic parsing, and that the generated
 /// parser compiles.
 use antlr4 from "./golden/antlr4.wado";
+use { TK_LINE_COMMENT, TK_BLOCK_COMMENT, TK_INT } from "./golden/antlr4.wado";
 
 test "tokenize grammar declaration" {
     let tokens = antlr4::tokenize(&"grammar Foo;");
@@ -65,4 +66,57 @@ test "parse minimal grammar" {
     // any input with identifiers fails to parse. Verify the error is sensible.
     let result = antlr4::parse(&"grammar Foo;");
     assert result matches { Err(_) }, "expected parse to fail due to missing semantic predicates";
+}
+
+// --- User-defined channel routing ---
+//
+// ANTLRv4Lexer declares `channels { OFF_CHANNEL, COMMENT }`, so DEFAULT=0,
+// HIDDEN=1, OFF_CHANNEL=2, COMMENT=3. DOC/BLOCK/LINE comments route to
+// channel(COMMENT), which is a non-HIDDEN user channel. The generated
+// lexer must: (a) keep those tokens out of the main stream, and (b) emit
+// them as trivia with `channel == 3`, not 0 or 1. This exercises the
+// generic `channel(X)` routing path, not just the HIDDEN shortcut.
+test "user channel: LINE_COMMENT routed to COMMENT channel" {
+    let tokens = antlr4::tokenize(&"// hi\n42");
+    // LINE_COMMENT must not appear in the main stream.
+    for let t of &tokens {
+        assert t.kind != TK_LINE_COMMENT,
+            "LINE_COMMENT leaked into main stream — channel routing dropped";
+    }
+    // The INT `42` must follow, carrying the LINE_COMMENT as trivia on
+    // channel 3 (the COMMENT channel).
+    let mut found = false;
+    for let t of &tokens {
+        if t.kind == TK_INT {
+            for let trivia of &t.leading_trivia {
+                if trivia.kind == TK_LINE_COMMENT {
+                    assert trivia.channel == 3,
+                        `expected COMMENT channel 3, got {trivia.channel}`;
+                    found = true;
+                }
+            }
+        }
+    }
+    assert found, "LINE_COMMENT trivia missing on INT token";
+}
+
+test "user channel: BLOCK_COMMENT routed to COMMENT channel" {
+    let tokens = antlr4::tokenize(&"/* hi */ 42");
+    for let t of &tokens {
+        assert t.kind != TK_BLOCK_COMMENT,
+            "BLOCK_COMMENT leaked into main stream";
+    }
+    let mut found = false;
+    for let t of &tokens {
+        if t.kind == TK_INT {
+            for let trivia of &t.leading_trivia {
+                if trivia.kind == TK_BLOCK_COMMENT {
+                    assert trivia.channel == 3,
+                        `expected COMMENT channel 3, got {trivia.channel}`;
+                    found = true;
+                }
+            }
+        }
+    }
+    assert found, "BLOCK_COMMENT trivia missing on INT token";
 }

--- a/package-gale/tests/driver_html_test.wado
+++ b/package-gale/tests/driver_html_test.wado
@@ -1,5 +1,6 @@
 use html from "./golden/html.wado";
 use { CstNode, CstChild, normalize_tree } from "./golden/html.wado";
+use { TK_TAG_WHITESPACE, TK_TAG_NAME } from "./golden/html.wado";
 
 fn assert_tree(input: &String, expected: &String) {
     let root = html::parse(input).unwrap();
@@ -118,4 +119,60 @@ test "tree: nested tags" {
           (htmlElements
             (htmlElement < p >)))
     ");
+}
+
+// --- HIDDEN channel routing ---
+//
+// HTMLLexer declares `TAG_WHITESPACE : [ \t\r\n] -> channel(HIDDEN)`. ANTLR4
+// routes HIDDEN tokens to a separate channel so the parser never sees them,
+// but they are NOT discarded — they remain available for downstream tools
+// (highlighters, formatters). Gale attaches them to the following token's
+// `leading_trivia` array with `channel == 1` (the predefined HIDDEN channel
+// id).
+//
+// This test exercises the full pipeline:
+//   1. Whitespace between the tag name and an attribute must NOT appear as
+//      its own entry in the `tokens` array.
+//   2. The whitespace must appear in the next token's `leading_trivia`.
+//   3. The trivia Token's `channel` field must be 1 (HIDDEN), not 0.
+test "HIDDEN channel: TAG_WHITESPACE routed to trivia" {
+    let tokens = html::tokenize(&"<p class=\"x\">");
+    // No main-channel token may have kind TAG_WHITESPACE — HIDDEN tokens
+    // are hidden from the parser.
+    for let t of &tokens {
+        assert t.kind != TK_TAG_WHITESPACE,
+            "TAG_WHITESPACE leaked into main token stream";
+    }
+    // After `<p` the next non-hidden token is the TAG_NAME `class`; the
+    // space between `p` and `class` must show up in its leading_trivia.
+    // (The first TAG_NAME is `p`; we want the second.)
+    let mut tag_name_count = 0;
+    let mut found_hidden_ws = false;
+    for let t of &tokens {
+        if t.kind == TK_TAG_NAME {
+            tag_name_count += 1;
+            if tag_name_count == 2 {
+                for let trivia of &t.leading_trivia {
+                    if trivia.kind == TK_TAG_WHITESPACE {
+                        assert trivia.channel == 1,
+                            `expected HIDDEN channel 1, got {trivia.channel}`;
+                        found_hidden_ws = true;
+                    }
+                }
+            }
+        }
+    }
+    assert tag_name_count >= 2, `expected >=2 TAG_NAME tokens, got {tag_name_count}`;
+    assert found_hidden_ws, "TAG_WHITESPACE trivia not found on second TAG_NAME token";
+}
+
+test "HIDDEN channel: parser accepts whitespace-separated attributes" {
+    // End-to-end: the parser must not see TAG_WHITESPACE at all, so
+    // `<img src="a" alt="b"/>` must parse successfully even though the
+    // whitespace between attributes would be a stray token without the
+    // HIDDEN routing.
+    let result = html::parse(&"<img src=\"a\" alt=\"b\"/>");
+    if let Err(e) = &result {
+        panic(`parse failed: {e.message}`);
+    }
 }

--- a/package-gale/tests/driver_sexpression_ast_test.wado
+++ b/package-gale/tests/driver_sexpression_ast_test.wado
@@ -7,7 +7,13 @@ use {
 } from "./golden/sexpression.wado";
 
 fn tok(kind: i32, text: String, start: i32, end: i32) -> Token {
-    return Token { kind, text: LexerSlice::from_string(text), span: Span { start, end }, leading_trivia: [] };
+    return Token {
+        kind,
+        text: LexerSlice::from_string(text),
+        span: Span { start, end },
+        leading_trivia: [],
+        channel: 0,
+    };
 }
 
 fn s(start: i32, end: i32) -> Span {

--- a/package-gale/tests/driver_typescript_test.wado
+++ b/package-gale/tests/driver_typescript_test.wado
@@ -5,6 +5,10 @@
 /// verify tokenization of various TypeScript constructs.
 use ts from "./golden/typescript.wado";
 use { normalize_tree } from "./golden/typescript.wado";
+use {
+    TK_BackTick, TK_BackTickInside, TK_TemplateStringAtom,
+    TK_WhiteSpaces, TK_Let,
+} from "./golden/typescript.wado";
 
 fn assert_tree(input: &String, expected: &String) {
     let root = ts::parse(input).unwrap();
@@ -347,4 +351,62 @@ test "tree: simple ternary" {
             :
             (singleExpression (literal (numericLiteral 3)))))
     ");
+}
+
+// --- Lexer command regression tests ---
+//
+// These exercise code paths that used to be silently dropped by the IR and
+// are now wired through the lexer generator: `type(X)` kind override,
+// `channel(HIDDEN)` routing, and the TEMPLATE-mode `pushMode` / `popMode`
+// that surrounds the type override.
+
+test "type override: BackTickInside rewrites kind to BackTick" {
+    // TypeScriptLexer declares:
+    //   BackTick:       '`' -> pushMode(TEMPLATE);
+    //   BackTickInside: '`' -> type(BackTick), popMode;
+    //
+    // Both the opening and closing backticks must be emitted with kind
+    // BackTick. The raw BackTickInside kind must NEVER appear in the
+    // token stream; if it did, the closing backtick would be classified
+    // as a separate token kind and the parser would see an inconsistent
+    // pair of open/close delimiters.
+    let tokens = ts::tokenize(&"`hi`");
+    let mut backtick_count = 0;
+    for let t of &tokens {
+        assert t.kind != TK_BackTickInside,
+            "BackTickInside leaked into stream — type(BackTick) override dropped";
+        if t.kind == TK_BackTick {
+            backtick_count += 1;
+        }
+    }
+    assert backtick_count == 2,
+        `expected 2 BackTick tokens (open + close), got {backtick_count}`;
+}
+
+test "HIDDEN channel: TypeScript WhiteSpaces routed to trivia" {
+    // TypeScriptLexer routes `WhiteSpaces` through HIDDEN. The token stream
+    // must contain `let` and `x` as adjacent main-channel tokens, with the
+    // space carried as trivia on `x`. The `x` becomes an Identifier token
+    // after keyword classification; we locate it by position (second
+    // non-EOF main-channel token).
+    let tokens = ts::tokenize(&"let x");
+    for let t of &tokens {
+        assert t.kind != TK_WhiteSpaces,
+            "WhiteSpaces leaked into main stream — HIDDEN routing dropped";
+    }
+    // `let` must be the first main-channel token.
+    assert tokens[0].kind == TK_Let,
+        `expected first token = Let, got kind {tokens[0].kind}`;
+    // The second token (the `x` identifier) must carry the HIDDEN
+    // whitespace as leading trivia on channel 1.
+    let mut found_hidden = false;
+    for let trivia of &tokens[1].leading_trivia {
+        if trivia.kind == TK_WhiteSpaces {
+            assert trivia.channel == 1,
+                `expected HIDDEN channel 1, got {trivia.channel}`;
+            found_hidden = true;
+        }
+    }
+    assert found_hidden,
+        "WhiteSpaces trivia missing from token following `let`";
 }

--- a/package-gale/tests/golden/antlr4.wado
+++ b/package-gale/tests/golden/antlr4.wado
@@ -117,20 +117,27 @@ impl Eq for LexerSlice {
 
 /// Token represents a lexed token with its kind, text, and position.
 /// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
 pub struct Token {
     pub kind: i32,
     pub text: LexerSlice,
     pub span: Span,
     pub leading_trivia: Array<Token>,
+    pub channel: i32,
 }
 
 impl Token {
     pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
-        return Token { kind, text, span, leading_trivia: [] };
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
     }
 
     pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
-        return Token { kind, text, span, leading_trivia };
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
     }
 }
 
@@ -3453,6 +3460,7 @@ pub fn tokenize(input: &String) -> Array<Token> {
     let mut lexer = Lexer::new(input);
     let mut tokens: Array<Token> = [];
     let mut trivia: Array<Token> = [];
+    let mut more_start: i32 = -1;
     let mut mode_stack: Array<i32> = [];
     let mut current_mode: i32 = 0;
     while !lexer.at_end() {
@@ -3463,127 +3471,129 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let first_char = lexer.chars[start];
         let mut best_push_mode: i32 = -1;
         let mut best_pop_mode = false;
+        let mut best_more = false;
+        let mut best_channel: i32 = 0;
         if current_mode == 0 {
             end = try_doc_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DOC_COMMENT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_DOC_COMMENT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 3; }
             end = try_block_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 3; }
             end = try_line_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LINE_COMMENT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LINE_COMMENT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 3; }
             end = try_int(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_INT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_unterminated_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNTERMINATED_STRING_LITERAL; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_UNTERMINATED_STRING_LITERAL; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_begin_argument(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BEGIN_ARGUMENT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_BEGIN_ARGUMENT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_action(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ACTION; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_ACTION; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_options(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OPTIONS; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_OPTIONS; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_tokens(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TOKENS; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_TOKENS; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_channels(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CHANNELS; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_CHANNELS; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_import(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IMPORT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_IMPORT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_fragment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FRAGMENT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_FRAGMENT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_lexer(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LEXER; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LEXER; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_parser(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PARSER; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_PARSER; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_grammar(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_GRAMMAR; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_GRAMMAR; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_protected(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PROTECTED; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_PROTECTED; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_public(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PUBLIC; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_PUBLIC; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_private(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PRIVATE; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_PRIVATE; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_returns(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RETURNS; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_RETURNS; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_locals(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LOCALS; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LOCALS; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_throws(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_THROWS; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_THROWS; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_catch(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CATCH; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_CATCH; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_finally(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FINALLY; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_FINALLY; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_mode(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MODE; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_MODE; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_colon(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_COLON; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_COLON; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_coloncolon(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_COLONCOLON; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_COLONCOLON; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_COMMA; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_COMMA; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_semi(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SEMI; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_SEMI; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_lparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LPAREN; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LPAREN; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_rparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RPAREN; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_RPAREN; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_rbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RBRACE; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_RBRACE; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_rarrow(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RARROW; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_RARROW; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_lt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_gt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_GT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_GT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_assign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ASSIGN; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_ASSIGN; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_question(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_QUESTION; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_QUESTION; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_star(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STAR; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_STAR; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_plus_assign(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PLUS_ASSIGN; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_PLUS_ASSIGN; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_plus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PLUS; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_PLUS; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_or(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OR; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_OR; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_dollar(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DOLLAR; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_DOLLAR; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_range(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RANGE; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_RANGE; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_dot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DOT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_DOT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_at(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_AT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_AT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_pound(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_POUND; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_POUND; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_not(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NOT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_NOT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_id(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ID; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_ID; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_ws(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_WS; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_WS; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 2; }
         } else if current_mode == 1 {
             end = try_nested_argument(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NESTED_ARGUMENT; best_push_mode = 1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_ARGUMENT_CONTENT; best_push_mode = 1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_argument_escape(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ARGUMENT_ESCAPE; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_ARGUMENT_CONTENT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_argument_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ARGUMENT_STRING_LITERAL; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_ARGUMENT_CONTENT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_argument_char_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ARGUMENT_CHAR_LITERAL; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_ARGUMENT_CONTENT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_end_argument(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_END_ARGUMENT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_END_ARGUMENT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
             end = try_unterminated_argument(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNTERMINATED_ARGUMENT; best_push_mode = -1; best_pop_mode = true; }
+            if end > best_end { best_end = end; best_kind = TK_UNTERMINATED_ARGUMENT; best_push_mode = -1; best_pop_mode = true; best_more = false; best_channel = 0; }
             end = try_argument_content(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ARGUMENT_CONTENT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_ARGUMENT_CONTENT; best_push_mode = -1; best_pop_mode = false; best_more = false; best_channel = 0; }
         } else if current_mode == 2 {
             end = try_lexer_char_set_body(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LEXER_CHAR_SET_BODY; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LEXER_CHAR_SET_BODY; best_push_mode = -1; best_pop_mode = false; best_more = true; best_channel = 0; }
             end = try_lexer_char_set(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LEXER_CHAR_SET; best_push_mode = -1; best_pop_mode = true; }
+            if end > best_end { best_end = end; best_kind = TK_LEXER_CHAR_SET; best_push_mode = -1; best_pop_mode = true; best_more = false; best_channel = 0; }
             end = try_unterminated_char_set(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNTERMINATED_CHAR_SET; best_push_mode = -1; best_pop_mode = true; }
+            if end > best_end { best_end = end; best_kind = TK_UNTERMINATED_CHAR_SET; best_push_mode = -1; best_pop_mode = true; best_more = false; best_channel = 0; }
         }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
@@ -3591,13 +3601,21 @@ pub fn tokenize(input: &String) -> Array<Token> {
             trivia = [];
             lexer.pos = start + 1;
         } else {
+            let tok_start = if more_start >= 0 { more_start } else { start };
             let is_skip = false;
-            if is_skip {
-                trivia.push(Token::new(best_kind, lexer.slice(start, best_end), Span::new(start, best_end)));
+            if best_more {
+                if more_start < 0 { more_start = start; }
+            } else if is_skip {
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+                more_start = -1;
+            } else if best_channel != 0 {
+                trivia.push(Token::with_channel(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), [], best_channel));
+                more_start = -1;
             } else {
-                let tok = Token::with_trivia(best_kind, lexer.slice(start, best_end), Span::new(start, best_end), trivia);
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
                 tokens.push(tok);
                 trivia = [];
+                more_start = -1;
             }
             if best_push_mode >= 0 {
                 mode_stack.push(current_mode);
@@ -3762,6 +3780,40 @@ impl Parser {
             `expected {name}, got "{tok.text}"`,
             tok.span,
             [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if *x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
         ));
     }
 }

--- a/package-gale/tests/golden/calculator.wado
+++ b/package-gale/tests/golden/calculator.wado
@@ -117,20 +117,27 @@ impl Eq for LexerSlice {
 
 /// Token represents a lexed token with its kind, text, and position.
 /// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
 pub struct Token {
     pub kind: i32,
     pub text: LexerSlice,
     pub span: Span,
     pub leading_trivia: Array<Token>,
+    pub channel: i32,
 }
 
 impl Token {
     pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
-        return Token { kind, text, span, leading_trivia: [] };
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
     }
 
     pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
-        return Token { kind, text, span, leading_trivia };
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
     }
 }
 
@@ -1302,11 +1309,12 @@ pub fn tokenize(input: &String) -> Array<Token> {
             trivia = [];
             lexer.pos = start + 1;
         } else {
+            let tok_start = start;
             let is_skip = best_kind matches { TK_WS };
             if is_skip {
-                trivia.push(Token::new(best_kind, lexer.slice(start, best_end), Span::new(start, best_end)));
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
             } else {
-                let tok = Token::with_trivia(best_kind, lexer.slice(start, best_end), Span::new(start, best_end), trivia);
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
                 tokens.push(tok);
                 trivia = [];
             }
@@ -1406,6 +1414,40 @@ impl Parser {
             `expected {name}, got "{tok.text}"`,
             tok.span,
             [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if *x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
         ));
     }
 }

--- a/package-gale/tests/golden/css3.wado
+++ b/package-gale/tests/golden/css3.wado
@@ -117,20 +117,27 @@ impl Eq for LexerSlice {
 
 /// Token represents a lexed token with its kind, text, and position.
 /// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
 pub struct Token {
     pub kind: i32,
     pub text: LexerSlice,
     pub span: Span,
     pub leading_trivia: Array<Token>,
+    pub channel: i32,
 }
 
 impl Token {
     pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
-        return Token { kind, text, span, leading_trivia: [] };
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
     }
 
     pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
-        return Token { kind, text, span, leading_trivia };
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
     }
 }
 
@@ -28482,652 +28489,653 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
         let first_char = lexer.chars[start];
+        let mut best_channel: i32 = 0;
         if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
             end = try_space(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Space; }
+            if end > best_end { best_end = end; best_kind = TK_Space; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '!' {
             end = try_important(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Important; }
+            if end > best_end { best_end = end; best_kind = TK_Important; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '"' || first_char == '\'' {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_string_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_String_; }
+            if end > best_end { best_end = end; best_kind = TK_String_; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '#' {
             end = try_hash(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Hash; }
+            if end > best_end { best_end = end; best_kind = TK_Hash; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '$' {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_suffixmatch(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SuffixMatch; }
+            if end > best_end { best_end = end; best_kind = TK_SuffixMatch; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '(' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LPAREN; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LPAREN; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == ')' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RPAREN; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RPAREN; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '*' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_substringmatch(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SubstringMatch; }
+            if end > best_end { best_end = end; best_kind = TK_SubstringMatch; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '+' {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_plus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Plus; }
+            if end > best_end { best_end = end; best_kind = TK_Plus; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == ',' {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Comma; }
+            if end > best_end { best_end = end; best_kind = TK_Comma; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '-' {
             end = try_cdc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Cdc; }
+            if end > best_end { best_end = end; best_kind = TK_Cdc; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_minus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Minus; }
+            if end > best_end { best_end = end; best_kind = TK_Minus; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_variable(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Variable; }
+            if end > best_end { best_end = end; best_kind = TK_Variable; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '.' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_DOT; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_DOT; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '/' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SLASH; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SLASH; best_channel = 0; }
             end = try_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Comment; }
+            if end > best_end { best_end = end; best_kind = TK_Comment; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == ':' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COLON; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COLON; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_pseudonot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PseudoNot; }
+            if end > best_end { best_end = end; best_kind = TK_PseudoNot; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == ';' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SEMI; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SEMI; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '<' {
             end = try_cdo(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Cdo; }
+            if end > best_end { best_end = end; best_kind = TK_Cdo; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '=' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_EQ; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_EQ; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '>' {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_greater(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Greater; }
+            if end > best_end { best_end = end; best_kind = TK_Greater; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '@' {
             end = try_import(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Import; }
+            if end > best_end { best_end = end; best_kind = TK_Import; best_channel = 0; }
             end = try_page(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Page; }
+            if end > best_end { best_end = end; best_kind = TK_Page; best_channel = 0; }
             end = try_media(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Media; }
+            if end > best_end { best_end = end; best_kind = TK_Media; best_channel = 0; }
             end = try_namespace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Namespace; }
+            if end > best_end { best_end = end; best_kind = TK_Namespace; best_channel = 0; }
             end = try_charset(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Charset; }
+            if end > best_end { best_end = end; best_kind = TK_Charset; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_fontface(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FontFace; }
+            if end > best_end { best_end = end; best_kind = TK_FontFace; best_channel = 0; }
             end = try_supports(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Supports; }
+            if end > best_end { best_end = end; best_kind = TK_Supports; best_channel = 0; }
             end = try_keyframes(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Keyframes; }
+            if end > best_end { best_end = end; best_kind = TK_Keyframes; best_channel = 0; }
             end = try_viewport(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Viewport; }
+            if end > best_end { best_end = end; best_kind = TK_Viewport; best_channel = 0; }
             end = try_counterstyle(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CounterStyle; }
+            if end > best_end { best_end = end; best_kind = TK_CounterStyle; best_channel = 0; }
             end = try_fontfeaturevalues(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FontFeatureValues; }
+            if end > best_end { best_end = end; best_kind = TK_FontFeatureValues; best_channel = 0; }
             end = try_atkeyword(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_AtKeyword; }
+            if end > best_end { best_end = end; best_kind = TK_AtKeyword; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == 'A' || first_char == 'a' {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_and(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_And; }
+            if end > best_end { best_end = end; best_kind = TK_And; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == 'F' {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_from(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_From; }
+            if end > best_end { best_end = end; best_kind = TK_From; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == 'N' || first_char == 'n' {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_not(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Not; }
+            if end > best_end { best_end = end; best_kind = TK_Not; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == 'O' || first_char == 'o' {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_mediaonly(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MediaOnly; }
+            if end > best_end { best_end = end; best_kind = TK_MediaOnly; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_or(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Or; }
+            if end > best_end { best_end = end; best_kind = TK_Or; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == 'T' || first_char == 't' {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_to(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_To; }
+            if end > best_end { best_end = end; best_kind = TK_To; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == 'U' {
             end = try_url(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Url; }
+            if end > best_end { best_end = end; best_kind = TK_Url; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_unicoderange(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnicodeRange; }
+            if end > best_end { best_end = end; best_kind = TK_UnicodeRange; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '[' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LBRACKET; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LBRACKET; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '\\' {
             end = try_url(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Url; }
+            if end > best_end { best_end = end; best_kind = TK_Url; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_mediaonly(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MediaOnly; }
+            if end > best_end { best_end = end; best_kind = TK_MediaOnly; best_channel = 0; }
             end = try_not(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Not; }
+            if end > best_end { best_end = end; best_kind = TK_Not; best_channel = 0; }
             end = try_and(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_And; }
+            if end > best_end { best_end = end; best_kind = TK_And; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_or(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Or; }
+            if end > best_end { best_end = end; best_kind = TK_Or; best_channel = 0; }
             end = try_from(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_From; }
+            if end > best_end { best_end = end; best_kind = TK_From; best_channel = 0; }
             end = try_to(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_To; }
+            if end > best_end { best_end = end; best_kind = TK_To; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == ']' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RBRACKET; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RBRACKET; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '^' {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_prefixmatch(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PrefixMatch; }
+            if end > best_end { best_end = end; best_kind = TK_PrefixMatch; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '_' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT__; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT__; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == 'c' {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_calc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Calc; }
+            if end > best_end { best_end = end; best_kind = TK_Calc; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == 'f' {
             end = try_space(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Space; }
+            if end > best_end { best_end = end; best_kind = TK_Space; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_from(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_From; }
+            if end > best_end { best_end = end; best_kind = TK_From; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == 'p' {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_dximagetransform(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DxImageTransform; }
+            if end > best_end { best_end = end; best_kind = TK_DxImageTransform; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == 'u' {
             end = try_url(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Url; }
+            if end > best_end { best_end = end; best_kind = TK_Url; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_url_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Url_; }
+            if end > best_end { best_end = end; best_kind = TK_Url_; best_channel = 0; }
             end = try_unicoderange(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnicodeRange; }
+            if end > best_end { best_end = end; best_kind = TK_UnicodeRange; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == 'v' {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_var(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Var; }
+            if end > best_end { best_end = end; best_kind = TK_Var; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '{' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LBRACE; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LBRACE; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '|' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PIPE; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PIPE; best_channel = 0; }
             end = try_dashmatch(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DashMatch; }
+            if end > best_end { best_end = end; best_kind = TK_DashMatch; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_unicoderange(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnicodeRange; }
+            if end > best_end { best_end = end; best_kind = TK_UnicodeRange; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '}' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RBRACE; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RBRACE; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else if first_char == '~' {
             end = try_includes(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Includes; }
+            if end > best_end { best_end = end; best_kind = TK_Includes; best_channel = 0; }
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_tilde(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Tilde; }
+            if end > best_end { best_end = end; best_kind = TK_Tilde; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
         } else {
             end = try_percentage(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Percentage; }
+            if end > best_end { best_end = end; best_kind = TK_Percentage; best_channel = 0; }
             end = try_dimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Dimension; }
+            if end > best_end { best_end = end; best_kind = TK_Dimension; best_channel = 0; }
             end = try_unknowndimension(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; }
+            if end > best_end { best_end = end; best_kind = TK_UnknownDimension; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_channel = 0; }
             end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Ident; }
+            if end > best_end { best_end = end; best_kind = TK_Ident; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_channel = 0; }
             end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; }
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; best_channel = 2; }
         }
         if best_end > start {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
@@ -29139,11 +29147,14 @@ pub fn tokenize(input: &String) -> Array<Token> {
             trivia = [];
             lexer.pos = start + 1;
         } else {
+            let tok_start = start;
             let is_skip = false;
             if is_skip {
-                trivia.push(Token::new(best_kind, lexer.slice(start, best_end), Span::new(start, best_end)));
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else if best_channel != 0 {
+                trivia.push(Token::with_channel(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), [], best_channel));
             } else {
-                let tok = Token::with_trivia(best_kind, lexer.slice(start, best_end), Span::new(start, best_end), trivia);
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
                 tokens.push(tok);
                 trivia = [];
             }
@@ -29294,6 +29305,40 @@ impl Parser {
             `expected {name}, got "{tok.text}"`,
             tok.span,
             [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if *x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
         ));
     }
 }

--- a/package-gale/tests/golden/html.wado
+++ b/package-gale/tests/golden/html.wado
@@ -117,20 +117,27 @@ impl Eq for LexerSlice {
 
 /// Token represents a lexed token with its kind, text, and position.
 /// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
 pub struct Token {
     pub kind: i32,
     pub text: LexerSlice,
     pub span: Span,
     pub leading_trivia: Array<Token>,
+    pub channel: i32,
 }
 
 impl Token {
     pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
-        return Token { kind, text, span, leading_trivia: [] };
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
     }
 
     pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
-        return Token { kind, text, span, leading_trivia };
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
     }
 }
 
@@ -1799,57 +1806,58 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let first_char = lexer.chars[start];
         let mut best_push_mode: i32 = -1;
         let mut best_pop_mode = false;
+        let mut best_channel: i32 = 0;
         if current_mode == 0 {
             end = try_html_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_HTML_COMMENT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_HTML_COMMENT; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_html_conditional_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_HTML_CONDITIONAL_COMMENT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_HTML_CONDITIONAL_COMMENT; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_xml(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_XML; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_XML; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_cdata(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CDATA; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_CDATA; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_dtd(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DTD; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_DTD; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_scriptlet(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SCRIPTLET; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_SCRIPTLET; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_sea_ws(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SEA_WS; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_SEA_WS; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_script_open(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SCRIPT_OPEN; best_push_mode = 1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_SCRIPT_OPEN; best_push_mode = 1; best_pop_mode = false; best_channel = 0; }
             end = try_style_open(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STYLE_OPEN; best_push_mode = 2; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_STYLE_OPEN; best_push_mode = 2; best_pop_mode = false; best_channel = 0; }
             end = try_tag_open(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TAG_OPEN; best_push_mode = 3; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_TAG_OPEN; best_push_mode = 3; best_pop_mode = false; best_channel = 0; }
             end = try_html_text(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_HTML_TEXT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_HTML_TEXT; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
         } else if current_mode == 1 {
             end = try_script_body(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SCRIPT_BODY; best_push_mode = -1; best_pop_mode = true; }
+            if end > best_end { best_end = end; best_kind = TK_SCRIPT_BODY; best_push_mode = -1; best_pop_mode = true; best_channel = 0; }
             end = try_script_short_body(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SCRIPT_SHORT_BODY; best_push_mode = -1; best_pop_mode = true; }
+            if end > best_end { best_end = end; best_kind = TK_SCRIPT_SHORT_BODY; best_push_mode = -1; best_pop_mode = true; best_channel = 0; }
         } else if current_mode == 2 {
             end = try_style_body(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STYLE_BODY; best_push_mode = -1; best_pop_mode = true; }
+            if end > best_end { best_end = end; best_kind = TK_STYLE_BODY; best_push_mode = -1; best_pop_mode = true; best_channel = 0; }
             end = try_style_short_body(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STYLE_SHORT_BODY; best_push_mode = -1; best_pop_mode = true; }
+            if end > best_end { best_end = end; best_kind = TK_STYLE_SHORT_BODY; best_push_mode = -1; best_pop_mode = true; best_channel = 0; }
         } else if current_mode == 3 {
             end = try_tag_close(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TAG_CLOSE; best_push_mode = -1; best_pop_mode = true; }
+            if end > best_end { best_end = end; best_kind = TK_TAG_CLOSE; best_push_mode = -1; best_pop_mode = true; best_channel = 0; }
             end = try_tag_slash_close(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TAG_SLASH_CLOSE; best_push_mode = -1; best_pop_mode = true; }
+            if end > best_end { best_end = end; best_kind = TK_TAG_SLASH_CLOSE; best_push_mode = -1; best_pop_mode = true; best_channel = 0; }
             end = try_tag_slash(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TAG_SLASH; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_TAG_SLASH; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_tag_equals(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TAG_EQUALS; best_push_mode = 4; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_TAG_EQUALS; best_push_mode = 4; best_pop_mode = false; best_channel = 0; }
             end = try_tag_name(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TAG_NAME; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_TAG_NAME; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_tag_whitespace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TAG_WHITESPACE; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_TAG_WHITESPACE; best_push_mode = -1; best_pop_mode = false; best_channel = 1; }
         } else if current_mode == 4 {
             end = try_attvalue_value(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ATTVALUE_VALUE; best_push_mode = -1; best_pop_mode = true; }
+            if end > best_end { best_end = end; best_kind = TK_ATTVALUE_VALUE; best_push_mode = -1; best_pop_mode = true; best_channel = 0; }
             end = try_attribute(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ATTRIBUTE; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_ATTRIBUTE; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
         }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
@@ -1857,11 +1865,14 @@ pub fn tokenize(input: &String) -> Array<Token> {
             trivia = [];
             lexer.pos = start + 1;
         } else {
-            let is_skip = best_kind matches { TK_TAG_WHITESPACE };
+            let tok_start = start;
+            let is_skip = false;
             if is_skip {
-                trivia.push(Token::new(best_kind, lexer.slice(start, best_end), Span::new(start, best_end)));
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else if best_channel != 0 {
+                trivia.push(Token::with_channel(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), [], best_channel));
             } else {
-                let tok = Token::with_trivia(best_kind, lexer.slice(start, best_end), Span::new(start, best_end), trivia);
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
                 tokens.push(tok);
                 trivia = [];
             }
@@ -1971,6 +1982,40 @@ impl Parser {
             `expected {name}, got "{tok.text}"`,
             tok.span,
             [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if *x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
         ));
     }
 }

--- a/package-gale/tests/golden/json.wado
+++ b/package-gale/tests/golden/json.wado
@@ -117,20 +117,27 @@ impl Eq for LexerSlice {
 
 /// Token represents a lexed token with its kind, text, and position.
 /// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
 pub struct Token {
     pub kind: i32,
     pub text: LexerSlice,
     pub span: Span,
     pub leading_trivia: Array<Token>,
+    pub channel: i32,
 }
 
 impl Token {
     pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
-        return Token { kind, text, span, leading_trivia: [] };
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
     }
 
     pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
-        return Token { kind, text, span, leading_trivia };
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
     }
 }
 
@@ -923,11 +930,12 @@ pub fn tokenize(input: &String) -> Array<Token> {
             trivia = [];
             lexer.pos = start + 1;
         } else {
+            let tok_start = start;
             let is_skip = best_kind matches { TK_WS };
             if is_skip {
-                trivia.push(Token::new(best_kind, lexer.slice(start, best_end), Span::new(start, best_end)));
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
             } else {
-                let tok = Token::with_trivia(best_kind, lexer.slice(start, best_end), Span::new(start, best_end), trivia);
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
                 tokens.push(tok);
                 trivia = [];
             }
@@ -1012,6 +1020,40 @@ impl Parser {
             `expected {name}, got "{tok.text}"`,
             tok.span,
             [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if *x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
         ));
     }
 }

--- a/package-gale/tests/golden/json_highlight.wado
+++ b/package-gale/tests/golden/json_highlight.wado
@@ -117,20 +117,27 @@ impl Eq for LexerSlice {
 
 /// Token represents a lexed token with its kind, text, and position.
 /// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
 pub struct Token {
     pub kind: i32,
     pub text: LexerSlice,
     pub span: Span,
     pub leading_trivia: Array<Token>,
+    pub channel: i32,
 }
 
 impl Token {
     pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
-        return Token { kind, text, span, leading_trivia: [] };
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
     }
 
     pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
-        return Token { kind, text, span, leading_trivia };
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
     }
 }
 
@@ -923,11 +930,12 @@ pub fn tokenize(input: &String) -> Array<Token> {
             trivia = [];
             lexer.pos = start + 1;
         } else {
+            let tok_start = start;
             let is_skip = best_kind matches { TK_WS };
             if is_skip {
-                trivia.push(Token::new(best_kind, lexer.slice(start, best_end), Span::new(start, best_end)));
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
             } else {
-                let tok = Token::with_trivia(best_kind, lexer.slice(start, best_end), Span::new(start, best_end), trivia);
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
                 tokens.push(tok);
                 trivia = [];
             }
@@ -1012,6 +1020,40 @@ impl Parser {
             `expected {name}, got "{tok.text}"`,
             tok.span,
             [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if *x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
         ));
     }
 }

--- a/package-gale/tests/golden/rust.wado
+++ b/package-gale/tests/golden/rust.wado
@@ -117,20 +117,27 @@ impl Eq for LexerSlice {
 
 /// Token represents a lexed token with its kind, text, and position.
 /// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
 pub struct Token {
     pub kind: i32,
     pub text: LexerSlice,
     pub span: Span,
     pub leading_trivia: Array<Token>,
+    pub channel: i32,
 }
 
 impl Token {
     pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
-        return Token { kind, text, span, leading_trivia: [] };
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
     }
 
     pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
-        return Token { kind, text, span, leading_trivia };
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
     }
 }
 
@@ -7739,988 +7746,989 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
         let first_char = lexer.chars[start];
+        let mut best_channel: i32 = 0;
         if first_char == '\n' || first_char == '\r' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_newline(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NEWLINE; }
+            if end > best_end { best_end = end; best_kind = TK_NEWLINE; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == ' ' || first_char == '\u{a0}' || first_char == '\u{1680}' || first_char == '\u{202f}' || first_char == '\u{205f}' || first_char == '\u{3000}' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_whitespace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
+            if end > best_end { best_end = end; best_kind = TK_WHITESPACE; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == '!' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_not(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NOT; }
+            if end > best_end { best_end = end; best_kind = TK_NOT; best_channel = 0; }
             end = try_ne(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NE; }
+            if end > best_end { best_end = end; best_kind = TK_NE; best_channel = 0; }
         } else if first_char == '"' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; best_channel = 0; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == '#' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_pound(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_POUND; }
+            if end > best_end { best_end = end; best_kind = TK_POUND; best_channel = 0; }
         } else if first_char == '$' {
             end = try_kw_dollarcrate(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_DOLLARCRATE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_DOLLARCRATE; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_dollar(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DOLLAR; }
+            if end > best_end { best_end = end; best_kind = TK_DOLLAR; best_channel = 0; }
         } else if first_char == '%' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_percent(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PERCENT; }
+            if end > best_end { best_end = end; best_kind = TK_PERCENT; best_channel = 0; }
             end = try_percenteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PERCENTEQ; }
+            if end > best_end { best_end = end; best_kind = TK_PERCENTEQ; best_channel = 0; }
         } else if first_char == '&' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_and(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_AND; }
+            if end > best_end { best_end = end; best_kind = TK_AND; best_channel = 0; }
             end = try_andand(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ANDAND; }
+            if end > best_end { best_end = end; best_kind = TK_ANDAND; best_channel = 0; }
             end = try_andeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ANDEQ; }
+            if end > best_end { best_end = end; best_kind = TK_ANDEQ; best_channel = 0; }
         } else if first_char == '\'' {
             end = try_kw_staticlifetime(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_STATICLIFETIME; }
+            if end > best_end { best_end = end; best_kind = TK_KW_STATICLIFETIME; best_channel = 0; }
             end = try_kw_underlinelifetime(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_UNDERLINELIFETIME; }
+            if end > best_end { best_end = end; best_kind = TK_KW_UNDERLINELIFETIME; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_char_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CHAR_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_CHAR_LITERAL; best_channel = 0; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_lifetime_or_label(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIFETIME_OR_LABEL; }
+            if end > best_end { best_end = end; best_kind = TK_LIFETIME_OR_LABEL; best_channel = 0; }
         } else if first_char == '(' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_lparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LPAREN; }
+            if end > best_end { best_end = end; best_kind = TK_LPAREN; best_channel = 0; }
         } else if first_char == ')' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_rparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RPAREN; }
+            if end > best_end { best_end = end; best_kind = TK_RPAREN; best_channel = 0; }
         } else if first_char == '*' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_star(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STAR; }
+            if end > best_end { best_end = end; best_kind = TK_STAR; best_channel = 0; }
             end = try_stareq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STAREQ; }
+            if end > best_end { best_end = end; best_kind = TK_STAREQ; best_channel = 0; }
         } else if first_char == '+' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_plus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PLUS; }
+            if end > best_end { best_end = end; best_kind = TK_PLUS; best_channel = 0; }
             end = try_pluseq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PLUSEQ; }
+            if end > best_end { best_end = end; best_kind = TK_PLUSEQ; best_channel = 0; }
         } else if first_char == ',' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_COMMA; }
+            if end > best_end { best_end = end; best_kind = TK_COMMA; best_channel = 0; }
         } else if first_char == '-' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_minus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MINUS; }
+            if end > best_end { best_end = end; best_kind = TK_MINUS; best_channel = 0; }
             end = try_minuseq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MINUSEQ; }
+            if end > best_end { best_end = end; best_kind = TK_MINUSEQ; best_channel = 0; }
             end = try_rarrow(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RARROW; }
+            if end > best_end { best_end = end; best_kind = TK_RARROW; best_channel = 0; }
         } else if first_char == '.' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_dot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DOT; }
+            if end > best_end { best_end = end; best_kind = TK_DOT; best_channel = 0; }
             end = try_dotdot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DOTDOT; }
+            if end > best_end { best_end = end; best_kind = TK_DOTDOT; best_channel = 0; }
             end = try_dotdotdot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DOTDOTDOT; }
+            if end > best_end { best_end = end; best_kind = TK_DOTDOTDOT; best_channel = 0; }
             end = try_dotdoteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DOTDOTEQ; }
+            if end > best_end { best_end = end; best_kind = TK_DOTDOTEQ; best_channel = 0; }
         } else if first_char == '/' {
             end = try_line_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LINE_COMMENT; }
+            if end > best_end { best_end = end; best_kind = TK_LINE_COMMENT; best_channel = 1; }
             end = try_block_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT; best_channel = 1; }
             end = try_inner_line_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INNER_LINE_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_INNER_LINE_DOC; best_channel = 1; }
             end = try_inner_block_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INNER_BLOCK_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_INNER_BLOCK_DOC; best_channel = 1; }
             end = try_outer_line_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OUTER_LINE_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_OUTER_LINE_DOC; best_channel = 1; }
             end = try_outer_block_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OUTER_BLOCK_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_OUTER_BLOCK_DOC; best_channel = 1; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_slash(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SLASH; }
+            if end > best_end { best_end = end; best_kind = TK_SLASH; best_channel = 0; }
             end = try_slasheq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SLASHEQ; }
+            if end > best_end { best_end = end; best_kind = TK_SLASHEQ; best_channel = 0; }
         } else if first_char == '0' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_dec_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DEC_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_DEC_LITERAL; best_channel = 0; }
             end = try_hex_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_HEX_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_HEX_LITERAL; best_channel = 0; }
             end = try_oct_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OCT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_OCT_LITERAL; best_channel = 0; }
             end = try_bin_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BIN_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_BIN_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == ':' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_colon(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_COLON; }
+            if end > best_end { best_end = end; best_kind = TK_COLON; best_channel = 0; }
             end = try_pathsep(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_PATHSEP; }
+            if end > best_end { best_end = end; best_kind = TK_PATHSEP; best_channel = 0; }
         } else if first_char == ';' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_semi(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SEMI; }
+            if end > best_end { best_end = end; best_kind = TK_SEMI; best_channel = 0; }
         } else if first_char == '<' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_shleq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHLEQ; }
+            if end > best_end { best_end = end; best_kind = TK_SHLEQ; best_channel = 0; }
             end = try_lt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LT; }
+            if end > best_end { best_end = end; best_kind = TK_LT; best_channel = 0; }
             end = try_le(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LE; }
+            if end > best_end { best_end = end; best_kind = TK_LE; best_channel = 0; }
         } else if first_char == '=' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_eq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_EQ; }
+            if end > best_end { best_end = end; best_kind = TK_EQ; best_channel = 0; }
             end = try_eqeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_EQEQ; }
+            if end > best_end { best_end = end; best_kind = TK_EQEQ; best_channel = 0; }
             end = try_fatarrow(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FATARROW; }
+            if end > best_end { best_end = end; best_kind = TK_FATARROW; best_channel = 0; }
         } else if first_char == '>' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_shreq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHREQ; }
+            if end > best_end { best_end = end; best_kind = TK_SHREQ; best_channel = 0; }
             end = try_gt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_GT; }
+            if end > best_end { best_end = end; best_kind = TK_GT; best_channel = 0; }
             end = try_ge(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_GE; }
+            if end > best_end { best_end = end; best_kind = TK_GE; best_channel = 0; }
         } else if first_char == '?' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_question(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_QUESTION; }
+            if end > best_end { best_end = end; best_kind = TK_QUESTION; best_channel = 0; }
         } else if first_char == '@' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_at(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_AT; }
+            if end > best_end { best_end = end; best_kind = TK_AT; best_channel = 0; }
         } else if first_char == 'S' {
             end = try_kw_selftype(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_SELFTYPE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_SELFTYPE; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == '[' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_lsquarebracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LSQUAREBRACKET; }
+            if end > best_end { best_end = end; best_kind = TK_LSQUAREBRACKET; best_channel = 0; }
         } else if first_char == ']' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_rsquarebracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RSQUAREBRACKET; }
+            if end > best_end { best_end = end; best_kind = TK_RSQUAREBRACKET; best_channel = 0; }
         } else if first_char == '^' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_caret(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CARET; }
+            if end > best_end { best_end = end; best_kind = TK_CARET; best_channel = 0; }
             end = try_careteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CARETEQ; }
+            if end > best_end { best_end = end; best_kind = TK_CARETEQ; best_channel = 0; }
         } else if first_char == '_' || first_char == '\u{2118}' || first_char == '\u{212e}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'a' {
             end = try_kw_as(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_AS; }
+            if end > best_end { best_end = end; best_kind = TK_KW_AS; best_channel = 0; }
             end = try_kw_async(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_ASYNC; }
+            if end > best_end { best_end = end; best_kind = TK_KW_ASYNC; best_channel = 0; }
             end = try_kw_await(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_AWAIT; }
+            if end > best_end { best_end = end; best_kind = TK_KW_AWAIT; best_channel = 0; }
             end = try_kw_abstract(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_ABSTRACT; }
+            if end > best_end { best_end = end; best_kind = TK_KW_ABSTRACT; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'b' {
             end = try_kw_break(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_BREAK; }
+            if end > best_end { best_end = end; best_kind = TK_KW_BREAK; best_channel = 0; }
             end = try_kw_become(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_BECOME; }
+            if end > best_end { best_end = end; best_kind = TK_KW_BECOME; best_channel = 0; }
             end = try_kw_box(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_BOX; }
+            if end > best_end { best_end = end; best_kind = TK_KW_BOX; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_byte_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BYTE_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_BYTE_LITERAL; best_channel = 0; }
             end = try_byte_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BYTE_STRING_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_BYTE_STRING_LITERAL; best_channel = 0; }
             end = try_raw_byte_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RAW_BYTE_STRING_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_RAW_BYTE_STRING_LITERAL; best_channel = 0; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'c' {
             end = try_kw_const(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_CONST; }
+            if end > best_end { best_end = end; best_kind = TK_KW_CONST; best_channel = 0; }
             end = try_kw_continue(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_CONTINUE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_CONTINUE; best_channel = 0; }
             end = try_kw_crate(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_CRATE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_CRATE; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'd' {
             end = try_kw_dyn(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_DYN; }
+            if end > best_end { best_end = end; best_kind = TK_KW_DYN; best_channel = 0; }
             end = try_kw_do(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_DO; }
+            if end > best_end { best_end = end; best_kind = TK_KW_DO; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'e' {
             end = try_kw_else(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_ELSE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_ELSE; best_channel = 0; }
             end = try_kw_enum(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_ENUM; }
+            if end > best_end { best_end = end; best_kind = TK_KW_ENUM; best_channel = 0; }
             end = try_kw_extern(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_EXTERN; }
+            if end > best_end { best_end = end; best_kind = TK_KW_EXTERN; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'f' {
             end = try_kw_false(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_FALSE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_FALSE; best_channel = 0; }
             end = try_kw_fn(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_FN; }
+            if end > best_end { best_end = end; best_kind = TK_KW_FN; best_channel = 0; }
             end = try_kw_for(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_FOR; }
+            if end > best_end { best_end = end; best_kind = TK_KW_FOR; best_channel = 0; }
             end = try_kw_final(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_FINAL; }
+            if end > best_end { best_end = end; best_kind = TK_KW_FINAL; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'i' {
             end = try_kw_if(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_IF; }
+            if end > best_end { best_end = end; best_kind = TK_KW_IF; best_channel = 0; }
             end = try_kw_impl(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_IMPL; }
+            if end > best_end { best_end = end; best_kind = TK_KW_IMPL; best_channel = 0; }
             end = try_kw_in(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_IN; }
+            if end > best_end { best_end = end; best_kind = TK_KW_IN; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'l' {
             end = try_kw_let(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_LET; }
+            if end > best_end { best_end = end; best_kind = TK_KW_LET; best_channel = 0; }
             end = try_kw_loop(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_LOOP; }
+            if end > best_end { best_end = end; best_kind = TK_KW_LOOP; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'm' {
             end = try_kw_match(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_MATCH; }
+            if end > best_end { best_end = end; best_kind = TK_KW_MATCH; best_channel = 0; }
             end = try_kw_mod(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_MOD; }
+            if end > best_end { best_end = end; best_kind = TK_KW_MOD; best_channel = 0; }
             end = try_kw_move(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_MOVE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_MOVE; best_channel = 0; }
             end = try_kw_mut(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_MUT; }
+            if end > best_end { best_end = end; best_kind = TK_KW_MUT; best_channel = 0; }
             end = try_kw_macro(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_MACRO; }
+            if end > best_end { best_end = end; best_kind = TK_KW_MACRO; best_channel = 0; }
             end = try_kw_macrorules(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_MACRORULES; }
+            if end > best_end { best_end = end; best_kind = TK_KW_MACRORULES; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'o' {
             end = try_kw_override(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_OVERRIDE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_OVERRIDE; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'p' {
             end = try_kw_pub(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_PUB; }
+            if end > best_end { best_end = end; best_kind = TK_KW_PUB; best_channel = 0; }
             end = try_kw_priv(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_PRIV; }
+            if end > best_end { best_end = end; best_kind = TK_KW_PRIV; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'r' {
             end = try_kw_ref(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_REF; }
+            if end > best_end { best_end = end; best_kind = TK_KW_REF; best_channel = 0; }
             end = try_kw_return(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_RETURN; }
+            if end > best_end { best_end = end; best_kind = TK_KW_RETURN; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_raw_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RAW_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_RAW_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_raw_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RAW_STRING_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_RAW_STRING_LITERAL; best_channel = 0; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 's' {
             end = try_kw_selfvalue(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_SELFVALUE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_SELFVALUE; best_channel = 0; }
             end = try_kw_static(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_STATIC; }
+            if end > best_end { best_end = end; best_kind = TK_KW_STATIC; best_channel = 0; }
             end = try_kw_struct(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_STRUCT; }
+            if end > best_end { best_end = end; best_kind = TK_KW_STRUCT; best_channel = 0; }
             end = try_kw_super(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_SUPER; }
+            if end > best_end { best_end = end; best_kind = TK_KW_SUPER; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 't' {
             end = try_kw_trait(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_TRAIT; }
+            if end > best_end { best_end = end; best_kind = TK_KW_TRAIT; best_channel = 0; }
             end = try_kw_true(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_TRUE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_TRUE; best_channel = 0; }
             end = try_kw_type(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_TYPE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_TYPE; best_channel = 0; }
             end = try_kw_typeof(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_TYPEOF; }
+            if end > best_end { best_end = end; best_kind = TK_KW_TYPEOF; best_channel = 0; }
             end = try_kw_try(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_TRY; }
+            if end > best_end { best_end = end; best_kind = TK_KW_TRY; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'u' {
             end = try_kw_unsafe(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_UNSAFE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_UNSAFE; best_channel = 0; }
             end = try_kw_use(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_USE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_USE; best_channel = 0; }
             end = try_kw_unsized(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_UNSIZED; }
+            if end > best_end { best_end = end; best_kind = TK_KW_UNSIZED; best_channel = 0; }
             end = try_kw_union(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_UNION; }
+            if end > best_end { best_end = end; best_kind = TK_KW_UNION; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'v' {
             end = try_kw_virtual(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_VIRTUAL; }
+            if end > best_end { best_end = end; best_kind = TK_KW_VIRTUAL; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'w' {
             end = try_kw_where(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_WHERE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_WHERE; best_channel = 0; }
             end = try_kw_while(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_WHILE; }
+            if end > best_end { best_end = end; best_kind = TK_KW_WHILE; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == 'y' {
             end = try_kw_yield(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KW_YIELD; }
+            if end > best_end { best_end = end; best_kind = TK_KW_YIELD; best_channel = 0; }
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if first_char == '{' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_lcurlybrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LCURLYBRACE; }
+            if end > best_end { best_end = end; best_kind = TK_LCURLYBRACE; best_channel = 0; }
         } else if first_char == '|' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_or(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OR; }
+            if end > best_end { best_end = end; best_kind = TK_OR; best_channel = 0; }
             end = try_oror(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OROR; }
+            if end > best_end { best_end = end; best_kind = TK_OROR; best_channel = 0; }
             end = try_oreq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OREQ; }
+            if end > best_end { best_end = end; best_kind = TK_OREQ; best_channel = 0; }
         } else if first_char == '}' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
             end = try_rcurlybrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RCURLYBRACE; }
+            if end > best_end { best_end = end; best_kind = TK_RCURLYBRACE; best_channel = 0; }
         } else if 'A' <= first_char <= 'Z' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if 'a' <= first_char <= 'z' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{c0}' <= first_char <= '\u{d6}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{d8}' <= first_char <= '\u{f6}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{f8}' <= first_char <= '\u{ff}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{100}' <= first_char <= '\u{24f}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{370}' <= first_char <= '\u{3ff}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{400}' <= first_char <= '\u{4ff}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{600}' <= first_char <= '\u{6ff}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{900}' <= first_char <= '\u{97f}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{4e00}' <= first_char <= '\u{9fff}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{3040}' <= first_char <= '\u{309f}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{30a0}' <= first_char <= '\u{30ff}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{ac00}' <= first_char <= '\u{d7af}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{2160}' <= first_char <= '\u{2188}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{16ee}' <= first_char <= '\u{16f0}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{1885}' <= first_char <= '\u{1886}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{309b}' <= first_char <= '\u{309c}' {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '\u{2000}' <= first_char <= '\u{200a}' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_whitespace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
+            if end > best_end { best_end = end; best_kind = TK_WHITESPACE; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else if '0' <= first_char <= '9' {
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_dec_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DEC_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_DEC_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         } else {
             end = try_non_keyword_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_NON_KEYWORD_IDENTIFIER; best_channel = 0; }
             end = try_block_comment_or_doc(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; }
+            if end > best_end { best_end = end; best_kind = TK_BLOCK_COMMENT_OR_DOC; best_channel = 1; }
             end = try_shebang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SHEBANG; }
+            if end > best_end { best_end = end; best_kind = TK_SHEBANG; best_channel = 1; }
             end = try_whitespace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_WHITESPACE; }
+            if end > best_end { best_end = end; best_kind = TK_WHITESPACE; best_channel = 1; }
             end = try_integer_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_INTEGER_LITERAL; best_channel = 0; }
             end = try_dec_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DEC_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_DEC_LITERAL; best_channel = 0; }
             end = try_float_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_FLOAT_LITERAL; best_channel = 0; }
         }
         if best_end > start {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
@@ -8732,11 +8740,14 @@ pub fn tokenize(input: &String) -> Array<Token> {
             trivia = [];
             lexer.pos = start + 1;
         } else {
-            let is_skip = best_kind matches { TK_LINE_COMMENT | TK_BLOCK_COMMENT | TK_INNER_LINE_DOC | TK_INNER_BLOCK_DOC | TK_OUTER_LINE_DOC | TK_OUTER_BLOCK_DOC | TK_BLOCK_COMMENT_OR_DOC | TK_SHEBANG | TK_WHITESPACE | TK_NEWLINE };
+            let tok_start = start;
+            let is_skip = false;
             if is_skip {
-                trivia.push(Token::new(best_kind, lexer.slice(start, best_end), Span::new(start, best_end)));
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else if best_channel != 0 {
+                trivia.push(Token::with_channel(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), [], best_channel));
             } else {
-                let tok = Token::with_trivia(best_kind, lexer.slice(start, best_end), Span::new(start, best_end), trivia);
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
                 tokens.push(tok);
                 trivia = [];
             }
@@ -8939,6 +8950,40 @@ impl Parser {
             `expected {name}, got "{tok.text}"`,
             tok.span,
             [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if *x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
         ));
     }
 }

--- a/package-gale/tests/golden/sexpression.wado
+++ b/package-gale/tests/golden/sexpression.wado
@@ -117,20 +117,27 @@ impl Eq for LexerSlice {
 
 /// Token represents a lexed token with its kind, text, and position.
 /// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
 pub struct Token {
     pub kind: i32,
     pub text: LexerSlice,
     pub span: Span,
     pub leading_trivia: Array<Token>,
+    pub channel: i32,
 }
 
 impl Token {
     pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
-        return Token { kind, text, span, leading_trivia: [] };
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
     }
 
     pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
-        return Token { kind, text, span, leading_trivia };
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
     }
 }
 
@@ -994,11 +1001,12 @@ pub fn tokenize(input: &String) -> Array<Token> {
             trivia = [];
             lexer.pos = start + 1;
         } else {
+            let tok_start = start;
             let is_skip = best_kind matches { TK_WHITESPACE };
             if is_skip {
-                trivia.push(Token::new(best_kind, lexer.slice(start, best_end), Span::new(start, best_end)));
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
             } else {
-                let tok = Token::with_trivia(best_kind, lexer.slice(start, best_end), Span::new(start, best_end), trivia);
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
                 tokens.push(tok);
                 trivia = [];
             }
@@ -1078,6 +1086,40 @@ impl Parser {
             `expected {name}, got "{tok.text}"`,
             tok.span,
             [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if *x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
         ));
     }
 }

--- a/package-gale/tests/golden/sqlite.wado
+++ b/package-gale/tests/golden/sqlite.wado
@@ -117,20 +117,27 @@ impl Eq for LexerSlice {
 
 /// Token represents a lexed token with its kind, text, and position.
 /// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
 pub struct Token {
     pub kind: i32,
     pub text: LexerSlice,
     pub span: Span,
     pub leading_trivia: Array<Token>,
+    pub channel: i32,
 }
 
 impl Token {
     pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
-        return Token { kind, text, span, leading_trivia: [] };
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
     }
 
     pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
-        return Token { kind, text, span, leading_trivia };
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
     }
 }
 
@@ -4442,94 +4449,95 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
         let first_char = lexer.chars[start];
+        let mut best_channel: i32 = 0;
         if first_char == '\t' || first_char == '\n' || first_char == '\u{b}' || first_char == '\r' || first_char == ' ' {
             end = try_spaces(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SPACES; }
+            if end > best_end { best_end = end; best_kind = TK_SPACES; best_channel = 1; }
         } else if first_char == '!' {
             end = try_lit_bangeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; best_channel = 0; }
         } else if first_char == '"' || first_char == '[' || first_char == '_' || first_char == '`' {
             end = try_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; best_channel = 0; }
         } else if first_char == '$' || first_char == ':' || first_char == '?' || first_char == '@' {
             end = try_bind_parameter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; }
+            if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; best_channel = 0; }
         } else if first_char == '%' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PERCENT; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PERCENT; best_channel = 0; }
         } else if first_char == '&' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_AMP; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_AMP; best_channel = 0; }
         } else if first_char == '\'' {
             end = try_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; best_channel = 0; }
         } else if first_char == '(' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LPAREN; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LPAREN; best_channel = 0; }
         } else if first_char == ')' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RPAREN; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RPAREN; best_channel = 0; }
         } else if first_char == '*' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; best_channel = 0; }
         } else if first_char == '+' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PLUS; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PLUS; best_channel = 0; }
         } else if first_char == ',' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COMMA; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COMMA; best_channel = 0; }
         } else if first_char == '-' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_MINUS; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_MINUS; best_channel = 0; }
             end = try_single_line_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; }
+            if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; best_channel = 1; }
         } else if first_char == '.' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_DOT; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_DOT; best_channel = 0; }
             end = try_numeric_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; best_channel = 0; }
         } else if first_char == '/' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SLASH; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SLASH; best_channel = 0; }
             end = try_multiline_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; }
+            if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; best_channel = 1; }
         } else if first_char == ';' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SEMI; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SEMI; best_channel = 0; }
         } else if first_char == '<' {
             end = try_lit_ltlt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; }
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LT; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; best_channel = 0; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LT; best_channel = 0; }
             end = try_lit_lteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; best_channel = 0; }
             end = try_lit_ltgt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; best_channel = 0; }
         } else if first_char == '=' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_EQ; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_EQ; best_channel = 0; }
             end = try_lit_eqeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; best_channel = 0; }
         } else if first_char == '>' {
             end = try_lit_gtgt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_GT; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; best_channel = 0; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_GT; best_channel = 0; }
             end = try_lit_gteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; best_channel = 0; }
         } else if first_char == 'X' || first_char == 'x' {
             end = try_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; best_channel = 0; }
             end = try_blob_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; best_channel = 0; }
         } else if first_char == '|' {
             end = try_lit_pipepipe(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; }
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PIPE; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; best_channel = 0; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PIPE; best_channel = 0; }
         } else if first_char == '~' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_TILDE; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_TILDE; best_channel = 0; }
         } else if 'a' <= first_char <= 'z' {
             end = try_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; best_channel = 0; }
         } else if 'A' <= first_char <= 'Z' {
             end = try_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; best_channel = 0; }
         } else if '0' <= first_char <= '9' {
             end = try_numeric_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; best_channel = 0; }
         } else {
             end = try_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; best_channel = 0; }
             end = try_numeric_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; best_channel = 0; }
             end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; best_channel = 0; }
         }
         if best_end > start {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
@@ -4541,11 +4549,14 @@ pub fn tokenize(input: &String) -> Array<Token> {
             trivia = [];
             lexer.pos = start + 1;
         } else {
-            let is_skip = best_kind matches { TK_SINGLE_LINE_COMMENT | TK_MULTILINE_COMMENT | TK_SPACES };
+            let tok_start = start;
+            let is_skip = false;
             if is_skip {
-                trivia.push(Token::new(best_kind, lexer.slice(start, best_end), Span::new(start, best_end)));
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else if best_channel != 0 {
+                trivia.push(Token::with_channel(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), [], best_channel));
             } else {
-                let tok = Token::with_trivia(best_kind, lexer.slice(start, best_end), Span::new(start, best_end), trivia);
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
                 tokens.push(tok);
                 trivia = [];
             }
@@ -4799,6 +4810,40 @@ impl Parser {
             `expected {name}, got "{tok.text}"`,
             tok.span,
             [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if *x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
         ));
     }
 }

--- a/package-gale/tests/golden/sqlite_highlight.wado
+++ b/package-gale/tests/golden/sqlite_highlight.wado
@@ -117,20 +117,27 @@ impl Eq for LexerSlice {
 
 /// Token represents a lexed token with its kind, text, and position.
 /// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
 pub struct Token {
     pub kind: i32,
     pub text: LexerSlice,
     pub span: Span,
     pub leading_trivia: Array<Token>,
+    pub channel: i32,
 }
 
 impl Token {
     pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
-        return Token { kind, text, span, leading_trivia: [] };
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
     }
 
     pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
-        return Token { kind, text, span, leading_trivia };
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
     }
 }
 
@@ -4442,94 +4449,95 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
         let first_char = lexer.chars[start];
+        let mut best_channel: i32 = 0;
         if first_char == '\t' || first_char == '\n' || first_char == '\u{b}' || first_char == '\r' || first_char == ' ' {
             end = try_spaces(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SPACES; }
+            if end > best_end { best_end = end; best_kind = TK_SPACES; best_channel = 1; }
         } else if first_char == '!' {
             end = try_lit_bangeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; best_channel = 0; }
         } else if first_char == '"' || first_char == '[' || first_char == '_' || first_char == '`' {
             end = try_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; best_channel = 0; }
         } else if first_char == '$' || first_char == ':' || first_char == '?' || first_char == '@' {
             end = try_bind_parameter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; }
+            if end > best_end { best_end = end; best_kind = TK_BIND_PARAMETER; best_channel = 0; }
         } else if first_char == '%' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PERCENT; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PERCENT; best_channel = 0; }
         } else if first_char == '&' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_AMP; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_AMP; best_channel = 0; }
         } else if first_char == '\'' {
             end = try_string_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_STRING_LITERAL; best_channel = 0; }
         } else if first_char == '(' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LPAREN; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LPAREN; best_channel = 0; }
         } else if first_char == ')' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RPAREN; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RPAREN; best_channel = 0; }
         } else if first_char == '*' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; best_channel = 0; }
         } else if first_char == '+' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PLUS; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PLUS; best_channel = 0; }
         } else if first_char == ',' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COMMA; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COMMA; best_channel = 0; }
         } else if first_char == '-' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_MINUS; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_MINUS; best_channel = 0; }
             end = try_single_line_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; }
+            if end > best_end { best_end = end; best_kind = TK_SINGLE_LINE_COMMENT; best_channel = 1; }
         } else if first_char == '.' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_DOT; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_DOT; best_channel = 0; }
             end = try_numeric_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; best_channel = 0; }
         } else if first_char == '/' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SLASH; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SLASH; best_channel = 0; }
             end = try_multiline_comment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; }
+            if end > best_end { best_end = end; best_kind = TK_MULTILINE_COMMENT; best_channel = 1; }
         } else if first_char == ';' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SEMI; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_SEMI; best_channel = 0; }
         } else if first_char == '<' {
             end = try_lit_ltlt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; }
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LT; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; best_channel = 0; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LT; best_channel = 0; }
             end = try_lit_lteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; best_channel = 0; }
             end = try_lit_ltgt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTGT; best_channel = 0; }
         } else if first_char == '=' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_EQ; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_EQ; best_channel = 0; }
             end = try_lit_eqeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; best_channel = 0; }
         } else if first_char == '>' {
             end = try_lit_gtgt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_GT; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; best_channel = 0; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_GT; best_channel = 0; }
             end = try_lit_gteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; best_channel = 0; }
         } else if first_char == 'X' || first_char == 'x' {
             end = try_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; best_channel = 0; }
             end = try_blob_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_BLOB_LITERAL; best_channel = 0; }
         } else if first_char == '|' {
             end = try_lit_pipepipe(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; }
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PIPE; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; best_channel = 0; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PIPE; best_channel = 0; }
         } else if first_char == '~' {
-            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_TILDE; }
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_TILDE; best_channel = 0; }
         } else if 'a' <= first_char <= 'z' {
             end = try_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; best_channel = 0; }
         } else if 'A' <= first_char <= 'Z' {
             end = try_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; best_channel = 0; }
         } else if '0' <= first_char <= '9' {
             end = try_numeric_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; best_channel = 0; }
         } else {
             end = try_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; }
+            if end > best_end { best_end = end; best_kind = TK_IDENTIFIER; best_channel = 0; }
             end = try_numeric_literal(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; }
+            if end > best_end { best_end = end; best_kind = TK_NUMERIC_LITERAL; best_channel = 0; }
             end = try_unexpected_char(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; }
+            if end > best_end { best_end = end; best_kind = TK_UNEXPECTED_CHAR; best_channel = 0; }
         }
         if best_end > start {
             let kw_kind = classify_keyword(&lexer.chars, start, best_end);
@@ -4541,11 +4549,14 @@ pub fn tokenize(input: &String) -> Array<Token> {
             trivia = [];
             lexer.pos = start + 1;
         } else {
-            let is_skip = best_kind matches { TK_SINGLE_LINE_COMMENT | TK_MULTILINE_COMMENT | TK_SPACES };
+            let tok_start = start;
+            let is_skip = false;
             if is_skip {
-                trivia.push(Token::new(best_kind, lexer.slice(start, best_end), Span::new(start, best_end)));
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else if best_channel != 0 {
+                trivia.push(Token::with_channel(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), [], best_channel));
             } else {
-                let tok = Token::with_trivia(best_kind, lexer.slice(start, best_end), Span::new(start, best_end), trivia);
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
                 tokens.push(tok);
                 trivia = [];
             }
@@ -4799,6 +4810,40 @@ impl Parser {
             `expected {name}, got "{tok.text}"`,
             tok.span,
             [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if *x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
         ));
     }
 }

--- a/package-gale/tests/golden/typescript.wado
+++ b/package-gale/tests/golden/typescript.wado
@@ -117,20 +117,27 @@ impl Eq for LexerSlice {
 
 /// Token represents a lexed token with its kind, text, and position.
 /// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
 pub struct Token {
     pub kind: i32,
     pub text: LexerSlice,
     pub span: Span,
     pub leading_trivia: Array<Token>,
+    pub channel: i32,
 }
 
 impl Token {
     pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
-        return Token { kind, text, span, leading_trivia: [] };
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
     }
 
     pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
-        return Token { kind, text, span, leading_trivia };
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
     }
 }
 
@@ -7294,304 +7301,305 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let first_char = lexer.chars[start];
         let mut best_push_mode: i32 = -1;
         let mut best_pop_mode = false;
+        let mut best_channel: i32 = 0;
         if current_mode == 0 {
             end = try_lit_eq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_lt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_LT; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_gt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_GT; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_comma(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_extends(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EXTENDS; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_EXTENDS; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_pipe(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPE; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_amp(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_AMP; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_AMP; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_lparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_rparen(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_lbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACKET; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_rbracket(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACKET; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_lbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_rbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_eqgt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EQGT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQGT; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_new(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_NEW; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_NEW; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_typeof(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_TYPEOF; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_TYPEOF; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_dot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit__(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT__; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT__; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_colon(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_COLON; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_COLON; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_dotdotdot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_DOTDOTDOT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_DOTDOTDOT; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_type(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_TYPE; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_TYPE; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit__(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT__; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT__; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_star(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit__(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT__; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT__; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit__dot(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT__DOT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT__DOT; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_bang(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_BANG; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_BANG; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_plusplus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PLUSPLUS; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUSPLUS; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_minusminus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_MINUSMINUS; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_MINUSMINUS; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_plus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_minus(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_MINUS; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_MINUS; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_tilde(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_TILDE; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_TILDE; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_starstar(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_STARSTAR; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_STARSTAR; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_slash(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_SLASH; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_percent(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PERCENT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_PERCENT; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit___(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT___; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT___; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_ltlt(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTLT; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_lteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_gteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_eqeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_bangeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_eqeqeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_EQEQEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQEQEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_bangeqeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_BANGEQEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_caret(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_CARET; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_CARET; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_ampamp(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_AMPAMP; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_AMPAMP; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_pipepipe(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPEPIPE; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_stareq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_STAREQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_STAREQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_slasheq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_SLASHEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_SLASHEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_percenteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PERCENTEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_PERCENTEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_pluseq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PLUSEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUSEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_minuseq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_MINUSEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_MINUSEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_ltlteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_LTLTEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_LTLTEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_gtgteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GTGTEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTGTEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_gtgtgteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_GTGTGTEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTGTGTEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_ampeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_AMPEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_AMPEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_careteq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_CARETEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_CARETEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_pipeeq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_PIPEEQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_PIPEEQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_starstareq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_STARSTAREQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_STARSTAREQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit___eq(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT___EQ; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LIT___EQ; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_multilinecomment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_MultiLineComment; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_MultiLineComment; best_push_mode = -1; best_pop_mode = false; best_channel = 1; }
             end = try_singlelinecomment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SingleLineComment; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_SingleLineComment; best_push_mode = -1; best_pop_mode = false; best_channel = 1; }
             end = try_regularexpressionliteral(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_RegularExpressionLiteral; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_RegularExpressionLiteral; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_semicolon(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_SemiColon; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_SemiColon; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_nullliteral(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_NullLiteral; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_NullLiteral; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_booleanliteral(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BooleanLiteral; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_BooleanLiteral; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_decimalliteral(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_DecimalLiteral; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_DecimalLiteral; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_hexintegerliteral(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_HexIntegerLiteral; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_HexIntegerLiteral; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_octalintegerliteral(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OctalIntegerLiteral; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_OctalIntegerLiteral; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_octalintegerliteral2(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_OctalIntegerLiteral2; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_OctalIntegerLiteral2; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_binaryintegerliteral(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BinaryIntegerLiteral; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_BinaryIntegerLiteral; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_bighexintegerliteral(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BigHexIntegerLiteral; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_BigHexIntegerLiteral; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_bigoctalintegerliteral(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BigOctalIntegerLiteral; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_BigOctalIntegerLiteral; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_bigbinaryintegerliteral(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BigBinaryIntegerLiteral; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_BigBinaryIntegerLiteral; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_bigdecimalintegerliteral(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BigDecimalIntegerLiteral; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_BigDecimalIntegerLiteral; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_break(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Break; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Break; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_do(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Do; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Do; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_instanceof(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Instanceof; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Instanceof; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_case(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Case; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Case; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_else(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Else; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Else; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_var(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Var; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Var; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_catch(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Catch; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Catch; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_finally(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Finally; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Finally; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_return(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Return; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Return; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_void(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Void; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Void; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_continue(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Continue; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Continue; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_for(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_For; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_For; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_switch(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Switch; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Switch; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_while(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_While; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_While; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_debugger(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Debugger; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Debugger; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_function_(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Function_; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Function_; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_this(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_This; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_This; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_with(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_With; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_With; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_default(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Default; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Default; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_if(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_If; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_If; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_throw(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Throw; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Throw; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_delete(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Delete; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Delete; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_in(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_In; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_In; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_try(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Try; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Try; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_as(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_As; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_As; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_from(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_From; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_From; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_readonly(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_ReadOnly; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_ReadOnly; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_async(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Async; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Async; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_await(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Await; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Await; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_yield(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Yield; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Yield; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_yieldstar(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_YieldStar; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_YieldStar; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_class(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Class; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Class; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_enum(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Enum; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Enum; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_super(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Super; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Super; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_const(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Const; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Const; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_export(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Export; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Export; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_import(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Import; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Import; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_implements(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Implements; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Implements; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_let(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Let; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Let; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_private(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Private; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Private; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_public(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Public; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Public; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_interface(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Interface; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Interface; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_package(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Package; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Package; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_protected(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Protected; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Protected; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_static(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Static; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Static; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_any(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Any; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Any; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_number(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Number; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Number; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_never(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Never; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Never; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_boolean(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Boolean; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Boolean; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_string(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_String; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_String; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_unique(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Unique; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Unique; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_symbol(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Symbol; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Symbol; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_undefined(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Undefined; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Undefined; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_object(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Object; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Object; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_of(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Of; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Of; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_keyof(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_KeyOf; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_KeyOf; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_constructor(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Constructor; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Constructor; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_namespace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Namespace; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Namespace; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_require(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Require; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Require; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_module(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Module; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Module; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_declare(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Declare; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Declare; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_abstract(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Abstract; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Abstract; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_is(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Is; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Is; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_identifier(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_Identifier; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_Identifier; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_stringliteral(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_StringLiteral; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_StringLiteral; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_backtick(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BackTick; best_push_mode = 1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_BackTick; best_push_mode = 1; best_pop_mode = false; best_channel = 0; }
             end = try_whitespaces(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_WhiteSpaces; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_WhiteSpaces; best_push_mode = -1; best_pop_mode = false; best_channel = 1; }
             end = try_lineterminator(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LineTerminator; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_LineTerminator; best_push_mode = -1; best_pop_mode = false; best_channel = 1; }
             end = try_htmlcomment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_HtmlComment; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_HtmlComment; best_push_mode = -1; best_pop_mode = false; best_channel = 1; }
             end = try_cdatacomment(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_CDataComment; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_CDataComment; best_push_mode = -1; best_pop_mode = false; best_channel = 1; }
             end = try_unexpectedcharacter(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_UnexpectedCharacter; best_push_mode = -1; best_pop_mode = false; best_channel = 2; }
         } else if current_mode == 1 {
             end = try_templatestringescapeatom(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TemplateStringEscapeAtom; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_TemplateStringEscapeAtom; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_backtickinside(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_BackTickInside; best_push_mode = -1; best_pop_mode = true; }
+            if end > best_end { best_end = end; best_kind = TK_BackTick; best_push_mode = -1; best_pop_mode = true; best_channel = 0; }
             end = try_templatestringstartexpression(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TemplateStringStartExpression; best_push_mode = 0; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_TemplateStringStartExpression; best_push_mode = 0; best_pop_mode = false; best_channel = 0; }
             end = try_templatestringatom(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_TemplateStringAtom; best_push_mode = -1; best_pop_mode = false; }
+            if end > best_end { best_end = end; best_kind = TK_TemplateStringAtom; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
         }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
@@ -7599,11 +7607,14 @@ pub fn tokenize(input: &String) -> Array<Token> {
             trivia = [];
             lexer.pos = start + 1;
         } else {
-            let is_skip = best_kind matches { TK_MultiLineComment | TK_SingleLineComment | TK_WhiteSpaces | TK_LineTerminator | TK_HtmlComment | TK_CDataComment };
+            let tok_start = start;
+            let is_skip = false;
             if is_skip {
-                trivia.push(Token::new(best_kind, lexer.slice(start, best_end), Span::new(start, best_end)));
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else if best_channel != 0 {
+                trivia.push(Token::with_channel(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), [], best_channel));
             } else {
-                let tok = Token::with_trivia(best_kind, lexer.slice(start, best_end), Span::new(start, best_end), trivia);
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
                 tokens.push(tok);
                 trivia = [];
             }
@@ -7897,6 +7908,40 @@ impl Parser {
             `expected {name}, got "{tok.text}"`,
             tok.span,
             [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if *x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
         ));
     }
 }


### PR DESCRIPTION
## Summary

Works through `package-gale/TODO.md` by extending the IR to preserve information the parser already saw but dropped, wiring the preserved data into the code generator, removing a stale `channel(HIDDEN)` approximation, and adding driver-level tests that verify the new behavior on real generated parsers.

### Section A — Parser accepts but IR drops information
- `Grammar.options`, `Grammar.channels`, `Grammar.named_actions`
- `ParserRule.visibility` / `ParserRule.options`
- `LexerRule.visibility` / `LexerRule.options` / `LexerRule.is_virtual`
- New `Visibility` enum plus `GrammarOption` / `NamedAction` structs. `merge_grammars` merges options (key override) and concatenates named actions.

### Section C — Generator now reads the IR fields
- `Element::Wildcard` (`.`) and parser-side `Element::Not` (`~TOK`)
- `LabelElement.list` (`+=`) collects into `Array`
- `LexerRule.set_mode` (`mode(X)`), `LexerRule.more`, `LexerRule.type_override` (`type(X)`), `LexerRule.channel` (integer + named)

### Section D — `channel(HIDDEN)` no longer collapses to `skip`
- Parser keeps `skip=false` and records channel id 1 for `channel(HIDDEN)`.
- `DEFAULT_CHANNEL=0` / `HIDDEN_CHANNEL=1` promoted to named constants in `ir.wado`.
- Lexer generator routes any `best_channel != 0` match to trivia via `Token::with_channel`, preserving the channel id so tooling can still inspect it. Parser contract is unchanged (non-default channels remain invisible to parser rules).

### Section F — Edge cases exercised with TDD
- `~(block)` at both parser and lexer levels
- Block label syntax `lbl=(a|b)` and `lbl+=(a|b)` (single-value and list)
- ARG_ACTION with whitespace only: `returns [ ]` and `rule [ ]`
- ANTLR3-style `tokens { A=1, B=2 }` — `parse_tokens_block` now tolerates `= INT` suffixes for permissive parsing of legacy `.g4` files

Golden fixtures regenerated via `mise run update-gale-golden` after the generator changes.

### Driver-level verification (new)

The previous commits changed runtime behavior of generated lexers
(HIDDEN routing, user channels, `type(X)` rewrite), but those changes
were only covered by unit tests and golden fixtures. Without driver
tests — i.e., compiling the generated parser and running it against
real input — there was no way to confirm the runtime behavior was
correct. This branch now adds end-to-end driver tests:

- **HIDDEN channel (HTML)** — `driver_html_test.wado` tokenizes
  `<p class="x">`, asserts `TAG_WHITESPACE` never appears in the
  main token stream, and asserts it re-surfaces as leading trivia
  with `channel == 1` on the following `TAG_NAME`. A second test
  parses `<img src="a" alt="b"/>` end-to-end, confirming the
  parser accepts whitespace-separated attributes.
- **HIDDEN channel (TypeScript)** — `driver_typescript_test.wado`
  asserts `WhiteSpaces` between `let` and `x` routes to trivia
  with `channel == 1`.
- **User-defined channel routing** — `driver_antlr4_test.wado`
  exercises `channel(COMMENT)`, the second user channel beyond
  DEFAULT/HIDDEN (ANTLRv4Lexer declares
  `channels { OFF_CHANNEL, COMMENT }` so `COMMENT == 3`). Both
  `//` `LINE_COMMENT` and `/* */` `BLOCK_COMMENT` must appear as
  trivia with `channel == 3`, verifying the generic `channel(X)`
  routing path — not just the HIDDEN shortcut.
- **`type(X)` override** — `driver_typescript_test.wado` tokenizes
  `` `hi` `` and asserts both backticks emit as `TK_BackTick`,
  never `TK_BackTickInside`, confirming the `type(BackTick)`
  rewrite fires on `popMode`.

`package-gale/TODO.md` section D is rewritten to document the added
coverage and to explicitly defer the remaining driver-level gaps
(parser-side `~TOK`, list labels `+=`, bare `mode(X)`, `more`
semantics, parser wildcard `.`) since no existing test grammar
exercises those features end-to-end.

## Test plan

- [x] `cargo run --bin wado -- test package-gale` — 433 tests pass
- [x] `mise run on-task-done` — 1709 tests pass, 10 benchmarks pass
- [x] Golden fixtures regenerated and committed
- [x] Driver tests added for HIDDEN channel (HTML + TypeScript), user channel (ANTLR4), and `type(X)` override (TypeScript)

https://claude.ai/code/session_01QXakqNKvteutbKvn72zwqy