### PR TITLE
chore: update syntax.rs & vscode ext

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -233,10 +233,11 @@ description = "Install wado-vscode extension for development"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
+cd wado-vscode
+npm install && npm run compile
 if [ -e ~/.vscode/extensions/wado-lang.wado-0.0.1 ]; then
     echo "wado-vscode is already installed"
 else
-    cd wado-vscode && npm install && npm run compile
     ln -s "$PWD" ~/.vscode/extensions/wado-lang.wado-0.0.1
 fi
 """

--- a/wado-cli/src/syntax.rs
+++ b/wado-cli/src/syntax.rs
@@ -174,19 +174,25 @@ fn generate_textmate_grammar(def: &SyntaxDefinition) -> serde_json::Value {
         result
     };
 
-    // Build operator patterns (sorted by length descending to match longer operators first)
-    let mut all_operators: Vec<&str> = def
-        .operators
-        .comparison
-        .iter()
-        .chain(def.operators.logical.iter())
-        .chain(def.operators.arithmetic.iter())
-        .chain(def.operators.bitwise.iter())
-        .chain(def.operators.assignment.iter())
-        .chain(def.operators.other.iter())
-        .copied()
-        .collect();
-    all_operators.sort_by_key(|op| std::cmp::Reverse(op.len()));
+    // Build an alternation for a single operator category.
+    // Operators are sorted by length descending so multi-char tokens win over their prefixes
+    // (e.g. `..=` matches before `..` before `.`). Word-shaped operators (like `matches`) are
+    // wrapped in `\b…\b` so they don't bleed into surrounding identifiers.
+    let operator_alternation = |ops: &[&str]| -> String {
+        let mut sorted: Vec<&str> = ops.to_vec();
+        sorted.sort_by_key(|op| std::cmp::Reverse(op.len()));
+        sorted
+            .iter()
+            .map(|op| {
+                if op.chars().all(|c| c.is_ascii_alphabetic() || c == '_') {
+                    format!("\\b{op}\\b")
+                } else {
+                    escape_regex(op)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("|")
+    };
 
     json!({
         "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
@@ -197,6 +203,7 @@ fn generate_textmate_grammar(def: &SyntaxDefinition) -> serde_json::Value {
             { "include": "#data-section" },
             { "include": "#comments" },
             { "include": "#attributes" },
+            { "include": "#compile-time-literals" },
             { "include": "#strings" },
             { "include": "#characters" },
             { "include": "#numbers" },
@@ -378,17 +385,30 @@ fn generate_textmate_grammar(def: &SyntaxDefinition) -> serde_json::Value {
                         "name": "keyword.control.wado",
                         "match": keyword_pattern(&def.keywords.control)
                     },
+                    // Dual-scope via capture 1: the outer `name` gives the semantic scope
+                    // (`storage.type`) while the capture layers a `keyword.control.*` scope
+                    // so themes that only style `keyword.control` (minimalist themes) still
+                    // color declaration keywords.
                     {
-                        "name": "keyword.declaration.wado",
-                        "match": keyword_pattern(&def.keywords.declaration)
+                        "name": "storage.type.wado",
+                        "match": keyword_pattern(&def.keywords.storage_type),
+                        "captures": {
+                            "1": { "name": "keyword.control.declaration.wado" }
+                        }
+                    },
+                    {
+                        "name": "storage.modifier.wado",
+                        "match": keyword_pattern(&def.keywords.storage_modifier),
+                        "captures": {
+                            "1": { "name": "keyword.control.modifier.wado" }
+                        }
                     },
                     {
                         "name": "keyword.other.wado",
-                        "match": keyword_pattern(&def.keywords.modifier)
-                    },
-                    {
-                        "name": "keyword.other.wado",
-                        "match": keyword_pattern(&def.keywords.other)
+                        "match": keyword_pattern(&def.keywords.other),
+                        "captures": {
+                            "1": { "name": "keyword.control.other.wado" }
+                        }
                     },
                     {
                         "name": "constant.language.wado",
@@ -418,7 +438,7 @@ fn generate_textmate_grammar(def: &SyntaxDefinition) -> serde_json::Value {
                         "name": "meta.function.definition.wado",
                         "match": "\\b(fn)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*(?:<|\\()",
                         "captures": {
-                            "1": { "name": "keyword.declaration.wado" },
+                            "1": { "name": "storage.type.wado" },
                             "2": { "name": "entity.name.function.wado" }
                         }
                     },
@@ -440,37 +460,39 @@ fn generate_textmate_grammar(def: &SyntaxDefinition) -> serde_json::Value {
             },
             "operators": {
                 "patterns": [
+                    // `other` is emitted first so multi-char tokens like `..<`, `..=`, `->` win
+                    // before the single-char comparison/assignment patterns match their prefix.
+                    {
+                        "name": "keyword.operator.other.wado",
+                        "match": operator_alternation(&def.operators.other)
+                    },
                     {
                         "name": "keyword.operator.comparison.wado",
-                        "match": def.operators.comparison.iter().map(|s| escape_regex(s)).collect::<Vec<_>>().join("|")
+                        "match": operator_alternation(&def.operators.comparison)
                     },
                     {
                         "name": "keyword.operator.logical.wado",
-                        "match": def.operators.logical.iter().map(|s| escape_regex(s)).collect::<Vec<_>>().join("|")
+                        "match": operator_alternation(&def.operators.logical)
                     },
                     {
                         "name": "keyword.operator.arithmetic.wado",
-                        "match": def.operators.arithmetic.iter().map(|s| escape_regex(s)).collect::<Vec<_>>().join("|")
+                        "match": operator_alternation(&def.operators.arithmetic)
                     },
                     {
                         "name": "keyword.operator.bitwise.wado",
-                        "match": def.operators.bitwise.iter().map(|s| escape_regex(s)).collect::<Vec<_>>().join("|")
+                        "match": operator_alternation(&def.operators.bitwise)
                     },
                     {
                         "name": "keyword.operator.assignment.wado",
-                        "match": def.operators.assignment.iter().map(|s| escape_regex(s)).collect::<Vec<_>>().join("|")
-                    },
+                        "match": operator_alternation(&def.operators.assignment)
+                    }
+                ]
+            },
+            "compile-time-literals": {
+                "patterns": [
                     {
-                        "name": "keyword.operator.arrow.wado",
-                        "match": "->|=>"
-                    },
-                    {
-                        "name": "keyword.operator.reference.wado",
-                        "match": "&(?=\\s*mut\\b)|&"
-                    },
-                    {
-                        "name": "keyword.operator.dereference.wado",
-                        "match": "\\*(?=[a-zA-Z_])"
+                        "name": "constant.language.compile-time.wado",
+                        "match": format!("#({})\\b", def.compile_time_literals.join("|"))
                     }
                 ]
             },

--- a/wado-compiler/src/syntax.rs
+++ b/wado-compiler/src/syntax.rs
@@ -13,21 +13,31 @@ pub struct SyntaxDefinition {
     pub operators: OperatorCategories,
     pub builtin_types: Vec<&'static str>,
     pub constants: Vec<&'static str>,
+    /// Compile-time literals introduced with `#`, e.g. `#file`, `#line`, `#include_str`.
+    pub compile_time_literals: Vec<&'static str>,
     pub comments: CommentStyles,
 }
 
-/// Keywords categorized by their semantic role
+/// Keywords categorized by their semantic role.
+///
+/// Categories are chosen so that the `TextMate` generator can map each directly
+/// onto a widely-themed scope (`keyword.control`, `storage.type`, `storage.modifier`,
+/// `keyword.other`). Themes that do not ship specific rules for obscure scopes
+/// like `keyword.declaration` still color these correctly.
 #[derive(Debug)]
 pub struct KeywordCategories {
     /// Control flow keywords: if, else, while, for, loop, break, continue, return, match
     pub control: Vec<&'static str>,
     // Note: `matches` is exposed via `OperatorCategories::other` since it is a
     // binary pattern-test operator, not a control-flow construct.
-    /// Declaration keywords: fn, let, global, const, struct, enum, variant, flags, impl, trait, type, use, from, pub, import, export, test
-    pub declaration: Vec<&'static str>,
-    /// Modifier keywords: as, with, mut, async, move, unique, in, of
-    pub modifier: Vec<&'static str>,
-    /// Other keywords: assert, effect, handler, reactive, resource, world
+    /// Storage-type keywords: items and bindings — fn, let, global, const, struct,
+    /// enum, variant, flags, impl, trait, type.
+    pub storage_type: Vec<&'static str>,
+    /// Storage-modifier keywords: visibility and qualifiers on declarations —
+    /// pub, export, mut, async, move, unique, stores.
+    pub storage_modifier: Vec<&'static str>,
+    /// Other keywords: everything else that lexes as a keyword but isn't a
+    /// control-flow, storage-type, or storage-modifier keyword.
     pub other: Vec<&'static str>,
 }
 
@@ -61,22 +71,18 @@ impl SyntaxDefinition {
             scope_name: "source.wado",
             file_extensions: vec![".wado"],
             keywords: KeywordCategories {
-                // Control flow
                 control: vec![
                     "if", "else", "while", "for", "loop", "break", "continue", "return", "match",
+                    "task",
                 ],
-                // Declarations
-                declaration: vec![
+                storage_type: vec![
                     "fn", "let", "global", "const", "struct", "enum", "variant", "flags", "impl",
-                    "trait", "type", "use", "from", "pub", "import", "export", "test",
+                    "trait", "type",
                 ],
-                // Modifiers
-                modifier: vec![
-                    "as", "with", "mut", "async", "move", "unique", "in", "of", "stores",
-                ],
-                // Other keywords
+                storage_modifier: vec!["pub", "export", "mut", "async", "move", "unique", "stores"],
                 other: vec![
-                    "assert", "effect", "handler", "reactive", "resource", "world",
+                    "use", "from", "import", "test", "as", "with", "in", "of", "assert", "effect",
+                    "handler", "reactive", "resource", "world",
                 ],
             },
             operators: OperatorCategories {
@@ -124,6 +130,14 @@ impl SyntaxDefinition {
                 "IndexAssign",
             ],
             constants: vec!["true", "false", "null", "self"],
+            compile_time_literals: vec![
+                "file",
+                "line",
+                "function",
+                "data",
+                "include_str",
+                "include_bytes",
+            ],
             comments: CommentStyles {
                 line: "//",
                 block_start: "/*",
@@ -146,7 +160,8 @@ mod tests {
         assert_eq!(def.name, "Wado");
         assert_eq!(def.scope_name, "source.wado");
         assert!(def.keywords.control.contains(&"if"));
-        assert!(def.keywords.declaration.contains(&"fn"));
+        assert!(def.keywords.storage_type.contains(&"fn"));
+        assert!(def.keywords.storage_modifier.contains(&"pub"));
     }
 
     /// Verify all keywords in `SyntaxDefinition` are recognized by the lexer
@@ -159,15 +174,16 @@ mod tests {
             .keywords
             .control
             .iter()
-            .chain(def.keywords.declaration.iter())
-            .chain(def.keywords.modifier.iter())
+            .chain(def.keywords.storage_type.iter())
+            .chain(def.keywords.storage_modifier.iter())
             .chain(def.keywords.other.iter())
             .copied()
             .collect();
 
         // Contextual keywords: these are in SyntaxDefinition for highlighting
         // but are parsed as identifiers by the lexer and handled specially by the parser
-        let contextual_keywords = ["test"];
+        // (e.g. `test` for test blocks, `task` for `task return` statements)
+        let contextual_keywords = ["test", "task"];
         // Keyword-shaped operators: lexer keywords exposed via OperatorCategories
         // rather than KeywordCategories (e.g. `matches`, the binary pattern-test op)
         let operator_keywords = ["matches"];
@@ -245,5 +261,35 @@ mod tests {
         }
 
         // Note: "self" is in constants but handled specially (as identifier in most contexts)
+    }
+
+    /// Verify compile-time literals in `SyntaxDefinition` match the names parsed by `parser.rs`.
+    #[test]
+    fn test_syntax_compile_time_literals_match_parser() {
+        let def = SyntaxDefinition::wado();
+
+        // Authoritative list from parser.rs `parse_expr` hash-literal branch.
+        let parser_literals = [
+            "file",
+            "line",
+            "function",
+            "data",
+            "include_str",
+            "include_bytes",
+        ];
+
+        for lit in parser_literals {
+            assert!(
+                def.compile_time_literals.contains(&lit),
+                "parser compile-time literal '#{lit}' is missing from SyntaxDefinition.compile_time_literals"
+            );
+        }
+
+        for lit in &def.compile_time_literals {
+            assert!(
+                parser_literals.contains(lit),
+                "SyntaxDefinition compile-time literal '#{lit}' is not in parser_literals"
+            );
+        }
     }
 }

--- a/wado-compiler/src/syntax.rs
+++ b/wado-compiler/src/syntax.rs
@@ -21,7 +21,9 @@ pub struct SyntaxDefinition {
 pub struct KeywordCategories {
     /// Control flow keywords: if, else, while, for, loop, break, continue, return, match
     pub control: Vec<&'static str>,
-    /// Declaration keywords: fn, let, struct, enum, impl, type, use, from, pub, import, export
+    // Note: `matches` is exposed via `OperatorCategories::other` since it is a
+    // binary pattern-test operator, not a control-flow construct.
+    /// Declaration keywords: fn, let, global, const, struct, enum, variant, flags, impl, trait, type, use, from, pub, import, export, test
     pub declaration: Vec<&'static str>,
     /// Modifier keywords: as, with, mut, async, move, unique, in, of
     pub modifier: Vec<&'static str>,
@@ -62,12 +64,11 @@ impl SyntaxDefinition {
                 // Control flow
                 control: vec![
                     "if", "else", "while", "for", "loop", "break", "continue", "return", "match",
-                    "matches",
                 ],
                 // Declarations
                 declaration: vec![
-                    "fn", "let", "global", "const", "struct", "enum", "variant", "impl", "trait",
-                    "type", "use", "from", "pub", "import", "export", "test",
+                    "fn", "let", "global", "const", "struct", "enum", "variant", "flags", "impl",
+                    "trait", "type", "use", "from", "pub", "import", "export", "test",
                 ],
                 // Modifiers
                 modifier: vec![
@@ -86,11 +87,41 @@ impl SyntaxDefinition {
                 assignment: vec![
                     "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=", "=",
                 ],
-                other: vec!["->", "=>", "::", "?", "..<", "..="],
+                other: vec!["->", "=>", "::", "?", "..<", "..=", "..", "...", "matches"],
             },
             builtin_types: vec![
-                "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "f32", "f64", "bool", "char",
-                "String", "Array", "Option", "Result", "Fn",
+                "i8",
+                "i16",
+                "i32",
+                "i64",
+                "i128",
+                "u8",
+                "u16",
+                "u32",
+                "u64",
+                "u128",
+                "f32",
+                "f64",
+                "bool",
+                "char",
+                "String",
+                "Array",
+                "Option",
+                "Result",
+                "Fn",
+                "Eq",
+                "Ord",
+                "Ordering",
+                "Default",
+                "Display",
+                "DisplayAlt",
+                "Inspect",
+                "InspectAlt",
+                "Iterator",
+                "IntoIterator",
+                "Index",
+                "IndexValue",
+                "IndexAssign",
             ],
             constants: vec!["true", "false", "null", "self"],
             comments: CommentStyles {
@@ -137,6 +168,9 @@ mod tests {
         // Contextual keywords: these are in SyntaxDefinition for highlighting
         // but are parsed as identifiers by the lexer and handled specially by the parser
         let contextual_keywords = ["test"];
+        // Keyword-shaped operators: lexer keywords exposed via OperatorCategories
+        // rather than KeywordCategories (e.g. `matches`, the binary pattern-test op)
+        let operator_keywords = ["matches"];
 
         // Verify each keyword is lexed as a keyword token (not an identifier)
         // Skip contextual keywords which are intentionally lexed as identifiers
@@ -158,19 +192,30 @@ mod tests {
         let lexer_keywords = [
             "use", "from", "as", "fn", "with", "let", "mut", "return", "if", "else", "match",
             "matches", "for", "while", "loop", "break", "continue", "in", "of", "pub", "effect",
-            "handler", "reactive", "move", "unique", "struct", "enum", "variant", "type", "impl",
-            "trait", "resource", "world", "async", "import", "export", "assert", "global", "const",
-            "stores",
+            "handler", "reactive", "move", "unique", "struct", "enum", "variant", "flags", "type",
+            "impl", "trait", "resource", "world", "async", "import", "export", "assert", "global",
+            "const", "stores",
         ];
 
-        // Contextual keywords: these are in SyntaxDefinition for highlighting
-        // but are parsed as identifiers by the lexer and handled specially by the parser
-        let contextual_keywords = ["test"];
-
         // Verify SyntaxDefinition covers all lexer keywords
+        // (operator keywords like `matches` live in OperatorCategories instead)
+        let def_operators = &def.operators;
+        let all_op_tokens: Vec<&str> = def_operators
+            .comparison
+            .iter()
+            .chain(def_operators.logical.iter())
+            .chain(def_operators.arithmetic.iter())
+            .chain(def_operators.bitwise.iter())
+            .chain(def_operators.assignment.iter())
+            .chain(def_operators.other.iter())
+            .copied()
+            .collect();
         for keyword in lexer_keywords {
+            let in_keywords = all_keywords.contains(&keyword);
+            let in_operators =
+                operator_keywords.contains(&keyword) && all_op_tokens.contains(&keyword);
             assert!(
-                all_keywords.contains(&keyword),
+                in_keywords || in_operators,
                 "lexer keyword '{keyword}' is missing from SyntaxDefinition"
             );
         }

--- a/wado-vscode/src/test/unit/tokenization.test.ts
+++ b/wado-vscode/src/test/unit/tokenization.test.ts
@@ -212,4 +212,120 @@ describe('Tokenization Tests', () => {
             );
         });
     });
+
+    describe('Declaration keywords scope mapping', () => {
+        function findToken(line: string, needle: string): vsctm.IToken | undefined {
+            const { tokens } = tokenizeLine(line);
+            return tokens.find(t => line.slice(t.startIndex, t.endIndex) === needle);
+        }
+
+        const storageTypeKeywords = ['fn', 'let', 'global', 'const', 'struct', 'enum', 'variant', 'flags', 'impl', 'trait', 'type'];
+        for (const kw of storageTypeKeywords) {
+            it(`should dual-scope \`${kw}\` under storage.type AND keyword.control`, () => {
+                const tok = findToken(`${kw} foo`, kw);
+                assert.ok(
+                    tok && tok.scopes.some(s => s.includes('storage.type'))
+                        && tok.scopes.some(s => s.includes('keyword.control')),
+                    `${kw} should have both storage.type and keyword.control scopes: ${JSON.stringify(tok)}`
+                );
+            });
+        }
+
+        const storageModifierKeywords = ['pub', 'mut', 'async'];
+        for (const kw of storageModifierKeywords) {
+            it(`should dual-scope \`${kw}\` under storage.modifier AND keyword.control`, () => {
+                const tok = findToken(`${kw} foo`, kw);
+                assert.ok(
+                    tok && tok.scopes.some(s => s.includes('storage.modifier'))
+                        && tok.scopes.some(s => s.includes('keyword.control')),
+                    `${kw} should have both storage.modifier and keyword.control scopes: ${JSON.stringify(tok)}`
+                );
+            });
+        }
+
+        it('should tokenize `task` as a control keyword', () => {
+            const tok = findToken('task return 42;', 'task');
+            assert.ok(
+                tok && tok.scopes.some(s => s.includes('keyword.control')),
+                `task should be under keyword.control: ${JSON.stringify(tok)}`
+            );
+        });
+
+        it('should tokenize `return` in `task return` as a control keyword', () => {
+            const tok = findToken('task return 42;', 'return');
+            assert.ok(
+                tok && tok.scopes.some(s => s.includes('keyword.control')),
+                `return should be under keyword.control: ${JSON.stringify(tok)}`
+            );
+        });
+    });
+
+    describe('Compile-time literals', () => {
+        const literals = ['#file', '#line', '#function', '#data'];
+        for (const lit of literals) {
+            it(`should tokenize ${lit} as compile-time literal`, () => {
+                const { tokens } = tokenizeLine(`let x = ${lit};`);
+                const hit = tokens.find(t =>
+                    t.scopes.some(s => s.includes('constant.language.compile-time'))
+                );
+                assert.ok(
+                    hit,
+                    `${lit} should have constant.language.compile-time scope: ${JSON.stringify(tokens)}`
+                );
+            });
+        }
+
+        it('should tokenize #include_str(...) as compile-time literal', () => {
+            const { tokens } = tokenizeLine('let x = #include_str("./foo.wado");');
+            const hit = tokens.find(t =>
+                t.scopes.some(s => s.includes('constant.language.compile-time'))
+            );
+            assert.ok(
+                hit,
+                `#include_str should have compile-time scope: ${JSON.stringify(tokens)}`
+            );
+        });
+
+        it('should tokenize #include_bytes(...) as compile-time literal', () => {
+            const { tokens } = tokenizeLine('let x = #include_bytes("./icon.png");');
+            const hit = tokens.find(t =>
+                t.scopes.some(s => s.includes('constant.language.compile-time'))
+            );
+            assert.ok(
+                hit,
+                `#include_bytes should have compile-time scope: ${JSON.stringify(tokens)}`
+            );
+        });
+    });
+
+    describe('Operators from OperatorCategories::other', () => {
+        function findToken(line: string, needle: string): vsctm.IToken | undefined {
+            const { tokens } = tokenizeLine(line);
+            return tokens.find(t => line.slice(t.startIndex, t.endIndex) === needle);
+        }
+
+        it('should tokenize `matches` as an operator', () => {
+            const tok = findToken('if opt matches { Some(_) } { }', 'matches');
+            assert.ok(
+                tok && tok.scopes.some(s => s.includes('keyword.operator')),
+                `matches should have keyword.operator scope: ${JSON.stringify(tok)}`
+            );
+        });
+
+        it('should tokenize `..<` as a single range operator', () => {
+            const tok = findToken('for let i of 0..<10 { }', '..<');
+            assert.ok(
+                tok && tok.scopes.some(s => s.includes('keyword.operator')),
+                `..< should be one token with keyword.operator scope: ${JSON.stringify(tok)}`
+            );
+        });
+
+        it('should tokenize `..=` as a single range operator', () => {
+            const tok = findToken('for let i of 1..=10 { }', '..=');
+            assert.ok(
+                tok && tok.scopes.some(s => s.includes('keyword.operator')),
+                `..= should be one token with keyword.operator scope: ${JSON.stringify(tok)}`
+            );
+        });
+    });
 });

--- a/wado-vscode/syntaxes/wado.tmLanguage.json
+++ b/wado-vscode/syntaxes/wado.tmLanguage.json
@@ -15,6 +15,9 @@
       "include": "#attributes"
     },
     {
+      "include": "#compile-time-literals"
+    },
+    {
       "include": "#strings"
     },
     {
@@ -118,6 +121,14 @@
         }
       ]
     },
+    "compile-time-literals": {
+      "patterns": [
+        {
+          "match": "#(file|line|function|data|include_str|include_bytes)\\b",
+          "name": "constant.language.compile-time.wado"
+        }
+      ]
+    },
     "data-section": {
       "begin": "^__DATA__\\s*$",
       "beginCaptures": {
@@ -150,7 +161,7 @@
         {
           "captures": {
             "1": {
-              "name": "keyword.declaration.wado"
+              "name": "storage.type.wado"
             },
             "2": {
               "name": "entity.name.function.wado"
@@ -182,19 +193,34 @@
     "keywords": {
       "patterns": [
         {
-          "match": "\\b(if|else|while|for|loop|break|continue|return|match)\\b",
+          "match": "\\b(if|else|while|for|loop|break|continue|return|match|task)\\b",
           "name": "keyword.control.wado"
         },
         {
-          "match": "\\b(fn|let|global|const|struct|enum|variant|flags|impl|trait|type|use|from|pub|import|export|test)\\b",
-          "name": "keyword.declaration.wado"
+          "captures": {
+            "1": {
+              "name": "keyword.control.declaration.wado"
+            }
+          },
+          "match": "\\b(fn|let|global|const|struct|enum|variant|flags|impl|trait|type)\\b",
+          "name": "storage.type.wado"
         },
         {
-          "match": "\\b(as|with|mut|async|move|unique|in|of|stores)\\b",
-          "name": "keyword.other.wado"
+          "captures": {
+            "1": {
+              "name": "keyword.control.modifier.wado"
+            }
+          },
+          "match": "\\b(pub|export|mut|async|move|unique|stores)\\b",
+          "name": "storage.modifier.wado"
         },
         {
-          "match": "\\b(assert|effect|handler|reactive|resource|world)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.other.wado"
+            }
+          },
+          "match": "\\b(use|from|import|test|as|with|in|of|assert|effect|handler|reactive|resource|world)\\b",
           "name": "keyword.other.wado"
         },
         {
@@ -230,6 +256,10 @@
     "operators": {
       "patterns": [
         {
+          "match": "\\bmatches\\b|\\.\\.<|\\.\\.=|\\.\\.\\.|->|=>|::|\\.\\.|\\?",
+          "name": "keyword.operator.other.wado"
+        },
+        {
           "match": "==|!=|<=|>=|<|>",
           "name": "keyword.operator.comparison.wado"
         },
@@ -242,24 +272,12 @@
           "name": "keyword.operator.arithmetic.wado"
         },
         {
-          "match": "&|\\||\\^|~|<<|>>",
+          "match": "<<|>>|&|\\||\\^|~",
           "name": "keyword.operator.bitwise.wado"
         },
         {
-          "match": "\\+=|-=|\\*=|/=|%=|&=|\\|=|\\^=|<<=|>>=|=",
+          "match": "<<=|>>=|\\+=|-=|\\*=|/=|%=|&=|\\|=|\\^=|=",
           "name": "keyword.operator.assignment.wado"
-        },
-        {
-          "match": "->|=>",
-          "name": "keyword.operator.arrow.wado"
-        },
-        {
-          "match": "&(?=\\s*mut\\b)|&",
-          "name": "keyword.operator.reference.wado"
-        },
-        {
-          "match": "\\*(?=[a-zA-Z_])",
-          "name": "keyword.operator.dereference.wado"
         }
       ]
     },

--- a/wado-vscode/syntaxes/wado.tmLanguage.json
+++ b/wado-vscode/syntaxes/wado.tmLanguage.json
@@ -182,11 +182,11 @@
     "keywords": {
       "patterns": [
         {
-          "match": "\\b(if|else|while|for|loop|break|continue|return|match|matches)\\b",
+          "match": "\\b(if|else|while|for|loop|break|continue|return|match)\\b",
           "name": "keyword.control.wado"
         },
         {
-          "match": "\\b(fn|let|global|const|struct|enum|variant|impl|trait|type|use|from|pub|import|export|test)\\b",
+          "match": "\\b(fn|let|global|const|struct|enum|variant|flags|impl|trait|type|use|from|pub|import|export|test)\\b",
           "name": "keyword.declaration.wado"
         },
         {

--- a/wado-vscode/tsconfig.json
+++ b/wado-vscode/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "commonjs",
     "target": "ES2022",
     "lib": ["ES2022"],
+    "types": ["node", "mocha", "vscode"],
     "outDir": "out",
     "rootDir": "src",
     "sourceMap": true,


### PR DESCRIPTION
## Summary

Expands the Wado VS Code grammar so that tokens introduced by recent language changes are both highlighted and robustly themed.

- **Operators** — the `TextMate` generator was silently dropping `OperatorCategories::other`, so `..`, `..<`, `..=`, `...`, `::`, `?`, and `matches` produced no highlighting. A new length-sorted `operator_alternation` helper emits them as one pattern (word-boundary-wrapping alphabetic operators like `matches`), folds in `->` / `=>`, and removes the shadowed `arrow`/`reference`/`dereference` patterns. `<<=` / `>>=` / `<<` / `>>` are now tried before their prefixes too.
- **Compile-time literals** — adds a `compile_time_literals` field to `SyntaxDefinition` and emits a `#(file|line|function|data|include_str|include_bytes)\b` pattern with scope `constant.language.compile-time.wado`.
- **Declaration coloring** — restructures `KeywordCategories` into `control` / `storage_type` / `storage_modifier` / `other`, and emits `fn`/`let`/`global`/`struct`/… with **dual scopes** via capture 1 (`storage.type.wado` + `keyword.control.declaration.wado`) so minimalist themes that only style `keyword.control.*` still color them.
- **`task` keyword** — added as a contextual control keyword (lexed as identifier, parser-recognized in `task return` statements) so it gets the same coloring as `return`.
- **Dev task** — `mise run install-wado-vscode-dev` now reruns `npm install && npm run compile` every invocation, so regenerated grammars propagate to the symlinked extension.
- **Tests** — Rust parser-sync tests and `vscode-textmate` tokenization tests lock in scopes for all the above (50 tokenization tests, up from 22).

## Test plan

- [x] `cargo test -p wado-compiler --lib syntax` — 4 passing
- [x] `cargo test -p wado-cli --lib` — schema validation + CLI parse tests passing
- [x] `cd wado-vscode && npm run test:unit` — 50 passing (grammar, language-config, tokenization)
- [x] `mise run update-wado-vscode-grammar` regenerates without diff churn
- [ ] Reload VS Code and visually confirm `fn`/`let`/`global`/`#include_str`/`task return` are now colored

🤖 Generated with [Claude Code](https://claude.com/claude-code)