### PR TITLE
json: refactor for clarity and simpler idioms

### DIFF
--- a/docs/cheatsheet-stdlib-core.md
+++ b/docs/cheatsheet-stdlib-core.md
@@ -869,6 +869,7 @@ impl String {
     pub fn concat(a: String, b: String) -> String;
     pub fn bytes(&self) -> StrUtf8ByteIter;
     pub fn chars(&self) -> StrCharIter;
+    pub fn char_at_byte(&self, byte_index: i32) -> Option<char>;
     pub fn push(&mut self, c: char);
     pub fn truncate(&mut self, byte_len: i32);
     pub fn truncate_chars(&mut self, char_count: i32);

--- a/docs/stdlib-core.md
+++ b/docs/stdlib-core.md
@@ -1628,6 +1628,13 @@ Returns an iterator over the UTF-8 bytes of the string.
 
 Returns an iterator over the Unicode scalar values (chars) of the string.
 
+##### `pub fn char_at_byte(&self, byte_index: i32) -> Option<char>`
+
+Decodes the UTF-8 character starting at the given byte index.
+Returns None if `byte_index` is past the end of the string or there
+aren't enough bytes to form a full UTF-8 sequence.
+Assumes `byte_index` is on a character boundary (the string is valid UTF-8).
+
 ##### `pub fn push(&mut self, c: char)`
 
 Appends a Unicode scalar value (char) to this string.

--- a/wado-compiler/lib/core/json.wado
+++ b/wado-compiler/lib/core/json.wado
@@ -30,49 +30,24 @@ use {
 
 use { parse as fpfmt_parse } from "core:prelude/fpfmt.wado";
 
-pub fn hex_digit(v: i32) -> char {
-    if v < 10 {
-        return ('0' as i32 + v) as u8 as char;
-    }
-    return ('a' as i32 + v - 10) as u8 as char;
-}
-
-pub fn utf8_sequence_length(leading_byte: i32) -> i32 {
-    if leading_byte < 0x80 {
-        return 1;
-    }
-    if leading_byte < 0xE0 {
-        return 2;
-    }
-    if leading_byte < 0xF0 {
-        return 3;
-    }
-    return 4;
-}
-
 /// Writes a JSON-escaped string (with surrounding quotes) into buf.
 pub fn write_escaped_string(buf: &mut String, s: &String) {
     buf.push('"');
     for let c of s.chars() {
-        if c == '"' {
-            buf.push_str("\\\"");
-        } else if c == '\\' {
-            buf.push_str("\\\\");
-        } else if c == '\n' {
-            buf.push_str("\\n");
-        } else if c == '\r' {
-            buf.push_str("\\r");
-        } else if c == '\t' {
-            buf.push_str("\\t");
-        } else if (c as u32) < 0x20 {
-            buf.push_str("\\u00");
-            let code = c as i32;
-            let hi = code >> 4 & 0xF;
-            let lo = code & 0xF;
-            buf.push(hex_digit(hi));
-            buf.push(hex_digit(lo));
-        } else {
-            buf.push(c);
+        match c {
+            '"' => buf.push_str("\\\""),
+            '\\' => buf.push_str("\\\\"),
+            '\n' => buf.push_str("\\n"),
+            '\r' => buf.push_str("\\r"),
+            '\t' => buf.push_str("\\t"),
+            _ => {
+                if (c as u32) < 0x20 {
+                    let code = c as i32;
+                    buf.push_str(`\\u{code:04x}`);
+                } else {
+                    buf.push(c);
+                }
+            },
         }
     }
     buf.push('"');
@@ -116,7 +91,7 @@ impl SerializeSeq for JsonSeqSerializer {
 
     fn end(&mut self) -> Result<(), SerializeError> {
         self.buf.push_str("]");
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 }
 
@@ -144,7 +119,7 @@ impl SerializeMap for JsonMapSerializer {
 
     fn end(&mut self) -> Result<(), SerializeError> {
         self.buf.push_str("}");
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 }
 
@@ -164,7 +139,7 @@ impl SerializeStruct for JsonStructSerializer {
 
     fn end(&mut self) -> Result<(), SerializeError> {
         self.buf.push_str("}");
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 }
 
@@ -178,7 +153,7 @@ impl SerializeVariant for JsonVariantSerializer {
 
     fn end(&mut self) -> Result<(), SerializeError> {
         self.buf.push_str("}");
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 }
 
@@ -190,7 +165,7 @@ impl Serializer for JsonSerializer {
 
     fn serialize_i32(&mut self, v: i32) -> Result<(), SerializeError> {
         self.buf.push_str(`{v}`);
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 
     fn serialize_i64(&mut self, v: i64) -> Result<(), SerializeError> {
@@ -200,12 +175,12 @@ impl Serializer for JsonSerializer {
         } else {
             self.buf.push_str(`{v}`);
         }
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 
     fn serialize_u32(&mut self, v: u32) -> Result<(), SerializeError> {
         self.buf.push_str(`{v}`);
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 
     fn serialize_u64(&mut self, v: u64) -> Result<(), SerializeError> {
@@ -215,53 +190,53 @@ impl Serializer for JsonSerializer {
         } else {
             self.buf.push_str(`{v}`);
         }
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 
     fn serialize_i128(&mut self, v: i128) -> Result<(), SerializeError> {
         // i128 always serialized as string (always exceeds JS safe integer range)
         self.buf.push_str(`"{v}"`);
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 
     fn serialize_u128(&mut self, v: u128) -> Result<(), SerializeError> {
         // u128 always serialized as string (always exceeds JS safe integer range)
         self.buf.push_str(`"{v}"`);
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 
     fn serialize_f32(&mut self, v: f32) -> Result<(), SerializeError> {
         if v.is_nan() {
-            return Result::<(), SerializeError>::Err(SerializeError {
+            return Result::Err(SerializeError {
                 kind: SerializeErrorKind::UnsupportedValue,
                 message: "NaN is not allowed in JSON",
             });
         }
         if !v.is_finite() {
-            return Result::<(), SerializeError>::Err(SerializeError {
+            return Result::Err(SerializeError {
                 kind: SerializeErrorKind::UnsupportedValue,
                 message: "Infinity is not allowed in JSON",
             });
         }
         self.buf.push_str(`{v as f64}`);
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 
     fn serialize_f64(&mut self, v: f64) -> Result<(), SerializeError> {
         if v.is_nan() {
-            return Result::<(), SerializeError>::Err(SerializeError {
+            return Result::Err(SerializeError {
                 kind: SerializeErrorKind::UnsupportedValue,
                 message: "NaN is not allowed in JSON",
             });
         }
         if !v.is_finite() {
-            return Result::<(), SerializeError>::Err(SerializeError {
+            return Result::Err(SerializeError {
                 kind: SerializeErrorKind::UnsupportedValue,
                 message: "Infinity is not allowed in JSON",
             });
         }
         self.buf.push_str(`{v}`);
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 
     fn serialize_bool(&mut self, v: bool) -> Result<(), SerializeError> {
@@ -270,28 +245,28 @@ impl Serializer for JsonSerializer {
         } else {
             self.buf.push_str("false");
         }
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 
     fn serialize_char(&mut self, v: char) -> Result<(), SerializeError> {
         let s = `{v}`;
         write_escaped_string(&mut self.buf, &s);
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 
     fn serialize_string(&mut self, v: &String) -> Result<(), SerializeError> {
         write_escaped_string(&mut self.buf, v);
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 
     fn serialize_null(&mut self) -> Result<(), SerializeError> {
         self.buf.push_str("null");
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 
     fn begin_seq(&mut self, len: i32) -> Result<JsonSeqSerializer, SerializeError> {
         self.buf.push_str("[");
-        return Result::<JsonSeqSerializer, SerializeError>::Ok(JsonSeqSerializer {
+        return Result::Ok(JsonSeqSerializer {
             buf: self.buf,
             count: 0,
         });
@@ -299,7 +274,7 @@ impl Serializer for JsonSerializer {
 
     fn begin_map(&mut self, len: i32) -> Result<JsonMapSerializer, SerializeError> {
         self.buf.push_str("{");
-        return Result::<JsonMapSerializer, SerializeError>::Ok(JsonMapSerializer {
+        return Result::Ok(JsonMapSerializer {
             buf: self.buf,
             count: 0,
             need_value: false,
@@ -308,7 +283,7 @@ impl Serializer for JsonSerializer {
 
     fn begin_struct(&mut self, name: &String, fields: i32) -> Result<JsonStructSerializer, SerializeError> {
         self.buf.push_str("{");
-        return Result::<JsonStructSerializer, SerializeError>::Ok(JsonStructSerializer {
+        return Result::Ok(JsonStructSerializer {
             buf: self.buf,
             count: 0,
         });
@@ -316,14 +291,14 @@ impl Serializer for JsonSerializer {
 
     fn serialize_unit_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<(), SerializeError> {
         write_escaped_string(&mut self.buf, variant_name);
-        return Result::<(), SerializeError>::Ok(());
+        return Result::Ok(());
     }
 
     fn begin_variant(&mut self, type_name: &String, variant_name: &String, disc: i32) -> Result<JsonVariantSerializer, SerializeError> {
         self.buf.push_str("{");
         write_escaped_string(&mut self.buf, variant_name);
         self.buf.push_str(":");
-        return Result::<JsonVariantSerializer, SerializeError>::Ok(JsonVariantSerializer {
+        return Result::Ok(JsonVariantSerializer {
             buf: self.buf,
         });
     }
@@ -360,43 +335,43 @@ impl JsonDeserializer {
     pub fn expect_char(&mut self, c: i32) -> Result<(), DeserializeError> {
         self.skip_whitespace();
         if self.pos >= self.input.len() {
-            return Result::<(), DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+            return Result::Err(DeserializeError::eof(self.pos as i64));
         }
         let b = self.input.get_byte(self.pos) as i32;
         if b != c {
-            return Result::<(), DeserializeError>::Err(DeserializeError::malformed(
+            return Result::Err(DeserializeError::malformed(
                 `expected '{c as u8 as char}', found '{b as u8 as char}'`,
                 self.pos as i64,
             ));
         }
         self.pos += 1;
-        return Result::<(), DeserializeError>::Ok(());
+        return Result::Ok(());
     }
 
-    pub fn expect_literal(&mut self, lit: &String) -> Result<(), DeserializeError> {
+    pub fn expect_literal(&mut self, lit: String) -> Result<(), DeserializeError> {
         let start = self.pos;
         for let b of lit.bytes() {
             if self.pos >= self.input.len() {
-                return Result::<(), DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+                return Result::Err(DeserializeError::eof(self.pos as i64));
             }
             if self.input.get_byte(self.pos) != b {
-                return Result::<(), DeserializeError>::Err(DeserializeError::malformed(
-                    `expected '{*lit}'`,
+                return Result::Err(DeserializeError::malformed(
+                    `expected '{lit}'`,
                     start as i64,
                 ));
             }
             self.pos += 1;
         }
-        return Result::<(), DeserializeError>::Ok(());
+        return Result::Ok(());
     }
 
     pub fn read_json_string(&mut self) -> Result<String, DeserializeError> {
         self.skip_whitespace();
         if self.pos >= self.input.len() {
-            return Result::<String, DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+            return Result::Err(DeserializeError::eof(self.pos as i64));
         }
         if self.input.get_byte(self.pos) as i32 != '"' as i32 {
-            return Result::<String, DeserializeError>::Err(DeserializeError::unexpected_type(
+            return Result::Err(DeserializeError::unexpected_type(
                 "expected string",
                 self.pos as i64,
             ));
@@ -424,7 +399,7 @@ impl JsonDeserializer {
                 result.set_byte(start + i, self.input.get_byte(prefix_start + i));
             }
             self.pos = scan_pos + 1;
-            return Result::<String, DeserializeError>::Ok(result);
+            return Result::Ok(result);
         }
 
         // Slow path: has escape sequences (or hit EOF).
@@ -440,141 +415,100 @@ impl JsonDeserializer {
             let b = self.input.get_byte(self.pos) as i32;
             if b == '"' as i32 {
                 self.pos += 1;
-                return Result::<String, DeserializeError>::Ok(result);
+                return Result::Ok(result);
             }
             if b == '\\' as i32 {
                 self.pos += 1;
                 if self.pos >= self.input.len() {
-                    return Result::<String, DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+                    return Result::Err(DeserializeError::eof(self.pos as i64));
                 }
-                let esc = self.input.get_byte(self.pos) as i32;
-                if esc == '"' as i32 {
-                    result.push('"');
-                } else if esc == '\\' as i32 {
-                    result.push('\\');
-                } else if esc == '/' as i32 {
-                    result.push('/');
-                } else if esc == 'n' as i32 {
-                    result.push('\n');
-                } else if esc == 'r' as i32 {
-                    result.push('\r');
-                } else if esc == 't' as i32 {
-                    result.push('\t');
-                } else if esc == 'b' as i32 {
-                    result.push(8 as u8 as char);
-                } else if esc == 'f' as i32 {
-                    result.push(12 as u8 as char);
-                } else if esc == 'u' as i32 {
-                    let r = self.read_unicode_escape();
-                    if let Ok(c) = r {
-                        result.push(c);
-                    }
-                    if let Err(e) = r {
-                        return Result::<String, DeserializeError>::Err(e);
-                    }
-                } else {
-                    return Result::<String, DeserializeError>::Err(DeserializeError::malformed(
-                        `invalid escape '\\{esc as u8 as char}'`,
+                let esc = self.input.get_byte(self.pos) as u8 as char;
+                match esc {
+                    '"' => result.push('"'),
+                    '\\' => result.push('\\'),
+                    '/' => result.push('/'),
+                    'n' => result.push('\n'),
+                    'r' => result.push('\r'),
+                    't' => result.push('\t'),
+                    'b' => result.push(8 as u8 as char),
+                    'f' => result.push(12 as u8 as char),
+                    'u' => match self.read_unicode_escape() {
+                        Ok(c) => result.push(c),
+                        Err(e) => return Result::Err(e),
+                    },
+                    _ => return Result::Err(DeserializeError::malformed(
+                        `invalid escape '\\{esc}'`,
                         self.pos as i64,
-                    ));
+                    )),
                 }
                 self.pos += 1;
             } else {
                 // Decode a full UTF-8 character from the input bytes.
-                // The input String is valid UTF-8, so we determine the sequence
-                // length from the leading byte, read all bytes, and build a char.
-                let seq_len = utf8_sequence_length(b);
-                if self.pos + seq_len > self.input.len() {
-                    return Result::<String, DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+                // The input String is valid UTF-8, so char_at_byte always succeeds
+                // unless we're past the end of the buffer.
+                match self.input.char_at_byte(self.pos) {
+                    Some(c) => {
+                        result.push(c);
+                        self.pos += c.len_utf8();
+                    },
+                    None => return Result::Err(
+                        DeserializeError::eof(self.pos as i64),
+                    ),
                 }
-                if seq_len == 1 {
-                    result.push(b as u8 as char);
-                } else if seq_len == 2 {
-                    let b0 = b as u32;
-                    let b1 = self.input.get_byte(self.pos + 1) as u32;
-                    let code = (b0 & 0x1F) << 6 | b1 & 0x3F;
-                    if let Some(c) = char::from_u32(code) {
-                        result.push(c);
-                    }
-                } else if seq_len == 3 {
-                    let b0 = b as u32;
-                    let b1 = self.input.get_byte(self.pos + 1) as u32;
-                    let b2 = self.input.get_byte(self.pos + 2) as u32;
-                    let code = (b0 & 0x0F) << 12 | (b1 & 0x3F) << 6 | b2 & 0x3F;
-                    if let Some(c) = char::from_u32(code) {
-                        result.push(c);
-                    }
-                } else {
-                    let b0 = b as u32;
-                    let b1 = self.input.get_byte(self.pos + 1) as u32;
-                    let b2 = self.input.get_byte(self.pos + 2) as u32;
-                    let b3 = self.input.get_byte(self.pos + 3) as u32;
-                    let code = (b0 & 0x07) << 18 | (b1 & 0x3F) << 12 | (b2 & 0x3F) << 6 | b3 & 0x3F;
-                    if let Some(c) = char::from_u32(code) {
-                        result.push(c);
-                    }
-                }
-                self.pos += seq_len;
             }
         }
-        return Result::<String, DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+        return Result::Err(DeserializeError::eof(self.pos as i64));
     }
 
     fn read_unicode_escape(&mut self) -> Result<char, DeserializeError> {
         self.pos += 1;
         let start = self.pos;
         if self.pos + 4 > self.input.len() {
-            return Result::<char, DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+            return Result::Err(DeserializeError::eof(self.pos as i64));
         }
         let mut code: u32 = 0;
         for let mut i = 0; i < 4; i += 1 {
-            let b = self.input.get_byte(self.pos + i) as u32;
-            code = code * 16;
-            if b >= '0' as u32 && b <= '9' as u32 {
-                code = code + b - '0' as u32;
-            } else if b >= 'a' as u32 && b <= 'f' as u32 {
-                code = code + 10 + b - 'a' as u32;
-            } else if b >= 'A' as u32 && b <= 'F' as u32 {
-                code = code + 10 + b - 'A' as u32;
-            } else {
-                return Result::<char, DeserializeError>::Err(DeserializeError::malformed(
+            let c = self.input.get_byte(self.pos + i) as u8 as char;
+            if !c.is_hexdigit() {
+                return Result::Err(DeserializeError::malformed(
                     "invalid unicode escape",
                     start as i64,
                 ));
             }
+            code = code * 16 + c.hex_digit_value() as u32;
         }
         self.pos += 3;
-        if let Some(c) = char::from_u32(code) {
-            return Result::<char, DeserializeError>::Ok(c);
-        }
-        return Result::<char, DeserializeError>::Err(DeserializeError::malformed(
-            "invalid unicode codepoint",
-            start as i64,
-        ));
+        return match char::from_u32(code) {
+            Some(c) => Result::Ok(c),
+            None => Result::Err(DeserializeError::malformed(
+                "invalid unicode codepoint",
+                start as i64,
+            )),
+        };
     }
 
     pub fn read_number_raw(&mut self) -> Result<String, DeserializeError> {
         self.skip_whitespace();
         let start = self.pos;
         if self.pos >= self.input.len() {
-            return Result::<String, DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+            return Result::Err(DeserializeError::eof(self.pos as i64));
         }
         if self.input.get_byte(self.pos) as i32 == '-' as i32 {
             self.pos += 1;
         }
         if self.pos >= self.input.len() {
-            return Result::<String, DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+            return Result::Err(DeserializeError::eof(self.pos as i64));
         }
         let first = self.input.get_byte(self.pos) as i32;
         if first < '0' as i32 || first > '9' as i32 {
-            return Result::<String, DeserializeError>::Err(DeserializeError::unexpected_type(
+            return Result::Err(DeserializeError::unexpected_type(
                 "expected number",
                 self.pos as i64,
             ));
         }
         while self.pos < self.input.len() {
             let b = self.input.get_byte(self.pos) as i32;
-            if b >= '0' as i32 && b <= '9' as i32 {
+            if '0' as i32 <= b <= '9' as i32 {
                 self.pos += 1;
             } else {
                 break;
@@ -584,7 +518,7 @@ impl JsonDeserializer {
             self.pos += 1;
             while self.pos < self.input.len() {
                 let b = self.input.get_byte(self.pos) as i32;
-                if b >= '0' as i32 && b <= '9' as i32 {
+                if '0' as i32 <= b <= '9' as i32 {
                     self.pos += 1;
                 } else {
                     break;
@@ -603,7 +537,7 @@ impl JsonDeserializer {
                 }
                 while self.pos < self.input.len() {
                     let b2 = self.input.get_byte(self.pos) as i32;
-                    if b2 >= '0' as i32 && b2 <= '9' as i32 {
+                    if '0' as i32 <= b2 <= '9' as i32 {
                         self.pos += 1;
                     } else {
                         break;
@@ -615,7 +549,7 @@ impl JsonDeserializer {
         for let mut i = start; i < self.pos; i += 1 {
             raw.push(self.input.get_byte(i) as char);
         }
-        return Result::<String, DeserializeError>::Ok(raw);
+        return Result::Ok(raw);
     }
 
     pub fn has_exp_or_dot(&self, raw: &String) -> bool {
@@ -632,26 +566,27 @@ impl JsonDeserializer {
         let has_exp = self.has_exp_or_dot(raw);
         if has_exp {
             // Parse via f64 for scientific notation (e.g. 1e2 → 100)
-            let parsed = f64::parse(*raw);
-            if let Some(v) = parsed {
-                if v != f64::floor(v) {
-                    return Result::<i32, DeserializeError>::Err(DeserializeError::unexpected_type(
-                        "expected integer, got float",
-                        start,
-                    ));
-                }
-                if v < -2147483648.0 || v > 2147483647.0 {
-                    return Result::<i32, DeserializeError>::Err(DeserializeError::overflow(
-                        "value out of range for i32",
-                        start,
-                    ));
-                }
-                return Result::<i32, DeserializeError>::Ok(v as i32);
+            match f64::parse(*raw) {
+                Some(v) => {
+                    if v != f64::floor(v) {
+                        return Result::Err(DeserializeError::unexpected_type(
+                            "expected integer, got float",
+                            start,
+                        ));
+                    }
+                    if v < -2147483648.0 || v > 2147483647.0 {
+                        return Result::Err(DeserializeError::overflow(
+                            "value out of range for i32",
+                            start,
+                        ));
+                    }
+                    return Result::Ok(v as i32);
+                },
+                None => return Result::Err(DeserializeError::invalid_value(
+                    "invalid number",
+                    start,
+                )),
             }
-            return Result::<i32, DeserializeError>::Err(DeserializeError::invalid_value(
-                "invalid number",
-                start,
-            ));
         }
         let mut neg = false;
         let mut idx = 0;
@@ -664,7 +599,7 @@ impl JsonDeserializer {
         while idx < len {
             let b = raw.get_byte(idx) as i32;
             if b < '0' as i32 || b > '9' as i32 {
-                return Result::<i32, DeserializeError>::Err(DeserializeError::invalid_value(
+                return Result::Err(DeserializeError::invalid_value(
                     "invalid digit in number",
                     start,
                 ));
@@ -676,27 +611,28 @@ impl JsonDeserializer {
         if neg {
             result = -result;
         }
-        return Result::<i32, DeserializeError>::Ok(result);
+        return Result::Ok(result);
     }
 
     pub fn parse_i64_from(&self, raw: &String, start: i64) -> Result<i64, DeserializeError> {
         let has_exp = self.has_exp_or_dot(raw);
         if has_exp {
-            let parsed = f64::parse(*raw);
-            if let Some(v) = parsed {
-                if v != f64::floor(v) {
-                    return Result::<i64, DeserializeError>::Err(DeserializeError::unexpected_type(
-                        "expected integer, got float",
-                        start,
-                    ));
-                }
-                // f64 can represent integers exactly up to 2^53
-                return Result::<i64, DeserializeError>::Ok(v as i64);
+            match f64::parse(*raw) {
+                Some(v) => {
+                    if v != f64::floor(v) {
+                        return Result::Err(DeserializeError::unexpected_type(
+                            "expected integer, got float",
+                            start,
+                        ));
+                    }
+                    // f64 can represent integers exactly up to 2^53
+                    return Result::Ok(v as i64);
+                },
+                None => return Result::Err(DeserializeError::invalid_value(
+                    "invalid number",
+                    start,
+                )),
             }
-            return Result::<i64, DeserializeError>::Err(DeserializeError::invalid_value(
-                "invalid number",
-                start,
-            ));
         }
         let mut neg = false;
         let mut idx = 0;
@@ -709,7 +645,7 @@ impl JsonDeserializer {
         while idx < len {
             let b = raw.get_byte(idx) as i32;
             if b < '0' as i32 || b > '9' as i32 {
-                return Result::<i64, DeserializeError>::Err(DeserializeError::invalid_value(
+                return Result::Err(DeserializeError::invalid_value(
                     "invalid digit in number",
                     start,
                 ));
@@ -721,32 +657,35 @@ impl JsonDeserializer {
         if neg {
             result = -result;
         }
-        return Result::<i64, DeserializeError>::Ok(result);
+        return Result::Ok(result);
     }
 
     pub fn parse_u64_from(&self, raw: &String, start: i64) -> Result<u64, DeserializeError> {
         if raw.len() > 0 && raw.get_byte(0) as i32 == '-' as i32 {
-            return Result::<u64, DeserializeError>::Err(DeserializeError::overflow("negative value for u64", start));
+            return Result::Err(DeserializeError::overflow("negative value for u64", start));
         }
         let has_exp = self.has_exp_or_dot(raw);
         if has_exp {
-            let parsed = f64::parse(*raw);
-            if let Some(v) = parsed {
-                if v < 0.0 {
-                    return Result::<u64, DeserializeError>::Err(DeserializeError::overflow(
-                        "negative value for u64",
-                        start,
-                    ));
-                }
-                if v != f64::floor(v) {
-                    return Result::<u64, DeserializeError>::Err(DeserializeError::unexpected_type(
-                        "expected integer, got float",
-                        start,
-                    ));
-                }
-                return Result::<u64, DeserializeError>::Ok(v as u64);
+            match f64::parse(*raw) {
+                Some(v) => {
+                    if v < 0.0 {
+                        return Result::Err(DeserializeError::overflow(
+                            "negative value for u64",
+                            start,
+                        ));
+                    }
+                    if v != f64::floor(v) {
+                        return Result::Err(DeserializeError::unexpected_type(
+                            "expected integer, got float",
+                            start,
+                        ));
+                    }
+                    return Result::Ok(v as u64);
+                },
+                None => return Result::Err(
+                    DeserializeError::invalid_value("invalid number", start),
+                ),
             }
-            return Result::<u64, DeserializeError>::Err(DeserializeError::invalid_value("invalid number", start));
         }
         let mut idx = 0;
         let len = raw.len();
@@ -754,13 +693,13 @@ impl JsonDeserializer {
         while idx < len {
             let b = raw.get_byte(idx) as i32;
             if b < '0' as i32 || b > '9' as i32 {
-                return Result::<u64, DeserializeError>::Err(DeserializeError::invalid_value("invalid digit", start));
+                return Result::Err(DeserializeError::invalid_value("invalid digit", start));
             }
             let digit = (b - '0' as i32) as u64;
             result = result * 10 + digit;
             idx += 1;
         }
-        return Result::<u64, DeserializeError>::Ok(result);
+        return Result::Ok(result);
     }
 
     /// Advances past a JSON number in `self.input` without allocating a String.
@@ -770,7 +709,7 @@ impl JsonDeserializer {
         }
         while self.pos < self.input.len() {
             let b = self.input.get_byte(self.pos) as i32;
-            if b >= '0' as i32 && b <= '9' as i32 {
+            if '0' as i32 <= b <= '9' as i32 {
                 self.pos += 1;
             } else {
                 break;
@@ -780,7 +719,7 @@ impl JsonDeserializer {
             self.pos += 1;
             while self.pos < self.input.len() {
                 let b = self.input.get_byte(self.pos) as i32;
-                if b >= '0' as i32 && b <= '9' as i32 {
+                if '0' as i32 <= b <= '9' as i32 {
                     self.pos += 1;
                 } else {
                     break;
@@ -799,7 +738,7 @@ impl JsonDeserializer {
                 }
                 while self.pos < self.input.len() {
                     let b2 = self.input.get_byte(self.pos) as i32;
-                    if b2 >= '0' as i32 && b2 <= '9' as i32 {
+                    if '0' as i32 <= b2 <= '9' as i32 {
                         self.pos += 1;
                     } else {
                         break;
@@ -815,7 +754,7 @@ impl JsonDeserializer {
         self.skip_whitespace();
         let start = self.pos as i64;
         if self.pos >= self.input.len() {
-            return Result::<i32, DeserializeError>::Err(DeserializeError::eof(start));
+            return Result::Err(DeserializeError::eof(start));
         }
         let mut neg = false;
         if self.input.get_byte(self.pos) as i32 == '-' as i32 {
@@ -823,11 +762,11 @@ impl JsonDeserializer {
             self.pos += 1;
         }
         if self.pos >= self.input.len() {
-            return Result::<i32, DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+            return Result::Err(DeserializeError::eof(self.pos as i64));
         }
         let first = self.input.get_byte(self.pos) as i32;
         if first < '0' as i32 || first > '9' as i32 {
-            return Result::<i32, DeserializeError>::Err(DeserializeError::unexpected_type(
+            return Result::Err(DeserializeError::unexpected_type(
                 "expected number",
                 self.pos as i64,
             ));
@@ -836,7 +775,7 @@ impl JsonDeserializer {
         self.pos += 1;
         while self.pos < self.input.len() {
             let b = self.input.get_byte(self.pos) as i32;
-            if b >= '0' as i32 && b <= '9' as i32 {
+            if '0' as i32 <= b <= '9' as i32 {
                 result = result * 10 + (b - '0' as i32);
                 self.pos += 1;
             } else if b == '.' as i32 || b == 'e' as i32 || b == 'E' as i32 {
@@ -848,7 +787,7 @@ impl JsonDeserializer {
                     self.pos += 1;
                     while self.pos < self.input.len() {
                         let b2 = self.input.get_byte(self.pos) as i32;
-                        if b2 >= '0' as i32 && b2 <= '9' as i32 {
+                        if '0' as i32 <= b2 <= '9' as i32 {
                             d = d * 10 + (b2 - '0' as i32) as u64;
                             frac += 1;
                             self.pos += 1;
@@ -874,7 +813,7 @@ impl JsonDeserializer {
                         }
                         while self.pos < self.input.len() {
                             let b3 = self.input.get_byte(self.pos) as i32;
-                            if b3 >= '0' as i32 && b3 <= '9' as i32 {
+                            if '0' as i32 <= b3 <= '9' as i32 {
                                 exp = exp * 10 + (b3 - '0' as i32);
                                 self.pos += 1;
                             } else {
@@ -889,18 +828,18 @@ impl JsonDeserializer {
                 let v = fpfmt_parse(d, exp - frac);
                 let v_signed = if neg { -v } else { v };
                 if v_signed != f64::floor(v_signed) {
-                    return Result::<i32, DeserializeError>::Err(DeserializeError::unexpected_type(
+                    return Result::Err(DeserializeError::unexpected_type(
                         "expected integer, got float",
                         start,
                     ));
                 }
                 if v_signed < -2147483648.0 || v_signed > 2147483647.0 {
-                    return Result::<i32, DeserializeError>::Err(DeserializeError::overflow(
+                    return Result::Err(DeserializeError::overflow(
                         "value out of range for i32",
                         start,
                     ));
                 }
-                return Result::<i32, DeserializeError>::Ok(v_signed as i32);
+                return Result::Ok(v_signed as i32);
             } else {
                 break;
             }
@@ -908,7 +847,7 @@ impl JsonDeserializer {
         if neg {
             result = -result;
         }
-        return Result::<i32, DeserializeError>::Ok(result);
+        return Result::Ok(result);
     }
 
     /// Single-pass i64 parsing directly from self.input.
@@ -916,7 +855,7 @@ impl JsonDeserializer {
         self.skip_whitespace();
         let start = self.pos as i64;
         if self.pos >= self.input.len() {
-            return Result::<i64, DeserializeError>::Err(DeserializeError::eof(start));
+            return Result::Err(DeserializeError::eof(start));
         }
         let mut neg = false;
         if self.input.get_byte(self.pos) as i32 == '-' as i32 {
@@ -924,11 +863,11 @@ impl JsonDeserializer {
             self.pos += 1;
         }
         if self.pos >= self.input.len() {
-            return Result::<i64, DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+            return Result::Err(DeserializeError::eof(self.pos as i64));
         }
         let first = self.input.get_byte(self.pos) as i32;
         if first < '0' as i32 || first > '9' as i32 {
-            return Result::<i64, DeserializeError>::Err(DeserializeError::unexpected_type(
+            return Result::Err(DeserializeError::unexpected_type(
                 "expected number",
                 self.pos as i64,
             ));
@@ -937,7 +876,7 @@ impl JsonDeserializer {
         self.pos += 1;
         while self.pos < self.input.len() {
             let b = self.input.get_byte(self.pos) as i32;
-            if b >= '0' as i32 && b <= '9' as i32 {
+            if '0' as i32 <= b <= '9' as i32 {
                 result = result * 10 + (b - '0' as i32) as i64;
                 self.pos += 1;
             } else if b == '.' as i32 || b == 'e' as i32 || b == 'E' as i32 {
@@ -947,7 +886,7 @@ impl JsonDeserializer {
                     self.pos += 1;
                     while self.pos < self.input.len() {
                         let b2 = self.input.get_byte(self.pos) as i32;
-                        if b2 >= '0' as i32 && b2 <= '9' as i32 {
+                        if '0' as i32 <= b2 <= '9' as i32 {
                             d = d * 10 + (b2 - '0' as i32) as u64;
                             frac += 1;
                             self.pos += 1;
@@ -973,7 +912,7 @@ impl JsonDeserializer {
                         }
                         while self.pos < self.input.len() {
                             let b3 = self.input.get_byte(self.pos) as i32;
-                            if b3 >= '0' as i32 && b3 <= '9' as i32 {
+                            if '0' as i32 <= b3 <= '9' as i32 {
                                 exp = exp * 10 + (b3 - '0' as i32);
                                 self.pos += 1;
                             } else {
@@ -988,12 +927,12 @@ impl JsonDeserializer {
                 let v = fpfmt_parse(d, exp - frac);
                 let v_signed = if neg { -v } else { v };
                 if v_signed != f64::floor(v_signed) {
-                    return Result::<i64, DeserializeError>::Err(DeserializeError::unexpected_type(
+                    return Result::Err(DeserializeError::unexpected_type(
                         "expected integer, got float",
                         start,
                     ));
                 }
-                return Result::<i64, DeserializeError>::Ok(v_signed as i64);
+                return Result::Ok(v_signed as i64);
             } else {
                 break;
             }
@@ -1001,7 +940,7 @@ impl JsonDeserializer {
         if neg {
             result = -result;
         }
-        return Result::<i64, DeserializeError>::Ok(result);
+        return Result::Ok(result);
     }
 
     /// Single-pass u64 parsing directly from self.input.
@@ -1009,14 +948,14 @@ impl JsonDeserializer {
         self.skip_whitespace();
         let start = self.pos as i64;
         if self.pos >= self.input.len() {
-            return Result::<u64, DeserializeError>::Err(DeserializeError::eof(start));
+            return Result::Err(DeserializeError::eof(start));
         }
         if self.input.get_byte(self.pos) as i32 == '-' as i32 {
-            return Result::<u64, DeserializeError>::Err(DeserializeError::overflow("negative value for u64", start));
+            return Result::Err(DeserializeError::overflow("negative value for u64", start));
         }
         let first = self.input.get_byte(self.pos) as i32;
         if first < '0' as i32 || first > '9' as i32 {
-            return Result::<u64, DeserializeError>::Err(DeserializeError::unexpected_type(
+            return Result::Err(DeserializeError::unexpected_type(
                 "expected number",
                 self.pos as i64,
             ));
@@ -1025,7 +964,7 @@ impl JsonDeserializer {
         self.pos += 1;
         while self.pos < self.input.len() {
             let b = self.input.get_byte(self.pos) as i32;
-            if b >= '0' as i32 && b <= '9' as i32 {
+            if '0' as i32 <= b <= '9' as i32 {
                 result = result * 10 + (b - '0' as i32) as u64;
                 self.pos += 1;
             } else if b == '.' as i32 || b == 'e' as i32 || b == 'E' as i32 {
@@ -1035,7 +974,7 @@ impl JsonDeserializer {
                     self.pos += 1;
                     while self.pos < self.input.len() {
                         let b2 = self.input.get_byte(self.pos) as i32;
-                        if b2 >= '0' as i32 && b2 <= '9' as i32 {
+                        if '0' as i32 <= b2 <= '9' as i32 {
                             d = d * 10 + (b2 - '0' as i32) as u64;
                             frac += 1;
                             self.pos += 1;
@@ -1061,7 +1000,7 @@ impl JsonDeserializer {
                         }
                         while self.pos < self.input.len() {
                             let b3 = self.input.get_byte(self.pos) as i32;
-                            if b3 >= '0' as i32 && b3 <= '9' as i32 {
+                            if '0' as i32 <= b3 <= '9' as i32 {
                                 exp = exp * 10 + (b3 - '0' as i32);
                                 self.pos += 1;
                             } else {
@@ -1075,23 +1014,23 @@ impl JsonDeserializer {
                 }
                 let v = fpfmt_parse(d, exp - frac);
                 if v < 0.0 {
-                    return Result::<u64, DeserializeError>::Err(DeserializeError::overflow(
+                    return Result::Err(DeserializeError::overflow(
                         "negative value for u64",
                         start,
                     ));
                 }
                 if v != f64::floor(v) {
-                    return Result::<u64, DeserializeError>::Err(DeserializeError::unexpected_type(
+                    return Result::Err(DeserializeError::unexpected_type(
                         "expected integer, got float",
                         start,
                     ));
                 }
-                return Result::<u64, DeserializeError>::Ok(v as u64);
+                return Result::Ok(v as u64);
             } else {
                 break;
             }
         }
-        return Result::<u64, DeserializeError>::Ok(result);
+        return Result::Ok(result);
     }
 
     /// Single-pass f64 parsing directly from self.input using fpfmt.
@@ -1100,7 +1039,7 @@ impl JsonDeserializer {
         self.skip_whitespace();
         let start = self.pos as i64;
         if self.pos >= self.input.len() {
-            return Result::<f64, DeserializeError>::Err(DeserializeError::eof(start));
+            return Result::Err(DeserializeError::eof(start));
         }
         let mut neg = false;
         if self.input.get_byte(self.pos) as i32 == '-' as i32 {
@@ -1108,11 +1047,11 @@ impl JsonDeserializer {
             self.pos += 1;
         }
         if self.pos >= self.input.len() {
-            return Result::<f64, DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+            return Result::Err(DeserializeError::eof(self.pos as i64));
         }
         let first = self.input.get_byte(self.pos) as i32;
         if first < '0' as i32 || first > '9' as i32 {
-            return Result::<f64, DeserializeError>::Err(DeserializeError::unexpected_type(
+            return Result::Err(DeserializeError::unexpected_type(
                 "expected number",
                 self.pos as i64,
             ));
@@ -1122,7 +1061,7 @@ impl JsonDeserializer {
         self.pos += 1;
         while self.pos < self.input.len() {
             let b = self.input.get_byte(self.pos) as i32;
-            if b >= '0' as i32 && b <= '9' as i32 {
+            if '0' as i32 <= b <= '9' as i32 {
                 if total_digits < 19 {
                     d = d * 10 + (b - '0' as i32) as u64;
                 }
@@ -1137,7 +1076,7 @@ impl JsonDeserializer {
             self.pos += 1;
             while self.pos < self.input.len() {
                 let b = self.input.get_byte(self.pos) as i32;
-                if b >= '0' as i32 && b <= '9' as i32 {
+                if '0' as i32 <= b <= '9' as i32 {
                     if total_digits < 19 {
                         d = d * 10 + (b - '0' as i32) as u64;
                         frac += 1;
@@ -1166,7 +1105,7 @@ impl JsonDeserializer {
                 }
                 while self.pos < self.input.len() {
                     let b3 = self.input.get_byte(self.pos) as i32;
-                    if b3 >= '0' as i32 && b3 <= '9' as i32 {
+                    if '0' as i32 <= b3 <= '9' as i32 {
                         exp = exp * 10 + (b3 - '0' as i32);
                         self.pos += 1;
                     } else {
@@ -1180,24 +1119,24 @@ impl JsonDeserializer {
         }
         if d == 0 {
             let v = if neg { -0.0 } else { 0.0 };
-            return Result::<f64, DeserializeError>::Ok(v);
+            return Result::Ok(v);
         }
         // Adjust for digits beyond 19 that were not accumulated
         let extra_int_digits = if total_digits - frac > 19 { total_digits - frac - 19 } else { 0 };
         let eff_p = exp - frac + extra_int_digits;
         if eff_p > 350 {
             let v = if neg { f64::NEG_INFINITY } else { f64::INFINITY };
-            return Result::<f64, DeserializeError>::Ok(v);
+            return Result::Ok(v);
         }
         if eff_p < -351 {
             let v = if neg { -0.0 } else { 0.0 };
-            return Result::<f64, DeserializeError>::Ok(v);
+            return Result::Ok(v);
         }
         let v = fpfmt_parse(d, eff_p);
         if neg {
-            return Result::<f64, DeserializeError>::Ok(-v);
+            return Result::Ok(-v);
         }
-        return Result::<f64, DeserializeError>::Ok(v);
+        return Result::Ok(v);
     }
 
     /// Advances past a JSON string without allocating.
@@ -1208,12 +1147,12 @@ impl JsonDeserializer {
             let b = self.input.get_byte(self.pos) as i32;
             if b == '"' as i32 {
                 self.pos += 1;
-                return Result::<(), DeserializeError>::Ok(());
+                return Result::Ok(());
             }
             if b == '\\' as i32 {
                 self.pos += 1;
                 if self.pos >= self.input.len() {
-                    return Result::<(), DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+                    return Result::Err(DeserializeError::eof(self.pos as i64));
                 }
                 let esc = self.input.get_byte(self.pos) as i32;
                 if esc == 'u' as i32 {
@@ -1223,113 +1162,95 @@ impl JsonDeserializer {
             }
             self.pos += 1;
         }
-        return Result::<(), DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+        return Result::Err(DeserializeError::eof(self.pos as i64));
     }
 
     /// Skips the next JSON value without allocating.
     pub fn skip_value(&mut self) -> Result<(), DeserializeError> {
         self.skip_whitespace();
         if self.pos >= self.input.len() {
-            return Result::<(), DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+            return Result::Err(DeserializeError::eof(self.pos as i64));
         }
-        let b = self.input.get_byte(self.pos) as i32;
-        if b == '"' as i32 {
-            return self.skip_string();
-        }
-        if b == 't' as i32 {
-            return self.expect_literal(&"true");
-        }
-        if b == 'f' as i32 {
-            return self.expect_literal(&"false");
-        }
-        if b == 'n' as i32 {
-            return self.expect_literal(&"null");
-        }
-        if b == '[' as i32 {
-            self.pos += 1;
-            self.skip_whitespace();
-            if self.pos < self.input.len() && self.input.get_byte(self.pos) as i32 == ']' as i32 {
+        let b = self.input.get_byte(self.pos) as u8 as char;
+        match b {
+            '"' => return self.skip_string(),
+            't' => return self.expect_literal("true"),
+            'f' => return self.expect_literal("false"),
+            'n' => return self.expect_literal("null"),
+            '[' => {
                 self.pos += 1;
-                return Result::<(), DeserializeError>::Ok(());
-            }
-            loop {
-                let r = self.skip_value();
-                if let Err(e) = r {
-                    return Result::<(), DeserializeError>::Err(e);
-                }
                 self.skip_whitespace();
-                if self.pos >= self.input.len() {
-                    return Result::<(), DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
-                }
-                let c = self.input.get_byte(self.pos) as i32;
-                if c == ']' as i32 {
+                if self.pos < self.input.len() && self.input.get_byte(self.pos) as i32 == ']' as i32 {
                     self.pos += 1;
-                    return Result::<(), DeserializeError>::Ok(());
+                    return Result::Ok(());
                 }
-                if c == ',' as i32 {
-                    self.pos += 1;
-                } else {
-                    return Result::<(), DeserializeError>::Err(DeserializeError::malformed(
-                        "expected ',' or ']'",
-                        self.pos as i64,
-                    ));
+                loop {
+                    self.skip_value()?;
+                    self.skip_whitespace();
+                    if self.pos >= self.input.len() {
+                        return Result::Err(DeserializeError::eof(self.pos as i64));
+                    }
+                    let c = self.input.get_byte(self.pos) as u8 as char;
+                    match c {
+                        ']' => {
+                            self.pos += 1;
+                            return Result::Ok(());
+                        },
+                        ',' => self.pos += 1,
+                        _ => return Result::Err(DeserializeError::malformed(
+                            "expected ',' or ']'",
+                            self.pos as i64,
+                        )),
+                    }
                 }
-            }
-        }
-        if b == '{' as i32 {
-            self.pos += 1;
-            self.skip_whitespace();
-            if self.pos < self.input.len() && self.input.get_byte(self.pos) as i32 == '}' as i32 {
+            },
+            '{' => {
                 self.pos += 1;
-                return Result::<(), DeserializeError>::Ok(());
-            }
-            loop {
                 self.skip_whitespace();
-                if self.pos >= self.input.len() || self.input.get_byte(self.pos) as i32 != '"' as i32 {
-                    return Result::<(), DeserializeError>::Err(DeserializeError::malformed(
-                        "expected string key",
-                        self.pos as i64,
-                    ));
-                }
-                let kr = self.skip_string();
-                if let Err(e) = kr {
-                    return Result::<(), DeserializeError>::Err(e);
-                }
-                let cr = self.expect_char(':' as i32);
-                if let Err(e) = cr {
-                    return Result::<(), DeserializeError>::Err(e);
-                }
-                let vr = self.skip_value();
-                if let Err(e) = vr {
-                    return Result::<(), DeserializeError>::Err(e);
-                }
-                self.skip_whitespace();
-                if self.pos >= self.input.len() {
-                    return Result::<(), DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
-                }
-                let c = self.input.get_byte(self.pos) as i32;
-                if c == '}' as i32 {
+                if self.pos < self.input.len() && self.input.get_byte(self.pos) as i32 == '}' as i32 {
                     self.pos += 1;
-                    return Result::<(), DeserializeError>::Ok(());
+                    return Result::Ok(());
                 }
-                if c == ',' as i32 {
-                    self.pos += 1;
-                } else {
-                    return Result::<(), DeserializeError>::Err(DeserializeError::malformed(
-                        "expected ',' or '}'",
-                        self.pos as i64,
-                    ));
+                loop {
+                    self.skip_whitespace();
+                    if self.pos >= self.input.len() || self.input.get_byte(self.pos) as i32 != '"' as i32 {
+                        return Result::Err(DeserializeError::malformed(
+                            "expected string key",
+                            self.pos as i64,
+                        ));
+                    }
+                    self.skip_string()?;
+                    self.expect_char(':' as i32)?;
+                    self.skip_value()?;
+                    self.skip_whitespace();
+                    if self.pos >= self.input.len() {
+                        return Result::Err(DeserializeError::eof(self.pos as i64));
+                    }
+                    let c = self.input.get_byte(self.pos) as u8 as char;
+                    match c {
+                        '}' => {
+                            self.pos += 1;
+                            return Result::Ok(());
+                        },
+                        ',' => self.pos += 1,
+                        _ => return Result::Err(DeserializeError::malformed(
+                            "expected ',' or '}'",
+                            self.pos as i64,
+                        )),
+                    }
                 }
-            }
+            },
+            _ => {
+                if b == '-' || '0' <= b <= '9' {
+                    self.skip_number();
+                    return Result::Ok(());
+                }
+                return Result::Err(DeserializeError::malformed(
+                    `unexpected character '{b}'`,
+                    self.pos as i64,
+                ));
+            },
         }
-        if b == '-' as i32 || b >= '0' as i32 && b <= '9' as i32 {
-            self.skip_number();
-            return Result::<(), DeserializeError>::Ok(());
-        }
-        return Result::<(), DeserializeError>::Err(DeserializeError::malformed(
-            `unexpected character '{b as u8 as char}'`,
-            self.pos as i64,
-        ));
     }
 }
 
@@ -1361,26 +1282,19 @@ impl DeserializeSeq for JsonSeqAccess {
     fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, DeserializeError> {
         self.de.skip_whitespace();
         if self.de.pos >= self.de.input.len() {
-            return Result::<Option<T>, DeserializeError>::Err(DeserializeError::eof(self.de.pos as i64));
+            return Result::Err(DeserializeError::eof(self.de.pos as i64));
         }
         if self.de.input.get_byte(self.de.pos) as i32 == ']' as i32 {
-            return Result::<Option<T>, DeserializeError>::Ok(null);
+            return Result::Ok(null);
         }
         if !self.first {
-            let r = self.de.expect_char(',' as i32);
-            if let Err(e) = r {
-                return Result::<Option<T>, DeserializeError>::Err(e);
-            }
+            self.de.expect_char(',' as i32)?;
         }
         self.first = false;
-        let elem = T::deserialize::<JsonDeserializer>(&mut self.de);
-        if let Ok(v) = elem {
-            return Result::<Option<T>, DeserializeError>::Ok(Option::<T>::Some(v));
-        }
-        if let Err(e) = elem {
-            return Result::<Option<T>, DeserializeError>::Err(e);
-        }
-        unreachable();
+        return match T::deserialize::<JsonDeserializer>(&mut self.de) {
+            Ok(v) => Result::Ok(Option::Some(v)),
+            Err(e) => Result::Err(e),
+        };
     }
 
     fn end(&mut self) -> Result<(), DeserializeError> {
@@ -1392,30 +1306,18 @@ impl DeserializeMap for JsonMapAccess {
     fn next_key_string(&mut self) -> Result<Option<String>, DeserializeError> {
         self.de.skip_whitespace();
         if self.de.pos >= self.de.input.len() {
-            return Result::<Option<String>, DeserializeError>::Err(DeserializeError::eof(self.de.pos as i64));
+            return Result::Err(DeserializeError::eof(self.de.pos as i64));
         }
         if self.de.input.get_byte(self.de.pos) as i32 == '}' as i32 {
-            return Result::<Option<String>, DeserializeError>::Ok(null);
+            return Result::Ok(null);
         }
         if !self.first {
-            let r = self.de.expect_char(',' as i32);
-            if let Err(e) = r {
-                return Result::<Option<String>, DeserializeError>::Err(e);
-            }
+            self.de.expect_char(',' as i32)?;
         }
         self.first = false;
-        let key_r = self.de.read_json_string();
-        if let Ok(key) = key_r {
-            let r = self.de.expect_char(':' as i32);
-            if let Err(e) = r {
-                return Result::<Option<String>, DeserializeError>::Err(e);
-            }
-            return Result::<Option<String>, DeserializeError>::Ok(Option::<String>::Some(key));
-        }
-        if let Err(e) = key_r {
-            return Result::<Option<String>, DeserializeError>::Err(e);
-        }
-        unreachable();
+        let key = self.de.read_json_string()?;
+        self.de.expect_char(':' as i32)?;
+        return Result::Ok(Option::Some(key));
     }
 
     fn next_value<V: Deserialize>(&mut self) -> Result<V, DeserializeError> {
@@ -1431,16 +1333,13 @@ impl DeserializeStruct for JsonStructAccess {
     fn next_field(&mut self) -> Result<Option<i32>, DeserializeError> {
         self.de.skip_whitespace();
         if self.de.pos >= self.de.input.len() {
-            return Result::<Option<i32>, DeserializeError>::Err(DeserializeError::eof(self.de.pos as i64));
+            return Result::Err(DeserializeError::eof(self.de.pos as i64));
         }
         if self.de.input.get_byte(self.de.pos) as i32 == '}' as i32 {
-            return Result::<Option<i32>, DeserializeError>::Ok(null);
+            return Result::Ok(null);
         }
         if !self.first {
-            let r = self.de.expect_char(',' as i32);
-            if let Err(e) = r {
-                return Result::<Option<i32>, DeserializeError>::Err(e);
-            }
+            self.de.expect_char(',' as i32)?;
         }
         self.first = false;
 
@@ -1449,7 +1348,7 @@ impl DeserializeStruct for JsonStructAccess {
         // directly to the lookup function, avoiding String allocation entirely.
         self.de.skip_whitespace();
         if self.de.pos >= self.de.input.len() || self.de.input.get_byte(self.de.pos) as i32 != '"' as i32 {
-            return Result::<Option<i32>, DeserializeError>::Err(DeserializeError::unexpected_type(
+            return Result::Err(DeserializeError::unexpected_type(
                 "expected string key",
                 self.de.pos as i64,
             ));
@@ -1473,36 +1372,24 @@ impl DeserializeStruct for JsonStructAccess {
             // Fast path: key has no escapes, compare directly from input buffer
             let key_end = self.de.pos;
             self.de.pos += 1;  // skip closing '"'
-            let r = self.de.expect_char(':' as i32);
-            if let Err(e) = r {
-                return Result::<Option<i32>, DeserializeError>::Err(e);
-            }
-            let idx = (self.lookup)(&self.de.input, key_start, key_end);
-            if let Some(i) = idx {
-                return Result::<Option<i32>, DeserializeError>::Ok(Option::<i32>::Some(i));
-            }
-            return Result::<Option<i32>, DeserializeError>::Ok(Option::<i32>::Some(-1));
+            self.de.expect_char(':' as i32)?;
+            let idx = match (self.lookup)(&self.de.input, key_start, key_end) {
+                Some(i) => i,
+                None => -1,
+            };
+            return Result::Ok(Option::Some(idx));
         }
 
         // Slow path: key has escape sequences, must parse fully.
         // Reset position to before the key and use read_json_string.
         self.de.pos = key_start - 1;
-        let key_r = self.de.read_json_string();
-        if let Ok(key) = key_r {
-            let r = self.de.expect_char(':' as i32);
-            if let Err(e) = r {
-                return Result::<Option<i32>, DeserializeError>::Err(e);
-            }
-            let idx = (self.lookup)(&key, 0, key.len());
-            if let Some(i) = idx {
-                return Result::<Option<i32>, DeserializeError>::Ok(Option::<i32>::Some(i));
-            }
-            return Result::<Option<i32>, DeserializeError>::Ok(Option::<i32>::Some(-1));
-        }
-        if let Err(e) = key_r {
-            return Result::<Option<i32>, DeserializeError>::Err(e);
-        }
-        unreachable();
+        let key = self.de.read_json_string()?;
+        self.de.expect_char(':' as i32)?;
+        let idx = match (self.lookup)(&key, 0, key.len()) {
+            Some(i) => i,
+            None => -1,
+        };
+        return Result::Ok(Option::Some(idx));
     }
 
     fn value<T: Deserialize>(&mut self) -> Result<T, DeserializeError> {
@@ -1520,11 +1407,11 @@ impl DeserializeStruct for JsonStructAccess {
 
 impl DeserializeVariant for JsonVariantAccess {
     fn variant_name(&mut self) -> Result<String, DeserializeError> {
-        return Result::<String, DeserializeError>::Ok(self.variant);
+        return Result::Ok(self.variant);
     }
 
     fn disc(&mut self) -> Result<i32, DeserializeError> {
-        return Result::<i32, DeserializeError>::Err(DeserializeError {
+        return Result::Err(DeserializeError {
             kind: DeserializeErrorKind::Custom,
             message: "JSON does not encode discriminants",
             offset: -1,
@@ -1536,14 +1423,14 @@ impl DeserializeVariant for JsonVariantAccess {
     }
 
     fn is_unit(&mut self) -> Result<bool, DeserializeError> {
-        return Result::<bool, DeserializeError>::Ok(!self.is_object);
+        return Result::Ok(!self.is_object);
     }
 
     fn end(&mut self) -> Result<(), DeserializeError> {
         if self.is_object {
             return self.de.expect_char('}' as i32);
         }
-        return Result::<(), DeserializeError>::Ok(());
+        return Result::Ok(());
     }
 }
 
@@ -1562,34 +1449,22 @@ impl Deserializer for JsonDeserializer {
         let start = self.pos as i64;
         // Accept string-encoded integers (for large values serialized as strings)
         if self.pos < self.input.len() && self.input.get_byte(self.pos) as i32 == '"' as i32 {
-            let sr = self.read_json_string();
-            if let Ok(s) = sr {
-                return self.parse_i64_from(&s, start);
-            }
-            if let Err(e) = sr {
-                return Result::<i64, DeserializeError>::Err(e);
-            }
-            unreachable();
+            let s = self.read_json_string()?;
+            return self.parse_i64_from(&s, start);
         }
         return self.parse_i64_direct();
     }
 
     fn deserialize_u32(&mut self) -> Result<u32, DeserializeError> {
         let start = self.pos as i64;
-        let ir = self.parse_i64_direct();
-        if let Ok(v) = ir {
-            if v < 0 || v > 4294967295 {
-                return Result::<u32, DeserializeError>::Err(DeserializeError::overflow(
-                    "value out of range for u32",
-                    start,
-                ));
-            }
-            return Result::<u32, DeserializeError>::Ok(v as u32);
+        let v = self.parse_i64_direct()?;
+        if v < 0 || v > 4294967295 {
+            return Result::Err(DeserializeError::overflow(
+                "value out of range for u32",
+                start,
+            ));
         }
-        if let Err(e) = ir {
-            return Result::<u32, DeserializeError>::Err(e);
-        }
-        unreachable();
+        return Result::Ok(v as u32);
     }
 
     fn deserialize_u64(&mut self) -> Result<u64, DeserializeError> {
@@ -1597,14 +1472,8 @@ impl Deserializer for JsonDeserializer {
         let start = self.pos as i64;
         // Accept string-encoded integers (for large values serialized as strings)
         if self.pos < self.input.len() && self.input.get_byte(self.pos) as i32 == '"' as i32 {
-            let sr = self.read_json_string();
-            if let Ok(s) = sr {
-                return self.parse_u64_from(&s, start);
-            }
-            if let Err(e) = sr {
-                return Result::<u64, DeserializeError>::Err(e);
-            }
-            unreachable();
+            let s = self.read_json_string()?;
+            return self.parse_u64_from(&s, start);
         }
         return self.parse_u64_direct();
     }
@@ -1614,36 +1483,30 @@ impl Deserializer for JsonDeserializer {
         let start = self.pos as i64;
         // String-encoded path for large values
         if self.pos < self.input.len() && self.input.get_byte(self.pos) as i32 == '"' as i32 {
-            let sr = self.read_json_string();
-            if let Ok(raw) = sr {
-                let mut neg = false;
-                let mut idx = 0;
-                let len = raw.len();
-                if len > 0 && raw.get_byte(0) as i32 == '-' as i32 {
-                    neg = true;
-                    idx = 1;
-                }
-                let mut result: i128 = 0;
-                while idx < len {
-                    let b = raw.get_byte(idx) as i32;
-                    if b < '0' as i32 || b > '9' as i32 {
-                        return Result::<i128, DeserializeError>::Err(DeserializeError::invalid_value(
-                            "invalid digit in i128",
-                            start,
-                        ));
-                    }
-                    result = result * 10 + (b - '0' as i32) as i128;
-                    idx += 1;
-                }
-                if neg {
-                    result = -result;
-                }
-                return Result::<i128, DeserializeError>::Ok(result);
+            let raw = self.read_json_string()?;
+            let mut neg = false;
+            let mut idx = 0;
+            let len = raw.len();
+            if len > 0 && raw.get_byte(0) as i32 == '-' as i32 {
+                neg = true;
+                idx = 1;
             }
-            if let Err(e) = sr {
-                return Result::<i128, DeserializeError>::Err(e);
+            let mut result: i128 = 0;
+            while idx < len {
+                let b = raw.get_byte(idx) as i32;
+                if b < '0' as i32 || b > '9' as i32 {
+                    return Result::Err(DeserializeError::invalid_value(
+                        "invalid digit in i128",
+                        start,
+                    ));
+                }
+                result = result * 10 + (b - '0' as i32) as i128;
+                idx += 1;
             }
-            unreachable();
+            if neg {
+                result = -result;
+            }
+            return Result::Ok(result);
         }
         // Direct parsing from input
         let mut neg = false;
@@ -1654,7 +1517,7 @@ impl Deserializer for JsonDeserializer {
         let mut result: i128 = 0;
         while self.pos < self.input.len() {
             let b = self.input.get_byte(self.pos) as i32;
-            if b >= '0' as i32 && b <= '9' as i32 {
+            if '0' as i32 <= b <= '9' as i32 {
                 result = result * 10 + (b - '0' as i32) as i128;
                 self.pos += 1;
             } else {
@@ -1664,7 +1527,7 @@ impl Deserializer for JsonDeserializer {
         if neg {
             result = -result;
         }
-        return Result::<i128, DeserializeError>::Ok(result);
+        return Result::Ok(result);
     }
 
     fn deserialize_u128(&mut self) -> Result<u128, DeserializeError> {
@@ -1672,61 +1535,49 @@ impl Deserializer for JsonDeserializer {
         let start = self.pos as i64;
         // String-encoded path
         if self.pos < self.input.len() && self.input.get_byte(self.pos) as i32 == '"' as i32 {
-            let sr = self.read_json_string();
-            if let Ok(raw) = sr {
-                let len = raw.len();
-                if len > 0 && raw.get_byte(0) as i32 == '-' as i32 {
-                    return Result::<u128, DeserializeError>::Err(DeserializeError::overflow(
-                        "negative value for u128",
+            let raw = self.read_json_string()?;
+            let len = raw.len();
+            if len > 0 && raw.get_byte(0) as i32 == '-' as i32 {
+                return Result::Err(DeserializeError::overflow(
+                    "negative value for u128",
+                    start,
+                ));
+            }
+            let mut result: u128 = 0;
+            let mut idx = 0;
+            while idx < len {
+                let b = raw.get_byte(idx) as i32;
+                if b < '0' as i32 || b > '9' as i32 {
+                    return Result::Err(DeserializeError::invalid_value(
+                        "invalid digit in u128",
                         start,
                     ));
                 }
-                let mut result: u128 = 0;
-                let mut idx = 0;
-                while idx < len {
-                    let b = raw.get_byte(idx) as i32;
-                    if b < '0' as i32 || b > '9' as i32 {
-                        return Result::<u128, DeserializeError>::Err(DeserializeError::invalid_value(
-                            "invalid digit in u128",
-                            start,
-                        ));
-                    }
-                    result = result * 10 + (b - '0' as i32) as u128;
-                    idx += 1;
-                }
-                return Result::<u128, DeserializeError>::Ok(result);
+                result = result * 10 + (b - '0' as i32) as u128;
+                idx += 1;
             }
-            if let Err(e) = sr {
-                return Result::<u128, DeserializeError>::Err(e);
-            }
-            unreachable();
+            return Result::Ok(result);
         }
         // Direct parsing from input
         if self.pos < self.input.len() && self.input.get_byte(self.pos) as i32 == '-' as i32 {
-            return Result::<u128, DeserializeError>::Err(DeserializeError::overflow("negative value for u128", start));
+            return Result::Err(DeserializeError::overflow("negative value for u128", start));
         }
         let mut result: u128 = 0;
         while self.pos < self.input.len() {
             let b = self.input.get_byte(self.pos) as i32;
-            if b >= '0' as i32 && b <= '9' as i32 {
+            if '0' as i32 <= b <= '9' as i32 {
                 result = result * 10 + (b - '0' as i32) as u128;
                 self.pos += 1;
             } else {
                 break;
             }
         }
-        return Result::<u128, DeserializeError>::Ok(result);
+        return Result::Ok(result);
     }
 
     fn deserialize_f32(&mut self) -> Result<f32, DeserializeError> {
-        let r = self.parse_f64_direct();
-        if let Ok(v) = r {
-            return Result::<f32, DeserializeError>::Ok(v as f32);
-        }
-        if let Err(e) = r {
-            return Result::<f32, DeserializeError>::Err(e);
-        }
-        unreachable();
+        let v = self.parse_f64_direct()?;
+        return Result::Ok(v as f32);
     }
 
     fn deserialize_f64(&mut self) -> Result<f64, DeserializeError> {
@@ -1736,50 +1587,43 @@ impl Deserializer for JsonDeserializer {
     fn deserialize_bool(&mut self) -> Result<bool, DeserializeError> {
         self.skip_whitespace();
         if self.pos >= self.input.len() {
-            return Result::<bool, DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+            return Result::Err(DeserializeError::eof(self.pos as i64));
         }
-        let b = self.input.get_byte(self.pos) as i32;
-        if b == 't' as i32 {
-            let r = self.expect_literal(&"true");
-            if let Err(e) = r {
-                return Result::<bool, DeserializeError>::Err(e);
-            }
-            return Result::<bool, DeserializeError>::Ok(true);
+        let b = self.input.get_byte(self.pos) as u8 as char;
+        match b {
+            't' => {
+                self.expect_literal("true")?;
+                return Result::Ok(true);
+            },
+            'f' => {
+                self.expect_literal("false")?;
+                return Result::Ok(false);
+            },
+            _ => return Result::Err(
+                DeserializeError::unexpected_type("expected bool", self.pos as i64),
+            ),
         }
-        if b == 'f' as i32 {
-            let r = self.expect_literal(&"false");
-            if let Err(e) = r {
-                return Result::<bool, DeserializeError>::Err(e);
-            }
-            return Result::<bool, DeserializeError>::Ok(false);
-        }
-        return Result::<bool, DeserializeError>::Err(
-            DeserializeError::unexpected_type("expected bool", self.pos as i64),
-        );
     }
 
     fn deserialize_char(&mut self) -> Result<char, DeserializeError> {
-        let r = self.read_json_string();
-        if let Ok(s) = r {
-            let mut iter = s.chars();
-            if let Some(c) = iter.next() {
-                if let Some(_) = iter.next() {
-                    return Result::<char, DeserializeError>::Err(DeserializeError::invalid_value(
+        let s = self.read_json_string()?;
+        let mut iter = s.chars();
+        return match iter.next() {
+            Some(c) => {
+                if iter.next() matches { Some(_) } {
+                    Result::Err(DeserializeError::invalid_value(
                         "expected single char",
                         self.pos as i64,
-                    ));
+                    ))
+                } else {
+                    Result::Ok(c)
                 }
-                return Result::<char, DeserializeError>::Ok(c);
-            }
-            return Result::<char, DeserializeError>::Err(DeserializeError::invalid_value(
+            },
+            None => Result::Err(DeserializeError::invalid_value(
                 "empty string for char",
                 self.pos as i64,
-            ));
-        }
-        if let Err(e) = r {
-            return Result::<char, DeserializeError>::Err(e);
-        }
-        unreachable();
+            )),
+        };
     }
 
     fn deserialize_string(&mut self) -> Result<String, DeserializeError> {
@@ -1794,40 +1638,31 @@ impl Deserializer for JsonDeserializer {
                 && self.input.get_byte(self.pos + 2) as i32 == 'l' as i32
                 && self.input.get_byte(self.pos + 3) as i32 == 'l' as i32 {
                 self.pos += 4;
-                return Result::<bool, DeserializeError>::Ok(true);
+                return Result::Ok(true);
             }
         }
-        return Result::<bool, DeserializeError>::Ok(false);
+        return Result::Ok(false);
     }
 
     fn begin_seq(&mut self) -> Result<JsonSeqAccess, DeserializeError> {
-        let r = self.expect_char('[' as i32);
-        if let Err(e) = r {
-            return Result::<JsonSeqAccess, DeserializeError>::Err(e);
-        }
-        return Result::<JsonSeqAccess, DeserializeError>::Ok(JsonSeqAccess {
+        self.expect_char('[' as i32)?;
+        return Result::Ok(JsonSeqAccess {
             de: *self,
             first: true,
         });
     }
 
     fn begin_map(&mut self) -> Result<JsonMapAccess, DeserializeError> {
-        let r = self.expect_char('{' as i32);
-        if let Err(e) = r {
-            return Result::<JsonMapAccess, DeserializeError>::Err(e);
-        }
-        return Result::<JsonMapAccess, DeserializeError>::Ok(JsonMapAccess {
+        self.expect_char('{' as i32)?;
+        return Result::Ok(JsonMapAccess {
             de: *self,
             first: true,
         });
     }
 
     fn begin_struct(&mut self, name: &String, num_fields: i32, lookup: fn(&String, i32, i32) -> Option<i32>) -> Result<JsonStructAccess, DeserializeError> {
-        let r = self.expect_char('{' as i32);
-        if let Err(e) = r {
-            return Result::<JsonStructAccess, DeserializeError>::Err(e);
-        }
-        return Result::<JsonStructAccess, DeserializeError>::Ok(JsonStructAccess {
+        self.expect_char('{' as i32)?;
+        return Result::Ok(JsonStructAccess {
             de: *self,
             lookup,
             first: true,
@@ -1837,136 +1672,90 @@ impl Deserializer for JsonDeserializer {
     fn begin_variant(&mut self, type_name: &String, num_cases: i32) -> Result<JsonVariantAccess, DeserializeError> {
         self.skip_whitespace();
         if self.pos >= self.input.len() {
-            return Result::<JsonVariantAccess, DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+            return Result::Err(DeserializeError::eof(self.pos as i64));
         }
-        let b = self.input.get_byte(self.pos) as i32;
-        if b == '"' as i32 {
-            let r = self.read_json_string();
-            if let Ok(name) = r {
-                return Result::<JsonVariantAccess, DeserializeError>::Ok(JsonVariantAccess {
+        let b = self.input.get_byte(self.pos) as u8 as char;
+        match b {
+            '"' => {
+                let name = self.read_json_string()?;
+                return Result::Ok(JsonVariantAccess {
                     de: *self,
                     variant: name,
                     is_object: false,
                 });
-            }
-            if let Err(e) = r {
-                return Result::<JsonVariantAccess, DeserializeError>::Err(e);
-            }
-        }
-        if b == '{' as i32 {
-            self.pos += 1;
-            let r = self.read_json_string();
-            if let Ok(name) = r {
-                let cr = self.expect_char(':' as i32);
-                if let Err(e) = cr {
-                    return Result::<JsonVariantAccess, DeserializeError>::Err(e);
-                }
-                return Result::<JsonVariantAccess, DeserializeError>::Ok(JsonVariantAccess {
+            },
+            '{' => {
+                self.pos += 1;
+                let name = self.read_json_string()?;
+                self.expect_char(':' as i32)?;
+                return Result::Ok(JsonVariantAccess {
                     de: *self,
                     variant: name,
                     is_object: true,
                 });
-            }
-            if let Err(e) = r {
-                return Result::<JsonVariantAccess, DeserializeError>::Err(e);
-            }
+            },
+            _ => return Result::Err(DeserializeError::unexpected_type(
+                "expected string or object for variant",
+                self.pos as i64,
+            )),
         }
-        return Result::<JsonVariantAccess, DeserializeError>::Err(DeserializeError::unexpected_type(
-            "expected string or object for variant",
-            self.pos as i64,
-        ));
     }
 
     fn deserialize_any<V: Visitor>(&mut self, visitor: &mut V) -> Result<V::Value, DeserializeError> {
         self.skip_whitespace();
         if self.pos >= self.input.len() {
-            return Result::<V::Value, DeserializeError>::Err(DeserializeError::eof(self.pos as i64));
+            return Result::Err(DeserializeError::eof(self.pos as i64));
         }
-        let b = self.peek();
-        if b == 'n' as i32 {
-            let r = self.is_null();
-            if let Ok(_) = r {
+        let b = self.input.get_byte(self.pos) as u8 as char;
+        match b {
+            'n' => {
+                self.is_null()?;
                 return visitor.visit_null();
-            }
-            if let Err(e) = r {
-                return Result::<V::Value, DeserializeError>::Err(e);
-            }
-        }
-        if b == 't' as i32 || b == 'f' as i32 {
-            let r = self.deserialize_bool();
-            if let Ok(v) = r {
+            },
+            't' | 'f' => {
+                let v = self.deserialize_bool()?;
                 return visitor.visit_bool(v);
-            }
-            if let Err(e) = r {
-                return Result::<V::Value, DeserializeError>::Err(e);
-            }
-        }
-        if b == '"' as i32 {
-            let r = self.deserialize_string();
-            if let Ok(v) = r {
+            },
+            '"' => {
+                let v = self.deserialize_string()?;
                 return visitor.visit_string(v);
-            }
-            if let Err(e) = r {
-                return Result::<V::Value, DeserializeError>::Err(e);
-            }
-        }
-        if b == '[' as i32 {
-            let seq_r = self.begin_seq();
-            if let Ok(mut seq) = seq_r {
+            },
+            '[' => {
+                let mut seq = self.begin_seq()?;
                 return visitor.visit_seq::<JsonSeqAccess>(&mut seq);
-            }
-            if let Err(e) = seq_r {
-                return Result::<V::Value, DeserializeError>::Err(e);
-            }
-        }
-        if b == '{' as i32 {
-            let map_r = self.begin_map();
-            if let Ok(mut map) = map_r {
+            },
+            '{' => {
+                let mut map = self.begin_map()?;
                 return visitor.visit_map::<JsonMapAccess>(&mut map);
-            }
-            if let Err(e) = map_r {
-                return Result::<V::Value, DeserializeError>::Err(e);
-            }
+            },
+            _ => {
+                if b == '-' || '0' <= b <= '9' {
+                    let v = self.deserialize_f64()?;
+                    return visitor.visit_f64(v);
+                }
+                return Result::Err(DeserializeError::unexpected_type(
+                    "unexpected byte in JSON value",
+                    self.pos as i64,
+                ));
+            },
         }
-        if b == '-' as i32 || b >= '0' as i32 && b <= '9' as i32 {
-            let r = self.deserialize_f64();
-            if let Ok(v) = r {
-                return visitor.visit_f64(v);
-            }
-            if let Err(e) = r {
-                return Result::<V::Value, DeserializeError>::Err(e);
-            }
-        }
-        return Result::<V::Value, DeserializeError>::Err(DeserializeError::unexpected_type(
-            "unexpected byte in JSON value",
-            self.pos as i64,
-        ));
     }
 }
 
 /// Serializes a value to a JSON string.
 pub fn to_string<T: Serialize>(value: &T) -> Result<String, SerializeError> {
     let mut ser = JsonSerializer { buf: "" };
-    let r = value.serialize::<JsonSerializer>(&mut ser);
-    if let Err(e) = r {
-        return Result::<String, SerializeError>::Err(e);
-    }
-    return Result::<String, SerializeError>::Ok(ser.buf);
+    value.serialize::<JsonSerializer>(&mut ser)?;
+    return Result::Ok(ser.buf);
 }
 
 /// Deserializes a value from a JSON string.
 pub fn from_string<T: Deserialize>(input: String) -> Result<T, DeserializeError> {
     let mut de = JsonDeserializer { input, pos: 0 };
-    let r = T::deserialize::<JsonDeserializer>(&mut de);
-    if let Ok(v) = r {
-        de.skip_whitespace();
-        if de.pos < de.input.len() {
-            return Result::<T, DeserializeError>::Err(DeserializeError::trailing(de.pos as i64));
-        }
-        return Result::<T, DeserializeError>::Ok(v);
+    let v = T::deserialize::<JsonDeserializer>(&mut de)?;
+    de.skip_whitespace();
+    if de.pos < de.input.len() {
+        return Result::Err(DeserializeError::trailing(de.pos as i64));
     }
-    if let Err(e) = r {
-        return Result::<T, DeserializeError>::Err(e);
-    }
-    unreachable();
+    return Result::Ok(v);
 }

--- a/wado-compiler/lib/core/prelude/string.wado
+++ b/wado-compiler/lib/core/prelude/string.wado
@@ -319,6 +319,45 @@ impl String {
         };
     }
 
+    /// Decodes the UTF-8 character starting at the given byte index.
+    /// Returns None if `byte_index` is past the end of the string or there
+    /// aren't enough bytes to form a full UTF-8 sequence.
+    /// Assumes `byte_index` is on a character boundary (the string is valid UTF-8).
+    pub fn char_at_byte(&self, byte_index: i32) -> Option<char> {
+        if byte_index >= self.used {
+            return null;
+        }
+        let b0 = builtin::array_get_u8(self.repr, byte_index);
+        if b0 < 0x80 {
+            return Option::Some(char::from_u32_unchecked(b0 as u32));
+        }
+        if b0 < 0xE0 {
+            if byte_index + 2 > self.used {
+                return null;
+            }
+            let b1 = builtin::array_get_u8(self.repr, byte_index + 1) as u32;
+            let code = (b0 as u32 & 0x1F) << 6 | b1 & 0x3F;
+            return Option::Some(char::from_u32_unchecked(code));
+        }
+        if b0 < 0xF0 {
+            if byte_index + 3 > self.used {
+                return null;
+            }
+            let b1 = builtin::array_get_u8(self.repr, byte_index + 1) as u32;
+            let b2 = builtin::array_get_u8(self.repr, byte_index + 2) as u32;
+            let code = (b0 as u32 & 0x0F) << 12 | (b1 & 0x3F) << 6 | b2 & 0x3F;
+            return Option::Some(char::from_u32_unchecked(code));
+        }
+        if byte_index + 4 > self.used {
+            return null;
+        }
+        let b1 = builtin::array_get_u8(self.repr, byte_index + 1) as u32;
+        let b2 = builtin::array_get_u8(self.repr, byte_index + 2) as u32;
+        let b3 = builtin::array_get_u8(self.repr, byte_index + 3) as u32;
+        let code = (b0 as u32 & 0x07) << 18 | (b1 & 0x3F) << 12 | (b2 & 0x3F) << 6 | b3 & 0x3F;
+        return Option::Some(char::from_u32_unchecked(code));
+    }
+
     /// Appends a Unicode scalar value (char) to this string.
     #[comp_feature("string_push_char")]
     pub fn push(&mut self, c: char) {

--- a/wado-compiler/tests/fixtures.golden/httpbin-404.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin-404.wir.wado
@@ -622,153 +622,165 @@ type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeI
 
 type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(149)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(150)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(150)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(151)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(151)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(152)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(152)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(153)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(153)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(154)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(154)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(155)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(155)
 
-type "functype//core:prelude/string.wado/String::concat" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(156)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(156)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(157)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(157)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(158)
+type "functype//core:prelude/string.wado/String::concat" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(158)
 
-type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(159)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(159)
 
-type "functype//core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect" = fn(ref "core:prelude/string.wado//StrUtf8ByteIter") -> ref "core:prelude//Array<u8>";  // TypeId(160)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(160)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(161)
+type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(161)
 
-type "functype//core:prelude/string.wado/String::substr_bytes" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/string.wado//String";  // TypeId(162)
+type "functype//core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect" = fn(ref "core:prelude/string.wado//StrUtf8ByteIter") -> ref "core:prelude//Array<u8>";  // TypeId(162)
 
-type "functype//core:prelude/string.wado/String::starts_with" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(163)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(163)
 
-type "functype//core:prelude/string.wado/StrSplitIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrSplitIter") -> ref null "core:prelude/string.wado//String";  // TypeId(164)
+type "functype//core:prelude/string.wado/String::substr_bytes" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/string.wado//String";  // TypeId(164)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(165)
+type "functype//core:prelude/string.wado/String::starts_with" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(165)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(166)
+type "functype//core:prelude/string.wado/StrSplitIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrSplitIter") -> ref null "core:prelude/string.wado//String";  // TypeId(166)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(167)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(167)
 
-type "functype//core:prelude/Array<Array<u8>>::push" = fn(ref "core:prelude//Array<Array<u8>>", ref "core:prelude//Array<u8>");  // TypeId(168)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(168)
 
-type "functype//core:prelude/array.wado/Array<Array<u8>>::grow" = fn(ref "core:prelude//Array<Array<u8>>");  // TypeId(169)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(169)
 
-type "functype//core:prelude/Array<Tuple<String,Array<u8>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>", ref "tuple//[String, Array<u8>]");  // TypeId(170)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(170)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>");  // TypeId(171)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(171)
 
-type "functype//core:prelude/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(172)
+type "functype//core:prelude/Array<Array<u8>>::push" = fn(ref "core:prelude//Array<Array<u8>>", ref "core:prelude//Array<u8>");  // TypeId(172)
 
-type "functype//core:prelude/array.wado/Array<u8>::grow" = fn(ref "core:prelude//Array<u8>");  // TypeId(173)
+type "functype//core:prelude/array.wado/Array<Array<u8>>::grow" = fn(ref "core:prelude//Array<Array<u8>>");  // TypeId(173)
 
-type "functype//core:collections/TreeMap<String,Value>::find_index" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(174)
+type "functype//core:prelude/Array<Tuple<String,Array<u8>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>", ref "tuple//[String, Array<u8>]");  // TypeId(174)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>") -> ref null "tuple//[String, Value]";  // TypeId(175)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>");  // TypeId(175)
 
-type "functype//core:collections/TreeMap<String,Value>::entries" = fn(ref "core:collections//TreeMap<String,Value>") -> ref "core:prelude//Array<Tuple<String,Value>>";  // TypeId(176)
+type "functype//core:prelude/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(176)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::push" = fn(ref "core:prelude//Array<Tuple<String,Value>>", ref "tuple//[String, Value]");  // TypeId(177)
+type "functype//core:prelude/array.wado/Array<u8>::grow" = fn(ref "core:prelude//Array<u8>");  // TypeId(177)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Value>>");  // TypeId(178)
+type "functype//core:collections/TreeMap<String,Value>::find_index" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(178)
 
-type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>") -> ref null "core:collections//TreeMapEntry<String,Value>";  // TypeId(179)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>") -> ref null "tuple//[String, Value]";  // TypeId(179)
 
-type "functype//core:prelude/array.wado/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(180)
+type "functype//core:collections/TreeMap<String,Value>::entries" = fn(ref "core:collections//TreeMap<String,Value>") -> ref "core:prelude//Array<Tuple<String,Value>>";  // TypeId(180)
 
-type "functype//core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(181)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::push" = fn(ref "core:prelude//Array<Tuple<String,Value>>", ref "tuple//[String, Value]");  // TypeId(181)
 
-type "functype//core:prelude/array.wado/ArrayIter<u8>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<u8>") -> ref "core:prelude/types.wado//Option<u8>";  // TypeId(182)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Value>>");  // TypeId(182)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(183)
+type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>") -> ref null "core:collections//TreeMapEntry<String,Value>";  // TypeId(183)
 
-type "functype//core:prelude/array.wado/ArrayIter<Value>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Value>") -> ref null "core:json_value//Value";  // TypeId(184)
+type "functype//core:prelude/array.wado/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(184)
 
-type "functype//core:prelude/string.wado/String::from_utf8_lossy<FieldValue>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(185)
+type "functype//core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(185)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<FieldName,FieldValue>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<FieldName,FieldValue>>") -> ref null "tuple//[String, Array<u8>]";  // TypeId(186)
+type "functype//core:prelude/array.wado/ArrayIter<u8>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<u8>") -> ref "core:prelude/types.wado//Option<u8>";  // TypeId(186)
 
-type "functype//core:collections/TreeMap<String,Value>::insert" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String", ref "core:json_value//Value");  // TypeId(187)
+type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(187)
 
-type "functype//core:collections/TreeMap<String,Value>::insert_node" = fn(ref "core:collections//TreeMap<String,Value>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(188)
+type "functype//core:prelude/array.wado/ArrayIter<Value>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Value>") -> ref null "core:json_value//Value";  // TypeId(188)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>", ref "core:collections//TreeMapEntry<String,Value>");  // TypeId(189)
+type "functype//core:prelude/string.wado/String::from_utf8_lossy<FieldValue>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(189)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>");  // TypeId(190)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<FieldName,FieldValue>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<FieldName,FieldValue>>") -> ref null "tuple//[String, Array<u8>]";  // TypeId(190)
 
-type "functype//wasi/future-new" = fn() -> i64;  // TypeId(191)
+type "functype//core:collections/TreeMap<String,Value>::insert" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String", ref "core:json_value//Value");  // TypeId(191)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(192)
+type "functype//core:collections/TreeMap<String,Value>::insert_node" = fn(ref "core:collections//TreeMap<String,Value>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(192)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(193)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>", ref "core:collections//TreeMapEntry<String,Value>");  // TypeId(193)
 
-type "functype//wasi/future-write" = fn(i32, i32) -> i32;  // TypeId(194)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>");  // TypeId(194)
 
-type "functype//wasi/future-new:transmission-http" = fn() -> i64;  // TypeId(195)
+type "functype//wasi/future-new" = fn() -> i64;  // TypeId(195)
 
-type "functype//wasi/stream-drop-readable" = fn(i32);  // TypeId(196)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(196)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(197)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(197)
 
-type "functype//wado-compiler/tests/fixtures/httpbin-404.wado/__cm_binding__Request_consume_body" = fn(i32, i32) -> [i32, i32];  // TypeId(198)
+type "functype//wasi/future-write" = fn(i32, i32) -> i32;  // TypeId(198)
 
-type "functype//wado-compiler/tests/fixtures/httpbin-404.wado/__cm_binding__Response_new" = fn(i32, ref "core:prelude/types.wado//Option<Stream<u8>>", i32) -> [i32, i32];  // TypeId(199)
+type "functype//wasi/future-new:transmission-http" = fn() -> i64;  // TypeId(199)
 
-type "functype//./sub/httpbin_handler.wado/split_path_query" = fn(ref "core:prelude/string.wado//String") -> [ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(200)
+type "functype//wasi/stream-drop-readable" = fn(i32);  // TypeId(200)
 
-type "functype//./sub/httpbin_handler.wado/parse_status_code" = fn(ref "core:prelude/string.wado//String") -> [i32, u16];  // TypeId(201)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(201)
 
-type "functype//./sub/httpbin_handler.wado/route" = fn(i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(202)
+type "functype//wado-compiler/tests/fixtures/httpbin-404.wado/__cm_binding__Request_consume_body" = fn(i32, i32) -> [i32, i32];  // TypeId(202)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(203)
+type "functype//wado-compiler/tests/fixtures/httpbin-404.wado/__cm_binding__Response_new" = fn(i32, ref "core:prelude/types.wado//Option<Stream<u8>>", i32) -> [i32, i32];  // TypeId(203)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(204)
+type "functype//./sub/httpbin_handler.wado/split_path_query" = fn(ref "core:prelude/string.wado//String") -> [ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(204)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(205)
+type "functype//./sub/httpbin_handler.wado/parse_status_code" = fn(ref "core:prelude/string.wado//String") -> [i32, u16];  // TypeId(205)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(206)
+type "functype//./sub/httpbin_handler.wado/route" = fn(i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(206)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(207)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(207)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(208)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(208)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(209)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(209)
 
-type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(210)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(210)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(211)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(211)
 
-type "functype//core:prelude/string.wado/String::find" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, i32];  // TypeId(212)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(212)
 
-type "functype//core:prelude/string.wado/String::from_utf8<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> [i32, ref null "core:prelude/string.wado//String"];  // TypeId(213)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(213)
 
-type "functype//core:json/core/json/to_string<Value>" = fn(ref "core:json_value//Value") -> ref "core:prelude/types.wado//Result<String,SerializeError>";  // TypeId(214)
+type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(214)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(215)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(215)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(216)
+type "functype//core:prelude/string.wado/String::find" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, i32];  // TypeId(216)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(217)
+type "functype//core:prelude/string.wado/String::from_utf8<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> [i32, ref null "core:prelude/string.wado//String"];  // TypeId(217)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(218)
+type "functype//core:json/core/json/to_string<Value>" = fn(ref "core:json_value//Value") -> ref "core:prelude/types.wado//Result<String,SerializeError>";  // TypeId(218)
 
-type "functype//core:json_value/Value^Serialize::serialize<JsonSerializer>" = fn(ref "core:json_value//Value", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(219)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(219)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::value<Value>" = fn(ref "core:json//JsonMapSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(220)
+type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(220)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Value>" = fn(ref "core:json//JsonSeqSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(221)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(221)
 
-type "functype//core:collections/TreeMap<String,Value>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(222)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(222)
 
-type "functype//core:collections/TreeMap<String,Value>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(223)
+type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(223)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(224)
+
+type "functype//core:json_value/Value^Serialize::serialize<JsonSerializer>" = fn(ref "core:json_value//Value", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(225)
+
+type "functype//core:json/JsonMapSerializer^SerializeMap::value<Value>" = fn(ref "core:json//JsonMapSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(226)
+
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Value>" = fn(ref "core:json//JsonSeqSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(227)
+
+type "functype//core:collections/TreeMap<String,Value>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(228)
+
+type "functype//core:collections/TreeMap<String,Value>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(229)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-read from "wasi/stream-read";
@@ -3933,6 +3945,67 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     return 0, f64.copysign(val, sign);
 }
 
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l371: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l371;
+                };
+            };
+        };
+    }
+}
+
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
+        return 1;
+    }
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l377: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l377;
+            };
+        };
+    };
+    return n;
+}
+
 fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     let mark: i32;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -3961,23 +4034,16 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
-    }
-    return ((97 + v) - 10) & 255;
-}
-
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b374: block {
-        l375: loop {
+    b383: block {
+        l384: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3998,23 +4064,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b374;
+                break b383;
             }
-            continue l375;
+            continue l384;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -4022,15 +4090,35 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/to_string<Value>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json_value/Value^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = ref.as_non_null(r);
-        return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Err" { discriminant: 1, payload_0: e };
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json_value/Value^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+        unreachable;
+    } else {
+        unreachable;
     }
     return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Ok" { discriminant: 0, payload_0: ser.buf };
+}
+
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
 }
 
 fn "core:prelude/primitive.wado/f64::fmt_into"(self, f) {
@@ -4197,6 +4285,20 @@ fn "core:prelude/primitive.wado/f64::fmt_fixed"(self, precision, f) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark_13);
 }
 
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
+}
+
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     let capacity: i32;
     let new_capacity: i32;
@@ -4217,6 +4319,18 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     new_repr = builtin::array_new<u8>(new_capacity);
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
+}
+
+fn "core:prelude/string.wado/String::internal_reserve_uninit"(self, n) {
+    let new_used: i32;
+    let start: i32;
+    new_used = self.used + n;
+    if builtin::unlikely(new_used > builtin::array_len(self.repr)) {
+        "core:prelude/string.wado/String::grow"(self, new_used);
+    }
+    start = self.used;
+    self.used = new_used;
+    return start;
 }
 
 fn "core:prelude/string.wado/String::append_byte_filled"(self, byte, n) {
@@ -4275,7 +4389,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l409: loop {
+            l421: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -4283,7 +4397,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l409;
+                continue l421;
             };
         };
     };
@@ -4307,7 +4421,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
     __for_2: block {
         i = 0;
         block {
-            l413: loop {
+            l425: loop {
                 if i >= min_len {
                     break __for_2;
                 }
@@ -4320,7 +4434,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
                     return 2;
                 }
                 i = i + 1;
-                continue l413;
+                continue l425;
             };
         };
     };
@@ -4347,18 +4461,18 @@ fn "core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect"(self) {
     _licm_used_11 = self.used;
     _licm_repr_12 = self.repr;
     _hfs_index_13 = self.index;
-    b419: block {
-        l420: loop {
+    b431: block {
+        l432: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_3: block {
                 if _hfs_index_13 >= _licm_used_11 {
-                    break b419;
+                    break b431;
                 }
                 byte = builtin::array_get_u8(_licm_repr_12, _hfs_index_13);
                 _hfs_index_13 = _hfs_index_13 + 1;
                 "core:prelude/array.wado/Array<u8>::push"(result, byte);
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_3;
             };
-            continue l420;
+            continue l432;
         };
     };
     self.index = _hfs_index_13;
@@ -4462,7 +4576,7 @@ fn "core:prelude/string.wado/String::starts_with"(self, pat) {
         i = 0;
         _licm_repr_7 = self.repr;
         block {
-            l433: loop {
+            l445: loop {
                 if i >= pat_len {
                     break __for_4;
                 }
@@ -4470,7 +4584,7 @@ fn "core:prelude/string.wado/String::starts_with"(self, pat) {
                     return 0;
                 }
                 i = i + 1;
-                continue l433;
+                continue l445;
             };
         };
     };
@@ -4498,7 +4612,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
         i = 0;
         _licm_repr_10 = self.repr;
         block {
-            l439: loop {
+            l451: loop {
                 if i > limit {
                     break __for_6;
                 }
@@ -4506,7 +4620,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                 __for_7: block {
                     j = 0;
                     block {
-                        l442: loop {
+                        l454: loop {
                             if j >= pat_len {
                                 break __for_7;
                             }
@@ -4515,7 +4629,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                                 break __for_7;
                             }
                             j = j + 1;
-                            continue l442;
+                            continue l454;
                         };
                     };
                 };
@@ -4523,7 +4637,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                     return 0, i;
                 }
                 i = i + 1;
-                continue l439;
+                continue l451;
             };
         };
     };
@@ -4550,16 +4664,16 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
     _licm_sep_len_13 = self.sep_len;
     _licm_repr_14 = self.repr;
     _licm_sep_repr_15 = self.sep_repr;
-    b447: block {
-        l448: loop {
+    b459: block {
+        l460: loop {
             if i > limit {
-                break b447;
+                break b459;
             }
             matched = 1;
             __for_12: block {
                 j = 0;
                 block {
-                    l451: loop {
+                    l463: loop {
                         if j >= _licm_sep_len_13 {
                             break __for_12;
                         }
@@ -4568,7 +4682,7 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                             break __for_12;
                         }
                         j = j + 1;
-                        continue l451;
+                        continue l463;
                     };
                 };
             };
@@ -4580,7 +4694,7 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                 return struct.new "core:prelude/string.wado//String" { repr: part_6, used: len_5 };
             }
             i = i + 1;
-            continue l448;
+            continue l460;
         };
     };
     len_7 = self.used - self.pos;
@@ -4626,6 +4740,25 @@ fn "core:json/JsonSerializer^Serializer::serialize_bool"(self, v) {
         "core:prelude/string.wado/String::push"(self, 101);
     }
     return ref.null none;
+}
+
+fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
+    let i: i32;
+    let _licm_buf_4: ref "core:prelude/string.wado//String";
+    __for_0: block {
+        i = 0;
+        _licm_buf_4 = self.buf;
+        block {
+            l471: loop {
+                if i >= n {
+                    break __for_0;
+                }
+                "core:prelude/string.wado/String::push"(_licm_buf_4, c);
+                i = i + 1;
+                continue l471;
+            };
+        };
+    };
 }
 
 fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
@@ -4681,10 +4814,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b462: block {
-            l463: loop {
+        b477: block {
+            l478: loop {
                 if i_8 < 0 {
-                    break b462;
+                    break b477;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -4693,7 +4826,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l463;
+                continue l478;
             };
         };
         __for_1: block {
@@ -4701,14 +4834,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l466: loop {
+                l481: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l466;
+                    continue l481;
                 };
             };
         };
@@ -4718,10 +4851,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b468: block {
-            l469: loop {
+        b483: block {
+            l484: loop {
                 if i_10 < 0 {
-                    break b468;
+                    break b483;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -4730,7 +4863,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l469;
+                continue l484;
             };
         };
         __for_2: block {
@@ -4738,17 +4871,99 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l472: loop {
+                l487: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l472;
+                    continue l487;
                 };
             };
         };
+    }
+}
+
+fn "core:prelude/format.wado/Formatter::prepare_int_write"(self, is_negative, prefix, digit_count) {
+    let sign: ref "core:prelude/string.wado//String";
+    let sign_len: i32;
+    let prefix_len: i32;
+    let content_len: i32;
+    let padding: i32;
+    let align: "core:prelude/format.wado//enum:Alignment";
+    let offset_10: i32;
+    let left_pad: i32;
+    let right_pad: i32;
+    let offset_13: i32;
+    sign = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+    if is_negative {
+        sign = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("-"), used: 1 };
+    } else if self.sign_plus {
+        sign = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("+"), used: 1 };
+    }
+    sign_len = sign.used;
+    prefix_len = prefix.used;
+    content_len = (sign_len + prefix_len) + digit_count;
+    if (if self.width <= 0 -> i32 {
+        1;
+    } else {
+        content_len >= self.width;
+    }) {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    }
+    padding = self.width - content_len;
+    if self.zero_pad {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        "core:prelude/format.wado/Formatter::write_char_n"(self, 48, padding);
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    }
+    align = self.align;
+    let __match_scrut_0: "core:prelude/format.wado//enum:Alignment";
+    __match_scrut_0 = align;
+    if __match_scrut_0 == 0 {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        offset_10 = "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, padding);
+        return offset_10;
+    } else if align == 1 {
+        left_pad = padding / 2;
+        right_pad = padding - left_pad;
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, left_pad);
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        offset_13 = "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, right_pad);
+        return offset_13;
+    } else {
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, padding);
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
     }
 }
 
@@ -4781,13 +4996,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l476: loop {
+            l508: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l476;
+                continue l508;
             };
         };
     };
@@ -4823,13 +5038,13 @@ fn "core:prelude/array.wado/Array<Array<u8>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l480: loop {
+            l512: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
                 i = i + 1;
-                continue l480;
+                continue l512;
             };
         };
     };
@@ -4865,13 +5080,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l484: loop {
+            l516: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
                 i = i + 1;
-                continue l484;
+                continue l516;
             };
         };
     };
@@ -4907,13 +5122,13 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l488: loop {
+            l520: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
                 i = i + 1;
-                continue l488;
+                continue l520;
             };
         };
     };
@@ -4933,8 +5148,8 @@ fn "core:collections/TreeMap<String,Value>::find_index"(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b490: block {
-        l491: loop {
+    b522: block {
+        l523: loop {
             __pattern_temp_0 = value_copy "core:prelude/types.wado//Option<TreeMapNode<String>>"(current);
             if ref.is_null(__pattern_temp_0) == 0 {
                 n = ref.as_non_null(__pattern_temp_0);
@@ -4958,9 +5173,9 @@ fn "core:collections/TreeMap<String,Value>::find_index"(self, key) {
                     current = n.right;
                 }
             } else {
-                break b490;
+                break b522;
             }
-            continue l491;
+            continue l523;
         };
     };
     return -1;
@@ -4991,8 +5206,8 @@ fn "core:collections/TreeMap<String,Value>::entries"(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_Value___IntoIterator__into_iter_3: struct.new "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>" { repr: __local_9.repr, used: __local_9.used, index: 0 };
     };
-    b498: block {
-        l499: loop {
+    b530: block {
+        l531: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next"(__iter_3);
             if ref.is_null(__pattern_temp_0) == 0 {
                 entry = value_copy "core:collections//TreeMapEntry<String,Value>"(ref.as_non_null(__pattern_temp_0));
@@ -5000,9 +5215,9 @@ fn "core:collections/TreeMap<String,Value>::entries"(self) {
                     "core:prelude/array.wado/Array<Tuple<String,Value>>::push"(result, struct.new "tuple//[String, Value]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b498;
+                break b530;
             }
-            continue l499;
+            continue l531;
         };
     };
     return result;
@@ -5037,13 +5252,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Value>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l504: loop {
+            l536: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
                 i = i + 1;
-                continue l504;
+                continue l536;
             };
         };
     };
@@ -5096,8 +5311,8 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>"(bytes) {
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
     pending = struct.new "core:prelude/types.wado//Option<u8>" { 1 };
-    b508: block {
-        l509: loop {
+    b540: block {
+        l541: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<u8>";
             __match_scrut_0 = pending;
             b0_opt = (if ref.test "core:prelude/types.wado//Option<u8>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<u8>" {
@@ -5247,9 +5462,9 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>"(bytes) {
                     "core:prelude/string.wado/String::push"(builder, 65533);
                 }
             } else {
-                break b508;
+                break b540;
             }
-            continue l509;
+            continue l541;
         };
     };
     return builder;
@@ -5334,8 +5549,8 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                 __local_36 = __local_5;
                 break __inline_Array_Value__IntoIterator__into_iter_4: struct.new "core:prelude/array.wado//ArrayIter<Value>" { repr: __local_36.repr, used: __local_36.used, index: 0 };
             };
-            b551: block {
-                l552: loop {
+            b583: block {
+                l584: loop {
                     __local_24 = "core:prelude/array.wado/ArrayIter<Value>^Iterator::next"(__local_8);
                     if ref.is_null(__local_24) == 0 {
                         __local_10 = "core:json/JsonSeqSerializer^SerializeSeq::element<Value>"(__local_7, ref.as_non_null(__local_24));
@@ -5344,9 +5559,9 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                             return __local_11;
                         }
                     } else {
-                        break b551;
+                        break b583;
                     }
-                    continue l552;
+                    continue l584;
                 };
             };
             __inline_JsonSeqSerializer_SerializeSeq__end_5: block -> ref null "core:serde//SerializeError" {
@@ -5380,8 +5595,8 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                 __local_41 = "core:collections/TreeMap<String,Value>::entries"(__local_13);
                 break __inline_Array_Tuple_String_Value___IntoIterator__into_iter_8: struct.new "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>" { repr: __local_41.repr, used: __local_41.used, index: 0 };
             };
-            b558: block {
-                l559: loop {
+            b590: block {
+                l591: loop {
                     __local_26 = "core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next"(__local_16);
                     if ref.is_null(__local_26) == 0 {
                         __local_27 = value_copy "tuple//[String, Value]"(ref.as_non_null(__local_26));
@@ -5397,9 +5612,9 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                             return __local_22;
                         }
                     } else {
-                        break b558;
+                        break b590;
                     }
-                    continue l559;
+                    continue l591;
                 };
             };
             __inline_JsonMapSerializer_SerializeMap__end_9: block -> ref null "core:serde//SerializeError" {
@@ -5490,8 +5705,8 @@ fn "core:prelude/string.wado/String::from_utf8<Array<u8>>"(bytes) {
     let __pattern_temp_6: ref "core:prelude/types.wado//Option<u8>";
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
-    b567: block {
-        l568: loop {
+    b599: block {
+        l600: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<u8>^Iterator::next"(iter);
             if ref.test "core:prelude/types.wado//Option<u8>::Some"(__pattern_temp_0) {
                 b0 = ref.cast "core:prelude/types.wado//Option<u8>::Some"(__pattern_temp_0).payload_0;
@@ -5617,9 +5832,9 @@ fn "core:prelude/string.wado/String::from_utf8<Array<u8>>"(bytes) {
                 }
                 "core:prelude/string.wado/String::push"(builder, code);
             } else {
-                break b567;
+                break b599;
             }
-            continue l568;
+            continue l600;
         };
     };
     return 0, builder;
@@ -5651,8 +5866,8 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<FieldValue>"(bytes) {
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
     pending = struct.new "core:prelude/types.wado//Option<u8>" { 1 };
-    b601: block {
-        l602: loop {
+    b633: block {
+        l634: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<u8>";
             __match_scrut_0 = pending;
             b0_opt = (if ref.test "core:prelude/types.wado//Option<u8>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<u8>" {
@@ -5802,9 +6017,9 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<FieldValue>"(bytes) {
                     "core:prelude/string.wado/String::push"(builder, 65533);
                 }
             } else {
-                break b601;
+                break b633;
             }
-            continue l602;
+            continue l634;
         };
     };
     return builder;
@@ -5946,13 +6161,13 @@ fn "core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l652: loop {
+            l684: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:collections//TreeMapEntry<String,Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<String,Value>">(old_repr, i));
                 i = i + 1;
-                continue l652;
+                continue l684;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/httpbin-405.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin-405.wir.wado
@@ -622,153 +622,165 @@ type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeI
 
 type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(149)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(150)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(150)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(151)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(151)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(152)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(152)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(153)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(153)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(154)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(154)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(155)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(155)
 
-type "functype//core:prelude/string.wado/String::concat" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(156)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(156)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(157)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(157)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(158)
+type "functype//core:prelude/string.wado/String::concat" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(158)
 
-type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(159)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(159)
 
-type "functype//core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect" = fn(ref "core:prelude/string.wado//StrUtf8ByteIter") -> ref "core:prelude//Array<u8>";  // TypeId(160)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(160)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(161)
+type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(161)
 
-type "functype//core:prelude/string.wado/String::substr_bytes" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/string.wado//String";  // TypeId(162)
+type "functype//core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect" = fn(ref "core:prelude/string.wado//StrUtf8ByteIter") -> ref "core:prelude//Array<u8>";  // TypeId(162)
 
-type "functype//core:prelude/string.wado/String::starts_with" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(163)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(163)
 
-type "functype//core:prelude/string.wado/StrSplitIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrSplitIter") -> ref null "core:prelude/string.wado//String";  // TypeId(164)
+type "functype//core:prelude/string.wado/String::substr_bytes" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/string.wado//String";  // TypeId(164)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(165)
+type "functype//core:prelude/string.wado/String::starts_with" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(165)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(166)
+type "functype//core:prelude/string.wado/StrSplitIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrSplitIter") -> ref null "core:prelude/string.wado//String";  // TypeId(166)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(167)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(167)
 
-type "functype//core:prelude/Array<Array<u8>>::push" = fn(ref "core:prelude//Array<Array<u8>>", ref "core:prelude//Array<u8>");  // TypeId(168)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(168)
 
-type "functype//core:prelude/array.wado/Array<Array<u8>>::grow" = fn(ref "core:prelude//Array<Array<u8>>");  // TypeId(169)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(169)
 
-type "functype//core:prelude/Array<Tuple<String,Array<u8>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>", ref "tuple//[String, Array<u8>]");  // TypeId(170)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(170)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>");  // TypeId(171)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(171)
 
-type "functype//core:prelude/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(172)
+type "functype//core:prelude/Array<Array<u8>>::push" = fn(ref "core:prelude//Array<Array<u8>>", ref "core:prelude//Array<u8>");  // TypeId(172)
 
-type "functype//core:prelude/array.wado/Array<u8>::grow" = fn(ref "core:prelude//Array<u8>");  // TypeId(173)
+type "functype//core:prelude/array.wado/Array<Array<u8>>::grow" = fn(ref "core:prelude//Array<Array<u8>>");  // TypeId(173)
 
-type "functype//core:collections/TreeMap<String,Value>::find_index" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(174)
+type "functype//core:prelude/Array<Tuple<String,Array<u8>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>", ref "tuple//[String, Array<u8>]");  // TypeId(174)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>") -> ref null "tuple//[String, Value]";  // TypeId(175)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>");  // TypeId(175)
 
-type "functype//core:collections/TreeMap<String,Value>::entries" = fn(ref "core:collections//TreeMap<String,Value>") -> ref "core:prelude//Array<Tuple<String,Value>>";  // TypeId(176)
+type "functype//core:prelude/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(176)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::push" = fn(ref "core:prelude//Array<Tuple<String,Value>>", ref "tuple//[String, Value]");  // TypeId(177)
+type "functype//core:prelude/array.wado/Array<u8>::grow" = fn(ref "core:prelude//Array<u8>");  // TypeId(177)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Value>>");  // TypeId(178)
+type "functype//core:collections/TreeMap<String,Value>::find_index" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(178)
 
-type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>") -> ref null "core:collections//TreeMapEntry<String,Value>";  // TypeId(179)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>") -> ref null "tuple//[String, Value]";  // TypeId(179)
 
-type "functype//core:prelude/array.wado/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(180)
+type "functype//core:collections/TreeMap<String,Value>::entries" = fn(ref "core:collections//TreeMap<String,Value>") -> ref "core:prelude//Array<Tuple<String,Value>>";  // TypeId(180)
 
-type "functype//core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(181)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::push" = fn(ref "core:prelude//Array<Tuple<String,Value>>", ref "tuple//[String, Value]");  // TypeId(181)
 
-type "functype//core:prelude/array.wado/ArrayIter<u8>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<u8>") -> ref "core:prelude/types.wado//Option<u8>";  // TypeId(182)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Value>>");  // TypeId(182)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(183)
+type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>") -> ref null "core:collections//TreeMapEntry<String,Value>";  // TypeId(183)
 
-type "functype//core:prelude/array.wado/ArrayIter<Value>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Value>") -> ref null "core:json_value//Value";  // TypeId(184)
+type "functype//core:prelude/array.wado/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(184)
 
-type "functype//core:prelude/string.wado/String::from_utf8_lossy<FieldValue>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(185)
+type "functype//core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(185)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<FieldName,FieldValue>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<FieldName,FieldValue>>") -> ref null "tuple//[String, Array<u8>]";  // TypeId(186)
+type "functype//core:prelude/array.wado/ArrayIter<u8>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<u8>") -> ref "core:prelude/types.wado//Option<u8>";  // TypeId(186)
 
-type "functype//core:collections/TreeMap<String,Value>::insert" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String", ref "core:json_value//Value");  // TypeId(187)
+type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(187)
 
-type "functype//core:collections/TreeMap<String,Value>::insert_node" = fn(ref "core:collections//TreeMap<String,Value>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(188)
+type "functype//core:prelude/array.wado/ArrayIter<Value>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Value>") -> ref null "core:json_value//Value";  // TypeId(188)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>", ref "core:collections//TreeMapEntry<String,Value>");  // TypeId(189)
+type "functype//core:prelude/string.wado/String::from_utf8_lossy<FieldValue>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(189)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>");  // TypeId(190)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<FieldName,FieldValue>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<FieldName,FieldValue>>") -> ref null "tuple//[String, Array<u8>]";  // TypeId(190)
 
-type "functype//wasi/future-new" = fn() -> i64;  // TypeId(191)
+type "functype//core:collections/TreeMap<String,Value>::insert" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String", ref "core:json_value//Value");  // TypeId(191)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(192)
+type "functype//core:collections/TreeMap<String,Value>::insert_node" = fn(ref "core:collections//TreeMap<String,Value>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(192)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(193)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>", ref "core:collections//TreeMapEntry<String,Value>");  // TypeId(193)
 
-type "functype//wasi/future-write" = fn(i32, i32) -> i32;  // TypeId(194)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>");  // TypeId(194)
 
-type "functype//wasi/future-new:transmission-http" = fn() -> i64;  // TypeId(195)
+type "functype//wasi/future-new" = fn() -> i64;  // TypeId(195)
 
-type "functype//wasi/stream-drop-readable" = fn(i32);  // TypeId(196)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(196)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(197)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(197)
 
-type "functype//wado-compiler/tests/fixtures/httpbin-405.wado/__cm_binding__Request_consume_body" = fn(i32, i32) -> [i32, i32];  // TypeId(198)
+type "functype//wasi/future-write" = fn(i32, i32) -> i32;  // TypeId(198)
 
-type "functype//wado-compiler/tests/fixtures/httpbin-405.wado/__cm_binding__Response_new" = fn(i32, ref "core:prelude/types.wado//Option<Stream<u8>>", i32) -> [i32, i32];  // TypeId(199)
+type "functype//wasi/future-new:transmission-http" = fn() -> i64;  // TypeId(199)
 
-type "functype//./sub/httpbin_handler.wado/split_path_query" = fn(ref "core:prelude/string.wado//String") -> [ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(200)
+type "functype//wasi/stream-drop-readable" = fn(i32);  // TypeId(200)
 
-type "functype//./sub/httpbin_handler.wado/parse_status_code" = fn(ref "core:prelude/string.wado//String") -> [i32, u16];  // TypeId(201)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(201)
 
-type "functype//./sub/httpbin_handler.wado/route" = fn(i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(202)
+type "functype//wado-compiler/tests/fixtures/httpbin-405.wado/__cm_binding__Request_consume_body" = fn(i32, i32) -> [i32, i32];  // TypeId(202)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(203)
+type "functype//wado-compiler/tests/fixtures/httpbin-405.wado/__cm_binding__Response_new" = fn(i32, ref "core:prelude/types.wado//Option<Stream<u8>>", i32) -> [i32, i32];  // TypeId(203)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(204)
+type "functype//./sub/httpbin_handler.wado/split_path_query" = fn(ref "core:prelude/string.wado//String") -> [ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(204)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(205)
+type "functype//./sub/httpbin_handler.wado/parse_status_code" = fn(ref "core:prelude/string.wado//String") -> [i32, u16];  // TypeId(205)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(206)
+type "functype//./sub/httpbin_handler.wado/route" = fn(i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(206)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(207)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(207)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(208)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(208)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(209)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(209)
 
-type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(210)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(210)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(211)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(211)
 
-type "functype//core:prelude/string.wado/String::find" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, i32];  // TypeId(212)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(212)
 
-type "functype//core:prelude/string.wado/String::from_utf8<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> [i32, ref null "core:prelude/string.wado//String"];  // TypeId(213)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(213)
 
-type "functype//core:json/core/json/to_string<Value>" = fn(ref "core:json_value//Value") -> ref "core:prelude/types.wado//Result<String,SerializeError>";  // TypeId(214)
+type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(214)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(215)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(215)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(216)
+type "functype//core:prelude/string.wado/String::find" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, i32];  // TypeId(216)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(217)
+type "functype//core:prelude/string.wado/String::from_utf8<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> [i32, ref null "core:prelude/string.wado//String"];  // TypeId(217)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(218)
+type "functype//core:json/core/json/to_string<Value>" = fn(ref "core:json_value//Value") -> ref "core:prelude/types.wado//Result<String,SerializeError>";  // TypeId(218)
 
-type "functype//core:json_value/Value^Serialize::serialize<JsonSerializer>" = fn(ref "core:json_value//Value", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(219)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(219)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::value<Value>" = fn(ref "core:json//JsonMapSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(220)
+type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(220)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Value>" = fn(ref "core:json//JsonSeqSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(221)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(221)
 
-type "functype//core:collections/TreeMap<String,Value>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(222)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(222)
 
-type "functype//core:collections/TreeMap<String,Value>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(223)
+type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(223)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(224)
+
+type "functype//core:json_value/Value^Serialize::serialize<JsonSerializer>" = fn(ref "core:json_value//Value", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(225)
+
+type "functype//core:json/JsonMapSerializer^SerializeMap::value<Value>" = fn(ref "core:json//JsonMapSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(226)
+
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Value>" = fn(ref "core:json//JsonSeqSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(227)
+
+type "functype//core:collections/TreeMap<String,Value>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(228)
+
+type "functype//core:collections/TreeMap<String,Value>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(229)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-read from "wasi/stream-read";
@@ -3933,6 +3945,67 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     return 0, f64.copysign(val, sign);
 }
 
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l371: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l371;
+                };
+            };
+        };
+    }
+}
+
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
+        return 1;
+    }
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l377: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l377;
+            };
+        };
+    };
+    return n;
+}
+
 fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     let mark: i32;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -3961,23 +4034,16 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
-    }
-    return ((97 + v) - 10) & 255;
-}
-
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b374: block {
-        l375: loop {
+    b383: block {
+        l384: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3998,23 +4064,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b374;
+                break b383;
             }
-            continue l375;
+            continue l384;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -4022,15 +4090,35 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/to_string<Value>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json_value/Value^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = ref.as_non_null(r);
-        return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Err" { discriminant: 1, payload_0: e };
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json_value/Value^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+        unreachable;
+    } else {
+        unreachable;
     }
     return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Ok" { discriminant: 0, payload_0: ser.buf };
+}
+
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
 }
 
 fn "core:prelude/primitive.wado/f64::fmt_into"(self, f) {
@@ -4197,6 +4285,20 @@ fn "core:prelude/primitive.wado/f64::fmt_fixed"(self, precision, f) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark_13);
 }
 
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
+}
+
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     let capacity: i32;
     let new_capacity: i32;
@@ -4217,6 +4319,18 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     new_repr = builtin::array_new<u8>(new_capacity);
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
+}
+
+fn "core:prelude/string.wado/String::internal_reserve_uninit"(self, n) {
+    let new_used: i32;
+    let start: i32;
+    new_used = self.used + n;
+    if builtin::unlikely(new_used > builtin::array_len(self.repr)) {
+        "core:prelude/string.wado/String::grow"(self, new_used);
+    }
+    start = self.used;
+    self.used = new_used;
+    return start;
 }
 
 fn "core:prelude/string.wado/String::append_byte_filled"(self, byte, n) {
@@ -4275,7 +4389,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l409: loop {
+            l421: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -4283,7 +4397,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l409;
+                continue l421;
             };
         };
     };
@@ -4307,7 +4421,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
     __for_2: block {
         i = 0;
         block {
-            l413: loop {
+            l425: loop {
                 if i >= min_len {
                     break __for_2;
                 }
@@ -4320,7 +4434,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
                     return 2;
                 }
                 i = i + 1;
-                continue l413;
+                continue l425;
             };
         };
     };
@@ -4347,18 +4461,18 @@ fn "core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect"(self) {
     _licm_used_11 = self.used;
     _licm_repr_12 = self.repr;
     _hfs_index_13 = self.index;
-    b419: block {
-        l420: loop {
+    b431: block {
+        l432: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_3: block {
                 if _hfs_index_13 >= _licm_used_11 {
-                    break b419;
+                    break b431;
                 }
                 byte = builtin::array_get_u8(_licm_repr_12, _hfs_index_13);
                 _hfs_index_13 = _hfs_index_13 + 1;
                 "core:prelude/array.wado/Array<u8>::push"(result, byte);
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_3;
             };
-            continue l420;
+            continue l432;
         };
     };
     self.index = _hfs_index_13;
@@ -4462,7 +4576,7 @@ fn "core:prelude/string.wado/String::starts_with"(self, pat) {
         i = 0;
         _licm_repr_7 = self.repr;
         block {
-            l433: loop {
+            l445: loop {
                 if i >= pat_len {
                     break __for_4;
                 }
@@ -4470,7 +4584,7 @@ fn "core:prelude/string.wado/String::starts_with"(self, pat) {
                     return 0;
                 }
                 i = i + 1;
-                continue l433;
+                continue l445;
             };
         };
     };
@@ -4498,7 +4612,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
         i = 0;
         _licm_repr_10 = self.repr;
         block {
-            l439: loop {
+            l451: loop {
                 if i > limit {
                     break __for_6;
                 }
@@ -4506,7 +4620,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                 __for_7: block {
                     j = 0;
                     block {
-                        l442: loop {
+                        l454: loop {
                             if j >= pat_len {
                                 break __for_7;
                             }
@@ -4515,7 +4629,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                                 break __for_7;
                             }
                             j = j + 1;
-                            continue l442;
+                            continue l454;
                         };
                     };
                 };
@@ -4523,7 +4637,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                     return 0, i;
                 }
                 i = i + 1;
-                continue l439;
+                continue l451;
             };
         };
     };
@@ -4550,16 +4664,16 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
     _licm_sep_len_13 = self.sep_len;
     _licm_repr_14 = self.repr;
     _licm_sep_repr_15 = self.sep_repr;
-    b447: block {
-        l448: loop {
+    b459: block {
+        l460: loop {
             if i > limit {
-                break b447;
+                break b459;
             }
             matched = 1;
             __for_12: block {
                 j = 0;
                 block {
-                    l451: loop {
+                    l463: loop {
                         if j >= _licm_sep_len_13 {
                             break __for_12;
                         }
@@ -4568,7 +4682,7 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                             break __for_12;
                         }
                         j = j + 1;
-                        continue l451;
+                        continue l463;
                     };
                 };
             };
@@ -4580,7 +4694,7 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                 return struct.new "core:prelude/string.wado//String" { repr: part_6, used: len_5 };
             }
             i = i + 1;
-            continue l448;
+            continue l460;
         };
     };
     len_7 = self.used - self.pos;
@@ -4626,6 +4740,25 @@ fn "core:json/JsonSerializer^Serializer::serialize_bool"(self, v) {
         "core:prelude/string.wado/String::push"(self, 101);
     }
     return ref.null none;
+}
+
+fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
+    let i: i32;
+    let _licm_buf_4: ref "core:prelude/string.wado//String";
+    __for_0: block {
+        i = 0;
+        _licm_buf_4 = self.buf;
+        block {
+            l471: loop {
+                if i >= n {
+                    break __for_0;
+                }
+                "core:prelude/string.wado/String::push"(_licm_buf_4, c);
+                i = i + 1;
+                continue l471;
+            };
+        };
+    };
 }
 
 fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
@@ -4681,10 +4814,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b462: block {
-            l463: loop {
+        b477: block {
+            l478: loop {
                 if i_8 < 0 {
-                    break b462;
+                    break b477;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -4693,7 +4826,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l463;
+                continue l478;
             };
         };
         __for_1: block {
@@ -4701,14 +4834,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l466: loop {
+                l481: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l466;
+                    continue l481;
                 };
             };
         };
@@ -4718,10 +4851,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b468: block {
-            l469: loop {
+        b483: block {
+            l484: loop {
                 if i_10 < 0 {
-                    break b468;
+                    break b483;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -4730,7 +4863,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l469;
+                continue l484;
             };
         };
         __for_2: block {
@@ -4738,17 +4871,99 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l472: loop {
+                l487: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l472;
+                    continue l487;
                 };
             };
         };
+    }
+}
+
+fn "core:prelude/format.wado/Formatter::prepare_int_write"(self, is_negative, prefix, digit_count) {
+    let sign: ref "core:prelude/string.wado//String";
+    let sign_len: i32;
+    let prefix_len: i32;
+    let content_len: i32;
+    let padding: i32;
+    let align: "core:prelude/format.wado//enum:Alignment";
+    let offset_10: i32;
+    let left_pad: i32;
+    let right_pad: i32;
+    let offset_13: i32;
+    sign = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+    if is_negative {
+        sign = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("-"), used: 1 };
+    } else if self.sign_plus {
+        sign = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("+"), used: 1 };
+    }
+    sign_len = sign.used;
+    prefix_len = prefix.used;
+    content_len = (sign_len + prefix_len) + digit_count;
+    if (if self.width <= 0 -> i32 {
+        1;
+    } else {
+        content_len >= self.width;
+    }) {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    }
+    padding = self.width - content_len;
+    if self.zero_pad {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        "core:prelude/format.wado/Formatter::write_char_n"(self, 48, padding);
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    }
+    align = self.align;
+    let __match_scrut_0: "core:prelude/format.wado//enum:Alignment";
+    __match_scrut_0 = align;
+    if __match_scrut_0 == 0 {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        offset_10 = "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, padding);
+        return offset_10;
+    } else if align == 1 {
+        left_pad = padding / 2;
+        right_pad = padding - left_pad;
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, left_pad);
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        offset_13 = "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, right_pad);
+        return offset_13;
+    } else {
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, padding);
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
     }
 }
 
@@ -4781,13 +4996,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l476: loop {
+            l508: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l476;
+                continue l508;
             };
         };
     };
@@ -4823,13 +5038,13 @@ fn "core:prelude/array.wado/Array<Array<u8>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l480: loop {
+            l512: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
                 i = i + 1;
-                continue l480;
+                continue l512;
             };
         };
     };
@@ -4865,13 +5080,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l484: loop {
+            l516: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
                 i = i + 1;
-                continue l484;
+                continue l516;
             };
         };
     };
@@ -4907,13 +5122,13 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l488: loop {
+            l520: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
                 i = i + 1;
-                continue l488;
+                continue l520;
             };
         };
     };
@@ -4933,8 +5148,8 @@ fn "core:collections/TreeMap<String,Value>::find_index"(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b490: block {
-        l491: loop {
+    b522: block {
+        l523: loop {
             __pattern_temp_0 = value_copy "core:prelude/types.wado//Option<TreeMapNode<String>>"(current);
             if ref.is_null(__pattern_temp_0) == 0 {
                 n = ref.as_non_null(__pattern_temp_0);
@@ -4958,9 +5173,9 @@ fn "core:collections/TreeMap<String,Value>::find_index"(self, key) {
                     current = n.right;
                 }
             } else {
-                break b490;
+                break b522;
             }
-            continue l491;
+            continue l523;
         };
     };
     return -1;
@@ -4991,8 +5206,8 @@ fn "core:collections/TreeMap<String,Value>::entries"(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_Value___IntoIterator__into_iter_3: struct.new "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>" { repr: __local_9.repr, used: __local_9.used, index: 0 };
     };
-    b498: block {
-        l499: loop {
+    b530: block {
+        l531: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next"(__iter_3);
             if ref.is_null(__pattern_temp_0) == 0 {
                 entry = value_copy "core:collections//TreeMapEntry<String,Value>"(ref.as_non_null(__pattern_temp_0));
@@ -5000,9 +5215,9 @@ fn "core:collections/TreeMap<String,Value>::entries"(self) {
                     "core:prelude/array.wado/Array<Tuple<String,Value>>::push"(result, struct.new "tuple//[String, Value]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b498;
+                break b530;
             }
-            continue l499;
+            continue l531;
         };
     };
     return result;
@@ -5037,13 +5252,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Value>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l504: loop {
+            l536: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
                 i = i + 1;
-                continue l504;
+                continue l536;
             };
         };
     };
@@ -5096,8 +5311,8 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>"(bytes) {
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
     pending = struct.new "core:prelude/types.wado//Option<u8>" { 1 };
-    b508: block {
-        l509: loop {
+    b540: block {
+        l541: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<u8>";
             __match_scrut_0 = pending;
             b0_opt = (if ref.test "core:prelude/types.wado//Option<u8>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<u8>" {
@@ -5247,9 +5462,9 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>"(bytes) {
                     "core:prelude/string.wado/String::push"(builder, 65533);
                 }
             } else {
-                break b508;
+                break b540;
             }
-            continue l509;
+            continue l541;
         };
     };
     return builder;
@@ -5334,8 +5549,8 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                 __local_36 = __local_5;
                 break __inline_Array_Value__IntoIterator__into_iter_4: struct.new "core:prelude/array.wado//ArrayIter<Value>" { repr: __local_36.repr, used: __local_36.used, index: 0 };
             };
-            b551: block {
-                l552: loop {
+            b583: block {
+                l584: loop {
                     __local_24 = "core:prelude/array.wado/ArrayIter<Value>^Iterator::next"(__local_8);
                     if ref.is_null(__local_24) == 0 {
                         __local_10 = "core:json/JsonSeqSerializer^SerializeSeq::element<Value>"(__local_7, ref.as_non_null(__local_24));
@@ -5344,9 +5559,9 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                             return __local_11;
                         }
                     } else {
-                        break b551;
+                        break b583;
                     }
-                    continue l552;
+                    continue l584;
                 };
             };
             __inline_JsonSeqSerializer_SerializeSeq__end_5: block -> ref null "core:serde//SerializeError" {
@@ -5380,8 +5595,8 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                 __local_41 = "core:collections/TreeMap<String,Value>::entries"(__local_13);
                 break __inline_Array_Tuple_String_Value___IntoIterator__into_iter_8: struct.new "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>" { repr: __local_41.repr, used: __local_41.used, index: 0 };
             };
-            b558: block {
-                l559: loop {
+            b590: block {
+                l591: loop {
                     __local_26 = "core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next"(__local_16);
                     if ref.is_null(__local_26) == 0 {
                         __local_27 = value_copy "tuple//[String, Value]"(ref.as_non_null(__local_26));
@@ -5397,9 +5612,9 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                             return __local_22;
                         }
                     } else {
-                        break b558;
+                        break b590;
                     }
-                    continue l559;
+                    continue l591;
                 };
             };
             __inline_JsonMapSerializer_SerializeMap__end_9: block -> ref null "core:serde//SerializeError" {
@@ -5490,8 +5705,8 @@ fn "core:prelude/string.wado/String::from_utf8<Array<u8>>"(bytes) {
     let __pattern_temp_6: ref "core:prelude/types.wado//Option<u8>";
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
-    b567: block {
-        l568: loop {
+    b599: block {
+        l600: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<u8>^Iterator::next"(iter);
             if ref.test "core:prelude/types.wado//Option<u8>::Some"(__pattern_temp_0) {
                 b0 = ref.cast "core:prelude/types.wado//Option<u8>::Some"(__pattern_temp_0).payload_0;
@@ -5617,9 +5832,9 @@ fn "core:prelude/string.wado/String::from_utf8<Array<u8>>"(bytes) {
                 }
                 "core:prelude/string.wado/String::push"(builder, code);
             } else {
-                break b567;
+                break b599;
             }
-            continue l568;
+            continue l600;
         };
     };
     return 0, builder;
@@ -5651,8 +5866,8 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<FieldValue>"(bytes) {
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
     pending = struct.new "core:prelude/types.wado//Option<u8>" { 1 };
-    b601: block {
-        l602: loop {
+    b633: block {
+        l634: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<u8>";
             __match_scrut_0 = pending;
             b0_opt = (if ref.test "core:prelude/types.wado//Option<u8>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<u8>" {
@@ -5802,9 +6017,9 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<FieldValue>"(bytes) {
                     "core:prelude/string.wado/String::push"(builder, 65533);
                 }
             } else {
-                break b601;
+                break b633;
             }
-            continue l602;
+            continue l634;
         };
     };
     return builder;
@@ -5946,13 +6161,13 @@ fn "core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l652: loop {
+            l684: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:collections//TreeMapEntry<String,Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<String,Value>">(old_repr, i));
                 i = i + 1;
-                continue l652;
+                continue l684;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/httpbin-anything.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin-anything.wir.wado
@@ -622,153 +622,165 @@ type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeI
 
 type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(149)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(150)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(150)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(151)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(151)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(152)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(152)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(153)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(153)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(154)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(154)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(155)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(155)
 
-type "functype//core:prelude/string.wado/String::concat" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(156)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(156)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(157)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(157)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(158)
+type "functype//core:prelude/string.wado/String::concat" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(158)
 
-type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(159)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(159)
 
-type "functype//core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect" = fn(ref "core:prelude/string.wado//StrUtf8ByteIter") -> ref "core:prelude//Array<u8>";  // TypeId(160)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(160)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(161)
+type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(161)
 
-type "functype//core:prelude/string.wado/String::substr_bytes" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/string.wado//String";  // TypeId(162)
+type "functype//core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect" = fn(ref "core:prelude/string.wado//StrUtf8ByteIter") -> ref "core:prelude//Array<u8>";  // TypeId(162)
 
-type "functype//core:prelude/string.wado/String::starts_with" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(163)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(163)
 
-type "functype//core:prelude/string.wado/StrSplitIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrSplitIter") -> ref null "core:prelude/string.wado//String";  // TypeId(164)
+type "functype//core:prelude/string.wado/String::substr_bytes" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/string.wado//String";  // TypeId(164)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(165)
+type "functype//core:prelude/string.wado/String::starts_with" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(165)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(166)
+type "functype//core:prelude/string.wado/StrSplitIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrSplitIter") -> ref null "core:prelude/string.wado//String";  // TypeId(166)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(167)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(167)
 
-type "functype//core:prelude/Array<Array<u8>>::push" = fn(ref "core:prelude//Array<Array<u8>>", ref "core:prelude//Array<u8>");  // TypeId(168)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(168)
 
-type "functype//core:prelude/array.wado/Array<Array<u8>>::grow" = fn(ref "core:prelude//Array<Array<u8>>");  // TypeId(169)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(169)
 
-type "functype//core:prelude/Array<Tuple<String,Array<u8>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>", ref "tuple//[String, Array<u8>]");  // TypeId(170)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(170)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>");  // TypeId(171)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(171)
 
-type "functype//core:prelude/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(172)
+type "functype//core:prelude/Array<Array<u8>>::push" = fn(ref "core:prelude//Array<Array<u8>>", ref "core:prelude//Array<u8>");  // TypeId(172)
 
-type "functype//core:prelude/array.wado/Array<u8>::grow" = fn(ref "core:prelude//Array<u8>");  // TypeId(173)
+type "functype//core:prelude/array.wado/Array<Array<u8>>::grow" = fn(ref "core:prelude//Array<Array<u8>>");  // TypeId(173)
 
-type "functype//core:collections/TreeMap<String,Value>::find_index" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(174)
+type "functype//core:prelude/Array<Tuple<String,Array<u8>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>", ref "tuple//[String, Array<u8>]");  // TypeId(174)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>") -> ref null "tuple//[String, Value]";  // TypeId(175)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>");  // TypeId(175)
 
-type "functype//core:collections/TreeMap<String,Value>::entries" = fn(ref "core:collections//TreeMap<String,Value>") -> ref "core:prelude//Array<Tuple<String,Value>>";  // TypeId(176)
+type "functype//core:prelude/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(176)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::push" = fn(ref "core:prelude//Array<Tuple<String,Value>>", ref "tuple//[String, Value]");  // TypeId(177)
+type "functype//core:prelude/array.wado/Array<u8>::grow" = fn(ref "core:prelude//Array<u8>");  // TypeId(177)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Value>>");  // TypeId(178)
+type "functype//core:collections/TreeMap<String,Value>::find_index" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(178)
 
-type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>") -> ref null "core:collections//TreeMapEntry<String,Value>";  // TypeId(179)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>") -> ref null "tuple//[String, Value]";  // TypeId(179)
 
-type "functype//core:prelude/array.wado/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(180)
+type "functype//core:collections/TreeMap<String,Value>::entries" = fn(ref "core:collections//TreeMap<String,Value>") -> ref "core:prelude//Array<Tuple<String,Value>>";  // TypeId(180)
 
-type "functype//core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(181)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::push" = fn(ref "core:prelude//Array<Tuple<String,Value>>", ref "tuple//[String, Value]");  // TypeId(181)
 
-type "functype//core:prelude/array.wado/ArrayIter<u8>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<u8>") -> ref "core:prelude/types.wado//Option<u8>";  // TypeId(182)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Value>>");  // TypeId(182)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(183)
+type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>") -> ref null "core:collections//TreeMapEntry<String,Value>";  // TypeId(183)
 
-type "functype//core:prelude/array.wado/ArrayIter<Value>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Value>") -> ref null "core:json_value//Value";  // TypeId(184)
+type "functype//core:prelude/array.wado/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(184)
 
-type "functype//core:prelude/string.wado/String::from_utf8_lossy<FieldValue>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(185)
+type "functype//core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(185)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<FieldName,FieldValue>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<FieldName,FieldValue>>") -> ref null "tuple//[String, Array<u8>]";  // TypeId(186)
+type "functype//core:prelude/array.wado/ArrayIter<u8>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<u8>") -> ref "core:prelude/types.wado//Option<u8>";  // TypeId(186)
 
-type "functype//core:collections/TreeMap<String,Value>::insert" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String", ref "core:json_value//Value");  // TypeId(187)
+type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(187)
 
-type "functype//core:collections/TreeMap<String,Value>::insert_node" = fn(ref "core:collections//TreeMap<String,Value>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(188)
+type "functype//core:prelude/array.wado/ArrayIter<Value>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Value>") -> ref null "core:json_value//Value";  // TypeId(188)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>", ref "core:collections//TreeMapEntry<String,Value>");  // TypeId(189)
+type "functype//core:prelude/string.wado/String::from_utf8_lossy<FieldValue>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(189)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>");  // TypeId(190)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<FieldName,FieldValue>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<FieldName,FieldValue>>") -> ref null "tuple//[String, Array<u8>]";  // TypeId(190)
 
-type "functype//wasi/future-new" = fn() -> i64;  // TypeId(191)
+type "functype//core:collections/TreeMap<String,Value>::insert" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String", ref "core:json_value//Value");  // TypeId(191)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(192)
+type "functype//core:collections/TreeMap<String,Value>::insert_node" = fn(ref "core:collections//TreeMap<String,Value>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(192)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(193)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>", ref "core:collections//TreeMapEntry<String,Value>");  // TypeId(193)
 
-type "functype//wasi/future-write" = fn(i32, i32) -> i32;  // TypeId(194)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>");  // TypeId(194)
 
-type "functype//wasi/future-new:transmission-http" = fn() -> i64;  // TypeId(195)
+type "functype//wasi/future-new" = fn() -> i64;  // TypeId(195)
 
-type "functype//wasi/stream-drop-readable" = fn(i32);  // TypeId(196)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(196)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(197)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(197)
 
-type "functype//wado-compiler/tests/fixtures/httpbin-anything.wado/__cm_binding__Request_consume_body" = fn(i32, i32) -> [i32, i32];  // TypeId(198)
+type "functype//wasi/future-write" = fn(i32, i32) -> i32;  // TypeId(198)
 
-type "functype//wado-compiler/tests/fixtures/httpbin-anything.wado/__cm_binding__Response_new" = fn(i32, ref "core:prelude/types.wado//Option<Stream<u8>>", i32) -> [i32, i32];  // TypeId(199)
+type "functype//wasi/future-new:transmission-http" = fn() -> i64;  // TypeId(199)
 
-type "functype//./sub/httpbin_handler.wado/split_path_query" = fn(ref "core:prelude/string.wado//String") -> [ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(200)
+type "functype//wasi/stream-drop-readable" = fn(i32);  // TypeId(200)
 
-type "functype//./sub/httpbin_handler.wado/parse_status_code" = fn(ref "core:prelude/string.wado//String") -> [i32, u16];  // TypeId(201)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(201)
 
-type "functype//./sub/httpbin_handler.wado/route" = fn(i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(202)
+type "functype//wado-compiler/tests/fixtures/httpbin-anything.wado/__cm_binding__Request_consume_body" = fn(i32, i32) -> [i32, i32];  // TypeId(202)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(203)
+type "functype//wado-compiler/tests/fixtures/httpbin-anything.wado/__cm_binding__Response_new" = fn(i32, ref "core:prelude/types.wado//Option<Stream<u8>>", i32) -> [i32, i32];  // TypeId(203)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(204)
+type "functype//./sub/httpbin_handler.wado/split_path_query" = fn(ref "core:prelude/string.wado//String") -> [ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(204)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(205)
+type "functype//./sub/httpbin_handler.wado/parse_status_code" = fn(ref "core:prelude/string.wado//String") -> [i32, u16];  // TypeId(205)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(206)
+type "functype//./sub/httpbin_handler.wado/route" = fn(i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(206)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(207)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(207)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(208)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(208)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(209)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(209)
 
-type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(210)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(210)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(211)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(211)
 
-type "functype//core:prelude/string.wado/String::find" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, i32];  // TypeId(212)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(212)
 
-type "functype//core:prelude/string.wado/String::from_utf8<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> [i32, ref null "core:prelude/string.wado//String"];  // TypeId(213)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(213)
 
-type "functype//core:json/core/json/to_string<Value>" = fn(ref "core:json_value//Value") -> ref "core:prelude/types.wado//Result<String,SerializeError>";  // TypeId(214)
+type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(214)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(215)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(215)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(216)
+type "functype//core:prelude/string.wado/String::find" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, i32];  // TypeId(216)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(217)
+type "functype//core:prelude/string.wado/String::from_utf8<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> [i32, ref null "core:prelude/string.wado//String"];  // TypeId(217)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(218)
+type "functype//core:json/core/json/to_string<Value>" = fn(ref "core:json_value//Value") -> ref "core:prelude/types.wado//Result<String,SerializeError>";  // TypeId(218)
 
-type "functype//core:json_value/Value^Serialize::serialize<JsonSerializer>" = fn(ref "core:json_value//Value", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(219)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(219)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::value<Value>" = fn(ref "core:json//JsonMapSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(220)
+type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(220)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Value>" = fn(ref "core:json//JsonSeqSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(221)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(221)
 
-type "functype//core:collections/TreeMap<String,Value>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(222)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(222)
 
-type "functype//core:collections/TreeMap<String,Value>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(223)
+type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(223)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(224)
+
+type "functype//core:json_value/Value^Serialize::serialize<JsonSerializer>" = fn(ref "core:json_value//Value", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(225)
+
+type "functype//core:json/JsonMapSerializer^SerializeMap::value<Value>" = fn(ref "core:json//JsonMapSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(226)
+
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Value>" = fn(ref "core:json//JsonSeqSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(227)
+
+type "functype//core:collections/TreeMap<String,Value>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(228)
+
+type "functype//core:collections/TreeMap<String,Value>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(229)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-read from "wasi/stream-read";
@@ -3933,6 +3945,67 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     return 0, f64.copysign(val, sign);
 }
 
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l371: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l371;
+                };
+            };
+        };
+    }
+}
+
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
+        return 1;
+    }
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l377: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l377;
+            };
+        };
+    };
+    return n;
+}
+
 fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     let mark: i32;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -3961,23 +4034,16 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
-    }
-    return ((97 + v) - 10) & 255;
-}
-
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b374: block {
-        l375: loop {
+    b383: block {
+        l384: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3998,23 +4064,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b374;
+                break b383;
             }
-            continue l375;
+            continue l384;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -4022,15 +4090,35 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/to_string<Value>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json_value/Value^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = ref.as_non_null(r);
-        return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Err" { discriminant: 1, payload_0: e };
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json_value/Value^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+        unreachable;
+    } else {
+        unreachable;
     }
     return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Ok" { discriminant: 0, payload_0: ser.buf };
+}
+
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
 }
 
 fn "core:prelude/primitive.wado/f64::fmt_into"(self, f) {
@@ -4197,6 +4285,20 @@ fn "core:prelude/primitive.wado/f64::fmt_fixed"(self, precision, f) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark_13);
 }
 
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
+}
+
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     let capacity: i32;
     let new_capacity: i32;
@@ -4217,6 +4319,18 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     new_repr = builtin::array_new<u8>(new_capacity);
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
+}
+
+fn "core:prelude/string.wado/String::internal_reserve_uninit"(self, n) {
+    let new_used: i32;
+    let start: i32;
+    new_used = self.used + n;
+    if builtin::unlikely(new_used > builtin::array_len(self.repr)) {
+        "core:prelude/string.wado/String::grow"(self, new_used);
+    }
+    start = self.used;
+    self.used = new_used;
+    return start;
 }
 
 fn "core:prelude/string.wado/String::append_byte_filled"(self, byte, n) {
@@ -4275,7 +4389,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l409: loop {
+            l421: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -4283,7 +4397,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l409;
+                continue l421;
             };
         };
     };
@@ -4307,7 +4421,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
     __for_2: block {
         i = 0;
         block {
-            l413: loop {
+            l425: loop {
                 if i >= min_len {
                     break __for_2;
                 }
@@ -4320,7 +4434,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
                     return 2;
                 }
                 i = i + 1;
-                continue l413;
+                continue l425;
             };
         };
     };
@@ -4347,18 +4461,18 @@ fn "core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect"(self) {
     _licm_used_11 = self.used;
     _licm_repr_12 = self.repr;
     _hfs_index_13 = self.index;
-    b419: block {
-        l420: loop {
+    b431: block {
+        l432: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_3: block {
                 if _hfs_index_13 >= _licm_used_11 {
-                    break b419;
+                    break b431;
                 }
                 byte = builtin::array_get_u8(_licm_repr_12, _hfs_index_13);
                 _hfs_index_13 = _hfs_index_13 + 1;
                 "core:prelude/array.wado/Array<u8>::push"(result, byte);
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_3;
             };
-            continue l420;
+            continue l432;
         };
     };
     self.index = _hfs_index_13;
@@ -4462,7 +4576,7 @@ fn "core:prelude/string.wado/String::starts_with"(self, pat) {
         i = 0;
         _licm_repr_7 = self.repr;
         block {
-            l433: loop {
+            l445: loop {
                 if i >= pat_len {
                     break __for_4;
                 }
@@ -4470,7 +4584,7 @@ fn "core:prelude/string.wado/String::starts_with"(self, pat) {
                     return 0;
                 }
                 i = i + 1;
-                continue l433;
+                continue l445;
             };
         };
     };
@@ -4498,7 +4612,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
         i = 0;
         _licm_repr_10 = self.repr;
         block {
-            l439: loop {
+            l451: loop {
                 if i > limit {
                     break __for_6;
                 }
@@ -4506,7 +4620,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                 __for_7: block {
                     j = 0;
                     block {
-                        l442: loop {
+                        l454: loop {
                             if j >= pat_len {
                                 break __for_7;
                             }
@@ -4515,7 +4629,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                                 break __for_7;
                             }
                             j = j + 1;
-                            continue l442;
+                            continue l454;
                         };
                     };
                 };
@@ -4523,7 +4637,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                     return 0, i;
                 }
                 i = i + 1;
-                continue l439;
+                continue l451;
             };
         };
     };
@@ -4550,16 +4664,16 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
     _licm_sep_len_13 = self.sep_len;
     _licm_repr_14 = self.repr;
     _licm_sep_repr_15 = self.sep_repr;
-    b447: block {
-        l448: loop {
+    b459: block {
+        l460: loop {
             if i > limit {
-                break b447;
+                break b459;
             }
             matched = 1;
             __for_12: block {
                 j = 0;
                 block {
-                    l451: loop {
+                    l463: loop {
                         if j >= _licm_sep_len_13 {
                             break __for_12;
                         }
@@ -4568,7 +4682,7 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                             break __for_12;
                         }
                         j = j + 1;
-                        continue l451;
+                        continue l463;
                     };
                 };
             };
@@ -4580,7 +4694,7 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                 return struct.new "core:prelude/string.wado//String" { repr: part_6, used: len_5 };
             }
             i = i + 1;
-            continue l448;
+            continue l460;
         };
     };
     len_7 = self.used - self.pos;
@@ -4626,6 +4740,25 @@ fn "core:json/JsonSerializer^Serializer::serialize_bool"(self, v) {
         "core:prelude/string.wado/String::push"(self, 101);
     }
     return ref.null none;
+}
+
+fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
+    let i: i32;
+    let _licm_buf_4: ref "core:prelude/string.wado//String";
+    __for_0: block {
+        i = 0;
+        _licm_buf_4 = self.buf;
+        block {
+            l471: loop {
+                if i >= n {
+                    break __for_0;
+                }
+                "core:prelude/string.wado/String::push"(_licm_buf_4, c);
+                i = i + 1;
+                continue l471;
+            };
+        };
+    };
 }
 
 fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
@@ -4681,10 +4814,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b462: block {
-            l463: loop {
+        b477: block {
+            l478: loop {
                 if i_8 < 0 {
-                    break b462;
+                    break b477;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -4693,7 +4826,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l463;
+                continue l478;
             };
         };
         __for_1: block {
@@ -4701,14 +4834,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l466: loop {
+                l481: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l466;
+                    continue l481;
                 };
             };
         };
@@ -4718,10 +4851,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b468: block {
-            l469: loop {
+        b483: block {
+            l484: loop {
                 if i_10 < 0 {
-                    break b468;
+                    break b483;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -4730,7 +4863,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l469;
+                continue l484;
             };
         };
         __for_2: block {
@@ -4738,17 +4871,99 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l472: loop {
+                l487: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l472;
+                    continue l487;
                 };
             };
         };
+    }
+}
+
+fn "core:prelude/format.wado/Formatter::prepare_int_write"(self, is_negative, prefix, digit_count) {
+    let sign: ref "core:prelude/string.wado//String";
+    let sign_len: i32;
+    let prefix_len: i32;
+    let content_len: i32;
+    let padding: i32;
+    let align: "core:prelude/format.wado//enum:Alignment";
+    let offset_10: i32;
+    let left_pad: i32;
+    let right_pad: i32;
+    let offset_13: i32;
+    sign = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+    if is_negative {
+        sign = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("-"), used: 1 };
+    } else if self.sign_plus {
+        sign = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("+"), used: 1 };
+    }
+    sign_len = sign.used;
+    prefix_len = prefix.used;
+    content_len = (sign_len + prefix_len) + digit_count;
+    if (if self.width <= 0 -> i32 {
+        1;
+    } else {
+        content_len >= self.width;
+    }) {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    }
+    padding = self.width - content_len;
+    if self.zero_pad {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        "core:prelude/format.wado/Formatter::write_char_n"(self, 48, padding);
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    }
+    align = self.align;
+    let __match_scrut_0: "core:prelude/format.wado//enum:Alignment";
+    __match_scrut_0 = align;
+    if __match_scrut_0 == 0 {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        offset_10 = "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, padding);
+        return offset_10;
+    } else if align == 1 {
+        left_pad = padding / 2;
+        right_pad = padding - left_pad;
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, left_pad);
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        offset_13 = "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, right_pad);
+        return offset_13;
+    } else {
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, padding);
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
     }
 }
 
@@ -4781,13 +4996,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l476: loop {
+            l508: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l476;
+                continue l508;
             };
         };
     };
@@ -4823,13 +5038,13 @@ fn "core:prelude/array.wado/Array<Array<u8>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l480: loop {
+            l512: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
                 i = i + 1;
-                continue l480;
+                continue l512;
             };
         };
     };
@@ -4865,13 +5080,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l484: loop {
+            l516: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
                 i = i + 1;
-                continue l484;
+                continue l516;
             };
         };
     };
@@ -4907,13 +5122,13 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l488: loop {
+            l520: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
                 i = i + 1;
-                continue l488;
+                continue l520;
             };
         };
     };
@@ -4933,8 +5148,8 @@ fn "core:collections/TreeMap<String,Value>::find_index"(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b490: block {
-        l491: loop {
+    b522: block {
+        l523: loop {
             __pattern_temp_0 = value_copy "core:prelude/types.wado//Option<TreeMapNode<String>>"(current);
             if ref.is_null(__pattern_temp_0) == 0 {
                 n = ref.as_non_null(__pattern_temp_0);
@@ -4958,9 +5173,9 @@ fn "core:collections/TreeMap<String,Value>::find_index"(self, key) {
                     current = n.right;
                 }
             } else {
-                break b490;
+                break b522;
             }
-            continue l491;
+            continue l523;
         };
     };
     return -1;
@@ -4991,8 +5206,8 @@ fn "core:collections/TreeMap<String,Value>::entries"(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_Value___IntoIterator__into_iter_3: struct.new "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>" { repr: __local_9.repr, used: __local_9.used, index: 0 };
     };
-    b498: block {
-        l499: loop {
+    b530: block {
+        l531: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next"(__iter_3);
             if ref.is_null(__pattern_temp_0) == 0 {
                 entry = value_copy "core:collections//TreeMapEntry<String,Value>"(ref.as_non_null(__pattern_temp_0));
@@ -5000,9 +5215,9 @@ fn "core:collections/TreeMap<String,Value>::entries"(self) {
                     "core:prelude/array.wado/Array<Tuple<String,Value>>::push"(result, struct.new "tuple//[String, Value]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b498;
+                break b530;
             }
-            continue l499;
+            continue l531;
         };
     };
     return result;
@@ -5037,13 +5252,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Value>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l504: loop {
+            l536: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
                 i = i + 1;
-                continue l504;
+                continue l536;
             };
         };
     };
@@ -5096,8 +5311,8 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>"(bytes) {
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
     pending = struct.new "core:prelude/types.wado//Option<u8>" { 1 };
-    b508: block {
-        l509: loop {
+    b540: block {
+        l541: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<u8>";
             __match_scrut_0 = pending;
             b0_opt = (if ref.test "core:prelude/types.wado//Option<u8>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<u8>" {
@@ -5247,9 +5462,9 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>"(bytes) {
                     "core:prelude/string.wado/String::push"(builder, 65533);
                 }
             } else {
-                break b508;
+                break b540;
             }
-            continue l509;
+            continue l541;
         };
     };
     return builder;
@@ -5334,8 +5549,8 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                 __local_36 = __local_5;
                 break __inline_Array_Value__IntoIterator__into_iter_4: struct.new "core:prelude/array.wado//ArrayIter<Value>" { repr: __local_36.repr, used: __local_36.used, index: 0 };
             };
-            b551: block {
-                l552: loop {
+            b583: block {
+                l584: loop {
                     __local_24 = "core:prelude/array.wado/ArrayIter<Value>^Iterator::next"(__local_8);
                     if ref.is_null(__local_24) == 0 {
                         __local_10 = "core:json/JsonSeqSerializer^SerializeSeq::element<Value>"(__local_7, ref.as_non_null(__local_24));
@@ -5344,9 +5559,9 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                             return __local_11;
                         }
                     } else {
-                        break b551;
+                        break b583;
                     }
-                    continue l552;
+                    continue l584;
                 };
             };
             __inline_JsonSeqSerializer_SerializeSeq__end_5: block -> ref null "core:serde//SerializeError" {
@@ -5380,8 +5595,8 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                 __local_41 = "core:collections/TreeMap<String,Value>::entries"(__local_13);
                 break __inline_Array_Tuple_String_Value___IntoIterator__into_iter_8: struct.new "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>" { repr: __local_41.repr, used: __local_41.used, index: 0 };
             };
-            b558: block {
-                l559: loop {
+            b590: block {
+                l591: loop {
                     __local_26 = "core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next"(__local_16);
                     if ref.is_null(__local_26) == 0 {
                         __local_27 = value_copy "tuple//[String, Value]"(ref.as_non_null(__local_26));
@@ -5397,9 +5612,9 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                             return __local_22;
                         }
                     } else {
-                        break b558;
+                        break b590;
                     }
-                    continue l559;
+                    continue l591;
                 };
             };
             __inline_JsonMapSerializer_SerializeMap__end_9: block -> ref null "core:serde//SerializeError" {
@@ -5490,8 +5705,8 @@ fn "core:prelude/string.wado/String::from_utf8<Array<u8>>"(bytes) {
     let __pattern_temp_6: ref "core:prelude/types.wado//Option<u8>";
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
-    b567: block {
-        l568: loop {
+    b599: block {
+        l600: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<u8>^Iterator::next"(iter);
             if ref.test "core:prelude/types.wado//Option<u8>::Some"(__pattern_temp_0) {
                 b0 = ref.cast "core:prelude/types.wado//Option<u8>::Some"(__pattern_temp_0).payload_0;
@@ -5617,9 +5832,9 @@ fn "core:prelude/string.wado/String::from_utf8<Array<u8>>"(bytes) {
                 }
                 "core:prelude/string.wado/String::push"(builder, code);
             } else {
-                break b567;
+                break b599;
             }
-            continue l568;
+            continue l600;
         };
     };
     return 0, builder;
@@ -5651,8 +5866,8 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<FieldValue>"(bytes) {
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
     pending = struct.new "core:prelude/types.wado//Option<u8>" { 1 };
-    b601: block {
-        l602: loop {
+    b633: block {
+        l634: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<u8>";
             __match_scrut_0 = pending;
             b0_opt = (if ref.test "core:prelude/types.wado//Option<u8>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<u8>" {
@@ -5802,9 +6017,9 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<FieldValue>"(bytes) {
                     "core:prelude/string.wado/String::push"(builder, 65533);
                 }
             } else {
-                break b601;
+                break b633;
             }
-            continue l602;
+            continue l634;
         };
     };
     return builder;
@@ -5946,13 +6161,13 @@ fn "core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l652: loop {
+            l684: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:collections//TreeMapEntry<String,Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<String,Value>">(old_repr, i));
                 i = i + 1;
-                continue l652;
+                continue l684;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/httpbin-get.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin-get.wir.wado
@@ -622,153 +622,165 @@ type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeI
 
 type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(149)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(150)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(150)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(151)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(151)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(152)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(152)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(153)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(153)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(154)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(154)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(155)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(155)
 
-type "functype//core:prelude/string.wado/String::concat" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(156)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(156)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(157)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(157)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(158)
+type "functype//core:prelude/string.wado/String::concat" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(158)
 
-type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(159)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(159)
 
-type "functype//core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect" = fn(ref "core:prelude/string.wado//StrUtf8ByteIter") -> ref "core:prelude//Array<u8>";  // TypeId(160)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(160)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(161)
+type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(161)
 
-type "functype//core:prelude/string.wado/String::substr_bytes" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/string.wado//String";  // TypeId(162)
+type "functype//core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect" = fn(ref "core:prelude/string.wado//StrUtf8ByteIter") -> ref "core:prelude//Array<u8>";  // TypeId(162)
 
-type "functype//core:prelude/string.wado/String::starts_with" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(163)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(163)
 
-type "functype//core:prelude/string.wado/StrSplitIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrSplitIter") -> ref null "core:prelude/string.wado//String";  // TypeId(164)
+type "functype//core:prelude/string.wado/String::substr_bytes" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/string.wado//String";  // TypeId(164)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(165)
+type "functype//core:prelude/string.wado/String::starts_with" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(165)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(166)
+type "functype//core:prelude/string.wado/StrSplitIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrSplitIter") -> ref null "core:prelude/string.wado//String";  // TypeId(166)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(167)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(167)
 
-type "functype//core:prelude/Array<Array<u8>>::push" = fn(ref "core:prelude//Array<Array<u8>>", ref "core:prelude//Array<u8>");  // TypeId(168)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(168)
 
-type "functype//core:prelude/array.wado/Array<Array<u8>>::grow" = fn(ref "core:prelude//Array<Array<u8>>");  // TypeId(169)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(169)
 
-type "functype//core:prelude/Array<Tuple<String,Array<u8>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>", ref "tuple//[String, Array<u8>]");  // TypeId(170)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(170)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>");  // TypeId(171)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(171)
 
-type "functype//core:prelude/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(172)
+type "functype//core:prelude/Array<Array<u8>>::push" = fn(ref "core:prelude//Array<Array<u8>>", ref "core:prelude//Array<u8>");  // TypeId(172)
 
-type "functype//core:prelude/array.wado/Array<u8>::grow" = fn(ref "core:prelude//Array<u8>");  // TypeId(173)
+type "functype//core:prelude/array.wado/Array<Array<u8>>::grow" = fn(ref "core:prelude//Array<Array<u8>>");  // TypeId(173)
 
-type "functype//core:collections/TreeMap<String,Value>::find_index" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(174)
+type "functype//core:prelude/Array<Tuple<String,Array<u8>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>", ref "tuple//[String, Array<u8>]");  // TypeId(174)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>") -> ref null "tuple//[String, Value]";  // TypeId(175)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>");  // TypeId(175)
 
-type "functype//core:collections/TreeMap<String,Value>::entries" = fn(ref "core:collections//TreeMap<String,Value>") -> ref "core:prelude//Array<Tuple<String,Value>>";  // TypeId(176)
+type "functype//core:prelude/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(176)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::push" = fn(ref "core:prelude//Array<Tuple<String,Value>>", ref "tuple//[String, Value]");  // TypeId(177)
+type "functype//core:prelude/array.wado/Array<u8>::grow" = fn(ref "core:prelude//Array<u8>");  // TypeId(177)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Value>>");  // TypeId(178)
+type "functype//core:collections/TreeMap<String,Value>::find_index" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(178)
 
-type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>") -> ref null "core:collections//TreeMapEntry<String,Value>";  // TypeId(179)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>") -> ref null "tuple//[String, Value]";  // TypeId(179)
 
-type "functype//core:prelude/array.wado/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(180)
+type "functype//core:collections/TreeMap<String,Value>::entries" = fn(ref "core:collections//TreeMap<String,Value>") -> ref "core:prelude//Array<Tuple<String,Value>>";  // TypeId(180)
 
-type "functype//core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(181)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::push" = fn(ref "core:prelude//Array<Tuple<String,Value>>", ref "tuple//[String, Value]");  // TypeId(181)
 
-type "functype//core:prelude/array.wado/ArrayIter<u8>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<u8>") -> ref "core:prelude/types.wado//Option<u8>";  // TypeId(182)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Value>>");  // TypeId(182)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(183)
+type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>") -> ref null "core:collections//TreeMapEntry<String,Value>";  // TypeId(183)
 
-type "functype//core:prelude/array.wado/ArrayIter<Value>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Value>") -> ref null "core:json_value//Value";  // TypeId(184)
+type "functype//core:prelude/array.wado/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(184)
 
-type "functype//core:prelude/string.wado/String::from_utf8_lossy<FieldValue>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(185)
+type "functype//core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(185)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<FieldName,FieldValue>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<FieldName,FieldValue>>") -> ref null "tuple//[String, Array<u8>]";  // TypeId(186)
+type "functype//core:prelude/array.wado/ArrayIter<u8>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<u8>") -> ref "core:prelude/types.wado//Option<u8>";  // TypeId(186)
 
-type "functype//core:collections/TreeMap<String,Value>::insert" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String", ref "core:json_value//Value");  // TypeId(187)
+type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(187)
 
-type "functype//core:collections/TreeMap<String,Value>::insert_node" = fn(ref "core:collections//TreeMap<String,Value>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(188)
+type "functype//core:prelude/array.wado/ArrayIter<Value>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Value>") -> ref null "core:json_value//Value";  // TypeId(188)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>", ref "core:collections//TreeMapEntry<String,Value>");  // TypeId(189)
+type "functype//core:prelude/string.wado/String::from_utf8_lossy<FieldValue>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(189)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>");  // TypeId(190)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<FieldName,FieldValue>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<FieldName,FieldValue>>") -> ref null "tuple//[String, Array<u8>]";  // TypeId(190)
 
-type "functype//wasi/future-new" = fn() -> i64;  // TypeId(191)
+type "functype//core:collections/TreeMap<String,Value>::insert" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String", ref "core:json_value//Value");  // TypeId(191)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(192)
+type "functype//core:collections/TreeMap<String,Value>::insert_node" = fn(ref "core:collections//TreeMap<String,Value>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(192)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(193)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>", ref "core:collections//TreeMapEntry<String,Value>");  // TypeId(193)
 
-type "functype//wasi/future-write" = fn(i32, i32) -> i32;  // TypeId(194)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>");  // TypeId(194)
 
-type "functype//wasi/future-new:transmission-http" = fn() -> i64;  // TypeId(195)
+type "functype//wasi/future-new" = fn() -> i64;  // TypeId(195)
 
-type "functype//wasi/stream-drop-readable" = fn(i32);  // TypeId(196)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(196)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(197)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(197)
 
-type "functype//wado-compiler/tests/fixtures/httpbin-get.wado/__cm_binding__Request_consume_body" = fn(i32, i32) -> [i32, i32];  // TypeId(198)
+type "functype//wasi/future-write" = fn(i32, i32) -> i32;  // TypeId(198)
 
-type "functype//wado-compiler/tests/fixtures/httpbin-get.wado/__cm_binding__Response_new" = fn(i32, ref "core:prelude/types.wado//Option<Stream<u8>>", i32) -> [i32, i32];  // TypeId(199)
+type "functype//wasi/future-new:transmission-http" = fn() -> i64;  // TypeId(199)
 
-type "functype//./sub/httpbin_handler.wado/split_path_query" = fn(ref "core:prelude/string.wado//String") -> [ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(200)
+type "functype//wasi/stream-drop-readable" = fn(i32);  // TypeId(200)
 
-type "functype//./sub/httpbin_handler.wado/parse_status_code" = fn(ref "core:prelude/string.wado//String") -> [i32, u16];  // TypeId(201)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(201)
 
-type "functype//./sub/httpbin_handler.wado/route" = fn(i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(202)
+type "functype//wado-compiler/tests/fixtures/httpbin-get.wado/__cm_binding__Request_consume_body" = fn(i32, i32) -> [i32, i32];  // TypeId(202)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(203)
+type "functype//wado-compiler/tests/fixtures/httpbin-get.wado/__cm_binding__Response_new" = fn(i32, ref "core:prelude/types.wado//Option<Stream<u8>>", i32) -> [i32, i32];  // TypeId(203)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(204)
+type "functype//./sub/httpbin_handler.wado/split_path_query" = fn(ref "core:prelude/string.wado//String") -> [ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(204)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(205)
+type "functype//./sub/httpbin_handler.wado/parse_status_code" = fn(ref "core:prelude/string.wado//String") -> [i32, u16];  // TypeId(205)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(206)
+type "functype//./sub/httpbin_handler.wado/route" = fn(i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(206)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(207)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(207)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(208)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(208)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(209)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(209)
 
-type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(210)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(210)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(211)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(211)
 
-type "functype//core:prelude/string.wado/String::find" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, i32];  // TypeId(212)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(212)
 
-type "functype//core:prelude/string.wado/String::from_utf8<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> [i32, ref null "core:prelude/string.wado//String"];  // TypeId(213)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(213)
 
-type "functype//core:json/core/json/to_string<Value>" = fn(ref "core:json_value//Value") -> ref "core:prelude/types.wado//Result<String,SerializeError>";  // TypeId(214)
+type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(214)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(215)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(215)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(216)
+type "functype//core:prelude/string.wado/String::find" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, i32];  // TypeId(216)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(217)
+type "functype//core:prelude/string.wado/String::from_utf8<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> [i32, ref null "core:prelude/string.wado//String"];  // TypeId(217)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(218)
+type "functype//core:json/core/json/to_string<Value>" = fn(ref "core:json_value//Value") -> ref "core:prelude/types.wado//Result<String,SerializeError>";  // TypeId(218)
 
-type "functype//core:json_value/Value^Serialize::serialize<JsonSerializer>" = fn(ref "core:json_value//Value", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(219)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(219)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::value<Value>" = fn(ref "core:json//JsonMapSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(220)
+type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(220)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Value>" = fn(ref "core:json//JsonSeqSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(221)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(221)
 
-type "functype//core:collections/TreeMap<String,Value>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(222)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(222)
 
-type "functype//core:collections/TreeMap<String,Value>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(223)
+type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(223)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(224)
+
+type "functype//core:json_value/Value^Serialize::serialize<JsonSerializer>" = fn(ref "core:json_value//Value", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(225)
+
+type "functype//core:json/JsonMapSerializer^SerializeMap::value<Value>" = fn(ref "core:json//JsonMapSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(226)
+
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Value>" = fn(ref "core:json//JsonSeqSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(227)
+
+type "functype//core:collections/TreeMap<String,Value>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(228)
+
+type "functype//core:collections/TreeMap<String,Value>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(229)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-read from "wasi/stream-read";
@@ -3933,6 +3945,67 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     return 0, f64.copysign(val, sign);
 }
 
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l371: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l371;
+                };
+            };
+        };
+    }
+}
+
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
+        return 1;
+    }
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l377: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l377;
+            };
+        };
+    };
+    return n;
+}
+
 fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     let mark: i32;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -3961,23 +4034,16 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
-    }
-    return ((97 + v) - 10) & 255;
-}
-
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b374: block {
-        l375: loop {
+    b383: block {
+        l384: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3998,23 +4064,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b374;
+                break b383;
             }
-            continue l375;
+            continue l384;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -4022,15 +4090,35 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/to_string<Value>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json_value/Value^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = ref.as_non_null(r);
-        return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Err" { discriminant: 1, payload_0: e };
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json_value/Value^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+        unreachable;
+    } else {
+        unreachable;
     }
     return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Ok" { discriminant: 0, payload_0: ser.buf };
+}
+
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
 }
 
 fn "core:prelude/primitive.wado/f64::fmt_into"(self, f) {
@@ -4197,6 +4285,20 @@ fn "core:prelude/primitive.wado/f64::fmt_fixed"(self, precision, f) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark_13);
 }
 
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
+}
+
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     let capacity: i32;
     let new_capacity: i32;
@@ -4217,6 +4319,18 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     new_repr = builtin::array_new<u8>(new_capacity);
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
+}
+
+fn "core:prelude/string.wado/String::internal_reserve_uninit"(self, n) {
+    let new_used: i32;
+    let start: i32;
+    new_used = self.used + n;
+    if builtin::unlikely(new_used > builtin::array_len(self.repr)) {
+        "core:prelude/string.wado/String::grow"(self, new_used);
+    }
+    start = self.used;
+    self.used = new_used;
+    return start;
 }
 
 fn "core:prelude/string.wado/String::append_byte_filled"(self, byte, n) {
@@ -4275,7 +4389,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l409: loop {
+            l421: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -4283,7 +4397,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l409;
+                continue l421;
             };
         };
     };
@@ -4307,7 +4421,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
     __for_2: block {
         i = 0;
         block {
-            l413: loop {
+            l425: loop {
                 if i >= min_len {
                     break __for_2;
                 }
@@ -4320,7 +4434,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
                     return 2;
                 }
                 i = i + 1;
-                continue l413;
+                continue l425;
             };
         };
     };
@@ -4347,18 +4461,18 @@ fn "core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect"(self) {
     _licm_used_11 = self.used;
     _licm_repr_12 = self.repr;
     _hfs_index_13 = self.index;
-    b419: block {
-        l420: loop {
+    b431: block {
+        l432: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_3: block {
                 if _hfs_index_13 >= _licm_used_11 {
-                    break b419;
+                    break b431;
                 }
                 byte = builtin::array_get_u8(_licm_repr_12, _hfs_index_13);
                 _hfs_index_13 = _hfs_index_13 + 1;
                 "core:prelude/array.wado/Array<u8>::push"(result, byte);
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_3;
             };
-            continue l420;
+            continue l432;
         };
     };
     self.index = _hfs_index_13;
@@ -4462,7 +4576,7 @@ fn "core:prelude/string.wado/String::starts_with"(self, pat) {
         i = 0;
         _licm_repr_7 = self.repr;
         block {
-            l433: loop {
+            l445: loop {
                 if i >= pat_len {
                     break __for_4;
                 }
@@ -4470,7 +4584,7 @@ fn "core:prelude/string.wado/String::starts_with"(self, pat) {
                     return 0;
                 }
                 i = i + 1;
-                continue l433;
+                continue l445;
             };
         };
     };
@@ -4498,7 +4612,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
         i = 0;
         _licm_repr_10 = self.repr;
         block {
-            l439: loop {
+            l451: loop {
                 if i > limit {
                     break __for_6;
                 }
@@ -4506,7 +4620,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                 __for_7: block {
                     j = 0;
                     block {
-                        l442: loop {
+                        l454: loop {
                             if j >= pat_len {
                                 break __for_7;
                             }
@@ -4515,7 +4629,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                                 break __for_7;
                             }
                             j = j + 1;
-                            continue l442;
+                            continue l454;
                         };
                     };
                 };
@@ -4523,7 +4637,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                     return 0, i;
                 }
                 i = i + 1;
-                continue l439;
+                continue l451;
             };
         };
     };
@@ -4550,16 +4664,16 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
     _licm_sep_len_13 = self.sep_len;
     _licm_repr_14 = self.repr;
     _licm_sep_repr_15 = self.sep_repr;
-    b447: block {
-        l448: loop {
+    b459: block {
+        l460: loop {
             if i > limit {
-                break b447;
+                break b459;
             }
             matched = 1;
             __for_12: block {
                 j = 0;
                 block {
-                    l451: loop {
+                    l463: loop {
                         if j >= _licm_sep_len_13 {
                             break __for_12;
                         }
@@ -4568,7 +4682,7 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                             break __for_12;
                         }
                         j = j + 1;
-                        continue l451;
+                        continue l463;
                     };
                 };
             };
@@ -4580,7 +4694,7 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                 return struct.new "core:prelude/string.wado//String" { repr: part_6, used: len_5 };
             }
             i = i + 1;
-            continue l448;
+            continue l460;
         };
     };
     len_7 = self.used - self.pos;
@@ -4626,6 +4740,25 @@ fn "core:json/JsonSerializer^Serializer::serialize_bool"(self, v) {
         "core:prelude/string.wado/String::push"(self, 101);
     }
     return ref.null none;
+}
+
+fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
+    let i: i32;
+    let _licm_buf_4: ref "core:prelude/string.wado//String";
+    __for_0: block {
+        i = 0;
+        _licm_buf_4 = self.buf;
+        block {
+            l471: loop {
+                if i >= n {
+                    break __for_0;
+                }
+                "core:prelude/string.wado/String::push"(_licm_buf_4, c);
+                i = i + 1;
+                continue l471;
+            };
+        };
+    };
 }
 
 fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
@@ -4681,10 +4814,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b462: block {
-            l463: loop {
+        b477: block {
+            l478: loop {
                 if i_8 < 0 {
-                    break b462;
+                    break b477;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -4693,7 +4826,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l463;
+                continue l478;
             };
         };
         __for_1: block {
@@ -4701,14 +4834,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l466: loop {
+                l481: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l466;
+                    continue l481;
                 };
             };
         };
@@ -4718,10 +4851,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b468: block {
-            l469: loop {
+        b483: block {
+            l484: loop {
                 if i_10 < 0 {
-                    break b468;
+                    break b483;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -4730,7 +4863,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l469;
+                continue l484;
             };
         };
         __for_2: block {
@@ -4738,17 +4871,99 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l472: loop {
+                l487: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l472;
+                    continue l487;
                 };
             };
         };
+    }
+}
+
+fn "core:prelude/format.wado/Formatter::prepare_int_write"(self, is_negative, prefix, digit_count) {
+    let sign: ref "core:prelude/string.wado//String";
+    let sign_len: i32;
+    let prefix_len: i32;
+    let content_len: i32;
+    let padding: i32;
+    let align: "core:prelude/format.wado//enum:Alignment";
+    let offset_10: i32;
+    let left_pad: i32;
+    let right_pad: i32;
+    let offset_13: i32;
+    sign = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+    if is_negative {
+        sign = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("-"), used: 1 };
+    } else if self.sign_plus {
+        sign = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("+"), used: 1 };
+    }
+    sign_len = sign.used;
+    prefix_len = prefix.used;
+    content_len = (sign_len + prefix_len) + digit_count;
+    if (if self.width <= 0 -> i32 {
+        1;
+    } else {
+        content_len >= self.width;
+    }) {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    }
+    padding = self.width - content_len;
+    if self.zero_pad {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        "core:prelude/format.wado/Formatter::write_char_n"(self, 48, padding);
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    }
+    align = self.align;
+    let __match_scrut_0: "core:prelude/format.wado//enum:Alignment";
+    __match_scrut_0 = align;
+    if __match_scrut_0 == 0 {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        offset_10 = "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, padding);
+        return offset_10;
+    } else if align == 1 {
+        left_pad = padding / 2;
+        right_pad = padding - left_pad;
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, left_pad);
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        offset_13 = "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, right_pad);
+        return offset_13;
+    } else {
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, padding);
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
     }
 }
 
@@ -4781,13 +4996,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l476: loop {
+            l508: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l476;
+                continue l508;
             };
         };
     };
@@ -4823,13 +5038,13 @@ fn "core:prelude/array.wado/Array<Array<u8>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l480: loop {
+            l512: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
                 i = i + 1;
-                continue l480;
+                continue l512;
             };
         };
     };
@@ -4865,13 +5080,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l484: loop {
+            l516: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
                 i = i + 1;
-                continue l484;
+                continue l516;
             };
         };
     };
@@ -4907,13 +5122,13 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l488: loop {
+            l520: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
                 i = i + 1;
-                continue l488;
+                continue l520;
             };
         };
     };
@@ -4933,8 +5148,8 @@ fn "core:collections/TreeMap<String,Value>::find_index"(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b490: block {
-        l491: loop {
+    b522: block {
+        l523: loop {
             __pattern_temp_0 = value_copy "core:prelude/types.wado//Option<TreeMapNode<String>>"(current);
             if ref.is_null(__pattern_temp_0) == 0 {
                 n = ref.as_non_null(__pattern_temp_0);
@@ -4958,9 +5173,9 @@ fn "core:collections/TreeMap<String,Value>::find_index"(self, key) {
                     current = n.right;
                 }
             } else {
-                break b490;
+                break b522;
             }
-            continue l491;
+            continue l523;
         };
     };
     return -1;
@@ -4991,8 +5206,8 @@ fn "core:collections/TreeMap<String,Value>::entries"(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_Value___IntoIterator__into_iter_3: struct.new "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>" { repr: __local_9.repr, used: __local_9.used, index: 0 };
     };
-    b498: block {
-        l499: loop {
+    b530: block {
+        l531: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next"(__iter_3);
             if ref.is_null(__pattern_temp_0) == 0 {
                 entry = value_copy "core:collections//TreeMapEntry<String,Value>"(ref.as_non_null(__pattern_temp_0));
@@ -5000,9 +5215,9 @@ fn "core:collections/TreeMap<String,Value>::entries"(self) {
                     "core:prelude/array.wado/Array<Tuple<String,Value>>::push"(result, struct.new "tuple//[String, Value]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b498;
+                break b530;
             }
-            continue l499;
+            continue l531;
         };
     };
     return result;
@@ -5037,13 +5252,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Value>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l504: loop {
+            l536: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
                 i = i + 1;
-                continue l504;
+                continue l536;
             };
         };
     };
@@ -5096,8 +5311,8 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>"(bytes) {
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
     pending = struct.new "core:prelude/types.wado//Option<u8>" { 1 };
-    b508: block {
-        l509: loop {
+    b540: block {
+        l541: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<u8>";
             __match_scrut_0 = pending;
             b0_opt = (if ref.test "core:prelude/types.wado//Option<u8>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<u8>" {
@@ -5247,9 +5462,9 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>"(bytes) {
                     "core:prelude/string.wado/String::push"(builder, 65533);
                 }
             } else {
-                break b508;
+                break b540;
             }
-            continue l509;
+            continue l541;
         };
     };
     return builder;
@@ -5334,8 +5549,8 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                 __local_36 = __local_5;
                 break __inline_Array_Value__IntoIterator__into_iter_4: struct.new "core:prelude/array.wado//ArrayIter<Value>" { repr: __local_36.repr, used: __local_36.used, index: 0 };
             };
-            b551: block {
-                l552: loop {
+            b583: block {
+                l584: loop {
                     __local_24 = "core:prelude/array.wado/ArrayIter<Value>^Iterator::next"(__local_8);
                     if ref.is_null(__local_24) == 0 {
                         __local_10 = "core:json/JsonSeqSerializer^SerializeSeq::element<Value>"(__local_7, ref.as_non_null(__local_24));
@@ -5344,9 +5559,9 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                             return __local_11;
                         }
                     } else {
-                        break b551;
+                        break b583;
                     }
-                    continue l552;
+                    continue l584;
                 };
             };
             __inline_JsonSeqSerializer_SerializeSeq__end_5: block -> ref null "core:serde//SerializeError" {
@@ -5380,8 +5595,8 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                 __local_41 = "core:collections/TreeMap<String,Value>::entries"(__local_13);
                 break __inline_Array_Tuple_String_Value___IntoIterator__into_iter_8: struct.new "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>" { repr: __local_41.repr, used: __local_41.used, index: 0 };
             };
-            b558: block {
-                l559: loop {
+            b590: block {
+                l591: loop {
                     __local_26 = "core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next"(__local_16);
                     if ref.is_null(__local_26) == 0 {
                         __local_27 = value_copy "tuple//[String, Value]"(ref.as_non_null(__local_26));
@@ -5397,9 +5612,9 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                             return __local_22;
                         }
                     } else {
-                        break b558;
+                        break b590;
                     }
-                    continue l559;
+                    continue l591;
                 };
             };
             __inline_JsonMapSerializer_SerializeMap__end_9: block -> ref null "core:serde//SerializeError" {
@@ -5490,8 +5705,8 @@ fn "core:prelude/string.wado/String::from_utf8<Array<u8>>"(bytes) {
     let __pattern_temp_6: ref "core:prelude/types.wado//Option<u8>";
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
-    b567: block {
-        l568: loop {
+    b599: block {
+        l600: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<u8>^Iterator::next"(iter);
             if ref.test "core:prelude/types.wado//Option<u8>::Some"(__pattern_temp_0) {
                 b0 = ref.cast "core:prelude/types.wado//Option<u8>::Some"(__pattern_temp_0).payload_0;
@@ -5617,9 +5832,9 @@ fn "core:prelude/string.wado/String::from_utf8<Array<u8>>"(bytes) {
                 }
                 "core:prelude/string.wado/String::push"(builder, code);
             } else {
-                break b567;
+                break b599;
             }
-            continue l568;
+            continue l600;
         };
     };
     return 0, builder;
@@ -5651,8 +5866,8 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<FieldValue>"(bytes) {
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
     pending = struct.new "core:prelude/types.wado//Option<u8>" { 1 };
-    b601: block {
-        l602: loop {
+    b633: block {
+        l634: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<u8>";
             __match_scrut_0 = pending;
             b0_opt = (if ref.test "core:prelude/types.wado//Option<u8>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<u8>" {
@@ -5802,9 +6017,9 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<FieldValue>"(bytes) {
                     "core:prelude/string.wado/String::push"(builder, 65533);
                 }
             } else {
-                break b601;
+                break b633;
             }
-            continue l602;
+            continue l634;
         };
     };
     return builder;
@@ -5946,13 +6161,13 @@ fn "core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l652: loop {
+            l684: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:collections//TreeMapEntry<String,Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<String,Value>">(old_repr, i));
                 i = i + 1;
-                continue l652;
+                continue l684;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/httpbin-headers.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin-headers.wir.wado
@@ -622,153 +622,165 @@ type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeI
 
 type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(149)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(150)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(150)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(151)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(151)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(152)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(152)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(153)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(153)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(154)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(154)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(155)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(155)
 
-type "functype//core:prelude/string.wado/String::concat" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(156)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(156)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(157)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(157)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(158)
+type "functype//core:prelude/string.wado/String::concat" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(158)
 
-type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(159)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(159)
 
-type "functype//core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect" = fn(ref "core:prelude/string.wado//StrUtf8ByteIter") -> ref "core:prelude//Array<u8>";  // TypeId(160)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(160)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(161)
+type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(161)
 
-type "functype//core:prelude/string.wado/String::substr_bytes" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/string.wado//String";  // TypeId(162)
+type "functype//core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect" = fn(ref "core:prelude/string.wado//StrUtf8ByteIter") -> ref "core:prelude//Array<u8>";  // TypeId(162)
 
-type "functype//core:prelude/string.wado/String::starts_with" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(163)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(163)
 
-type "functype//core:prelude/string.wado/StrSplitIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrSplitIter") -> ref null "core:prelude/string.wado//String";  // TypeId(164)
+type "functype//core:prelude/string.wado/String::substr_bytes" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/string.wado//String";  // TypeId(164)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(165)
+type "functype//core:prelude/string.wado/String::starts_with" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(165)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(166)
+type "functype//core:prelude/string.wado/StrSplitIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrSplitIter") -> ref null "core:prelude/string.wado//String";  // TypeId(166)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(167)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(167)
 
-type "functype//core:prelude/Array<Array<u8>>::push" = fn(ref "core:prelude//Array<Array<u8>>", ref "core:prelude//Array<u8>");  // TypeId(168)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(168)
 
-type "functype//core:prelude/array.wado/Array<Array<u8>>::grow" = fn(ref "core:prelude//Array<Array<u8>>");  // TypeId(169)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(169)
 
-type "functype//core:prelude/Array<Tuple<String,Array<u8>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>", ref "tuple//[String, Array<u8>]");  // TypeId(170)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(170)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>");  // TypeId(171)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(171)
 
-type "functype//core:prelude/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(172)
+type "functype//core:prelude/Array<Array<u8>>::push" = fn(ref "core:prelude//Array<Array<u8>>", ref "core:prelude//Array<u8>");  // TypeId(172)
 
-type "functype//core:prelude/array.wado/Array<u8>::grow" = fn(ref "core:prelude//Array<u8>");  // TypeId(173)
+type "functype//core:prelude/array.wado/Array<Array<u8>>::grow" = fn(ref "core:prelude//Array<Array<u8>>");  // TypeId(173)
 
-type "functype//core:collections/TreeMap<String,Value>::find_index" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(174)
+type "functype//core:prelude/Array<Tuple<String,Array<u8>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>", ref "tuple//[String, Array<u8>]");  // TypeId(174)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>") -> ref null "tuple//[String, Value]";  // TypeId(175)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>");  // TypeId(175)
 
-type "functype//core:collections/TreeMap<String,Value>::entries" = fn(ref "core:collections//TreeMap<String,Value>") -> ref "core:prelude//Array<Tuple<String,Value>>";  // TypeId(176)
+type "functype//core:prelude/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(176)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::push" = fn(ref "core:prelude//Array<Tuple<String,Value>>", ref "tuple//[String, Value]");  // TypeId(177)
+type "functype//core:prelude/array.wado/Array<u8>::grow" = fn(ref "core:prelude//Array<u8>");  // TypeId(177)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Value>>");  // TypeId(178)
+type "functype//core:collections/TreeMap<String,Value>::find_index" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(178)
 
-type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>") -> ref null "core:collections//TreeMapEntry<String,Value>";  // TypeId(179)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>") -> ref null "tuple//[String, Value]";  // TypeId(179)
 
-type "functype//core:prelude/array.wado/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(180)
+type "functype//core:collections/TreeMap<String,Value>::entries" = fn(ref "core:collections//TreeMap<String,Value>") -> ref "core:prelude//Array<Tuple<String,Value>>";  // TypeId(180)
 
-type "functype//core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(181)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::push" = fn(ref "core:prelude//Array<Tuple<String,Value>>", ref "tuple//[String, Value]");  // TypeId(181)
 
-type "functype//core:prelude/array.wado/ArrayIter<u8>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<u8>") -> ref "core:prelude/types.wado//Option<u8>";  // TypeId(182)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Value>>");  // TypeId(182)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(183)
+type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>") -> ref null "core:collections//TreeMapEntry<String,Value>";  // TypeId(183)
 
-type "functype//core:prelude/array.wado/ArrayIter<Value>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Value>") -> ref null "core:json_value//Value";  // TypeId(184)
+type "functype//core:prelude/array.wado/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(184)
 
-type "functype//core:prelude/string.wado/String::from_utf8_lossy<FieldValue>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(185)
+type "functype//core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(185)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<FieldName,FieldValue>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<FieldName,FieldValue>>") -> ref null "tuple//[String, Array<u8>]";  // TypeId(186)
+type "functype//core:prelude/array.wado/ArrayIter<u8>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<u8>") -> ref "core:prelude/types.wado//Option<u8>";  // TypeId(186)
 
-type "functype//core:collections/TreeMap<String,Value>::insert" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String", ref "core:json_value//Value");  // TypeId(187)
+type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(187)
 
-type "functype//core:collections/TreeMap<String,Value>::insert_node" = fn(ref "core:collections//TreeMap<String,Value>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(188)
+type "functype//core:prelude/array.wado/ArrayIter<Value>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Value>") -> ref null "core:json_value//Value";  // TypeId(188)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>", ref "core:collections//TreeMapEntry<String,Value>");  // TypeId(189)
+type "functype//core:prelude/string.wado/String::from_utf8_lossy<FieldValue>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(189)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>");  // TypeId(190)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<FieldName,FieldValue>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<FieldName,FieldValue>>") -> ref null "tuple//[String, Array<u8>]";  // TypeId(190)
 
-type "functype//wasi/future-new" = fn() -> i64;  // TypeId(191)
+type "functype//core:collections/TreeMap<String,Value>::insert" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String", ref "core:json_value//Value");  // TypeId(191)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(192)
+type "functype//core:collections/TreeMap<String,Value>::insert_node" = fn(ref "core:collections//TreeMap<String,Value>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(192)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(193)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>", ref "core:collections//TreeMapEntry<String,Value>");  // TypeId(193)
 
-type "functype//wasi/future-write" = fn(i32, i32) -> i32;  // TypeId(194)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>");  // TypeId(194)
 
-type "functype//wasi/future-new:transmission-http" = fn() -> i64;  // TypeId(195)
+type "functype//wasi/future-new" = fn() -> i64;  // TypeId(195)
 
-type "functype//wasi/stream-drop-readable" = fn(i32);  // TypeId(196)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(196)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(197)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(197)
 
-type "functype//wado-compiler/tests/fixtures/httpbin-headers.wado/__cm_binding__Request_consume_body" = fn(i32, i32) -> [i32, i32];  // TypeId(198)
+type "functype//wasi/future-write" = fn(i32, i32) -> i32;  // TypeId(198)
 
-type "functype//wado-compiler/tests/fixtures/httpbin-headers.wado/__cm_binding__Response_new" = fn(i32, ref "core:prelude/types.wado//Option<Stream<u8>>", i32) -> [i32, i32];  // TypeId(199)
+type "functype//wasi/future-new:transmission-http" = fn() -> i64;  // TypeId(199)
 
-type "functype//./sub/httpbin_handler.wado/split_path_query" = fn(ref "core:prelude/string.wado//String") -> [ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(200)
+type "functype//wasi/stream-drop-readable" = fn(i32);  // TypeId(200)
 
-type "functype//./sub/httpbin_handler.wado/parse_status_code" = fn(ref "core:prelude/string.wado//String") -> [i32, u16];  // TypeId(201)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(201)
 
-type "functype//./sub/httpbin_handler.wado/route" = fn(i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(202)
+type "functype//wado-compiler/tests/fixtures/httpbin-headers.wado/__cm_binding__Request_consume_body" = fn(i32, i32) -> [i32, i32];  // TypeId(202)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(203)
+type "functype//wado-compiler/tests/fixtures/httpbin-headers.wado/__cm_binding__Response_new" = fn(i32, ref "core:prelude/types.wado//Option<Stream<u8>>", i32) -> [i32, i32];  // TypeId(203)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(204)
+type "functype//./sub/httpbin_handler.wado/split_path_query" = fn(ref "core:prelude/string.wado//String") -> [ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(204)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(205)
+type "functype//./sub/httpbin_handler.wado/parse_status_code" = fn(ref "core:prelude/string.wado//String") -> [i32, u16];  // TypeId(205)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(206)
+type "functype//./sub/httpbin_handler.wado/route" = fn(i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(206)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(207)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(207)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(208)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(208)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(209)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(209)
 
-type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(210)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(210)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(211)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(211)
 
-type "functype//core:prelude/string.wado/String::find" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, i32];  // TypeId(212)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(212)
 
-type "functype//core:prelude/string.wado/String::from_utf8<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> [i32, ref null "core:prelude/string.wado//String"];  // TypeId(213)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(213)
 
-type "functype//core:json/core/json/to_string<Value>" = fn(ref "core:json_value//Value") -> ref "core:prelude/types.wado//Result<String,SerializeError>";  // TypeId(214)
+type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(214)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(215)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(215)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(216)
+type "functype//core:prelude/string.wado/String::find" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, i32];  // TypeId(216)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(217)
+type "functype//core:prelude/string.wado/String::from_utf8<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> [i32, ref null "core:prelude/string.wado//String"];  // TypeId(217)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(218)
+type "functype//core:json/core/json/to_string<Value>" = fn(ref "core:json_value//Value") -> ref "core:prelude/types.wado//Result<String,SerializeError>";  // TypeId(218)
 
-type "functype//core:json_value/Value^Serialize::serialize<JsonSerializer>" = fn(ref "core:json_value//Value", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(219)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(219)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::value<Value>" = fn(ref "core:json//JsonMapSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(220)
+type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(220)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Value>" = fn(ref "core:json//JsonSeqSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(221)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(221)
 
-type "functype//core:collections/TreeMap<String,Value>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(222)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(222)
 
-type "functype//core:collections/TreeMap<String,Value>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(223)
+type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(223)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(224)
+
+type "functype//core:json_value/Value^Serialize::serialize<JsonSerializer>" = fn(ref "core:json_value//Value", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(225)
+
+type "functype//core:json/JsonMapSerializer^SerializeMap::value<Value>" = fn(ref "core:json//JsonMapSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(226)
+
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Value>" = fn(ref "core:json//JsonSeqSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(227)
+
+type "functype//core:collections/TreeMap<String,Value>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(228)
+
+type "functype//core:collections/TreeMap<String,Value>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(229)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-read from "wasi/stream-read";
@@ -3933,6 +3945,67 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     return 0, f64.copysign(val, sign);
 }
 
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l371: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l371;
+                };
+            };
+        };
+    }
+}
+
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
+        return 1;
+    }
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l377: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l377;
+            };
+        };
+    };
+    return n;
+}
+
 fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     let mark: i32;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -3961,23 +4034,16 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
-    }
-    return ((97 + v) - 10) & 255;
-}
-
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b374: block {
-        l375: loop {
+    b383: block {
+        l384: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3998,23 +4064,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b374;
+                break b383;
             }
-            continue l375;
+            continue l384;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -4022,15 +4090,35 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/to_string<Value>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json_value/Value^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = ref.as_non_null(r);
-        return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Err" { discriminant: 1, payload_0: e };
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json_value/Value^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+        unreachable;
+    } else {
+        unreachable;
     }
     return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Ok" { discriminant: 0, payload_0: ser.buf };
+}
+
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
 }
 
 fn "core:prelude/primitive.wado/f64::fmt_into"(self, f) {
@@ -4197,6 +4285,20 @@ fn "core:prelude/primitive.wado/f64::fmt_fixed"(self, precision, f) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark_13);
 }
 
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
+}
+
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     let capacity: i32;
     let new_capacity: i32;
@@ -4217,6 +4319,18 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     new_repr = builtin::array_new<u8>(new_capacity);
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
+}
+
+fn "core:prelude/string.wado/String::internal_reserve_uninit"(self, n) {
+    let new_used: i32;
+    let start: i32;
+    new_used = self.used + n;
+    if builtin::unlikely(new_used > builtin::array_len(self.repr)) {
+        "core:prelude/string.wado/String::grow"(self, new_used);
+    }
+    start = self.used;
+    self.used = new_used;
+    return start;
 }
 
 fn "core:prelude/string.wado/String::append_byte_filled"(self, byte, n) {
@@ -4275,7 +4389,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l409: loop {
+            l421: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -4283,7 +4397,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l409;
+                continue l421;
             };
         };
     };
@@ -4307,7 +4421,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
     __for_2: block {
         i = 0;
         block {
-            l413: loop {
+            l425: loop {
                 if i >= min_len {
                     break __for_2;
                 }
@@ -4320,7 +4434,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
                     return 2;
                 }
                 i = i + 1;
-                continue l413;
+                continue l425;
             };
         };
     };
@@ -4347,18 +4461,18 @@ fn "core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect"(self) {
     _licm_used_11 = self.used;
     _licm_repr_12 = self.repr;
     _hfs_index_13 = self.index;
-    b419: block {
-        l420: loop {
+    b431: block {
+        l432: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_3: block {
                 if _hfs_index_13 >= _licm_used_11 {
-                    break b419;
+                    break b431;
                 }
                 byte = builtin::array_get_u8(_licm_repr_12, _hfs_index_13);
                 _hfs_index_13 = _hfs_index_13 + 1;
                 "core:prelude/array.wado/Array<u8>::push"(result, byte);
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_3;
             };
-            continue l420;
+            continue l432;
         };
     };
     self.index = _hfs_index_13;
@@ -4462,7 +4576,7 @@ fn "core:prelude/string.wado/String::starts_with"(self, pat) {
         i = 0;
         _licm_repr_7 = self.repr;
         block {
-            l433: loop {
+            l445: loop {
                 if i >= pat_len {
                     break __for_4;
                 }
@@ -4470,7 +4584,7 @@ fn "core:prelude/string.wado/String::starts_with"(self, pat) {
                     return 0;
                 }
                 i = i + 1;
-                continue l433;
+                continue l445;
             };
         };
     };
@@ -4498,7 +4612,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
         i = 0;
         _licm_repr_10 = self.repr;
         block {
-            l439: loop {
+            l451: loop {
                 if i > limit {
                     break __for_6;
                 }
@@ -4506,7 +4620,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                 __for_7: block {
                     j = 0;
                     block {
-                        l442: loop {
+                        l454: loop {
                             if j >= pat_len {
                                 break __for_7;
                             }
@@ -4515,7 +4629,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                                 break __for_7;
                             }
                             j = j + 1;
-                            continue l442;
+                            continue l454;
                         };
                     };
                 };
@@ -4523,7 +4637,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                     return 0, i;
                 }
                 i = i + 1;
-                continue l439;
+                continue l451;
             };
         };
     };
@@ -4550,16 +4664,16 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
     _licm_sep_len_13 = self.sep_len;
     _licm_repr_14 = self.repr;
     _licm_sep_repr_15 = self.sep_repr;
-    b447: block {
-        l448: loop {
+    b459: block {
+        l460: loop {
             if i > limit {
-                break b447;
+                break b459;
             }
             matched = 1;
             __for_12: block {
                 j = 0;
                 block {
-                    l451: loop {
+                    l463: loop {
                         if j >= _licm_sep_len_13 {
                             break __for_12;
                         }
@@ -4568,7 +4682,7 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                             break __for_12;
                         }
                         j = j + 1;
-                        continue l451;
+                        continue l463;
                     };
                 };
             };
@@ -4580,7 +4694,7 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                 return struct.new "core:prelude/string.wado//String" { repr: part_6, used: len_5 };
             }
             i = i + 1;
-            continue l448;
+            continue l460;
         };
     };
     len_7 = self.used - self.pos;
@@ -4626,6 +4740,25 @@ fn "core:json/JsonSerializer^Serializer::serialize_bool"(self, v) {
         "core:prelude/string.wado/String::push"(self, 101);
     }
     return ref.null none;
+}
+
+fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
+    let i: i32;
+    let _licm_buf_4: ref "core:prelude/string.wado//String";
+    __for_0: block {
+        i = 0;
+        _licm_buf_4 = self.buf;
+        block {
+            l471: loop {
+                if i >= n {
+                    break __for_0;
+                }
+                "core:prelude/string.wado/String::push"(_licm_buf_4, c);
+                i = i + 1;
+                continue l471;
+            };
+        };
+    };
 }
 
 fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
@@ -4681,10 +4814,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b462: block {
-            l463: loop {
+        b477: block {
+            l478: loop {
                 if i_8 < 0 {
-                    break b462;
+                    break b477;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -4693,7 +4826,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l463;
+                continue l478;
             };
         };
         __for_1: block {
@@ -4701,14 +4834,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l466: loop {
+                l481: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l466;
+                    continue l481;
                 };
             };
         };
@@ -4718,10 +4851,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b468: block {
-            l469: loop {
+        b483: block {
+            l484: loop {
                 if i_10 < 0 {
-                    break b468;
+                    break b483;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -4730,7 +4863,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l469;
+                continue l484;
             };
         };
         __for_2: block {
@@ -4738,17 +4871,99 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l472: loop {
+                l487: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l472;
+                    continue l487;
                 };
             };
         };
+    }
+}
+
+fn "core:prelude/format.wado/Formatter::prepare_int_write"(self, is_negative, prefix, digit_count) {
+    let sign: ref "core:prelude/string.wado//String";
+    let sign_len: i32;
+    let prefix_len: i32;
+    let content_len: i32;
+    let padding: i32;
+    let align: "core:prelude/format.wado//enum:Alignment";
+    let offset_10: i32;
+    let left_pad: i32;
+    let right_pad: i32;
+    let offset_13: i32;
+    sign = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+    if is_negative {
+        sign = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("-"), used: 1 };
+    } else if self.sign_plus {
+        sign = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("+"), used: 1 };
+    }
+    sign_len = sign.used;
+    prefix_len = prefix.used;
+    content_len = (sign_len + prefix_len) + digit_count;
+    if (if self.width <= 0 -> i32 {
+        1;
+    } else {
+        content_len >= self.width;
+    }) {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    }
+    padding = self.width - content_len;
+    if self.zero_pad {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        "core:prelude/format.wado/Formatter::write_char_n"(self, 48, padding);
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    }
+    align = self.align;
+    let __match_scrut_0: "core:prelude/format.wado//enum:Alignment";
+    __match_scrut_0 = align;
+    if __match_scrut_0 == 0 {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        offset_10 = "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, padding);
+        return offset_10;
+    } else if align == 1 {
+        left_pad = padding / 2;
+        right_pad = padding - left_pad;
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, left_pad);
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        offset_13 = "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, right_pad);
+        return offset_13;
+    } else {
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, padding);
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
     }
 }
 
@@ -4781,13 +4996,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l476: loop {
+            l508: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l476;
+                continue l508;
             };
         };
     };
@@ -4823,13 +5038,13 @@ fn "core:prelude/array.wado/Array<Array<u8>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l480: loop {
+            l512: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
                 i = i + 1;
-                continue l480;
+                continue l512;
             };
         };
     };
@@ -4865,13 +5080,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l484: loop {
+            l516: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
                 i = i + 1;
-                continue l484;
+                continue l516;
             };
         };
     };
@@ -4907,13 +5122,13 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l488: loop {
+            l520: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
                 i = i + 1;
-                continue l488;
+                continue l520;
             };
         };
     };
@@ -4933,8 +5148,8 @@ fn "core:collections/TreeMap<String,Value>::find_index"(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b490: block {
-        l491: loop {
+    b522: block {
+        l523: loop {
             __pattern_temp_0 = value_copy "core:prelude/types.wado//Option<TreeMapNode<String>>"(current);
             if ref.is_null(__pattern_temp_0) == 0 {
                 n = ref.as_non_null(__pattern_temp_0);
@@ -4958,9 +5173,9 @@ fn "core:collections/TreeMap<String,Value>::find_index"(self, key) {
                     current = n.right;
                 }
             } else {
-                break b490;
+                break b522;
             }
-            continue l491;
+            continue l523;
         };
     };
     return -1;
@@ -4991,8 +5206,8 @@ fn "core:collections/TreeMap<String,Value>::entries"(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_Value___IntoIterator__into_iter_3: struct.new "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>" { repr: __local_9.repr, used: __local_9.used, index: 0 };
     };
-    b498: block {
-        l499: loop {
+    b530: block {
+        l531: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next"(__iter_3);
             if ref.is_null(__pattern_temp_0) == 0 {
                 entry = value_copy "core:collections//TreeMapEntry<String,Value>"(ref.as_non_null(__pattern_temp_0));
@@ -5000,9 +5215,9 @@ fn "core:collections/TreeMap<String,Value>::entries"(self) {
                     "core:prelude/array.wado/Array<Tuple<String,Value>>::push"(result, struct.new "tuple//[String, Value]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b498;
+                break b530;
             }
-            continue l499;
+            continue l531;
         };
     };
     return result;
@@ -5037,13 +5252,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Value>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l504: loop {
+            l536: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
                 i = i + 1;
-                continue l504;
+                continue l536;
             };
         };
     };
@@ -5096,8 +5311,8 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>"(bytes) {
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
     pending = struct.new "core:prelude/types.wado//Option<u8>" { 1 };
-    b508: block {
-        l509: loop {
+    b540: block {
+        l541: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<u8>";
             __match_scrut_0 = pending;
             b0_opt = (if ref.test "core:prelude/types.wado//Option<u8>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<u8>" {
@@ -5247,9 +5462,9 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>"(bytes) {
                     "core:prelude/string.wado/String::push"(builder, 65533);
                 }
             } else {
-                break b508;
+                break b540;
             }
-            continue l509;
+            continue l541;
         };
     };
     return builder;
@@ -5334,8 +5549,8 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                 __local_36 = __local_5;
                 break __inline_Array_Value__IntoIterator__into_iter_4: struct.new "core:prelude/array.wado//ArrayIter<Value>" { repr: __local_36.repr, used: __local_36.used, index: 0 };
             };
-            b551: block {
-                l552: loop {
+            b583: block {
+                l584: loop {
                     __local_24 = "core:prelude/array.wado/ArrayIter<Value>^Iterator::next"(__local_8);
                     if ref.is_null(__local_24) == 0 {
                         __local_10 = "core:json/JsonSeqSerializer^SerializeSeq::element<Value>"(__local_7, ref.as_non_null(__local_24));
@@ -5344,9 +5559,9 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                             return __local_11;
                         }
                     } else {
-                        break b551;
+                        break b583;
                     }
-                    continue l552;
+                    continue l584;
                 };
             };
             __inline_JsonSeqSerializer_SerializeSeq__end_5: block -> ref null "core:serde//SerializeError" {
@@ -5380,8 +5595,8 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                 __local_41 = "core:collections/TreeMap<String,Value>::entries"(__local_13);
                 break __inline_Array_Tuple_String_Value___IntoIterator__into_iter_8: struct.new "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>" { repr: __local_41.repr, used: __local_41.used, index: 0 };
             };
-            b558: block {
-                l559: loop {
+            b590: block {
+                l591: loop {
                     __local_26 = "core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next"(__local_16);
                     if ref.is_null(__local_26) == 0 {
                         __local_27 = value_copy "tuple//[String, Value]"(ref.as_non_null(__local_26));
@@ -5397,9 +5612,9 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                             return __local_22;
                         }
                     } else {
-                        break b558;
+                        break b590;
                     }
-                    continue l559;
+                    continue l591;
                 };
             };
             __inline_JsonMapSerializer_SerializeMap__end_9: block -> ref null "core:serde//SerializeError" {
@@ -5490,8 +5705,8 @@ fn "core:prelude/string.wado/String::from_utf8<Array<u8>>"(bytes) {
     let __pattern_temp_6: ref "core:prelude/types.wado//Option<u8>";
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
-    b567: block {
-        l568: loop {
+    b599: block {
+        l600: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<u8>^Iterator::next"(iter);
             if ref.test "core:prelude/types.wado//Option<u8>::Some"(__pattern_temp_0) {
                 b0 = ref.cast "core:prelude/types.wado//Option<u8>::Some"(__pattern_temp_0).payload_0;
@@ -5617,9 +5832,9 @@ fn "core:prelude/string.wado/String::from_utf8<Array<u8>>"(bytes) {
                 }
                 "core:prelude/string.wado/String::push"(builder, code);
             } else {
-                break b567;
+                break b599;
             }
-            continue l568;
+            continue l600;
         };
     };
     return 0, builder;
@@ -5651,8 +5866,8 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<FieldValue>"(bytes) {
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
     pending = struct.new "core:prelude/types.wado//Option<u8>" { 1 };
-    b601: block {
-        l602: loop {
+    b633: block {
+        l634: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<u8>";
             __match_scrut_0 = pending;
             b0_opt = (if ref.test "core:prelude/types.wado//Option<u8>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<u8>" {
@@ -5802,9 +6017,9 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<FieldValue>"(bytes) {
                     "core:prelude/string.wado/String::push"(builder, 65533);
                 }
             } else {
-                break b601;
+                break b633;
             }
-            continue l602;
+            continue l634;
         };
     };
     return builder;
@@ -5946,13 +6161,13 @@ fn "core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l652: loop {
+            l684: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:collections//TreeMapEntry<String,Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<String,Value>">(old_repr, i));
                 i = i + 1;
-                continue l652;
+                continue l684;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/httpbin-post.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin-post.wir.wado
@@ -622,153 +622,165 @@ type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeI
 
 type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(149)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(150)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(150)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(151)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(151)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(152)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(152)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(153)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(153)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(154)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(154)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(155)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(155)
 
-type "functype//core:prelude/string.wado/String::concat" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(156)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(156)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(157)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(157)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(158)
+type "functype//core:prelude/string.wado/String::concat" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(158)
 
-type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(159)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(159)
 
-type "functype//core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect" = fn(ref "core:prelude/string.wado//StrUtf8ByteIter") -> ref "core:prelude//Array<u8>";  // TypeId(160)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(160)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(161)
+type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(161)
 
-type "functype//core:prelude/string.wado/String::substr_bytes" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/string.wado//String";  // TypeId(162)
+type "functype//core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect" = fn(ref "core:prelude/string.wado//StrUtf8ByteIter") -> ref "core:prelude//Array<u8>";  // TypeId(162)
 
-type "functype//core:prelude/string.wado/String::starts_with" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(163)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(163)
 
-type "functype//core:prelude/string.wado/StrSplitIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrSplitIter") -> ref null "core:prelude/string.wado//String";  // TypeId(164)
+type "functype//core:prelude/string.wado/String::substr_bytes" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/string.wado//String";  // TypeId(164)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(165)
+type "functype//core:prelude/string.wado/String::starts_with" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(165)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(166)
+type "functype//core:prelude/string.wado/StrSplitIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrSplitIter") -> ref null "core:prelude/string.wado//String";  // TypeId(166)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(167)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(167)
 
-type "functype//core:prelude/Array<Array<u8>>::push" = fn(ref "core:prelude//Array<Array<u8>>", ref "core:prelude//Array<u8>");  // TypeId(168)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(168)
 
-type "functype//core:prelude/array.wado/Array<Array<u8>>::grow" = fn(ref "core:prelude//Array<Array<u8>>");  // TypeId(169)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(169)
 
-type "functype//core:prelude/Array<Tuple<String,Array<u8>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>", ref "tuple//[String, Array<u8>]");  // TypeId(170)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(170)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>");  // TypeId(171)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(171)
 
-type "functype//core:prelude/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(172)
+type "functype//core:prelude/Array<Array<u8>>::push" = fn(ref "core:prelude//Array<Array<u8>>", ref "core:prelude//Array<u8>");  // TypeId(172)
 
-type "functype//core:prelude/array.wado/Array<u8>::grow" = fn(ref "core:prelude//Array<u8>");  // TypeId(173)
+type "functype//core:prelude/array.wado/Array<Array<u8>>::grow" = fn(ref "core:prelude//Array<Array<u8>>");  // TypeId(173)
 
-type "functype//core:collections/TreeMap<String,Value>::find_index" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(174)
+type "functype//core:prelude/Array<Tuple<String,Array<u8>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>", ref "tuple//[String, Array<u8>]");  // TypeId(174)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>") -> ref null "tuple//[String, Value]";  // TypeId(175)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>");  // TypeId(175)
 
-type "functype//core:collections/TreeMap<String,Value>::entries" = fn(ref "core:collections//TreeMap<String,Value>") -> ref "core:prelude//Array<Tuple<String,Value>>";  // TypeId(176)
+type "functype//core:prelude/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(176)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::push" = fn(ref "core:prelude//Array<Tuple<String,Value>>", ref "tuple//[String, Value]");  // TypeId(177)
+type "functype//core:prelude/array.wado/Array<u8>::grow" = fn(ref "core:prelude//Array<u8>");  // TypeId(177)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Value>>");  // TypeId(178)
+type "functype//core:collections/TreeMap<String,Value>::find_index" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(178)
 
-type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>") -> ref null "core:collections//TreeMapEntry<String,Value>";  // TypeId(179)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>") -> ref null "tuple//[String, Value]";  // TypeId(179)
 
-type "functype//core:prelude/array.wado/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(180)
+type "functype//core:collections/TreeMap<String,Value>::entries" = fn(ref "core:collections//TreeMap<String,Value>") -> ref "core:prelude//Array<Tuple<String,Value>>";  // TypeId(180)
 
-type "functype//core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(181)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::push" = fn(ref "core:prelude//Array<Tuple<String,Value>>", ref "tuple//[String, Value]");  // TypeId(181)
 
-type "functype//core:prelude/array.wado/ArrayIter<u8>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<u8>") -> ref "core:prelude/types.wado//Option<u8>";  // TypeId(182)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Value>>");  // TypeId(182)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(183)
+type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>") -> ref null "core:collections//TreeMapEntry<String,Value>";  // TypeId(183)
 
-type "functype//core:prelude/array.wado/ArrayIter<Value>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Value>") -> ref null "core:json_value//Value";  // TypeId(184)
+type "functype//core:prelude/array.wado/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(184)
 
-type "functype//core:prelude/string.wado/String::from_utf8_lossy<FieldValue>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(185)
+type "functype//core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(185)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<FieldName,FieldValue>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<FieldName,FieldValue>>") -> ref null "tuple//[String, Array<u8>]";  // TypeId(186)
+type "functype//core:prelude/array.wado/ArrayIter<u8>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<u8>") -> ref "core:prelude/types.wado//Option<u8>";  // TypeId(186)
 
-type "functype//core:collections/TreeMap<String,Value>::insert" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String", ref "core:json_value//Value");  // TypeId(187)
+type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(187)
 
-type "functype//core:collections/TreeMap<String,Value>::insert_node" = fn(ref "core:collections//TreeMap<String,Value>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(188)
+type "functype//core:prelude/array.wado/ArrayIter<Value>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Value>") -> ref null "core:json_value//Value";  // TypeId(188)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>", ref "core:collections//TreeMapEntry<String,Value>");  // TypeId(189)
+type "functype//core:prelude/string.wado/String::from_utf8_lossy<FieldValue>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(189)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>");  // TypeId(190)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<FieldName,FieldValue>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<FieldName,FieldValue>>") -> ref null "tuple//[String, Array<u8>]";  // TypeId(190)
 
-type "functype//wasi/future-new" = fn() -> i64;  // TypeId(191)
+type "functype//core:collections/TreeMap<String,Value>::insert" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String", ref "core:json_value//Value");  // TypeId(191)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(192)
+type "functype//core:collections/TreeMap<String,Value>::insert_node" = fn(ref "core:collections//TreeMap<String,Value>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(192)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(193)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>", ref "core:collections//TreeMapEntry<String,Value>");  // TypeId(193)
 
-type "functype//wasi/future-write" = fn(i32, i32) -> i32;  // TypeId(194)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>");  // TypeId(194)
 
-type "functype//wasi/future-new:transmission-http" = fn() -> i64;  // TypeId(195)
+type "functype//wasi/future-new" = fn() -> i64;  // TypeId(195)
 
-type "functype//wasi/stream-drop-readable" = fn(i32);  // TypeId(196)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(196)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(197)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(197)
 
-type "functype//wado-compiler/tests/fixtures/httpbin-post.wado/__cm_binding__Request_consume_body" = fn(i32, i32) -> [i32, i32];  // TypeId(198)
+type "functype//wasi/future-write" = fn(i32, i32) -> i32;  // TypeId(198)
 
-type "functype//wado-compiler/tests/fixtures/httpbin-post.wado/__cm_binding__Response_new" = fn(i32, ref "core:prelude/types.wado//Option<Stream<u8>>", i32) -> [i32, i32];  // TypeId(199)
+type "functype//wasi/future-new:transmission-http" = fn() -> i64;  // TypeId(199)
 
-type "functype//./sub/httpbin_handler.wado/split_path_query" = fn(ref "core:prelude/string.wado//String") -> [ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(200)
+type "functype//wasi/stream-drop-readable" = fn(i32);  // TypeId(200)
 
-type "functype//./sub/httpbin_handler.wado/parse_status_code" = fn(ref "core:prelude/string.wado//String") -> [i32, u16];  // TypeId(201)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(201)
 
-type "functype//./sub/httpbin_handler.wado/route" = fn(i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(202)
+type "functype//wado-compiler/tests/fixtures/httpbin-post.wado/__cm_binding__Request_consume_body" = fn(i32, i32) -> [i32, i32];  // TypeId(202)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(203)
+type "functype//wado-compiler/tests/fixtures/httpbin-post.wado/__cm_binding__Response_new" = fn(i32, ref "core:prelude/types.wado//Option<Stream<u8>>", i32) -> [i32, i32];  // TypeId(203)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(204)
+type "functype//./sub/httpbin_handler.wado/split_path_query" = fn(ref "core:prelude/string.wado//String") -> [ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(204)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(205)
+type "functype//./sub/httpbin_handler.wado/parse_status_code" = fn(ref "core:prelude/string.wado//String") -> [i32, u16];  // TypeId(205)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(206)
+type "functype//./sub/httpbin_handler.wado/route" = fn(i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(206)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(207)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(207)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(208)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(208)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(209)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(209)
 
-type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(210)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(210)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(211)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(211)
 
-type "functype//core:prelude/string.wado/String::find" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, i32];  // TypeId(212)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(212)
 
-type "functype//core:prelude/string.wado/String::from_utf8<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> [i32, ref null "core:prelude/string.wado//String"];  // TypeId(213)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(213)
 
-type "functype//core:json/core/json/to_string<Value>" = fn(ref "core:json_value//Value") -> ref "core:prelude/types.wado//Result<String,SerializeError>";  // TypeId(214)
+type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(214)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(215)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(215)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(216)
+type "functype//core:prelude/string.wado/String::find" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, i32];  // TypeId(216)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(217)
+type "functype//core:prelude/string.wado/String::from_utf8<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> [i32, ref null "core:prelude/string.wado//String"];  // TypeId(217)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(218)
+type "functype//core:json/core/json/to_string<Value>" = fn(ref "core:json_value//Value") -> ref "core:prelude/types.wado//Result<String,SerializeError>";  // TypeId(218)
 
-type "functype//core:json_value/Value^Serialize::serialize<JsonSerializer>" = fn(ref "core:json_value//Value", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(219)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(219)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::value<Value>" = fn(ref "core:json//JsonMapSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(220)
+type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(220)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Value>" = fn(ref "core:json//JsonSeqSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(221)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(221)
 
-type "functype//core:collections/TreeMap<String,Value>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(222)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(222)
 
-type "functype//core:collections/TreeMap<String,Value>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(223)
+type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(223)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(224)
+
+type "functype//core:json_value/Value^Serialize::serialize<JsonSerializer>" = fn(ref "core:json_value//Value", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(225)
+
+type "functype//core:json/JsonMapSerializer^SerializeMap::value<Value>" = fn(ref "core:json//JsonMapSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(226)
+
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Value>" = fn(ref "core:json//JsonSeqSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(227)
+
+type "functype//core:collections/TreeMap<String,Value>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(228)
+
+type "functype//core:collections/TreeMap<String,Value>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(229)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-read from "wasi/stream-read";
@@ -3933,6 +3945,67 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     return 0, f64.copysign(val, sign);
 }
 
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l371: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l371;
+                };
+            };
+        };
+    }
+}
+
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
+        return 1;
+    }
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l377: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l377;
+            };
+        };
+    };
+    return n;
+}
+
 fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     let mark: i32;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -3961,23 +4034,16 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
-    }
-    return ((97 + v) - 10) & 255;
-}
-
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b374: block {
-        l375: loop {
+    b383: block {
+        l384: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3998,23 +4064,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b374;
+                break b383;
             }
-            continue l375;
+            continue l384;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -4022,15 +4090,35 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/to_string<Value>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json_value/Value^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = ref.as_non_null(r);
-        return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Err" { discriminant: 1, payload_0: e };
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json_value/Value^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+        unreachable;
+    } else {
+        unreachable;
     }
     return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Ok" { discriminant: 0, payload_0: ser.buf };
+}
+
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
 }
 
 fn "core:prelude/primitive.wado/f64::fmt_into"(self, f) {
@@ -4197,6 +4285,20 @@ fn "core:prelude/primitive.wado/f64::fmt_fixed"(self, precision, f) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark_13);
 }
 
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
+}
+
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     let capacity: i32;
     let new_capacity: i32;
@@ -4217,6 +4319,18 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     new_repr = builtin::array_new<u8>(new_capacity);
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
+}
+
+fn "core:prelude/string.wado/String::internal_reserve_uninit"(self, n) {
+    let new_used: i32;
+    let start: i32;
+    new_used = self.used + n;
+    if builtin::unlikely(new_used > builtin::array_len(self.repr)) {
+        "core:prelude/string.wado/String::grow"(self, new_used);
+    }
+    start = self.used;
+    self.used = new_used;
+    return start;
 }
 
 fn "core:prelude/string.wado/String::append_byte_filled"(self, byte, n) {
@@ -4275,7 +4389,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l409: loop {
+            l421: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -4283,7 +4397,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l409;
+                continue l421;
             };
         };
     };
@@ -4307,7 +4421,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
     __for_2: block {
         i = 0;
         block {
-            l413: loop {
+            l425: loop {
                 if i >= min_len {
                     break __for_2;
                 }
@@ -4320,7 +4434,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
                     return 2;
                 }
                 i = i + 1;
-                continue l413;
+                continue l425;
             };
         };
     };
@@ -4347,18 +4461,18 @@ fn "core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect"(self) {
     _licm_used_11 = self.used;
     _licm_repr_12 = self.repr;
     _hfs_index_13 = self.index;
-    b419: block {
-        l420: loop {
+    b431: block {
+        l432: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_3: block {
                 if _hfs_index_13 >= _licm_used_11 {
-                    break b419;
+                    break b431;
                 }
                 byte = builtin::array_get_u8(_licm_repr_12, _hfs_index_13);
                 _hfs_index_13 = _hfs_index_13 + 1;
                 "core:prelude/array.wado/Array<u8>::push"(result, byte);
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_3;
             };
-            continue l420;
+            continue l432;
         };
     };
     self.index = _hfs_index_13;
@@ -4462,7 +4576,7 @@ fn "core:prelude/string.wado/String::starts_with"(self, pat) {
         i = 0;
         _licm_repr_7 = self.repr;
         block {
-            l433: loop {
+            l445: loop {
                 if i >= pat_len {
                     break __for_4;
                 }
@@ -4470,7 +4584,7 @@ fn "core:prelude/string.wado/String::starts_with"(self, pat) {
                     return 0;
                 }
                 i = i + 1;
-                continue l433;
+                continue l445;
             };
         };
     };
@@ -4498,7 +4612,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
         i = 0;
         _licm_repr_10 = self.repr;
         block {
-            l439: loop {
+            l451: loop {
                 if i > limit {
                     break __for_6;
                 }
@@ -4506,7 +4620,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                 __for_7: block {
                     j = 0;
                     block {
-                        l442: loop {
+                        l454: loop {
                             if j >= pat_len {
                                 break __for_7;
                             }
@@ -4515,7 +4629,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                                 break __for_7;
                             }
                             j = j + 1;
-                            continue l442;
+                            continue l454;
                         };
                     };
                 };
@@ -4523,7 +4637,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                     return 0, i;
                 }
                 i = i + 1;
-                continue l439;
+                continue l451;
             };
         };
     };
@@ -4550,16 +4664,16 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
     _licm_sep_len_13 = self.sep_len;
     _licm_repr_14 = self.repr;
     _licm_sep_repr_15 = self.sep_repr;
-    b447: block {
-        l448: loop {
+    b459: block {
+        l460: loop {
             if i > limit {
-                break b447;
+                break b459;
             }
             matched = 1;
             __for_12: block {
                 j = 0;
                 block {
-                    l451: loop {
+                    l463: loop {
                         if j >= _licm_sep_len_13 {
                             break __for_12;
                         }
@@ -4568,7 +4682,7 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                             break __for_12;
                         }
                         j = j + 1;
-                        continue l451;
+                        continue l463;
                     };
                 };
             };
@@ -4580,7 +4694,7 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                 return struct.new "core:prelude/string.wado//String" { repr: part_6, used: len_5 };
             }
             i = i + 1;
-            continue l448;
+            continue l460;
         };
     };
     len_7 = self.used - self.pos;
@@ -4626,6 +4740,25 @@ fn "core:json/JsonSerializer^Serializer::serialize_bool"(self, v) {
         "core:prelude/string.wado/String::push"(self, 101);
     }
     return ref.null none;
+}
+
+fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
+    let i: i32;
+    let _licm_buf_4: ref "core:prelude/string.wado//String";
+    __for_0: block {
+        i = 0;
+        _licm_buf_4 = self.buf;
+        block {
+            l471: loop {
+                if i >= n {
+                    break __for_0;
+                }
+                "core:prelude/string.wado/String::push"(_licm_buf_4, c);
+                i = i + 1;
+                continue l471;
+            };
+        };
+    };
 }
 
 fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
@@ -4681,10 +4814,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b462: block {
-            l463: loop {
+        b477: block {
+            l478: loop {
                 if i_8 < 0 {
-                    break b462;
+                    break b477;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -4693,7 +4826,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l463;
+                continue l478;
             };
         };
         __for_1: block {
@@ -4701,14 +4834,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l466: loop {
+                l481: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l466;
+                    continue l481;
                 };
             };
         };
@@ -4718,10 +4851,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b468: block {
-            l469: loop {
+        b483: block {
+            l484: loop {
                 if i_10 < 0 {
-                    break b468;
+                    break b483;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -4730,7 +4863,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l469;
+                continue l484;
             };
         };
         __for_2: block {
@@ -4738,17 +4871,99 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l472: loop {
+                l487: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l472;
+                    continue l487;
                 };
             };
         };
+    }
+}
+
+fn "core:prelude/format.wado/Formatter::prepare_int_write"(self, is_negative, prefix, digit_count) {
+    let sign: ref "core:prelude/string.wado//String";
+    let sign_len: i32;
+    let prefix_len: i32;
+    let content_len: i32;
+    let padding: i32;
+    let align: "core:prelude/format.wado//enum:Alignment";
+    let offset_10: i32;
+    let left_pad: i32;
+    let right_pad: i32;
+    let offset_13: i32;
+    sign = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+    if is_negative {
+        sign = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("-"), used: 1 };
+    } else if self.sign_plus {
+        sign = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("+"), used: 1 };
+    }
+    sign_len = sign.used;
+    prefix_len = prefix.used;
+    content_len = (sign_len + prefix_len) + digit_count;
+    if (if self.width <= 0 -> i32 {
+        1;
+    } else {
+        content_len >= self.width;
+    }) {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    }
+    padding = self.width - content_len;
+    if self.zero_pad {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        "core:prelude/format.wado/Formatter::write_char_n"(self, 48, padding);
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    }
+    align = self.align;
+    let __match_scrut_0: "core:prelude/format.wado//enum:Alignment";
+    __match_scrut_0 = align;
+    if __match_scrut_0 == 0 {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        offset_10 = "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, padding);
+        return offset_10;
+    } else if align == 1 {
+        left_pad = padding / 2;
+        right_pad = padding - left_pad;
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, left_pad);
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        offset_13 = "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, right_pad);
+        return offset_13;
+    } else {
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, padding);
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
     }
 }
 
@@ -4781,13 +4996,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l476: loop {
+            l508: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l476;
+                continue l508;
             };
         };
     };
@@ -4823,13 +5038,13 @@ fn "core:prelude/array.wado/Array<Array<u8>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l480: loop {
+            l512: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
                 i = i + 1;
-                continue l480;
+                continue l512;
             };
         };
     };
@@ -4865,13 +5080,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l484: loop {
+            l516: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
                 i = i + 1;
-                continue l484;
+                continue l516;
             };
         };
     };
@@ -4907,13 +5122,13 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l488: loop {
+            l520: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
                 i = i + 1;
-                continue l488;
+                continue l520;
             };
         };
     };
@@ -4933,8 +5148,8 @@ fn "core:collections/TreeMap<String,Value>::find_index"(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b490: block {
-        l491: loop {
+    b522: block {
+        l523: loop {
             __pattern_temp_0 = value_copy "core:prelude/types.wado//Option<TreeMapNode<String>>"(current);
             if ref.is_null(__pattern_temp_0) == 0 {
                 n = ref.as_non_null(__pattern_temp_0);
@@ -4958,9 +5173,9 @@ fn "core:collections/TreeMap<String,Value>::find_index"(self, key) {
                     current = n.right;
                 }
             } else {
-                break b490;
+                break b522;
             }
-            continue l491;
+            continue l523;
         };
     };
     return -1;
@@ -4991,8 +5206,8 @@ fn "core:collections/TreeMap<String,Value>::entries"(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_Value___IntoIterator__into_iter_3: struct.new "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>" { repr: __local_9.repr, used: __local_9.used, index: 0 };
     };
-    b498: block {
-        l499: loop {
+    b530: block {
+        l531: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next"(__iter_3);
             if ref.is_null(__pattern_temp_0) == 0 {
                 entry = value_copy "core:collections//TreeMapEntry<String,Value>"(ref.as_non_null(__pattern_temp_0));
@@ -5000,9 +5215,9 @@ fn "core:collections/TreeMap<String,Value>::entries"(self) {
                     "core:prelude/array.wado/Array<Tuple<String,Value>>::push"(result, struct.new "tuple//[String, Value]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b498;
+                break b530;
             }
-            continue l499;
+            continue l531;
         };
     };
     return result;
@@ -5037,13 +5252,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Value>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l504: loop {
+            l536: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
                 i = i + 1;
-                continue l504;
+                continue l536;
             };
         };
     };
@@ -5096,8 +5311,8 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>"(bytes) {
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
     pending = struct.new "core:prelude/types.wado//Option<u8>" { 1 };
-    b508: block {
-        l509: loop {
+    b540: block {
+        l541: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<u8>";
             __match_scrut_0 = pending;
             b0_opt = (if ref.test "core:prelude/types.wado//Option<u8>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<u8>" {
@@ -5247,9 +5462,9 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>"(bytes) {
                     "core:prelude/string.wado/String::push"(builder, 65533);
                 }
             } else {
-                break b508;
+                break b540;
             }
-            continue l509;
+            continue l541;
         };
     };
     return builder;
@@ -5334,8 +5549,8 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                 __local_36 = __local_5;
                 break __inline_Array_Value__IntoIterator__into_iter_4: struct.new "core:prelude/array.wado//ArrayIter<Value>" { repr: __local_36.repr, used: __local_36.used, index: 0 };
             };
-            b551: block {
-                l552: loop {
+            b583: block {
+                l584: loop {
                     __local_24 = "core:prelude/array.wado/ArrayIter<Value>^Iterator::next"(__local_8);
                     if ref.is_null(__local_24) == 0 {
                         __local_10 = "core:json/JsonSeqSerializer^SerializeSeq::element<Value>"(__local_7, ref.as_non_null(__local_24));
@@ -5344,9 +5559,9 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                             return __local_11;
                         }
                     } else {
-                        break b551;
+                        break b583;
                     }
-                    continue l552;
+                    continue l584;
                 };
             };
             __inline_JsonSeqSerializer_SerializeSeq__end_5: block -> ref null "core:serde//SerializeError" {
@@ -5380,8 +5595,8 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                 __local_41 = "core:collections/TreeMap<String,Value>::entries"(__local_13);
                 break __inline_Array_Tuple_String_Value___IntoIterator__into_iter_8: struct.new "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>" { repr: __local_41.repr, used: __local_41.used, index: 0 };
             };
-            b558: block {
-                l559: loop {
+            b590: block {
+                l591: loop {
                     __local_26 = "core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next"(__local_16);
                     if ref.is_null(__local_26) == 0 {
                         __local_27 = value_copy "tuple//[String, Value]"(ref.as_non_null(__local_26));
@@ -5397,9 +5612,9 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                             return __local_22;
                         }
                     } else {
-                        break b558;
+                        break b590;
                     }
-                    continue l559;
+                    continue l591;
                 };
             };
             __inline_JsonMapSerializer_SerializeMap__end_9: block -> ref null "core:serde//SerializeError" {
@@ -5490,8 +5705,8 @@ fn "core:prelude/string.wado/String::from_utf8<Array<u8>>"(bytes) {
     let __pattern_temp_6: ref "core:prelude/types.wado//Option<u8>";
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
-    b567: block {
-        l568: loop {
+    b599: block {
+        l600: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<u8>^Iterator::next"(iter);
             if ref.test "core:prelude/types.wado//Option<u8>::Some"(__pattern_temp_0) {
                 b0 = ref.cast "core:prelude/types.wado//Option<u8>::Some"(__pattern_temp_0).payload_0;
@@ -5617,9 +5832,9 @@ fn "core:prelude/string.wado/String::from_utf8<Array<u8>>"(bytes) {
                 }
                 "core:prelude/string.wado/String::push"(builder, code);
             } else {
-                break b567;
+                break b599;
             }
-            continue l568;
+            continue l600;
         };
     };
     return 0, builder;
@@ -5651,8 +5866,8 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<FieldValue>"(bytes) {
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
     pending = struct.new "core:prelude/types.wado//Option<u8>" { 1 };
-    b601: block {
-        l602: loop {
+    b633: block {
+        l634: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<u8>";
             __match_scrut_0 = pending;
             b0_opt = (if ref.test "core:prelude/types.wado//Option<u8>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<u8>" {
@@ -5802,9 +6017,9 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<FieldValue>"(bytes) {
                     "core:prelude/string.wado/String::push"(builder, 65533);
                 }
             } else {
-                break b601;
+                break b633;
             }
-            continue l602;
+            continue l634;
         };
     };
     return builder;
@@ -5946,13 +6161,13 @@ fn "core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l652: loop {
+            l684: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:collections//TreeMapEntry<String,Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<String,Value>">(old_repr, i));
                 i = i + 1;
-                continue l652;
+                continue l684;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/httpbin-status.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin-status.wir.wado
@@ -622,153 +622,165 @@ type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeI
 
 type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(149)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(150)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(150)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(151)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(151)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(152)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(152)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(153)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(153)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(154)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(154)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(155)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(155)
 
-type "functype//core:prelude/string.wado/String::concat" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(156)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(156)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(157)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(157)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(158)
+type "functype//core:prelude/string.wado/String::concat" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(158)
 
-type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(159)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(159)
 
-type "functype//core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect" = fn(ref "core:prelude/string.wado//StrUtf8ByteIter") -> ref "core:prelude//Array<u8>";  // TypeId(160)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(160)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(161)
+type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(161)
 
-type "functype//core:prelude/string.wado/String::substr_bytes" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/string.wado//String";  // TypeId(162)
+type "functype//core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect" = fn(ref "core:prelude/string.wado//StrUtf8ByteIter") -> ref "core:prelude//Array<u8>";  // TypeId(162)
 
-type "functype//core:prelude/string.wado/String::starts_with" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(163)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(163)
 
-type "functype//core:prelude/string.wado/StrSplitIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrSplitIter") -> ref null "core:prelude/string.wado//String";  // TypeId(164)
+type "functype//core:prelude/string.wado/String::substr_bytes" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/string.wado//String";  // TypeId(164)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(165)
+type "functype//core:prelude/string.wado/String::starts_with" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(165)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(166)
+type "functype//core:prelude/string.wado/StrSplitIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrSplitIter") -> ref null "core:prelude/string.wado//String";  // TypeId(166)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(167)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(167)
 
-type "functype//core:prelude/Array<Array<u8>>::push" = fn(ref "core:prelude//Array<Array<u8>>", ref "core:prelude//Array<u8>");  // TypeId(168)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(168)
 
-type "functype//core:prelude/array.wado/Array<Array<u8>>::grow" = fn(ref "core:prelude//Array<Array<u8>>");  // TypeId(169)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(169)
 
-type "functype//core:prelude/Array<Tuple<String,Array<u8>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>", ref "tuple//[String, Array<u8>]");  // TypeId(170)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(170)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>");  // TypeId(171)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(171)
 
-type "functype//core:prelude/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(172)
+type "functype//core:prelude/Array<Array<u8>>::push" = fn(ref "core:prelude//Array<Array<u8>>", ref "core:prelude//Array<u8>");  // TypeId(172)
 
-type "functype//core:prelude/array.wado/Array<u8>::grow" = fn(ref "core:prelude//Array<u8>");  // TypeId(173)
+type "functype//core:prelude/array.wado/Array<Array<u8>>::grow" = fn(ref "core:prelude//Array<Array<u8>>");  // TypeId(173)
 
-type "functype//core:collections/TreeMap<String,Value>::find_index" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(174)
+type "functype//core:prelude/Array<Tuple<String,Array<u8>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>", ref "tuple//[String, Array<u8>]");  // TypeId(174)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>") -> ref null "tuple//[String, Value]";  // TypeId(175)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<u8>>>");  // TypeId(175)
 
-type "functype//core:collections/TreeMap<String,Value>::entries" = fn(ref "core:collections//TreeMap<String,Value>") -> ref "core:prelude//Array<Tuple<String,Value>>";  // TypeId(176)
+type "functype//core:prelude/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(176)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::push" = fn(ref "core:prelude//Array<Tuple<String,Value>>", ref "tuple//[String, Value]");  // TypeId(177)
+type "functype//core:prelude/array.wado/Array<u8>::grow" = fn(ref "core:prelude//Array<u8>");  // TypeId(177)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Value>>");  // TypeId(178)
+type "functype//core:collections/TreeMap<String,Value>::find_index" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(178)
 
-type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>") -> ref null "core:collections//TreeMapEntry<String,Value>";  // TypeId(179)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>") -> ref null "tuple//[String, Value]";  // TypeId(179)
 
-type "functype//core:prelude/array.wado/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(180)
+type "functype//core:collections/TreeMap<String,Value>::entries" = fn(ref "core:collections//TreeMap<String,Value>") -> ref "core:prelude//Array<Tuple<String,Value>>";  // TypeId(180)
 
-type "functype//core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(181)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::push" = fn(ref "core:prelude//Array<Tuple<String,Value>>", ref "tuple//[String, Value]");  // TypeId(181)
 
-type "functype//core:prelude/array.wado/ArrayIter<u8>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<u8>") -> ref "core:prelude/types.wado//Option<u8>";  // TypeId(182)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Value>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Value>>");  // TypeId(182)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(183)
+type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>") -> ref null "core:collections//TreeMapEntry<String,Value>";  // TypeId(183)
 
-type "functype//core:prelude/array.wado/ArrayIter<Value>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Value>") -> ref null "core:json_value//Value";  // TypeId(184)
+type "functype//core:prelude/array.wado/Array<u8>::push" = fn(ref "core:prelude//Array<u8>", u8);  // TypeId(184)
 
-type "functype//core:prelude/string.wado/String::from_utf8_lossy<FieldValue>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(185)
+type "functype//core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(185)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<FieldName,FieldValue>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<FieldName,FieldValue>>") -> ref null "tuple//[String, Array<u8>]";  // TypeId(186)
+type "functype//core:prelude/array.wado/ArrayIter<u8>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<u8>") -> ref "core:prelude/types.wado//Option<u8>";  // TypeId(186)
 
-type "functype//core:collections/TreeMap<String,Value>::insert" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String", ref "core:json_value//Value");  // TypeId(187)
+type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(187)
 
-type "functype//core:collections/TreeMap<String,Value>::insert_node" = fn(ref "core:collections//TreeMap<String,Value>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(188)
+type "functype//core:prelude/array.wado/ArrayIter<Value>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Value>") -> ref null "core:json_value//Value";  // TypeId(188)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>", ref "core:collections//TreeMapEntry<String,Value>");  // TypeId(189)
+type "functype//core:prelude/string.wado/String::from_utf8_lossy<FieldValue>" = fn(ref "core:prelude//Array<u8>") -> ref "core:prelude/string.wado//String";  // TypeId(189)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>");  // TypeId(190)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<FieldName,FieldValue>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<FieldName,FieldValue>>") -> ref null "tuple//[String, Array<u8>]";  // TypeId(190)
 
-type "functype//wasi/future-new" = fn() -> i64;  // TypeId(191)
+type "functype//core:collections/TreeMap<String,Value>::insert" = fn(ref "core:collections//TreeMap<String,Value>", ref "core:prelude/string.wado//String", ref "core:json_value//Value");  // TypeId(191)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(192)
+type "functype//core:collections/TreeMap<String,Value>::insert_node" = fn(ref "core:collections//TreeMap<String,Value>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(192)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(193)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>", ref "core:collections//TreeMapEntry<String,Value>");  // TypeId(193)
 
-type "functype//wasi/future-write" = fn(i32, i32) -> i32;  // TypeId(194)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Value>>");  // TypeId(194)
 
-type "functype//wasi/future-new:transmission-http" = fn() -> i64;  // TypeId(195)
+type "functype//wasi/future-new" = fn() -> i64;  // TypeId(195)
 
-type "functype//wasi/stream-drop-readable" = fn(i32);  // TypeId(196)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(196)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(197)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(197)
 
-type "functype//wado-compiler/tests/fixtures/httpbin-status.wado/__cm_binding__Request_consume_body" = fn(i32, i32) -> [i32, i32];  // TypeId(198)
+type "functype//wasi/future-write" = fn(i32, i32) -> i32;  // TypeId(198)
 
-type "functype//wado-compiler/tests/fixtures/httpbin-status.wado/__cm_binding__Response_new" = fn(i32, ref "core:prelude/types.wado//Option<Stream<u8>>", i32) -> [i32, i32];  // TypeId(199)
+type "functype//wasi/future-new:transmission-http" = fn() -> i64;  // TypeId(199)
 
-type "functype//./sub/httpbin_handler.wado/split_path_query" = fn(ref "core:prelude/string.wado//String") -> [ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(200)
+type "functype//wasi/stream-drop-readable" = fn(i32);  // TypeId(200)
 
-type "functype//./sub/httpbin_handler.wado/parse_status_code" = fn(ref "core:prelude/string.wado//String") -> [i32, u16];  // TypeId(201)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(201)
 
-type "functype//./sub/httpbin_handler.wado/route" = fn(i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(202)
+type "functype//wado-compiler/tests/fixtures/httpbin-status.wado/__cm_binding__Request_consume_body" = fn(i32, i32) -> [i32, i32];  // TypeId(202)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(203)
+type "functype//wado-compiler/tests/fixtures/httpbin-status.wado/__cm_binding__Response_new" = fn(i32, ref "core:prelude/types.wado//Option<Stream<u8>>", i32) -> [i32, i32];  // TypeId(203)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(204)
+type "functype//./sub/httpbin_handler.wado/split_path_query" = fn(ref "core:prelude/string.wado//String") -> [ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(204)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(205)
+type "functype//./sub/httpbin_handler.wado/parse_status_code" = fn(ref "core:prelude/string.wado//String") -> [i32, u16];  // TypeId(205)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(206)
+type "functype//./sub/httpbin_handler.wado/route" = fn(i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String"];  // TypeId(206)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(207)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(207)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(208)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(208)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(209)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(209)
 
-type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(210)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(210)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(211)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(211)
 
-type "functype//core:prelude/string.wado/String::find" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, i32];  // TypeId(212)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(212)
 
-type "functype//core:prelude/string.wado/String::from_utf8<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> [i32, ref null "core:prelude/string.wado//String"];  // TypeId(213)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(213)
 
-type "functype//core:json/core/json/to_string<Value>" = fn(ref "core:json_value//Value") -> ref "core:prelude/types.wado//Result<String,SerializeError>";  // TypeId(214)
+type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(214)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(215)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(215)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(216)
+type "functype//core:prelude/string.wado/String::find" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, i32];  // TypeId(216)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(217)
+type "functype//core:prelude/string.wado/String::from_utf8<Array<u8>>" = fn(ref "core:prelude//Array<u8>") -> [i32, ref null "core:prelude/string.wado//String"];  // TypeId(217)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(218)
+type "functype//core:json/core/json/to_string<Value>" = fn(ref "core:json_value//Value") -> ref "core:prelude/types.wado//Result<String,SerializeError>";  // TypeId(218)
 
-type "functype//core:json_value/Value^Serialize::serialize<JsonSerializer>" = fn(ref "core:json_value//Value", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(219)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(219)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::value<Value>" = fn(ref "core:json//JsonMapSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(220)
+type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(220)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Value>" = fn(ref "core:json//JsonSeqSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(221)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(221)
 
-type "functype//core:collections/TreeMap<String,Value>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(222)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(222)
 
-type "functype//core:collections/TreeMap<String,Value>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(223)
+type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(223)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(224)
+
+type "functype//core:json_value/Value^Serialize::serialize<JsonSerializer>" = fn(ref "core:json_value//Value", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(225)
+
+type "functype//core:json/JsonMapSerializer^SerializeMap::value<Value>" = fn(ref "core:json//JsonMapSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(226)
+
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Value>" = fn(ref "core:json//JsonSeqSerializer", ref "core:json_value//Value") -> ref null "core:serde//SerializeError";  // TypeId(227)
+
+type "functype//core:collections/TreeMap<String,Value>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(228)
+
+type "functype//core:collections/TreeMap<String,Value>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(229)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-read from "wasi/stream-read";
@@ -3933,6 +3945,67 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     return 0, f64.copysign(val, sign);
 }
 
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l371: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l371;
+                };
+            };
+        };
+    }
+}
+
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
+        return 1;
+    }
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l377: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l377;
+            };
+        };
+    };
+    return n;
+}
+
 fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     let mark: i32;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -3961,23 +4034,16 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
-    }
-    return ((97 + v) - 10) & 255;
-}
-
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b374: block {
-        l375: loop {
+    b383: block {
+        l384: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3998,23 +4064,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b374;
+                break b383;
             }
-            continue l375;
+            continue l384;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -4022,15 +4090,35 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/to_string<Value>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json_value/Value^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = ref.as_non_null(r);
-        return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Err" { discriminant: 1, payload_0: e };
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json_value/Value^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+        unreachable;
+    } else {
+        unreachable;
     }
     return struct.new "core:prelude/types.wado//Result<String,SerializeError>::Ok" { discriminant: 0, payload_0: ser.buf };
+}
+
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
 }
 
 fn "core:prelude/primitive.wado/f64::fmt_into"(self, f) {
@@ -4197,6 +4285,20 @@ fn "core:prelude/primitive.wado/f64::fmt_fixed"(self, precision, f) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark_13);
 }
 
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
+}
+
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     let capacity: i32;
     let new_capacity: i32;
@@ -4217,6 +4319,18 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     new_repr = builtin::array_new<u8>(new_capacity);
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
+}
+
+fn "core:prelude/string.wado/String::internal_reserve_uninit"(self, n) {
+    let new_used: i32;
+    let start: i32;
+    new_used = self.used + n;
+    if builtin::unlikely(new_used > builtin::array_len(self.repr)) {
+        "core:prelude/string.wado/String::grow"(self, new_used);
+    }
+    start = self.used;
+    self.used = new_used;
+    return start;
 }
 
 fn "core:prelude/string.wado/String::append_byte_filled"(self, byte, n) {
@@ -4275,7 +4389,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l409: loop {
+            l421: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -4283,7 +4397,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l409;
+                continue l421;
             };
         };
     };
@@ -4307,7 +4421,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
     __for_2: block {
         i = 0;
         block {
-            l413: loop {
+            l425: loop {
                 if i >= min_len {
                     break __for_2;
                 }
@@ -4320,7 +4434,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
                     return 2;
                 }
                 i = i + 1;
-                continue l413;
+                continue l425;
             };
         };
     };
@@ -4347,18 +4461,18 @@ fn "core:prelude/string.wado/StrUtf8ByteIter^Iterator::collect"(self) {
     _licm_used_11 = self.used;
     _licm_repr_12 = self.repr;
     _hfs_index_13 = self.index;
-    b419: block {
-        l420: loop {
+    b431: block {
+        l432: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_3: block {
                 if _hfs_index_13 >= _licm_used_11 {
-                    break b419;
+                    break b431;
                 }
                 byte = builtin::array_get_u8(_licm_repr_12, _hfs_index_13);
                 _hfs_index_13 = _hfs_index_13 + 1;
                 "core:prelude/array.wado/Array<u8>::push"(result, byte);
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_3;
             };
-            continue l420;
+            continue l432;
         };
     };
     self.index = _hfs_index_13;
@@ -4462,7 +4576,7 @@ fn "core:prelude/string.wado/String::starts_with"(self, pat) {
         i = 0;
         _licm_repr_7 = self.repr;
         block {
-            l433: loop {
+            l445: loop {
                 if i >= pat_len {
                     break __for_4;
                 }
@@ -4470,7 +4584,7 @@ fn "core:prelude/string.wado/String::starts_with"(self, pat) {
                     return 0;
                 }
                 i = i + 1;
-                continue l433;
+                continue l445;
             };
         };
     };
@@ -4498,7 +4612,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
         i = 0;
         _licm_repr_10 = self.repr;
         block {
-            l439: loop {
+            l451: loop {
                 if i > limit {
                     break __for_6;
                 }
@@ -4506,7 +4620,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                 __for_7: block {
                     j = 0;
                     block {
-                        l442: loop {
+                        l454: loop {
                             if j >= pat_len {
                                 break __for_7;
                             }
@@ -4515,7 +4629,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                                 break __for_7;
                             }
                             j = j + 1;
-                            continue l442;
+                            continue l454;
                         };
                     };
                 };
@@ -4523,7 +4637,7 @@ fn "core:prelude/string.wado/String::find"(self, pat) {
                     return 0, i;
                 }
                 i = i + 1;
-                continue l439;
+                continue l451;
             };
         };
     };
@@ -4550,16 +4664,16 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
     _licm_sep_len_13 = self.sep_len;
     _licm_repr_14 = self.repr;
     _licm_sep_repr_15 = self.sep_repr;
-    b447: block {
-        l448: loop {
+    b459: block {
+        l460: loop {
             if i > limit {
-                break b447;
+                break b459;
             }
             matched = 1;
             __for_12: block {
                 j = 0;
                 block {
-                    l451: loop {
+                    l463: loop {
                         if j >= _licm_sep_len_13 {
                             break __for_12;
                         }
@@ -4568,7 +4682,7 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                             break __for_12;
                         }
                         j = j + 1;
-                        continue l451;
+                        continue l463;
                     };
                 };
             };
@@ -4580,7 +4694,7 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                 return struct.new "core:prelude/string.wado//String" { repr: part_6, used: len_5 };
             }
             i = i + 1;
-            continue l448;
+            continue l460;
         };
     };
     len_7 = self.used - self.pos;
@@ -4626,6 +4740,25 @@ fn "core:json/JsonSerializer^Serializer::serialize_bool"(self, v) {
         "core:prelude/string.wado/String::push"(self, 101);
     }
     return ref.null none;
+}
+
+fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
+    let i: i32;
+    let _licm_buf_4: ref "core:prelude/string.wado//String";
+    __for_0: block {
+        i = 0;
+        _licm_buf_4 = self.buf;
+        block {
+            l471: loop {
+                if i >= n {
+                    break __for_0;
+                }
+                "core:prelude/string.wado/String::push"(_licm_buf_4, c);
+                i = i + 1;
+                continue l471;
+            };
+        };
+    };
 }
 
 fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
@@ -4681,10 +4814,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b462: block {
-            l463: loop {
+        b477: block {
+            l478: loop {
                 if i_8 < 0 {
-                    break b462;
+                    break b477;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -4693,7 +4826,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l463;
+                continue l478;
             };
         };
         __for_1: block {
@@ -4701,14 +4834,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l466: loop {
+                l481: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l466;
+                    continue l481;
                 };
             };
         };
@@ -4718,10 +4851,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b468: block {
-            l469: loop {
+        b483: block {
+            l484: loop {
                 if i_10 < 0 {
-                    break b468;
+                    break b483;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -4730,7 +4863,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l469;
+                continue l484;
             };
         };
         __for_2: block {
@@ -4738,17 +4871,99 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l472: loop {
+                l487: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l472;
+                    continue l487;
                 };
             };
         };
+    }
+}
+
+fn "core:prelude/format.wado/Formatter::prepare_int_write"(self, is_negative, prefix, digit_count) {
+    let sign: ref "core:prelude/string.wado//String";
+    let sign_len: i32;
+    let prefix_len: i32;
+    let content_len: i32;
+    let padding: i32;
+    let align: "core:prelude/format.wado//enum:Alignment";
+    let offset_10: i32;
+    let left_pad: i32;
+    let right_pad: i32;
+    let offset_13: i32;
+    sign = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+    if is_negative {
+        sign = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("-"), used: 1 };
+    } else if self.sign_plus {
+        sign = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("+"), used: 1 };
+    }
+    sign_len = sign.used;
+    prefix_len = prefix.used;
+    content_len = (sign_len + prefix_len) + digit_count;
+    if (if self.width <= 0 -> i32 {
+        1;
+    } else {
+        content_len >= self.width;
+    }) {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    }
+    padding = self.width - content_len;
+    if self.zero_pad {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        "core:prelude/format.wado/Formatter::write_char_n"(self, 48, padding);
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    }
+    align = self.align;
+    let __match_scrut_0: "core:prelude/format.wado//enum:Alignment";
+    __match_scrut_0 = align;
+    if __match_scrut_0 == 0 {
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        offset_10 = "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, padding);
+        return offset_10;
+    } else if align == 1 {
+        left_pad = padding / 2;
+        right_pad = padding - left_pad;
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, left_pad);
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        offset_13 = "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, right_pad);
+        return offset_13;
+    } else {
+        "core:prelude/format.wado/Formatter::write_char_n"(self, self.fill, padding);
+        if sign_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        }
+        if prefix_len > 0 {
+            "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        }
+        return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
     }
 }
 
@@ -4781,13 +4996,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l476: loop {
+            l508: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l476;
+                continue l508;
             };
         };
     };
@@ -4823,13 +5038,13 @@ fn "core:prelude/array.wado/Array<Array<u8>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l480: loop {
+            l512: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
                 i = i + 1;
-                continue l480;
+                continue l512;
             };
         };
     };
@@ -4865,13 +5080,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Array<u8>>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l484: loop {
+            l516: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
                 i = i + 1;
-                continue l484;
+                continue l516;
             };
         };
     };
@@ -4907,13 +5122,13 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l488: loop {
+            l520: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
                 i = i + 1;
-                continue l488;
+                continue l520;
             };
         };
     };
@@ -4933,8 +5148,8 @@ fn "core:collections/TreeMap<String,Value>::find_index"(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b490: block {
-        l491: loop {
+    b522: block {
+        l523: loop {
             __pattern_temp_0 = value_copy "core:prelude/types.wado//Option<TreeMapNode<String>>"(current);
             if ref.is_null(__pattern_temp_0) == 0 {
                 n = ref.as_non_null(__pattern_temp_0);
@@ -4958,9 +5173,9 @@ fn "core:collections/TreeMap<String,Value>::find_index"(self, key) {
                     current = n.right;
                 }
             } else {
-                break b490;
+                break b522;
             }
-            continue l491;
+            continue l523;
         };
     };
     return -1;
@@ -4991,8 +5206,8 @@ fn "core:collections/TreeMap<String,Value>::entries"(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_Value___IntoIterator__into_iter_3: struct.new "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Value>>" { repr: __local_9.repr, used: __local_9.used, index: 0 };
     };
-    b498: block {
-        l499: loop {
+    b530: block {
+        l531: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Value>>^Iterator::next"(__iter_3);
             if ref.is_null(__pattern_temp_0) == 0 {
                 entry = value_copy "core:collections//TreeMapEntry<String,Value>"(ref.as_non_null(__pattern_temp_0));
@@ -5000,9 +5215,9 @@ fn "core:collections/TreeMap<String,Value>::entries"(self) {
                     "core:prelude/array.wado/Array<Tuple<String,Value>>::push"(result, struct.new "tuple//[String, Value]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b498;
+                break b530;
             }
-            continue l499;
+            continue l531;
         };
     };
     return result;
@@ -5037,13 +5252,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Value>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l504: loop {
+            l536: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
                 i = i + 1;
-                continue l504;
+                continue l536;
             };
         };
     };
@@ -5096,8 +5311,8 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>"(bytes) {
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
     pending = struct.new "core:prelude/types.wado//Option<u8>" { 1 };
-    b508: block {
-        l509: loop {
+    b540: block {
+        l541: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<u8>";
             __match_scrut_0 = pending;
             b0_opt = (if ref.test "core:prelude/types.wado//Option<u8>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<u8>" {
@@ -5247,9 +5462,9 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<Array<u8>>"(bytes) {
                     "core:prelude/string.wado/String::push"(builder, 65533);
                 }
             } else {
-                break b508;
+                break b540;
             }
-            continue l509;
+            continue l541;
         };
     };
     return builder;
@@ -5334,8 +5549,8 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                 __local_36 = __local_5;
                 break __inline_Array_Value__IntoIterator__into_iter_4: struct.new "core:prelude/array.wado//ArrayIter<Value>" { repr: __local_36.repr, used: __local_36.used, index: 0 };
             };
-            b551: block {
-                l552: loop {
+            b583: block {
+                l584: loop {
                     __local_24 = "core:prelude/array.wado/ArrayIter<Value>^Iterator::next"(__local_8);
                     if ref.is_null(__local_24) == 0 {
                         __local_10 = "core:json/JsonSeqSerializer^SerializeSeq::element<Value>"(__local_7, ref.as_non_null(__local_24));
@@ -5344,9 +5559,9 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                             return __local_11;
                         }
                     } else {
-                        break b551;
+                        break b583;
                     }
-                    continue l552;
+                    continue l584;
                 };
             };
             __inline_JsonSeqSerializer_SerializeSeq__end_5: block -> ref null "core:serde//SerializeError" {
@@ -5380,8 +5595,8 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                 __local_41 = "core:collections/TreeMap<String,Value>::entries"(__local_13);
                 break __inline_Array_Tuple_String_Value___IntoIterator__into_iter_8: struct.new "core:prelude/array.wado//ArrayIter<Tuple<String,Value>>" { repr: __local_41.repr, used: __local_41.used, index: 0 };
             };
-            b558: block {
-                l559: loop {
+            b590: block {
+                l591: loop {
                     __local_26 = "core:prelude/array.wado/ArrayIter<Tuple<String,Value>>^Iterator::next"(__local_16);
                     if ref.is_null(__local_26) == 0 {
                         __local_27 = value_copy "tuple//[String, Value]"(ref.as_non_null(__local_26));
@@ -5397,9 +5612,9 @@ fn "core:json_value/Value^Serialize::serialize<JsonSerializer>"(self, s) {
                             return __local_22;
                         }
                     } else {
-                        break b558;
+                        break b590;
                     }
-                    continue l559;
+                    continue l591;
                 };
             };
             __inline_JsonMapSerializer_SerializeMap__end_9: block -> ref null "core:serde//SerializeError" {
@@ -5490,8 +5705,8 @@ fn "core:prelude/string.wado/String::from_utf8<Array<u8>>"(bytes) {
     let __pattern_temp_6: ref "core:prelude/types.wado//Option<u8>";
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
-    b567: block {
-        l568: loop {
+    b599: block {
+        l600: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<u8>^Iterator::next"(iter);
             if ref.test "core:prelude/types.wado//Option<u8>::Some"(__pattern_temp_0) {
                 b0 = ref.cast "core:prelude/types.wado//Option<u8>::Some"(__pattern_temp_0).payload_0;
@@ -5617,9 +5832,9 @@ fn "core:prelude/string.wado/String::from_utf8<Array<u8>>"(bytes) {
                 }
                 "core:prelude/string.wado/String::push"(builder, code);
             } else {
-                break b567;
+                break b599;
             }
-            continue l568;
+            continue l600;
         };
     };
     return 0, builder;
@@ -5651,8 +5866,8 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<FieldValue>"(bytes) {
     builder = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(8), used: 0 };
     iter = struct.new "core:prelude/array.wado//ArrayIter<u8>" { repr: bytes.repr, used: bytes.used, index: 0 };
     pending = struct.new "core:prelude/types.wado//Option<u8>" { 1 };
-    b601: block {
-        l602: loop {
+    b633: block {
+        l634: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<u8>";
             __match_scrut_0 = pending;
             b0_opt = (if ref.test "core:prelude/types.wado//Option<u8>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<u8>" {
@@ -5802,9 +6017,9 @@ fn "core:prelude/string.wado/String::from_utf8_lossy<FieldValue>"(bytes) {
                     "core:prelude/string.wado/String::push"(builder, 65533);
                 }
             } else {
-                break b601;
+                break b633;
             }
-            continue l602;
+            continue l634;
         };
     };
     return builder;
@@ -5946,13 +6161,13 @@ fn "core:prelude/array.wado/Array<TreeMapEntry<String,Value>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l652: loop {
+            l684: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:collections//TreeMapEntry<String,Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<String,Value>">(old_repr, i));
                 i = i + 1;
-                continue l652;
+                continue l684;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/opt_sroa_variant_br_exit.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/opt_sroa_variant_br_exit.wir.wado
@@ -48,134 +48,147 @@ struct core:prelude/types.wado//Result<f32,DeserializeError>::Err {  // TypeId(8
     payload_0: ref "core:serde//DeserializeError",
 }
 
-struct core:prelude//Array<u64> {  // TypeId(9)
+variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(9)
+    Ok(f64),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(10)
+    discriminant: i32,
+    payload_0: f64,
+}
+
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(11)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+struct core:prelude//Array<u64> {  // TypeId(12)
     mut repr: ref builtin::array<u64>,
     mut used: i32,
 }
 
-enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(10)
+enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(13)
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(11)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(14)
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(12)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(15)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(13)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(16)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(14)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(17)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(15)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(18)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(16)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(19)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(17)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(20)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(18)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(21)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(19)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(22)
 
-type "functype//wado-compiler/tests/fixtures/opt_sroa_variant_br_exit.wado/__test_0_f32_deserialize_via_sroa" = fn();  // TypeId(20)
+type "functype//wado-compiler/tests/fixtures/opt_sroa_variant_br_exit.wado/__test_0_f32_deserialize_via_sroa" = fn();  // TypeId(23)
 
-type "functype//wado-compiler/tests/fixtures/opt_sroa_variant_br_exit.wado/__cm_export____test_0_f32_deserialize_via_sroa" = fn();  // TypeId(21)
+type "functype//wado-compiler/tests/fixtures/opt_sroa_variant_br_exit.wado/__cm_export____test_0_f32_deserialize_via_sroa" = fn();  // TypeId(24)
 
-type "functype//wado-compiler/tests/fixtures/opt_sroa_variant_br_exit.wado/__initialize_module" = fn();  // TypeId(22)
+type "functype//wado-compiler/tests/fixtures/opt_sroa_variant_br_exit.wado/__initialize_module" = fn();  // TypeId(25)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(23)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(26)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(24)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(27)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(25)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(28)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(26)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(29)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(27)
+type "functype//core:internal/unreachable" = fn();  // TypeId(30)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(28)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(31)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(29)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(32)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(30)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(33)
 
-type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(31)
+type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(34)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(32)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(35)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(33)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(36)
 
-type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(34)
+type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(37)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(35)
+type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(38)
 
-type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(36)
+type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(39)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(37)
+type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(40)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(38)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(41)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(39)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(42)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(40)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(43)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(41)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(44)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(42)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(45)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(43)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(46)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(44)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(47)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(45)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(48)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(46)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(49)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(47)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(50)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(48)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(51)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_f32" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f32,DeserializeError>";  // TypeId(49)
+type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(52)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(50)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(53)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(51)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(54)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(52)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(55)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(53)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(56)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(54)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(57)
 
-type "functype//wado-compiler/tests/fixtures/opt_sroa_variant_br_exit.wado/f32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f32,DeserializeError>";  // TypeId(55)
+type "functype//wado-compiler/tests/fixtures/opt_sroa_variant_br_exit.wado/f32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f32,DeserializeError>";  // TypeId(58)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(56)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(59)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(57)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(60)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(58)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(61)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(59)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(62)
 
-type "functype//core:prelude/fpfmt.wado/unpack32" = fn(f32) -> [u64, i32];  // TypeId(60)
+type "functype//core:prelude/fpfmt.wado/unpack32" = fn(f32) -> [u64, i32];  // TypeId(63)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(61)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(64)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(62)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(65)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(63)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(66)
 
-type "functype//core:prelude/fpfmt.wado/short32" = fn(f32) -> [u64, i32];  // TypeId(64)
+type "functype//core:prelude/fpfmt.wado/short32" = fn(f32) -> [u64, i32];  // TypeId(67)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(65)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(68)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(66)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(69)
 
-type "functype//core:json/core/json/from_string<f32>" = fn(ref "core:prelude/string.wado//String") -> [i32, f32, ref null "core:serde//DeserializeError"];  // TypeId(67)
+type "functype//core:json/core/json/from_string<f32>" = fn(ref "core:prelude/string.wado//String") -> [i32, f32, ref null "core:serde//DeserializeError"];  // TypeId(70)
 
-type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> [i32, f64, ref null "core:serde//DeserializeError"];  // TypeId(68)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(71)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(69)
+type "functype//core:prelude/primitive.wado/f32::inspect_into" = fn(f32, ref "core:prelude/format.wado//Formatter");  // TypeId(72)
 
-type "functype//core:prelude/primitive.wado/f32::inspect_into" = fn(f32, ref "core:prelude/format.wado//Formatter");  // TypeId(70)
-
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(71)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(73)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -1345,33 +1358,39 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
 
 fn "core:json/core/json/from_string<f32>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<f32,DeserializeError>";
+    let __local_2: f32;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: f32;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/opt_sroa_variant_br_exit.wado/f32^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<f32,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<f32,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0_f32, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<f32,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/opt_sroa_variant_br_exit.wado/f32^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<f32,DeserializeError>::Ok"(__match_scrut_0) -> f32 {
+        let __cast_2: ref "core:prelude/types.wado//Result<f32,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<f32,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<f32,DeserializeError>::Err"(__match_scrut_0) -> f32 {
+        let __cast_1: ref "core:prelude/types.wado//Result<f32,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<f32,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0_f32, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0_f32, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<f32,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<f32,DeserializeError>::Err"(r).payload_0);
-        return 1, 0_f32, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1766,7 +1785,7 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
         __local_20 = self.input;
         break __inline_String__len_0: __local_20.used;
     } {
-        return 1, 0, struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: start };
+        return struct.new "core:prelude/types.wado//Result<f64,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: start } };
     }
     neg = 0;
     if __inline_String__get_byte_2: block -> u8 {
@@ -1781,10 +1800,10 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
         __local_24 = self.input;
         break __inline_String__len_3: __local_24.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_4: block -> ref "core:serde//DeserializeError" {
+        return struct.new "core:prelude/types.wado//Result<f64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_4: block -> ref "core:serde//DeserializeError" {
             __local_25 = builtin::i64_extend_i32_s(self.pos);
             break __inline_DeserializeError__eof_4: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_25 };
-        });
+        }) };
     }
     first = __inline_String__get_byte_5: block -> u8 {
         __local_26 = self.input;
@@ -1796,11 +1815,11 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
     } else {
         first > 57;
     }) {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__unexpected_type_6: block -> ref "core:serde//DeserializeError" {
+        return struct.new "core:prelude/types.wado//Result<f64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_6: block -> ref "core:serde//DeserializeError" {
             __local_28 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected number"), used: 15 };
             __local_29 = builtin::i64_extend_i32_s(self.pos);
             break __inline_DeserializeError__unexpected_type_6: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_28, offset: __local_29 };
-        });
+        }) };
     }
     d = builtin::i64_extend_i32_s(first - 48);
     total_digits = 1;
@@ -1818,7 +1837,7 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                 __local_32 = _hfs_pos_57;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_50, __local_32);
             };
-            if (if b_6 >= 48 -> i32 {
+            if (if 48 <= b_6 -> i32 {
                 b_6 <= 57;
             } else {
                 0;
@@ -1862,7 +1881,7 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                     __local_38 = _hfs_pos_58;
                     break __inline_String__get_byte_12: builtin::array_get_u8(_licm_repr_53, __local_38);
                 };
-                if (if b_8 >= 48 -> i32 {
+                if (if 48 <= b_8 -> i32 {
                     b_8 <= 57;
                 } else {
                     0;
@@ -1927,7 +1946,7 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                         __local_47 = _hfs_pos_59;
                         break __inline_String__get_byte_18: builtin::array_get_u8(_licm_repr_56, __local_47);
                     };
-                    if (if b3 >= 48 -> i32 {
+                    if (if 48 <= b3 -> i32 {
                         b3 <= 57;
                     } else {
                         0;
@@ -1948,7 +1967,7 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
     }
     if d == 0_i64 {
         v_14 = select f64(neg, -0, 0);
-        return 0, v_14, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<f64,DeserializeError>::Ok" { discriminant: 0, payload_0: v_14 };
     }
     extra_int_digits = (if (total_digits - frac) > 19 -> i32 {
         (total_digits - frac) - 19;
@@ -1958,36 +1977,17 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
     eff_p = (exp - frac) + extra_int_digits;
     if eff_p > 350 {
         v_17 = select f64(neg, -inf, inf);
-        return 0, v_17, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<f64,DeserializeError>::Ok" { discriminant: 0, payload_0: v_17 };
     }
     if eff_p < -351 {
         v_18 = select f64(neg, -0, 0);
-        return 0, v_18, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<f64,DeserializeError>::Ok" { discriminant: 0, payload_0: v_18 };
     }
     v_19 = "core:prelude/fpfmt.wado/parse"(d, eff_p);
     if neg {
-        return 0, builtin::f64_neg(v_19), ref.null none;
+        return struct.new "core:prelude/types.wado//Result<f64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::f64_neg(v_19) };
     }
-    return 0, v_19, ref.null none;
-}
-
-fn "core:json/JsonDeserializer^Deserializer::deserialize_f32"(self) {
-    let v: f64;
-    let e: ref "core:serde//DeserializeError";
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: f64;
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::parse_f64_direct"(self);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        return struct.new "core:prelude/types.wado//Result<f32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::f32_demote_f64(v) };
-    }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return struct.new "core:prelude/types.wado//Result<f32,DeserializeError>::Err" { discriminant: 1, payload_0: e };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return struct.new "core:prelude/types.wado//Result<f64,DeserializeError>::Ok" { discriminant: 0, payload_0: v_19 };
 }
 
 fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
@@ -1997,13 +1997,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l210: loop {
+            l208: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l210;
+                continue l208;
             };
         };
     };
@@ -2062,10 +2062,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b216: block {
-            l217: loop {
+        b214: block {
+            l215: loop {
                 if i_8 < 0 {
-                    break b216;
+                    break b214;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -2074,7 +2074,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l217;
+                continue l215;
             };
         };
         __for_1: block {
@@ -2082,14 +2082,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l220: loop {
+                l218: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l220;
+                    continue l218;
                 };
             };
         };
@@ -2099,10 +2099,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b222: block {
-            l223: loop {
+        b220: block {
+            l221: loop {
                 if i_10 < 0 {
-                    break b222;
+                    break b220;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -2111,7 +2111,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l223;
+                continue l221;
             };
         };
         __for_2: block {
@@ -2119,14 +2119,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l226: loop {
+                l224: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l226;
+                    continue l224;
                 };
             };
         };
@@ -2244,13 +2244,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l247: loop {
+            l245: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l247;
+                continue l245;
             };
         };
     };
@@ -2258,7 +2258,28 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
 }
 
 fn "wado-compiler/tests/fixtures/opt_sroa_variant_br_exit.wado/f32^Deserialize::deserialize<JsonDeserializer>"(d) {
-    return "core:json/JsonDeserializer^Deserializer::deserialize_f32"(d);
+    let __local_2: f64;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: f64;
+    return __inline_JsonDeserializer_Deserializer__deserialize_f32_0: block -> ref "core:prelude/types.wado//Result<f32,DeserializeError>" {
+        let __match_scrut_0: ref "core:prelude/types.wado//Result<f64,DeserializeError>";
+        __match_scrut_0 = "core:json/JsonDeserializer::parse_f64_direct"(d);
+        __local_4 = (if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(__match_scrut_0) -> f64 {
+            let __cast_2: ref "core:prelude/types.wado//Result<f64,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(__match_scrut_0);
+            __local_2 = __cast_2.payload_0;
+            __local_2;
+        } else if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__match_scrut_0) -> f64 {
+            let __cast_1: ref "core:prelude/types.wado//Result<f64,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__match_scrut_0);
+            __local_3 = __cast_1.payload_0;
+            break __inline_JsonDeserializer_Deserializer__deserialize_f32_0: struct.new "core:prelude/types.wado//Result<f32,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
+        });
+        break __inline_JsonDeserializer_Deserializer__deserialize_f32_0: struct.new "core:prelude/types.wado//Result<f32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::f32_demote_f64(__local_4) };
+    };
 }
 
 export fn "wado-compiler/tests/fixtures/opt_sroa_variant_br_exit.wado/__cm_export____test_0_f32_deserialize_via_sroa" as "__test_0_f32_deserialize_via_sroa"

--- a/wado-compiler/tests/fixtures.golden/serde_default_init.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_default_init.wir.wado
@@ -65,224 +65,276 @@ struct wado-compiler/tests/fixtures/serde_default_init.wado//Config {  // TypeId
     mut debug: bool,
 }
 
-variant core:prelude/types.wado//Option<i32> {  // TypeId(12)
+variant core:prelude/types.wado//Option<char> {  // TypeId(12)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(13)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<i32> {  // TypeId(14)
     Some(i32),
     None,
 }
 
-struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(13)
+struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(15)
     discriminant: i32,
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(14)
+variant core:prelude/types.wado//Result<Config,DeserializeError> {  // TypeId(16)
+    Ok(ref "wado-compiler/tests/fixtures/serde_default_init.wado//Config"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Config,DeserializeError>::Ok {  // TypeId(17)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_default_init.wado//Config",
+}
+
+struct core:prelude/types.wado//Result<Config,DeserializeError>::Err {  // TypeId(18)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(19)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(15)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(20)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(16)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(21)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(17)
+variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(22)
     Ok(bool),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(18)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(23)
     discriminant: i32,
     payload_0: bool,
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(19)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(24)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(20)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(25)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(26)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(27)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(28)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(21)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(29)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(22)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(30)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(23)
+variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(31)
     Ok(ref "core:prelude/types.wado//Option<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(24)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(32)
     discriminant: i32,
     payload_0: ref "core:prelude/types.wado//Option<i32>",
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(25)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(33)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(26)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(34)
 
-type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(27)
+type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(35)
 
-struct canonical//CanonicalClosure_0 {  // TypeId(28)
+struct canonical//CanonicalClosure_0 {  // TypeId(36)
     env: ref null struct,
     func: ref "functype/$canonical_closure_fn_0",
 }
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(29)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(37)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(30)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(38)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(31)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(39)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(32)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(40)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(33)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(41)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(34)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(42)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(35)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(43)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(36)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(44)
 
-type "functype//wado-compiler/tests/fixtures/serde_default_init.wado/run" = fn();  // TypeId(37)
+type "functype//wado-compiler/tests/fixtures/serde_default_init.wado/run" = fn();  // TypeId(45)
 
-type "functype//wado-compiler/tests/fixtures/serde_default_init.wado/_config_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(38)
+type "functype//wado-compiler/tests/fixtures/serde_default_init.wado/_config_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(46)
 
-type "functype//wado-compiler/tests/fixtures/serde_default_init.wado/__cm_export__run" = fn();  // TypeId(39)
+type "functype//wado-compiler/tests/fixtures/serde_default_init.wado/__cm_export__run" = fn();  // TypeId(47)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(40)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(48)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(41)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(49)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(42)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(50)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(43)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(51)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(44)
+type "functype//core:internal/unreachable" = fn();  // TypeId(52)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(45)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(53)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(46)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(54)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(47)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(55)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(48)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(56)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(49)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(57)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(50)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(58)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(51)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(59)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(52)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(60)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(53)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(61)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(54)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(62)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(55)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(63)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(56)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(64)
 
-type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(57)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(65)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(58)
+type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(66)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(59)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(67)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(60)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(68)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(61)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(69)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(62)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(70)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(63)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(71)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(64)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(72)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(65)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(73)
 
-type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(66)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(74)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(67)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(75)
 
-type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(68)
+type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(76)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(69)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(77)
 
-type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(70)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(78)
 
-type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(71)
+type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(79)
 
-type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(72)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(80)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(73)
+type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(81)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(74)
+type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(82)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(75)
+type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(83)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(76)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(84)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(77)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(85)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<String>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(78)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(86)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(79)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(87)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(80)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(88)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(81)
+type "functype//wado-compiler/tests/fixtures/serde_default_init.wado/Config^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Config,DeserializeError>";  // TypeId(89)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(82)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<String>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(90)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(83)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(91)
 
-type "functype//core:json/core/json/from_string<Config>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_default_init.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(84)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(92)
 
-type "functype//core:json/core/json/to_string<Config>" = fn(ref "wado-compiler/tests/fixtures/serde_default_init.wado//Config") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(85)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(93)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(86)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(94)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(87)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(95)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(88)
+type "functype//core:json/core/json/from_string<Config>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_default_init.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(96)
 
-type "functype//wado-compiler/tests/fixtures/serde_default_init.wado/Config^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_default_init.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(89)
+type "functype//core:json/core/json/to_string<Config>" = fn(ref "wado-compiler/tests/fixtures/serde_default_init.wado//Config") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(97)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(90)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(98)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(91)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(99)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(92)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(100)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(93)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(101)
 
-type "functype//wado-compiler/tests/fixtures/serde_default_init.wado/Config^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_default_init.wado//Config", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(94)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(102)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<bool>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(95)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(103)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<i32>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(96)
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(104)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(97)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(105)
 
-type "functype//wado-compiler/tests/fixtures/serde_default_init.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(98)
+type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(106)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(107)
+
+type "functype//wado-compiler/tests/fixtures/serde_default_init.wado/Config^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_default_init.wado//Config", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(108)
+
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<bool>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(109)
+
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<i32>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(110)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(111)
+
+type "functype//wado-compiler/tests/fixtures/serde_default_init.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(112)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -997,36 +1049,77 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l101: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l101;
+                };
+            };
+        };
     }
-    return ((97 + v) - 10) & 255;
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
         return 1;
     }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l107: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l107;
+            };
+        };
+    };
+    return n;
 }
 
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b103: block {
-        l104: loop {
+    b109: block {
+        l110: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -1047,23 +1140,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b103;
+                break b109;
             }
-            continue l104;
+            continue l110;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -1071,62 +1166,135 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/from_string<Config>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_default_init.wado//Config";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_default_init.wado//Config";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_default_init.wado//Config";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_default_init.wado/Config^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_default_init.wado//Config"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Config,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_default_init.wado/Config^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Config,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_default_init.wado//Config" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Config,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Config,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Config,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_default_init.wado//Config" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Config,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Config,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Config>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_default_init.wado/Config^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_default_init.wado/Config^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1149,6 +1317,20 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     }, offset, abs_val, digit_count);
 }
 
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
+}
+
 fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     let s: ref "core:prelude/string.wado//String";
     let c: char;
@@ -1160,6 +1342,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
         "core:prelude/string.wado/String::push"(s, self);
         "core:prelude/format.wado/Formatter::pad"(f, s);
     }
+}
+
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
 }
 
 fn "core:prelude/string.wado/String::get_byte"(self, index) {
@@ -1229,7 +1425,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l127: loop {
+            l149: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -1237,7 +1433,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l127;
+                continue l149;
             };
         };
     };
@@ -1286,6 +1482,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -1354,10 +1599,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b139: block {
-        l140: loop {
+    b168: block {
+        l169: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b139;
+                break b168;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -1381,7 +1626,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l140;
+            continue l169;
         };
     };
     self.pos = _hfs_pos_8;
@@ -1460,11 +1705,11 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b148: block {
-        l149: loop {
+    b177: block {
+        l178: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= _licm_used_19 {
-                    break b148;
+                    break b177;
                 }
                 byte = builtin::array_get_u8(_licm_repr_20, __sroa___iter_3_index);
                 __sroa___iter_3_index = __sroa___iter_3_index + 1;
@@ -1499,7 +1744,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
                 _hfs_pos_27 = _hfs_pos_27 + 1;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l149;
+            continue l178;
         };
     };
     self.pos = _hfs_pos_27;
@@ -1518,130 +1763,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b155: block {
-        l156: loop {
-            if scan_pos >= _licm_used_90 {
-                break b155;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b184: block {
+        l185: loop {
+            if scan_pos >= _licm_used_56 {
+                break b184;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b155;
+                break b184;
             }
             scan_pos = scan_pos + 1;
-            continue l156;
+            continue l185;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -1650,22 +1867,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l163: loop {
+                l192: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l163;
+                    continue l192;
                 };
             };
         };
@@ -1673,71 +1890,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l166: loop {
+            l195: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l166;
+                continue l195;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b168: block {
-        l169: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b197: block {
+        l198: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b168;
+                break b197;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -1755,125 +1973,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l169;
+            continue l198;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -1881,87 +2042,71 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l194: loop {
+            l218: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l194;
+                continue l218;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -2016,25 +2161,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b205: block {
-        l206: loop {
+    b225: block {
+        l226: loop {
             if _hfs_pos_36 >= _licm_used_28 {
-                break b205;
+                break b225;
             }
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
                 break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr_29, __local_11);
             };
-            if (if b_1 >= 48 -> i32 {
+            if (if 48 <= b_1 -> i32 {
                 b_1 <= 57;
             } else {
                 0;
             }) {
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
-                break b205;
+                break b225;
             }
-            continue l206;
+            continue l226;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2055,25 +2200,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b212: block {
-            l213: loop {
+        b232: block {
+            l233: loop {
                 if _hfs_pos_37 >= _licm_used_31 {
-                    break b212;
+                    break b232;
                 }
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
                     break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_32, __local_17);
                 };
-                if (if b_2 >= 48 -> i32 {
+                if (if 48 <= b_2 -> i32 {
                     b_2 <= 57;
                 } else {
                     0;
                 }) {
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
-                    break b212;
+                    break b232;
                 }
-                continue l213;
+                continue l233;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2114,25 +2259,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b223: block {
-                l224: loop {
+            b243: block {
+                l244: loop {
                     if _hfs_pos_38 >= _licm_used_34 {
-                        break b223;
+                        break b243;
                     }
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
                         break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_35, __local_26);
                     };
-                    if (if b2 >= 48 -> i32 {
+                    if (if 48 <= b2 -> i32 {
                         b2 <= 57;
                     } else {
                         0;
                     }) {
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
-                        break b223;
+                        break b243;
                     }
-                    continue l224;
+                    continue l244;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -2226,16 +2371,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b233: block {
-        l234: loop {
+    b253: block {
+        l254: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b233;
+                break b253;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -2256,17 +2401,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b242: block {
-                        l243: loop {
+                    b262: block {
+                        l263: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b242;
+                                break b262;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -2276,9 +2421,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b242;
+                                break b262;
                             }
-                            continue l243;
+                            continue l263;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -2309,17 +2454,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b252: block {
-                            l253: loop {
+                        b272: block {
+                            l273: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b252;
+                                    break b272;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -2328,9 +2473,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b252;
+                                    break b272;
                                 }
-                                continue l253;
+                                continue l273;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -2368,9 +2513,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b233;
+                break b253;
             }
-            continue l234;
+            continue l254;
         };
     };
     self.pos = _hfs_pos_51;
@@ -2396,10 +2541,10 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b263: block {
-        l264: loop {
+    b283: block {
+        l284: loop {
             if _hfs_pos_14 >= _licm_used_12 {
-                break b263;
+                break b283;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -2429,7 +2574,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
                 }
             }
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l264;
+            continue l284;
         };
     };
     self.pos = _hfs_pos_14;
@@ -2440,19 +2585,284 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
 }
 
 fn "core:json/JsonDeserializer::skip_value"(self) {
-    let b: i32;
-    let r: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let c_4: i32;
-    let kr: ref null "core:serde//DeserializeError";
-    let e_6: ref "core:serde//DeserializeError";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let vr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let c_11: i32;
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: char;
+    let __local_6: ref "core:serde//DeserializeError";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_10: ref "core:serde//DeserializeError";
+    let __local_11: char;
     let __local_12: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/format.wado//Formatter";
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i64;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i32;
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
+    let __local_20: i32;
+    let __local_21: ref "core:prelude/string.wado//String";
+    let __local_22: i64;
+    let __local_23: ref "core:prelude/string.wado//String";
+    let __local_24: i32;
+    let __local_25: ref "core:prelude/string.wado//String";
+    let __local_26: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let __local_30: ref "core:prelude/string.wado//String";
+    let __local_31: ref "core:prelude/string.wado//String";
+    let __local_32: i32;
+    let __local_33: ref "core:prelude/string.wado//String";
+    let __local_34: i64;
+    let __local_35: ref "core:prelude/string.wado//String";
+    let __local_36: i64;
+    let __local_37: ref "core:prelude/string.wado//String";
+    let __local_38: i32;
+    let __local_39: ref "core:prelude/string.wado//String";
+    let __local_40: i64;
+    let __local_43: ref "core:prelude/string.wado//String";
+    let __local_44: i64;
+    "core:json/JsonDeserializer::skip_whitespace"(self);
+    if self.pos >= __inline_String__len_0: block -> i32 {
+        __local_14 = self.input;
+        break __inline_String__len_0: __local_14.used;
+    } {
+        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_15 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_15 };
+        });
+    }
+    b = __inline_String__get_byte_2: block -> u8 {
+        __local_16 = self.input;
+        __local_17 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_16.repr, __local_17);
+    } & 255;
+    if b == 34 {
+        return "core:json/JsonDeserializer::skip_string"(self);
+        unreachable;
+    } else if b == 116 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        unreachable;
+    } else if b == 102 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        unreachable;
+    } else if b == 110 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
+        unreachable;
+    } else if b == 91 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_3: block -> i32 {
+            __local_18 = self.input;
+            break __inline_String__len_3: __local_18.used;
+        } -> i32 {
+            __inline_String__get_byte_4: block -> u8 {
+                __local_19 = self.input;
+                __local_20 = self.pos;
+                break __inline_String__get_byte_4: builtin::array_get_u8(__local_19.repr, __local_20);
+            } == 93;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l299: loop {
+                let __match_scrut_5: ref null "core:serde//DeserializeError";
+                __match_scrut_5 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_5) {
+                } else if ref.is_null(__match_scrut_5) == 0 {
+                    let __cast_4: ref null "core:serde//DeserializeError";
+                    __cast_4 = ref.as_non_null(__match_scrut_5);
+                    __local_3 = ref.as_non_null(__cast_4);
+                    return __local_3;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_5: block -> i32 {
+                    __local_21 = self.input;
+                    break __inline_String__len_5: __local_21.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
+                        __local_22 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_22 };
+                    });
+                }
+                __local_4 = __inline_String__get_byte_7: block -> u8 {
+                    __local_23 = self.input;
+                    __local_24 = self.pos;
+                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_23.repr, __local_24);
+                } & 255;
+                if __local_4 == 93 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_4 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
+                        __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
+                        __local_26 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_25, offset: __local_26 };
+                    });
+                    unreachable;
+                }
+                continue l299;
+            };
+        };
+    } else if b == 123 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_9: block -> i32 {
+            __local_27 = self.input;
+            break __inline_String__len_9: __local_27.used;
+        } -> i32 {
+            __inline_String__get_byte_10: block -> u8 {
+                __local_28 = self.input;
+                __local_29 = self.pos;
+                break __inline_String__get_byte_10: builtin::array_get_u8(__local_28.repr, __local_29);
+            } == 125;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l309: loop {
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if (if self.pos >= __inline_String__len_11: block -> i32 {
+                    __local_30 = self.input;
+                    break __inline_String__len_11: __local_30.used;
+                } -> i32 {
+                    1;
+                } else {
+                    __inline_String__get_byte_12: block -> u8 {
+                        __local_31 = self.input;
+                        __local_32 = self.pos;
+                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_31.repr, __local_32);
+                    } != 34;
+                }) {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
+                        __local_33 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+                        __local_34 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_33, offset: __local_34 };
+                    });
+                }
+                let __match_scrut_1: ref null "core:serde//DeserializeError";
+                __match_scrut_1 = "core:json/JsonDeserializer::skip_string"(self);
+                if ref.is_null(__match_scrut_1) {
+                } else if ref.is_null(__match_scrut_1) == 0 {
+                    let __cast_1: ref null "core:serde//DeserializeError";
+                    __cast_1 = ref.as_non_null(__match_scrut_1);
+                    __local_6 = ref.as_non_null(__cast_1);
+                    return __local_6;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_2: ref null "core:serde//DeserializeError";
+                __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+                if ref.is_null(__match_scrut_2) {
+                } else if ref.is_null(__match_scrut_2) == 0 {
+                    let __cast_2: ref null "core:serde//DeserializeError";
+                    __cast_2 = ref.as_non_null(__match_scrut_2);
+                    __local_8 = ref.as_non_null(__cast_2);
+                    return __local_8;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_3: ref null "core:serde//DeserializeError";
+                __match_scrut_3 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_3) {
+                } else if ref.is_null(__match_scrut_3) == 0 {
+                    let __cast_3: ref null "core:serde//DeserializeError";
+                    __cast_3 = ref.as_non_null(__match_scrut_3);
+                    __local_10 = ref.as_non_null(__cast_3);
+                    return __local_10;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_14: block -> i32 {
+                    __local_35 = self.input;
+                    break __inline_String__len_14: __local_35.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
+                        __local_36 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_36 };
+                    });
+                }
+                __local_11 = __inline_String__get_byte_16: block -> u8 {
+                    __local_37 = self.input;
+                    __local_38 = self.pos;
+                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_37.repr, __local_38);
+                } & 255;
+                if __local_11 == 125 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_11 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
+                        __local_39 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
+                        __local_40 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_39, offset: __local_40 };
+                    });
+                    unreachable;
+                }
+                continue l309;
+            };
+        };
+    } else {
+        if (if b == 45 -> i32 {
+            1;
+        } else if 48 <= b -> i32 {
+            b <= 57;
+        } else {
+            0;
+        }) {
+            "core:json/JsonDeserializer::skip_number"(self);
+            return ref.null none;
+        }
+        return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
+            __local_43 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
+                "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
+                __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
+                "core:prelude/primitive.wado/char^Display::fmt"(b, __local_13);
+                "core:prelude/string.wado/String::push"(__local_12, 39);
+                break __tmpl: __local_12;
+            };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
+        });
+        unreachable;
+    }
+}
+
+fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
+    let __local_2: ref "core:serde//DeserializeError";
+    let key_start: i32;
+    let has_escape: bool;
+    let b: i32;
+    let key_end: i32;
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: i32;
+    let idx_10: i32;
+    let __local_11: ref "core:prelude/string.wado//String";
+    let __local_12: ref "core:serde//DeserializeError";
+    let key: ref "core:prelude/string.wado//String";
+    let __local_15: ref "core:serde//DeserializeError";
+    let __local_16: i32;
+    let idx_17: i32;
     let __local_18: ref "core:prelude/string.wado//String";
     let __local_19: i64;
     let __local_20: ref "core:prelude/string.wado//String";
@@ -2463,464 +2873,244 @@ fn "core:json/JsonDeserializer::skip_value"(self) {
     let __local_25: ref "core:prelude/string.wado//String";
     let __local_26: i64;
     let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: i64;
-    let __local_31: ref "core:prelude/string.wado//String";
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i32;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
-    let __local_37: ref "core:prelude/string.wado//String";
-    let __local_38: i64;
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
-    let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_47: ref "core:prelude/string.wado//String";
-    let __local_48: i64;
-    let _hfs_pos_49: i32;
-    let _hfs_pos_50: i32;
-    "core:json/JsonDeserializer::skip_whitespace"(self);
-    if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_18 = self.input;
-        break __inline_String__len_0: __local_18.used;
-    } {
-        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_19 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
-        });
-    }
-    b = __inline_String__get_byte_2: block -> u8 {
-        __local_20 = self.input;
-        __local_21 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
-    };
-    if b == 34 {
-        return "core:json/JsonDeserializer::skip_string"(self);
-    }
-    if b == 116 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-    }
-    if b == 102 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-    }
-    if b == 110 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
-    }
-    if b == 91 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_3: block -> i32 {
-            __local_22 = self.input;
-            break __inline_String__len_3: __local_22.used;
-        } -> i32 {
-            __inline_String__get_byte_4: block -> u8 {
-                __local_23 = self.input;
-                __local_24 = self.pos;
-                break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
-            } == 93;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_49 = self.pos;
-        block {
-            l279: loop {
-                self.pos = _hfs_pos_49;
-                r = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_49 = self.pos;
-                if ref.is_null(r) == 0 {
-                    e_3 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-                    self.pos = _hfs_pos_49;
-                    return e_3;
-                }
-                self.pos = _hfs_pos_49;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_49 = self.pos;
-                if _hfs_pos_49 >= __inline_String__len_5: block -> i32 {
-                    __local_25 = self.input;
-                    self.pos = _hfs_pos_49;
-                    break __inline_String__len_5: __local_25.used;
-                } {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
-                        __local_26 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
-                    });
-                }
-                c_4 = __inline_String__get_byte_7: block -> u8 {
-                    __local_27 = self.input;
-                    __local_28 = _hfs_pos_49;
-                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_27.repr, __local_28);
-                };
-                if c_4 == 93 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                    self.pos = _hfs_pos_49;
-                    return ref.null none;
-                }
-                if c_4 == 44 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                } else {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
-                        __local_29 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
-                        __local_30 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_29, offset: __local_30 };
-                    });
-                }
-                continue l279;
-            };
-        };
-        self.pos = _hfs_pos_49;
-    }
-    if b == 123 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_9: block -> i32 {
-            __local_31 = self.input;
-            break __inline_String__len_9: __local_31.used;
-        } -> i32 {
-            __inline_String__get_byte_10: block -> u8 {
-                __local_32 = self.input;
-                __local_33 = self.pos;
-                break __inline_String__get_byte_10: builtin::array_get_u8(__local_32.repr, __local_33);
-            } == 125;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_50 = self.pos;
-        block {
-            l288: loop {
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if (if _hfs_pos_50 >= __inline_String__len_11: block -> i32 {
-                    __local_34 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_11: __local_34.used;
-                } -> i32 {
-                    1;
-                } else {
-                    __inline_String__get_byte_12: block -> u8 {
-                        __local_35 = self.input;
-                        __local_36 = _hfs_pos_50;
-                        self.pos = _hfs_pos_50;
-                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_35.repr, __local_36);
-                    } != 34;
-                }) {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
-                        __local_37 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-                        __local_38 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_37, offset: __local_38 };
-                    });
-                }
-                self.pos = _hfs_pos_50;
-                kr = "core:json/JsonDeserializer::skip_string"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(kr) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(kr));
-                    self.pos = _hfs_pos_50;
-                    return e_6;
-                }
-                self.pos = _hfs_pos_50;
-                cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(cr) == 0 {
-                    e_8 = value_copy "core:serde//DeserializeError"(ref.as_non_null(cr));
-                    self.pos = _hfs_pos_50;
-                    return e_8;
-                }
-                self.pos = _hfs_pos_50;
-                vr = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(vr) == 0 {
-                    e_10 = value_copy "core:serde//DeserializeError"(ref.as_non_null(vr));
-                    self.pos = _hfs_pos_50;
-                    return e_10;
-                }
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if _hfs_pos_50 >= __inline_String__len_14: block -> i32 {
-                    __local_39 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_14: __local_39.used;
-                } {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
-                        __local_40 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-                    });
-                }
-                c_11 = __inline_String__get_byte_16: block -> u8 {
-                    __local_41 = self.input;
-                    __local_42 = _hfs_pos_50;
-                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_41.repr, __local_42);
-                };
-                if c_11 == 125 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                    self.pos = _hfs_pos_50;
-                    return ref.null none;
-                }
-                if c_11 == 44 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                } else {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
-                        __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
-                        __local_44 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
-                    });
-                }
-                continue l288;
-            };
-        };
-        self.pos = _hfs_pos_50;
-    }
-    if (if b == 45 -> i32 {
-        1;
-    } else if b >= 48 -> i32 {
-        b <= 57;
-    } else {
-        0;
-    }) {
-        "core:json/JsonDeserializer::skip_number"(self);
-        return ref.null none;
-    }
-    return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
-        __local_47 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-            __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
-            "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
-            __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
-            "core:prelude/primitive.wado/char^Display::fmt"(b & 255, __local_13);
-            "core:prelude/string.wado/String::push"(__local_12, 39);
-            break __tmpl: __local_12;
-        };
-        __local_48 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_47, offset: __local_48 };
-    });
-}
-
-fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
-    let r_1: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let key_start: i32;
-    let has_escape: bool;
-    let b: i32;
-    let key_end: i32;
-    let r_7: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let idx_9: ref "core:prelude/types.wado//Option<i32>";
-    let i_10: i32;
-    let key_r: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let key: ref "core:prelude/string.wado//String";
-    let r_13: ref null "core:serde//DeserializeError";
-    let e_14: ref "core:serde//DeserializeError";
-    let idx_15: ref "core:prelude/types.wado//Option<i32>";
-    let i_16: i32;
-    let e_17: ref "core:serde//DeserializeError";
-    let __local_25: ref "core:prelude/string.wado//String";
-    let __local_26: i64;
-    let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: ref "core:prelude/string.wado//String";
-    let __local_31: i32;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i64;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_25 = self.de.input;
-        break __inline_String__len_0: __local_25.used;
+        __local_18 = self.de.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
+            __local_19 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_27 = self.de.input;
-        __local_28 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_27.repr, __local_28);
+        __local_20 = self.de.input;
+        __local_21 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } == 125 {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r_1 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r_1) == 0 {
-            e_2 = ref.as_non_null(r_1);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if (if self.de.pos >= __inline_String__len_3: block -> i32 {
-        __local_29 = self.de.input;
-        break __inline_String__len_3: __local_29.used;
+        __local_22 = self.de.input;
+        break __inline_String__len_3: __local_22.used;
     } -> i32 {
         1;
     } else {
         __inline_String__get_byte_4: block -> u8 {
-            __local_30 = self.de.input;
-            __local_31 = self.de.pos;
-            break __inline_String__get_byte_4: builtin::array_get_u8(__local_30.repr, __local_31);
+            __local_23 = self.de.input;
+            __local_24 = self.de.pos;
+            break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
         } != 34;
     }) {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_5: block -> ref "core:serde//DeserializeError" {
-            __local_32 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-            __local_33 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_32, offset: __local_33 };
+            __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_25, offset: __local_26 };
         }) };
     }
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b306: block {
-        l307: loop {
+    b331: block {
+        l332: loop {
             if self.de.pos >= __inline_String__len_6: block -> i32 {
-                __local_34 = self.de.input;
-                break __inline_String__len_6: __local_34.used;
+                __local_27 = self.de.input;
+                break __inline_String__len_6: __local_27.used;
             } {
-                break b306;
+                break b331;
             }
             b = __inline_String__get_byte_7: block -> u8 {
-                __local_35 = self.de.input;
-                __local_36 = self.de.pos;
-                break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
+                __local_28 = self.de.input;
+                __local_29 = self.de.pos;
+                break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
             };
             if b == 34 {
-                break b306;
+                break b331;
             }
             if b == 92 {
                 has_escape = 1;
-                break b306;
+                break b331;
             }
             self.de.pos = self.de.pos + 1;
-            continue l307;
+            continue l332;
         };
     };
     if has_escape == 0 {
         key_end = self.de.pos;
         self.de.pos = self.de.pos + 1;
-        r_7 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_7) == 0 {
-            e_8 = ref.as_non_null(r_7);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_8 };
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_1);
+            __local_8 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        idx_9 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_0: ref "canonical//CanonicalClosure_0";
-            __indirect_call_0 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_0.func, __indirect_call_0.env, self.de.input, key_start, key_end);
+        let __match_scrut_2: ref "core:prelude/types.wado//Option<i32>";
+        __match_scrut_2 = block -> ref "core:prelude/types.wado//Option<i32>" {
+            let __indirect_call_2: ref "canonical//CanonicalClosure_0";
+            __indirect_call_2 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_2.func, __indirect_call_2.env, self.de.input, key_start, key_end);
         };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_9) {
-            i_10 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_9).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_10 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+        idx_10 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2) -> i32 {
+            let __cast_4: ref "core:prelude/types.wado//Option<i32>::Some";
+            __cast_4 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2);
+            __local_9 = __cast_4.payload_0;
+            __local_9;
+        } else if __match_scrut_2.discriminant == 1 -> i32 {
+            -1;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_10 } };
     }
     self.de.pos = key_start - 1;
-    key_r = "core:json/JsonDeserializer::read_json_string"(self.de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r) {
-        key = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r).payload_0);
-        r_13 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_13) == 0 {
-            e_14 = ref.as_non_null(r_13);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_14 };
-        }
-        idx_15 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_1: ref "canonical//CanonicalClosure_0";
-            __indirect_call_1 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_1.func, __indirect_call_1.env, key, 0, key.used);
-        };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_15) {
-            i_16 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_15).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_16 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+    key = value_copy "core:prelude/string.wado//String"(let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self.de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_6: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_6 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+        __local_11 = __cast_6.payload_0;
+        __local_11;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+        __local_12 = __cast_5.payload_0;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_12 };
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    let __match_scrut_4: ref null "core:serde//DeserializeError";
+    __match_scrut_4 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+    if ref.is_null(__match_scrut_4) {
+    } else if ref.is_null(__match_scrut_4) == 0 {
+        let __cast_7: ref null "core:serde//DeserializeError";
+        __cast_7 = ref.as_non_null(__match_scrut_4);
+        __local_15 = ref.as_non_null(__cast_7);
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_15 };
+        unreachable;
+    } else {
+        unreachable;
     }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r) {
-        e_17 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    let __match_scrut_5: ref "core:prelude/types.wado//Option<i32>";
+    __match_scrut_5 = block -> ref "core:prelude/types.wado//Option<i32>" {
+        let __indirect_call_7: ref "canonical//CanonicalClosure_0";
+        __indirect_call_7 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+        call_ref "functype/$canonical_closure_fn_0"(__indirect_call_7.func, __indirect_call_7.env, key, 0, key.used);
+    };
+    idx_17 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5) -> i32 {
+        let __cast_9: ref "core:prelude/types.wado//Option<i32>::Some";
+        __cast_9 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5);
+        __local_16 = __cast_9.payload_0;
+        __local_16;
+    } else if __match_scrut_5.discriminant == 1 -> i32 {
+        -1;
+    } else {
+        unreachable;
+    });
+    return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_17 } };
 }
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_bool"(self) {
-    let b: i32;
-    let r_2: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let r_4: ref null "core:serde//DeserializeError";
-    let e_5: ref "core:serde//DeserializeError";
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:serde//DeserializeError";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
     let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i64;
+    let __local_9: i32;
     let __local_10: ref "core:prelude/string.wado//String";
-    let __local_11: i32;
-    let __local_12: ref "core:prelude/string.wado//String";
-    let __local_13: i64;
+    let __local_11: i64;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_8 = self.input;
-        break __inline_String__len_0: __local_8.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_9 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_9 };
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
         }) };
     }
     b = __inline_String__get_byte_2: block -> u8 {
-        __local_10 = self.input;
-        __local_11 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_10.repr, __local_11);
-    };
+        __local_8 = self.input;
+        __local_9 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_8.repr, __local_9);
+    } & 255;
     if b == 116 {
-        r_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-        if ref.is_null(r_2) == 0 {
-            e_3 = ref.as_non_null(r_2);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_3 };
+        let __match_scrut_2: ref null "core:serde//DeserializeError";
+        __match_scrut_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        if ref.is_null(__match_scrut_2) {
+        } else if ref.is_null(__match_scrut_2) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_2);
+            __local_3 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 1 };
-    }
-    if b == 102 {
-        r_4 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-        if ref.is_null(r_4) == 0 {
-            e_5 = ref.as_non_null(r_4);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
+        unreachable;
+    } else if b == 102 {
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_1);
+            __local_5 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_5 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 0 };
+        unreachable;
+    } else {
+        return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
+            __local_11 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_10, offset: __local_11 };
+        }) };
+        unreachable;
     }
-    return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-        __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
-        __local_13 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_12, offset: __local_13 };
-    }) };
+    unreachable;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_struct"(self, lookup) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 123);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_5: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 123);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_5 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_5;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonStructAccess" { de: self, lookup: lookup, first: 1 }, ref.null none;
 }
@@ -2932,13 +3122,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l327: loop {
+            l359: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l327;
+                continue l359;
             };
         };
     };
@@ -3075,8 +3265,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b350: block {
-        l351: loop {
+    b382: block {
+        l383: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3101,9 +3291,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b350;
+                break b382;
             }
-            continue l351;
+            continue l383;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -3141,8 +3331,8 @@ fn "wado-compiler/tests/fixtures/serde_default_init.wado/Config^Deserialize::des
         host = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
         port = 0;
         debug = 0;
-        b359: block {
-            l360: loop {
+        b391: block {
+            l392: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -3160,7 +3350,7 @@ fn "wado-compiler/tests/fixtures/serde_default_init.wado/Config^Deserialize::des
                                 host = __local_11;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_10).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_10).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_12 = __inline_i32_Deserialize__deserialize_JsonDeserializer__6: block -> ref "core:prelude/types.wado//Result<i32,DeserializeError>" {
@@ -3173,7 +3363,7 @@ fn "wado-compiler/tests/fixtures/serde_default_init.wado/Config^Deserialize::des
                                 port = __local_13;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_12).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_12).payload_0 };
                             }
                         } else if __idx == 2 {
                             __local_14 = __inline_bool_Deserialize__deserialize_JsonDeserializer__8: block -> ref "core:prelude/types.wado//Result<bool,DeserializeError>" {
@@ -3186,27 +3376,27 @@ fn "wado-compiler/tests/fixtures/serde_default_init.wado/Config^Deserialize::des
                                 debug = __local_15;
                                 seen = seen | 4;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__local_14).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__local_14).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b359;
+                        break b391;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l360;
+                continue l392;
             };
         };
         if (seen & 7) != 7 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_default_init.wado//Config" { host: host, port: port, debug: debug }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_default_init.wado//Config" { host: host, port: port, debug: debug } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 

--- a/wado-compiler/tests/fixtures.golden/serde_json_array_string.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_array_string.wir.wado
@@ -165,77 +165,83 @@ type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32; 
 
 type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(49)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(50)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(50)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(51)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(51)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(52)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(52)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(53)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(53)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(54)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(54)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(55)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(55)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(56)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(56)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(57)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(57)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(58)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(58)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(59)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(59)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(60)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(60)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(61)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(61)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(62)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(62)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_array_string.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(63)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(63)
 
-type "functype//core:prelude/array.wado/Array<i32>::push" = fn(ref "core:prelude//Array<i32>", i32);  // TypeId(64)
+type "functype//wado-compiler/tests/fixtures/serde_json_array_string.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(64)
 
-type "functype//core:prelude/array.wado/Array<i32>::grow" = fn(ref "core:prelude//Array<i32>");  // TypeId(65)
+type "functype//core:prelude/array.wado/Array<i32>::push" = fn(ref "core:prelude//Array<i32>", i32);  // TypeId(65)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<String>" = fn(ref "core:json//JsonSeqSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(66)
+type "functype//core:prelude/array.wado/Array<i32>::grow" = fn(ref "core:prelude//Array<i32>");  // TypeId(66)
 
-type "functype//core:prelude/array.wado/ArrayIter<String>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<String>") -> ref null "core:prelude/string.wado//String";  // TypeId(67)
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<String>" = fn(ref "core:json//JsonSeqSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(67)
 
-type "functype//core:prelude/array.wado/Array<String>::push" = fn(ref "core:prelude//Array<String>", ref "core:prelude/string.wado//String");  // TypeId(68)
+type "functype//core:prelude/array.wado/ArrayIter<String>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<String>") -> ref null "core:prelude/string.wado//String";  // TypeId(68)
 
-type "functype//core:prelude/array.wado/Array<String>::grow" = fn(ref "core:prelude//Array<String>");  // TypeId(69)
+type "functype//core:prelude/array.wado/Array<String>::push" = fn(ref "core:prelude//Array<String>", ref "core:prelude/string.wado//String");  // TypeId(69)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(70)
+type "functype//core:prelude/array.wado/Array<String>::grow" = fn(ref "core:prelude//Array<String>");  // TypeId(70)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(71)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(71)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(72)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(72)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(73)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(73)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(74)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(74)
 
-type "functype//core:json/core/json/from_string<i32>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(75)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(75)
 
-type "functype//core:json/core/json/to_string<Array<i32>>" = fn(ref "core:prelude//Array<i32>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(76)
+type "functype//core:json/core/json/from_string<i32>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(76)
 
-type "functype//core:json/core/json/to_string<Array<String>>" = fn(ref "core:prelude//Array<String>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(77)
+type "functype//core:json/core/json/to_string<Array<i32>>" = fn(ref "core:prelude//Array<i32>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(77)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(78)
+type "functype//core:json/core/json/to_string<Array<String>>" = fn(ref "core:prelude//Array<String>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(78)
 
-type "functype//core:prelude/array.wado/ArrayIter<i32>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<i32>") -> [i32, i32];  // TypeId(79)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(79)
 
-type "functype//core:json/core/json/to_string<i32>" = fn(i32) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(80)
+type "functype//core:prelude/array.wado/ArrayIter<i32>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<i32>") -> [i32, i32];  // TypeId(80)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(81)
+type "functype//core:json/core/json/to_string<i32>" = fn(i32) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(81)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(82)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(82)
 
-type "functype//core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<i32>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(83)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(83)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<i32>" = fn(ref "core:json//JsonSeqSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(84)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(84)
 
-type "functype//core:prelude/array.wado/Array<String>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<String>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(85)
+type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(85)
+
+type "functype//core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<i32>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(86)
+
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<i32>" = fn(ref "core:json//JsonSeqSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(87)
+
+type "functype//core:prelude/array.wado/Array<String>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<String>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(88)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -909,23 +915,77 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l86: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l86;
+                };
+            };
+        };
     }
-    return ((97 + v) - 10) & 255;
+}
+
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
+        return 1;
+    }
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l92: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l92;
+            };
+        };
+    };
+    return n;
 }
 
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b85: block {
-        l86: loop {
+    b94: block {
+        l95: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -946,23 +1006,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b85;
+                break b94;
             }
-            continue l86;
+            continue l95;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -970,70 +1032,94 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/from_string<i32>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
+    let __local_2: i32;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: i32;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_array_string.wado/i32^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_array_string.wado/i32^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_0) -> i32 {
+        let __cast_2: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_0) -> i32 {
+        let __cast_1: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(r).payload_0);
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<i32>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_i32"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_i32"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Array<i32>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Array<String>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:prelude/array.wado/Array<String>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:prelude/array.wado/Array<String>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
@@ -1056,6 +1142,34 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
         __local_6 = f.buf;
         break __inline_String__internal_raw_bytes_0: __local_6.repr;
     }, offset, abs_val, digit_count);
+}
+
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
+}
+
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
 }
 
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
@@ -1121,7 +1235,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l107: loop {
+            l120: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -1129,7 +1243,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l107;
+                continue l120;
             };
         };
     };
@@ -1230,10 +1344,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b118: block {
-        l119: loop {
+    b131: block {
+        l132: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b118;
+                break b131;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -1257,7 +1371,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l119;
+            continue l132;
         };
     };
     self.pos = _hfs_pos_8;
@@ -1349,16 +1463,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b130: block {
-        l131: loop {
+    b143: block {
+        l144: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b130;
+                break b143;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -1379,17 +1493,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b139: block {
-                        l140: loop {
+                    b152: block {
+                        l153: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b139;
+                                break b152;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -1399,9 +1513,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b139;
+                                break b152;
                             }
-                            continue l140;
+                            continue l153;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -1432,17 +1546,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b149: block {
-                            l150: loop {
+                        b162: block {
+                            l163: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b149;
+                                    break b162;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -1451,9 +1565,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b149;
+                                    break b162;
                                 }
-                                continue l150;
+                                continue l163;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -1491,9 +1605,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b130;
+                break b143;
             }
-            continue l131;
+            continue l144;
         };
     };
     self.pos = _hfs_pos_51;
@@ -1510,13 +1624,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l161: loop {
+            l174: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l161;
+                continue l174;
             };
         };
     };
@@ -1619,8 +1733,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b180: block {
-        l181: loop {
+    b193: block {
+        l194: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -1645,9 +1759,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b180;
+                break b193;
             }
-            continue l181;
+            continue l194;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -1677,8 +1791,8 @@ fn "core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>"(sel
             __local_16 = self;
             break __inline_Array_i32__IntoIterator__into_iter_2: struct.new "core:prelude/array.wado//ArrayIter<i32>" { repr: __local_16.repr, used: __local_16.used, index: 0 };
         };
-        b189: block {
-            l190: loop {
+        b202: block {
+            l203: loop {
                 let __sroa___pattern_temp_1_discriminant: i32;
                 let __sroa___pattern_temp_1_payload_0: i32;
                 multivalue_bind [__sroa___pattern_temp_1_discriminant, __sroa___pattern_temp_1_payload_0] = "core:prelude/array.wado/ArrayIter<i32>^Iterator::next"(__iter_4);
@@ -1689,9 +1803,9 @@ fn "core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>"(sel
                         return e_7;
                     }
                 } else {
-                    break b189;
+                    break b202;
                 }
-                continue l190;
+                continue l203;
             };
         };
         return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref null "core:serde//SerializeError" {
@@ -1758,13 +1872,13 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l198: loop {
+            l211: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
                 i = i + 1;
-                continue l198;
+                continue l211;
             };
         };
     };
@@ -1793,8 +1907,8 @@ fn "core:prelude/array.wado/Array<String>^Serialize::serialize<JsonSerializer>"(
             __local_16 = self;
             break __inline_Array_String__IntoIterator__into_iter_2: struct.new "core:prelude/array.wado//ArrayIter<String>" { repr: __local_16.repr, used: __local_16.used, index: 0 };
         };
-        b201: block {
-            l202: loop {
+        b214: block {
+            l215: loop {
                 __pattern_temp_1 = "core:prelude/array.wado/ArrayIter<String>^Iterator::next"(__iter_4);
                 if ref.is_null(__pattern_temp_1) == 0 {
                     item = value_copy "core:prelude/string.wado//String"(ref.as_non_null(__pattern_temp_1));
@@ -1804,9 +1918,9 @@ fn "core:prelude/array.wado/Array<String>^Serialize::serialize<JsonSerializer>"(
                         return e_7;
                     }
                 } else {
-                    break b201;
+                    break b214;
                 }
-                continue l202;
+                continue l215;
             };
         };
         return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref null "core:serde//SerializeError" {
@@ -1876,13 +1990,13 @@ fn "core:prelude/array.wado/Array<String>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l210: loop {
+            l223: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
                 i = i + 1;
-                continue l210;
+                continue l223;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/serde_json_default.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_default.wir.wado
@@ -60,263 +60,314 @@ struct wado-compiler/tests/fixtures/serde_json_default.wado//Config {  // TypeId
 
 array builtin::array<String> (mut ref "core:prelude/string.wado//String");  // TypeId(10)
 
-variant core:prelude/types.wado//Option<i32> {  // TypeId(11)
+variant core:prelude/types.wado//Option<String> {  // TypeId(11)
+    Some(ref "core:prelude/string.wado//String"),
+    None,
+}
+
+variant core:prelude/types.wado//Option<char> {  // TypeId(12)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(13)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<i32> {  // TypeId(14)
     Some(i32),
     None,
 }
 
-struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(12)
+struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(15)
     discriminant: i32,
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(13)
+variant core:prelude/types.wado//Result<Config,DeserializeError> {  // TypeId(16)
+    Ok(ref "wado-compiler/tests/fixtures/serde_json_default.wado//Config"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Config,DeserializeError>::Ok {  // TypeId(17)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_json_default.wado//Config",
+}
+
+struct core:prelude/types.wado//Result<Config,DeserializeError>::Err {  // TypeId(18)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(19)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(14)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(20)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(15)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(21)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(16)
+variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(22)
     Ok(bool),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(17)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(23)
     discriminant: i32,
     payload_0: bool,
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(18)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(24)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(19)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(25)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(26)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(27)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(28)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(20)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(29)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(21)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(30)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(22)
+variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(31)
     Ok(ref "core:prelude/types.wado//Option<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(23)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(32)
     discriminant: i32,
     payload_0: ref "core:prelude/types.wado//Option<i32>",
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(24)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(33)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<String>,DeserializeError> {  // TypeId(25)
+variant core:prelude/types.wado//Result<Option<String>,DeserializeError> {  // TypeId(34)
     Ok(ref null "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok {  // TypeId(26)
+struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok {  // TypeId(35)
     discriminant: i32,
     payload_0: ref null "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err {  // TypeId(27)
+struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err {  // TypeId(36)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-struct core:prelude//Array<String> {  // TypeId(28)
+struct core:prelude//Array<String> {  // TypeId(37)
     mut repr: ref builtin::array<String>,
     mut used: i32,
 }
 
-variant core:prelude/types.wado//Result<Array<String>,DeserializeError> {  // TypeId(29)
+variant core:prelude/types.wado//Result<Array<String>,DeserializeError> {  // TypeId(38)
     Ok(ref "core:prelude//Array<String>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Array<String>,DeserializeError>::Ok {  // TypeId(30)
+struct core:prelude/types.wado//Result<Array<String>,DeserializeError>::Ok {  // TypeId(39)
     discriminant: i32,
     payload_0: ref "core:prelude//Array<String>",
 }
 
-struct core:prelude/types.wado//Result<Array<String>,DeserializeError>::Err {  // TypeId(31)
+struct core:prelude/types.wado//Result<Array<String>,DeserializeError>::Err {  // TypeId(40)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(32)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(41)
 
-type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(33)
+type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(42)
 
-struct canonical//CanonicalClosure_0 {  // TypeId(34)
+struct canonical//CanonicalClosure_0 {  // TypeId(43)
     env: ref null struct,
     func: ref "functype/$canonical_closure_fn_0",
 }
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(35)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(44)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(36)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(45)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(37)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(46)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(38)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(47)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(39)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(48)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(40)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(49)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(41)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(50)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(42)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(51)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/__test_0_missing_default_fields_use_zero_values" = fn();  // TypeId(43)
+type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/__test_0_missing_default_fields_use_zero_values" = fn();  // TypeId(52)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/__test_1_provided_fields_override_defaults" = fn();  // TypeId(44)
+type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/__test_1_provided_fields_override_defaults" = fn();  // TypeId(53)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/_config_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(45)
+type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/_config_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(54)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/__cm_export____test_0_missing_default_fields_use_zero_values" = fn();  // TypeId(46)
+type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/__cm_export____test_0_missing_default_fields_use_zero_values" = fn();  // TypeId(55)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/__cm_export____test_1_provided_fields_override_defaults" = fn();  // TypeId(47)
+type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/__cm_export____test_1_provided_fields_override_defaults" = fn();  // TypeId(56)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/__cm_export____test_2_missing_required_field_still_errors" = fn();  // TypeId(48)
+type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/__cm_export____test_2_missing_required_field_still_errors" = fn();  // TypeId(57)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(49)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(58)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(50)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(59)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(51)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(60)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(52)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(61)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(53)
+type "functype//core:internal/unreachable" = fn();  // TypeId(62)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(54)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(63)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(55)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(64)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(56)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(65)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(57)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(66)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(58)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(67)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(59)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(68)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(60)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(69)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(61)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(70)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(62)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(71)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(63)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(72)
 
-type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(64)
+type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(73)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(65)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(74)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(66)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(75)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(67)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(76)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(68)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(77)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(69)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(78)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(70)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(79)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(71)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(80)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(72)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(81)
 
-type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(73)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(82)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(74)
+type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(83)
 
-type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(75)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(84)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(76)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(85)
 
-type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(77)
+type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(86)
 
-type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(78)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(87)
 
-type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(79)
+type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(88)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(80)
+type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(89)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(81)
+type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(90)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(82)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(91)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(83)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(92)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(84)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(93)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/Option<String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";  // TypeId(85)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(94)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(86)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(95)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/Array<String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Array<String>,DeserializeError>";  // TypeId(87)
+type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/Config^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Config,DeserializeError>";  // TypeId(96)
 
-type "functype//core:prelude/array.wado/Array<String>::push" = fn(ref "core:prelude//Array<String>", ref "core:prelude/string.wado//String");  // TypeId(88)
+type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/Option<String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";  // TypeId(97)
 
-type "functype//core:prelude/array.wado/Array<String>::grow" = fn(ref "core:prelude//Array<String>");  // TypeId(89)
+type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(98)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(90)
+type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/Array<String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Array<String>,DeserializeError>";  // TypeId(99)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(91)
+type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<String>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";  // TypeId(100)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(92)
+type "functype//core:prelude/array.wado/Array<String>::push" = fn(ref "core:prelude//Array<String>", ref "core:prelude/string.wado//String");  // TypeId(101)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(93)
+type "functype//core:prelude/array.wado/Array<String>::grow" = fn(ref "core:prelude//Array<String>");  // TypeId(102)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(94)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(103)
 
-type "functype//core:json/core/json/from_string<Config>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_default.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(95)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(104)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(96)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(105)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(97)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(106)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(98)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(107)
 
-type "functype//core:json/JsonDeserializer^Deserializer::is_null" = fn(ref "core:json//JsonDeserializer") -> [i32, bool, ref null "core:serde//DeserializeError"];  // TypeId(99)
+type "functype//core:json/core/json/from_string<Config>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_default.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(108)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_seq" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:json//JsonSeqAccess", ref null "core:serde//DeserializeError"];  // TypeId(100)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(109)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/Config^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_default.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(101)
+type "functype//core:json/JsonDeserializer^Deserializer::is_null" = fn(ref "core:json//JsonDeserializer") -> [i32, bool, ref null "core:serde//DeserializeError"];  // TypeId(110)
 
-type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<String>" = fn(ref "core:json//JsonSeqAccess") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(102)
+type "functype//core:json/JsonDeserializer^Deserializer::begin_seq" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:json//JsonSeqAccess", ref null "core:serde//DeserializeError"];  // TypeId(111)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(103)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(112)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(104)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(113)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(105)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(114)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(106)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(115)
+
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(116)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(117)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_default.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(118)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -1362,64 +1413,118 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/core/json/from_string<Config>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_json_default.wado//Config";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_json_default.wado//Config";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_json_default.wado//Config";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_default.wado/Config^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_json_default.wado//Config"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Config,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_default.wado/Config^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Config,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_default.wado//Config" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Config,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Config,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Config,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_default.wado//Config" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Config,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Config,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1522,7 +1627,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l145: loop {
+            l156: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -1530,7 +1635,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l145;
+                continue l156;
             };
         };
     };
@@ -1581,6 +1686,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     return 0, code_10;
 }
 
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
+}
+
 fn "core:prelude/string.wado/String::push"(self, c) {
     let code: u32;
     code = c;
@@ -1619,10 +1773,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b156: block {
-        l157: loop {
+    b174: block {
+        l175: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b156;
+                break b174;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -1646,7 +1800,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l157;
+            continue l175;
         };
     };
     self.pos = _hfs_pos_8;
@@ -1725,11 +1879,11 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b165: block {
-        l166: loop {
+    b183: block {
+        l184: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= _licm_used_19 {
-                    break b165;
+                    break b183;
                 }
                 byte = builtin::array_get_u8(_licm_repr_20, __sroa___iter_3_index);
                 __sroa___iter_3_index = __sroa___iter_3_index + 1;
@@ -1764,7 +1918,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
                 _hfs_pos_27 = _hfs_pos_27 + 1;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l166;
+            continue l184;
         };
     };
     self.pos = _hfs_pos_27;
@@ -1783,130 +1937,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b172: block {
-        l173: loop {
-            if scan_pos >= _licm_used_90 {
-                break b172;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b190: block {
+        l191: loop {
+            if scan_pos >= _licm_used_56 {
+                break b190;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b172;
+                break b190;
             }
             scan_pos = scan_pos + 1;
-            continue l173;
+            continue l191;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -1915,22 +2041,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l180: loop {
+                l198: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l180;
+                    continue l198;
                 };
             };
         };
@@ -1938,71 +2064,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l183: loop {
+            l201: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l183;
+                continue l201;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b185: block {
-        l186: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b203: block {
+        l204: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b185;
+                break b203;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -2020,125 +2147,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l186;
+            continue l204;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -2146,87 +2216,71 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l211: loop {
+            l224: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l211;
+                continue l224;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -2281,25 +2335,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b222: block {
-        l223: loop {
+    b231: block {
+        l232: loop {
             if _hfs_pos_36 >= _licm_used_28 {
-                break b222;
+                break b231;
             }
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
                 break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr_29, __local_11);
             };
-            if (if b_1 >= 48 -> i32 {
+            if (if 48 <= b_1 -> i32 {
                 b_1 <= 57;
             } else {
                 0;
             }) {
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
-                break b222;
+                break b231;
             }
-            continue l223;
+            continue l232;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2320,25 +2374,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b229: block {
-            l230: loop {
+        b238: block {
+            l239: loop {
                 if _hfs_pos_37 >= _licm_used_31 {
-                    break b229;
+                    break b238;
                 }
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
                     break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_32, __local_17);
                 };
-                if (if b_2 >= 48 -> i32 {
+                if (if 48 <= b_2 -> i32 {
                     b_2 <= 57;
                 } else {
                     0;
                 }) {
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
-                    break b229;
+                    break b238;
                 }
-                continue l230;
+                continue l239;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2379,25 +2433,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b240: block {
-                l241: loop {
+            b249: block {
+                l250: loop {
                     if _hfs_pos_38 >= _licm_used_34 {
-                        break b240;
+                        break b249;
                     }
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
                         break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_35, __local_26);
                     };
-                    if (if b2 >= 48 -> i32 {
+                    if (if 48 <= b2 -> i32 {
                         b2 <= 57;
                     } else {
                         0;
                     }) {
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
-                        break b240;
+                        break b249;
                     }
-                    continue l241;
+                    continue l250;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -2491,16 +2545,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b250: block {
-        l251: loop {
+    b259: block {
+        l260: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b250;
+                break b259;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -2521,17 +2575,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b259: block {
-                        l260: loop {
+                    b268: block {
+                        l269: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b259;
+                                break b268;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -2541,9 +2595,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b259;
+                                break b268;
                             }
-                            continue l260;
+                            continue l269;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -2574,17 +2628,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b269: block {
-                            l270: loop {
+                        b278: block {
+                            l279: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b269;
+                                    break b278;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -2593,9 +2647,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b269;
+                                    break b278;
                                 }
-                                continue l270;
+                                continue l279;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -2633,9 +2687,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b250;
+                break b259;
             }
-            continue l251;
+            continue l260;
         };
     };
     self.pos = _hfs_pos_51;
@@ -2661,10 +2715,10 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b280: block {
-        l281: loop {
+    b289: block {
+        l290: loop {
             if _hfs_pos_14 >= _licm_used_12 {
-                break b280;
+                break b289;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -2694,7 +2748,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
                 }
             }
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l281;
+            continue l290;
         };
     };
     self.pos = _hfs_pos_14;
@@ -2705,19 +2759,284 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
 }
 
 fn "core:json/JsonDeserializer::skip_value"(self) {
-    let b: i32;
-    let r: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let c_4: i32;
-    let kr: ref null "core:serde//DeserializeError";
-    let e_6: ref "core:serde//DeserializeError";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let vr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let c_11: i32;
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: char;
+    let __local_6: ref "core:serde//DeserializeError";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_10: ref "core:serde//DeserializeError";
+    let __local_11: char;
     let __local_12: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/format.wado//Formatter";
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i64;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i32;
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
+    let __local_20: i32;
+    let __local_21: ref "core:prelude/string.wado//String";
+    let __local_22: i64;
+    let __local_23: ref "core:prelude/string.wado//String";
+    let __local_24: i32;
+    let __local_25: ref "core:prelude/string.wado//String";
+    let __local_26: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let __local_30: ref "core:prelude/string.wado//String";
+    let __local_31: ref "core:prelude/string.wado//String";
+    let __local_32: i32;
+    let __local_33: ref "core:prelude/string.wado//String";
+    let __local_34: i64;
+    let __local_35: ref "core:prelude/string.wado//String";
+    let __local_36: i64;
+    let __local_37: ref "core:prelude/string.wado//String";
+    let __local_38: i32;
+    let __local_39: ref "core:prelude/string.wado//String";
+    let __local_40: i64;
+    let __local_43: ref "core:prelude/string.wado//String";
+    let __local_44: i64;
+    "core:json/JsonDeserializer::skip_whitespace"(self);
+    if self.pos >= __inline_String__len_0: block -> i32 {
+        __local_14 = self.input;
+        break __inline_String__len_0: __local_14.used;
+    } {
+        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_15 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_15 };
+        });
+    }
+    b = __inline_String__get_byte_2: block -> u8 {
+        __local_16 = self.input;
+        __local_17 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_16.repr, __local_17);
+    } & 255;
+    if b == 34 {
+        return "core:json/JsonDeserializer::skip_string"(self);
+        unreachable;
+    } else if b == 116 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        unreachable;
+    } else if b == 102 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        unreachable;
+    } else if b == 110 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
+        unreachable;
+    } else if b == 91 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_3: block -> i32 {
+            __local_18 = self.input;
+            break __inline_String__len_3: __local_18.used;
+        } -> i32 {
+            __inline_String__get_byte_4: block -> u8 {
+                __local_19 = self.input;
+                __local_20 = self.pos;
+                break __inline_String__get_byte_4: builtin::array_get_u8(__local_19.repr, __local_20);
+            } == 93;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l305: loop {
+                let __match_scrut_5: ref null "core:serde//DeserializeError";
+                __match_scrut_5 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_5) {
+                } else if ref.is_null(__match_scrut_5) == 0 {
+                    let __cast_4: ref null "core:serde//DeserializeError";
+                    __cast_4 = ref.as_non_null(__match_scrut_5);
+                    __local_3 = ref.as_non_null(__cast_4);
+                    return __local_3;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_5: block -> i32 {
+                    __local_21 = self.input;
+                    break __inline_String__len_5: __local_21.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
+                        __local_22 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_22 };
+                    });
+                }
+                __local_4 = __inline_String__get_byte_7: block -> u8 {
+                    __local_23 = self.input;
+                    __local_24 = self.pos;
+                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_23.repr, __local_24);
+                } & 255;
+                if __local_4 == 93 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_4 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
+                        __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
+                        __local_26 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_25, offset: __local_26 };
+                    });
+                    unreachable;
+                }
+                continue l305;
+            };
+        };
+    } else if b == 123 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_9: block -> i32 {
+            __local_27 = self.input;
+            break __inline_String__len_9: __local_27.used;
+        } -> i32 {
+            __inline_String__get_byte_10: block -> u8 {
+                __local_28 = self.input;
+                __local_29 = self.pos;
+                break __inline_String__get_byte_10: builtin::array_get_u8(__local_28.repr, __local_29);
+            } == 125;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l315: loop {
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if (if self.pos >= __inline_String__len_11: block -> i32 {
+                    __local_30 = self.input;
+                    break __inline_String__len_11: __local_30.used;
+                } -> i32 {
+                    1;
+                } else {
+                    __inline_String__get_byte_12: block -> u8 {
+                        __local_31 = self.input;
+                        __local_32 = self.pos;
+                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_31.repr, __local_32);
+                    } != 34;
+                }) {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
+                        __local_33 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+                        __local_34 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_33, offset: __local_34 };
+                    });
+                }
+                let __match_scrut_1: ref null "core:serde//DeserializeError";
+                __match_scrut_1 = "core:json/JsonDeserializer::skip_string"(self);
+                if ref.is_null(__match_scrut_1) {
+                } else if ref.is_null(__match_scrut_1) == 0 {
+                    let __cast_1: ref null "core:serde//DeserializeError";
+                    __cast_1 = ref.as_non_null(__match_scrut_1);
+                    __local_6 = ref.as_non_null(__cast_1);
+                    return __local_6;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_2: ref null "core:serde//DeserializeError";
+                __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+                if ref.is_null(__match_scrut_2) {
+                } else if ref.is_null(__match_scrut_2) == 0 {
+                    let __cast_2: ref null "core:serde//DeserializeError";
+                    __cast_2 = ref.as_non_null(__match_scrut_2);
+                    __local_8 = ref.as_non_null(__cast_2);
+                    return __local_8;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_3: ref null "core:serde//DeserializeError";
+                __match_scrut_3 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_3) {
+                } else if ref.is_null(__match_scrut_3) == 0 {
+                    let __cast_3: ref null "core:serde//DeserializeError";
+                    __cast_3 = ref.as_non_null(__match_scrut_3);
+                    __local_10 = ref.as_non_null(__cast_3);
+                    return __local_10;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_14: block -> i32 {
+                    __local_35 = self.input;
+                    break __inline_String__len_14: __local_35.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
+                        __local_36 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_36 };
+                    });
+                }
+                __local_11 = __inline_String__get_byte_16: block -> u8 {
+                    __local_37 = self.input;
+                    __local_38 = self.pos;
+                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_37.repr, __local_38);
+                } & 255;
+                if __local_11 == 125 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_11 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
+                        __local_39 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
+                        __local_40 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_39, offset: __local_40 };
+                    });
+                    unreachable;
+                }
+                continue l315;
+            };
+        };
+    } else {
+        if (if b == 45 -> i32 {
+            1;
+        } else if 48 <= b -> i32 {
+            b <= 57;
+        } else {
+            0;
+        }) {
+            "core:json/JsonDeserializer::skip_number"(self);
+            return ref.null none;
+        }
+        return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
+            __local_43 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
+                "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
+                __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
+                "core:prelude/primitive.wado/char^Display::fmt"(b, __local_13);
+                "core:prelude/string.wado/String::push"(__local_12, 39);
+                break __tmpl: __local_12;
+            };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
+        });
+        unreachable;
+    }
+}
+
+fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
+    let __local_2: ref "core:serde//DeserializeError";
+    let key_start: i32;
+    let has_escape: bool;
+    let b: i32;
+    let key_end: i32;
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: i32;
+    let idx_10: i32;
+    let __local_11: ref "core:prelude/string.wado//String";
+    let __local_12: ref "core:serde//DeserializeError";
+    let key: ref "core:prelude/string.wado//String";
+    let __local_15: ref "core:serde//DeserializeError";
+    let __local_16: i32;
+    let idx_17: i32;
     let __local_18: ref "core:prelude/string.wado//String";
     let __local_19: i64;
     let __local_20: ref "core:prelude/string.wado//String";
@@ -2728,455 +3047,229 @@ fn "core:json/JsonDeserializer::skip_value"(self) {
     let __local_25: ref "core:prelude/string.wado//String";
     let __local_26: i64;
     let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: i64;
-    let __local_31: ref "core:prelude/string.wado//String";
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i32;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
-    let __local_37: ref "core:prelude/string.wado//String";
-    let __local_38: i64;
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
-    let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_47: ref "core:prelude/string.wado//String";
-    let __local_48: i64;
-    let _hfs_pos_49: i32;
-    let _hfs_pos_50: i32;
-    "core:json/JsonDeserializer::skip_whitespace"(self);
-    if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_18 = self.input;
-        break __inline_String__len_0: __local_18.used;
-    } {
-        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_19 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
-        });
-    }
-    b = __inline_String__get_byte_2: block -> u8 {
-        __local_20 = self.input;
-        __local_21 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
-    };
-    if b == 34 {
-        return "core:json/JsonDeserializer::skip_string"(self);
-    }
-    if b == 116 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-    }
-    if b == 102 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-    }
-    if b == 110 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
-    }
-    if b == 91 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_3: block -> i32 {
-            __local_22 = self.input;
-            break __inline_String__len_3: __local_22.used;
-        } -> i32 {
-            __inline_String__get_byte_4: block -> u8 {
-                __local_23 = self.input;
-                __local_24 = self.pos;
-                break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
-            } == 93;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_49 = self.pos;
-        block {
-            l296: loop {
-                self.pos = _hfs_pos_49;
-                r = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_49 = self.pos;
-                if ref.is_null(r) == 0 {
-                    e_3 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-                    self.pos = _hfs_pos_49;
-                    return e_3;
-                }
-                self.pos = _hfs_pos_49;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_49 = self.pos;
-                if _hfs_pos_49 >= __inline_String__len_5: block -> i32 {
-                    __local_25 = self.input;
-                    self.pos = _hfs_pos_49;
-                    break __inline_String__len_5: __local_25.used;
-                } {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
-                        __local_26 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
-                    });
-                }
-                c_4 = __inline_String__get_byte_7: block -> u8 {
-                    __local_27 = self.input;
-                    __local_28 = _hfs_pos_49;
-                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_27.repr, __local_28);
-                };
-                if c_4 == 93 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                    self.pos = _hfs_pos_49;
-                    return ref.null none;
-                }
-                if c_4 == 44 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                } else {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
-                        __local_29 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
-                        __local_30 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_29, offset: __local_30 };
-                    });
-                }
-                continue l296;
-            };
-        };
-        self.pos = _hfs_pos_49;
-    }
-    if b == 123 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_9: block -> i32 {
-            __local_31 = self.input;
-            break __inline_String__len_9: __local_31.used;
-        } -> i32 {
-            __inline_String__get_byte_10: block -> u8 {
-                __local_32 = self.input;
-                __local_33 = self.pos;
-                break __inline_String__get_byte_10: builtin::array_get_u8(__local_32.repr, __local_33);
-            } == 125;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_50 = self.pos;
-        block {
-            l305: loop {
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if (if _hfs_pos_50 >= __inline_String__len_11: block -> i32 {
-                    __local_34 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_11: __local_34.used;
-                } -> i32 {
-                    1;
-                } else {
-                    __inline_String__get_byte_12: block -> u8 {
-                        __local_35 = self.input;
-                        __local_36 = _hfs_pos_50;
-                        self.pos = _hfs_pos_50;
-                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_35.repr, __local_36);
-                    } != 34;
-                }) {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
-                        __local_37 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-                        __local_38 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_37, offset: __local_38 };
-                    });
-                }
-                self.pos = _hfs_pos_50;
-                kr = "core:json/JsonDeserializer::skip_string"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(kr) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(kr));
-                    self.pos = _hfs_pos_50;
-                    return e_6;
-                }
-                self.pos = _hfs_pos_50;
-                cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(cr) == 0 {
-                    e_8 = value_copy "core:serde//DeserializeError"(ref.as_non_null(cr));
-                    self.pos = _hfs_pos_50;
-                    return e_8;
-                }
-                self.pos = _hfs_pos_50;
-                vr = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(vr) == 0 {
-                    e_10 = value_copy "core:serde//DeserializeError"(ref.as_non_null(vr));
-                    self.pos = _hfs_pos_50;
-                    return e_10;
-                }
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if _hfs_pos_50 >= __inline_String__len_14: block -> i32 {
-                    __local_39 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_14: __local_39.used;
-                } {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
-                        __local_40 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-                    });
-                }
-                c_11 = __inline_String__get_byte_16: block -> u8 {
-                    __local_41 = self.input;
-                    __local_42 = _hfs_pos_50;
-                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_41.repr, __local_42);
-                };
-                if c_11 == 125 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                    self.pos = _hfs_pos_50;
-                    return ref.null none;
-                }
-                if c_11 == 44 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                } else {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
-                        __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
-                        __local_44 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
-                    });
-                }
-                continue l305;
-            };
-        };
-        self.pos = _hfs_pos_50;
-    }
-    if (if b == 45 -> i32 {
-        1;
-    } else if b >= 48 -> i32 {
-        b <= 57;
-    } else {
-        0;
-    }) {
-        "core:json/JsonDeserializer::skip_number"(self);
-        return ref.null none;
-    }
-    return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
-        __local_47 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-            __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
-            "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
-            __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
-            "core:prelude/primitive.wado/char^Display::fmt"(b & 255, __local_13);
-            "core:prelude/string.wado/String::push"(__local_12, 39);
-            break __tmpl: __local_12;
-        };
-        __local_48 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_47, offset: __local_48 };
-    });
-}
-
-fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
-    let r_1: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let key_start: i32;
-    let has_escape: bool;
-    let b: i32;
-    let key_end: i32;
-    let r_7: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let idx_9: ref "core:prelude/types.wado//Option<i32>";
-    let i_10: i32;
-    let key_r: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let key: ref "core:prelude/string.wado//String";
-    let r_13: ref null "core:serde//DeserializeError";
-    let e_14: ref "core:serde//DeserializeError";
-    let idx_15: ref "core:prelude/types.wado//Option<i32>";
-    let i_16: i32;
-    let e_17: ref "core:serde//DeserializeError";
-    let __local_25: ref "core:prelude/string.wado//String";
-    let __local_26: i64;
-    let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: ref "core:prelude/string.wado//String";
-    let __local_31: i32;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i64;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_25 = self.de.input;
-        break __inline_String__len_0: __local_25.used;
+        __local_18 = self.de.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
+            __local_19 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_27 = self.de.input;
-        __local_28 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_27.repr, __local_28);
+        __local_20 = self.de.input;
+        __local_21 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } == 125 {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r_1 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r_1) == 0 {
-            e_2 = ref.as_non_null(r_1);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if (if self.de.pos >= __inline_String__len_3: block -> i32 {
-        __local_29 = self.de.input;
-        break __inline_String__len_3: __local_29.used;
+        __local_22 = self.de.input;
+        break __inline_String__len_3: __local_22.used;
     } -> i32 {
         1;
     } else {
         __inline_String__get_byte_4: block -> u8 {
-            __local_30 = self.de.input;
-            __local_31 = self.de.pos;
-            break __inline_String__get_byte_4: builtin::array_get_u8(__local_30.repr, __local_31);
+            __local_23 = self.de.input;
+            __local_24 = self.de.pos;
+            break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
         } != 34;
     }) {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_5: block -> ref "core:serde//DeserializeError" {
-            __local_32 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-            __local_33 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_32, offset: __local_33 };
+            __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_25, offset: __local_26 };
         }) };
     }
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b323: block {
-        l324: loop {
+    b337: block {
+        l338: loop {
             if self.de.pos >= __inline_String__len_6: block -> i32 {
-                __local_34 = self.de.input;
-                break __inline_String__len_6: __local_34.used;
+                __local_27 = self.de.input;
+                break __inline_String__len_6: __local_27.used;
             } {
-                break b323;
+                break b337;
             }
             b = __inline_String__get_byte_7: block -> u8 {
-                __local_35 = self.de.input;
-                __local_36 = self.de.pos;
-                break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
+                __local_28 = self.de.input;
+                __local_29 = self.de.pos;
+                break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
             };
             if b == 34 {
-                break b323;
+                break b337;
             }
             if b == 92 {
                 has_escape = 1;
-                break b323;
+                break b337;
             }
             self.de.pos = self.de.pos + 1;
-            continue l324;
+            continue l338;
         };
     };
     if has_escape == 0 {
         key_end = self.de.pos;
         self.de.pos = self.de.pos + 1;
-        r_7 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_7) == 0 {
-            e_8 = ref.as_non_null(r_7);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_8 };
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_1);
+            __local_8 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        idx_9 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_0: ref "canonical//CanonicalClosure_0";
-            __indirect_call_0 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_0.func, __indirect_call_0.env, self.de.input, key_start, key_end);
+        let __match_scrut_2: ref "core:prelude/types.wado//Option<i32>";
+        __match_scrut_2 = block -> ref "core:prelude/types.wado//Option<i32>" {
+            let __indirect_call_2: ref "canonical//CanonicalClosure_0";
+            __indirect_call_2 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_2.func, __indirect_call_2.env, self.de.input, key_start, key_end);
         };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_9) {
-            i_10 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_9).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_10 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+        idx_10 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2) -> i32 {
+            let __cast_4: ref "core:prelude/types.wado//Option<i32>::Some";
+            __cast_4 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2);
+            __local_9 = __cast_4.payload_0;
+            __local_9;
+        } else if __match_scrut_2.discriminant == 1 -> i32 {
+            -1;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_10 } };
     }
     self.de.pos = key_start - 1;
-    key_r = "core:json/JsonDeserializer::read_json_string"(self.de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r) {
-        key = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r).payload_0);
-        r_13 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_13) == 0 {
-            e_14 = ref.as_non_null(r_13);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_14 };
-        }
-        idx_15 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_1: ref "canonical//CanonicalClosure_0";
-            __indirect_call_1 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_1.func, __indirect_call_1.env, key, 0, key.used);
-        };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_15) {
-            i_16 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_15).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_16 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+    key = value_copy "core:prelude/string.wado//String"(let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self.de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_6: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_6 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+        __local_11 = __cast_6.payload_0;
+        __local_11;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+        __local_12 = __cast_5.payload_0;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_12 };
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    let __match_scrut_4: ref null "core:serde//DeserializeError";
+    __match_scrut_4 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+    if ref.is_null(__match_scrut_4) {
+    } else if ref.is_null(__match_scrut_4) == 0 {
+        let __cast_7: ref null "core:serde//DeserializeError";
+        __cast_7 = ref.as_non_null(__match_scrut_4);
+        __local_15 = ref.as_non_null(__cast_7);
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_15 };
+        unreachable;
+    } else {
+        unreachable;
     }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r) {
-        e_17 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    let __match_scrut_5: ref "core:prelude/types.wado//Option<i32>";
+    __match_scrut_5 = block -> ref "core:prelude/types.wado//Option<i32>" {
+        let __indirect_call_7: ref "canonical//CanonicalClosure_0";
+        __indirect_call_7 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+        call_ref "functype/$canonical_closure_fn_0"(__indirect_call_7.func, __indirect_call_7.env, key, 0, key.used);
+    };
+    idx_17 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5) -> i32 {
+        let __cast_9: ref "core:prelude/types.wado//Option<i32>::Some";
+        __cast_9 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5);
+        __local_16 = __cast_9.payload_0;
+        __local_16;
+    } else if __match_scrut_5.discriminant == 1 -> i32 {
+        -1;
+    } else {
+        unreachable;
+    });
+    return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_17 } };
 }
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_bool"(self) {
-    let b: i32;
-    let r_2: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let r_4: ref null "core:serde//DeserializeError";
-    let e_5: ref "core:serde//DeserializeError";
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:serde//DeserializeError";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
     let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i64;
+    let __local_9: i32;
     let __local_10: ref "core:prelude/string.wado//String";
-    let __local_11: i32;
-    let __local_12: ref "core:prelude/string.wado//String";
-    let __local_13: i64;
+    let __local_11: i64;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_8 = self.input;
-        break __inline_String__len_0: __local_8.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_9 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_9 };
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
         }) };
     }
     b = __inline_String__get_byte_2: block -> u8 {
-        __local_10 = self.input;
-        __local_11 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_10.repr, __local_11);
-    };
+        __local_8 = self.input;
+        __local_9 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_8.repr, __local_9);
+    } & 255;
     if b == 116 {
-        r_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-        if ref.is_null(r_2) == 0 {
-            e_3 = ref.as_non_null(r_2);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_3 };
+        let __match_scrut_2: ref null "core:serde//DeserializeError";
+        __match_scrut_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        if ref.is_null(__match_scrut_2) {
+        } else if ref.is_null(__match_scrut_2) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_2);
+            __local_3 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 1 };
-    }
-    if b == 102 {
-        r_4 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-        if ref.is_null(r_4) == 0 {
-            e_5 = ref.as_non_null(r_4);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
+        unreachable;
+    } else if b == 102 {
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_1);
+            __local_5 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_5 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 0 };
+        unreachable;
+    } else {
+        return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
+            __local_11 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_10, offset: __local_11 };
+        }) };
+        unreachable;
     }
-    return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-        __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
-        __local_13 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_12, offset: __local_13 };
-    }) };
+    unreachable;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::is_null"(self) {
@@ -3231,23 +3324,35 @@ fn "core:json/JsonDeserializer^Deserializer::is_null"(self) {
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_seq"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 91);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 91);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_2 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_2;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonSeqAccess" { de: self, first: 1 }, ref.null none;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_struct"(self, lookup) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 123);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_5: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 123);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_5 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_5;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonStructAccess" { de: self, lookup: lookup, first: 1 }, ref.null none;
 }
@@ -3259,13 +3364,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l350: loop {
+            l372: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l350;
+                continue l372;
             };
         };
     };
@@ -3402,8 +3507,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b373: block {
-        l374: loop {
+    b395: block {
+        l396: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3428,9 +3533,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b373;
+                break b395;
             }
-            continue l374;
+            continue l396;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -3482,8 +3587,8 @@ fn "wado-compiler/tests/fixtures/serde_json_default.wado/Config^Deserialize::des
             break __seq_lit: __local_30;
         };
         description = ref.null none;
-        b382: block {
-            l383: loop {
+        b404: block {
+            l405: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -3501,7 +3606,7 @@ fn "wado-compiler/tests/fixtures/serde_json_default.wado/Config^Deserialize::des
                                 host = __local_13;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_12).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_12).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_14 = __inline_i32_Deserialize__deserialize_JsonDeserializer__11: block -> ref "core:prelude/types.wado//Result<i32,DeserializeError>" {
@@ -3514,7 +3619,7 @@ fn "wado-compiler/tests/fixtures/serde_json_default.wado/Config^Deserialize::des
                                 port = __local_15;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_14).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_14).payload_0 };
                             }
                         } else if __idx == 2 {
                             __local_16 = __inline_bool_Deserialize__deserialize_JsonDeserializer__13: block -> ref "core:prelude/types.wado//Result<bool,DeserializeError>" {
@@ -3527,7 +3632,7 @@ fn "wado-compiler/tests/fixtures/serde_json_default.wado/Config^Deserialize::des
                                 verbose = __local_17;
                                 seen = seen | 4;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__local_16).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__local_16).payload_0 };
                             }
                         } else if __idx == 3 {
                             __local_18 = "wado-compiler/tests/fixtures/serde_json_default.wado/Array<String>^Deserialize::deserialize<JsonDeserializer>"(sd.de);
@@ -3537,7 +3642,7 @@ fn "wado-compiler/tests/fixtures/serde_json_default.wado/Config^Deserialize::des
                                 tags = __local_19;
                                 seen = seen | 8;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Array<String>,DeserializeError>::Err"(__local_18).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Array<String>,DeserializeError>::Err"(__local_18).payload_0 };
                             }
                         } else if __idx == 4 {
                             __local_20 = "wado-compiler/tests/fixtures/serde_json_default.wado/Option<String>^Deserialize::deserialize<JsonDeserializer>"(sd.de);
@@ -3547,27 +3652,27 @@ fn "wado-compiler/tests/fixtures/serde_json_default.wado/Config^Deserialize::des
                                 description = __local_21;
                                 seen = seen | 16;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(__local_20).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(__local_20).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b382;
+                        break b404;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l383;
+                continue l405;
             };
         };
         if (seen & 1) != 1 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_json_default.wado//Config" { host: host, port: port, verbose: verbose, tags: tags, description: description }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_json_default.wado//Config" { host: host, port: port, verbose: verbose, tags: tags, description: description } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 
@@ -3610,12 +3715,14 @@ fn "wado-compiler/tests/fixtures/serde_json_default.wado/String^Deserialize::des
 
 fn "wado-compiler/tests/fixtures/serde_json_default.wado/Array<String>^Deserialize::deserialize<JsonDeserializer>"(d) {
     let seq: ref "core:json//JsonSeqAccess";
+    let first: ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";
     let first_opt: ref null "core:prelude/string.wado//String";
     let end_result_5: ref null "core:serde//DeserializeError";
     let e_6: ref "core:serde//DeserializeError";
     let __local_7: ref "core:prelude//Array<String>";
     let first_elem: ref "core:prelude/string.wado//String";
     let items: ref "core:prelude//Array<String>";
+    let next: ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";
     let next_opt: ref null "core:prelude/string.wado//String";
     let end_result_12: ref null "core:serde//DeserializeError";
     let e_13: ref "core:serde//DeserializeError";
@@ -3629,24 +3736,18 @@ fn "wado-compiler/tests/fixtures/serde_json_default.wado/Array<String>^Deseriali
     multivalue_bind [__sroa_seq_result_discriminant, __sroa_seq_result_case0_payload_0, __sroa_seq_result_case1_payload_0] = "core:json/JsonDeserializer^Deserializer::begin_seq"(d);
     if __sroa_seq_result_discriminant == 0 {
         seq = __sroa_seq_result_case0_payload_0;
-        let __sroa_first_discriminant: i32;
-        let __sroa_first_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_first_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_first_discriminant, __sroa_first_case0_payload_0, __sroa_first_case1_payload_0] = "core:json/JsonSeqAccess^DeserializeSeq::next_element<String>"(seq);
-        if __sroa_first_discriminant == 0 {
-            first_opt = __sroa_first_case0_payload_0;
+        first = "core:json/JsonSeqAccess^DeserializeSeq::next_element<String>"(seq);
+        if ref.test "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok"(first) {
+            first_opt = value_copy "core:prelude/types.wado//Option<String>"(ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok"(first).payload_0);
             if ref.is_null(first_opt) == 0 {
                 first_elem = value_copy "core:prelude/string.wado//String"(ref.as_non_null(first_opt));
                 items = struct.new "core:prelude//Array<String>" { repr: builtin::array_new<ref "core:prelude/string.wado//String">(2), used: 0 };
                 "core:prelude/array.wado/Array<String>::push"(items, first_elem);
                 block {
-                    l406: loop {
-                        let __sroa_next_discriminant: i32;
-                        let __sroa_next_case0_payload_0: ref null "core:prelude/string.wado//String";
-                        let __sroa_next_case1_payload_0: ref null "core:serde//DeserializeError";
-                        multivalue_bind [__sroa_next_discriminant, __sroa_next_case0_payload_0, __sroa_next_case1_payload_0] = "core:json/JsonSeqAccess^DeserializeSeq::next_element<String>"(seq);
-                        if __sroa_next_discriminant == 0 {
-                            next_opt = __sroa_next_case0_payload_0;
+                    l428: loop {
+                        next = "core:json/JsonSeqAccess^DeserializeSeq::next_element<String>"(seq);
+                        if ref.test "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok"(next) {
+                            next_opt = value_copy "core:prelude/types.wado//Option<String>"(ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok"(next).payload_0);
                             if ref.is_null(next_opt) == 0 {
                                 item = value_copy "core:prelude/string.wado//String"(ref.as_non_null(next_opt));
                                 "core:prelude/array.wado/Array<String>::push"(items, item);
@@ -3659,11 +3760,11 @@ fn "wado-compiler/tests/fixtures/serde_json_default.wado/Array<String>^Deseriali
                                 return struct.new "core:prelude/types.wado//Result<Array<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: items };
                             }
                         }
-                        if __sroa_next_discriminant == 1 {
-                            e_15 = __sroa_next_case1_payload_0;
+                        if ref.test "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(next) {
+                            e_15 = ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(next).payload_0;
                             return struct.new "core:prelude/types.wado//Result<Array<String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_15 };
                         }
-                        continue l406;
+                        continue l428;
                     };
                 };
             } else {
@@ -3678,8 +3779,8 @@ fn "wado-compiler/tests/fixtures/serde_json_default.wado/Array<String>^Deseriali
                 }) };
             }
         }
-        if __sroa_first_discriminant == 1 {
-            e_16 = __sroa_first_case1_payload_0;
+        if ref.test "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(first) {
+            e_16 = ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(first).payload_0;
             return struct.new "core:prelude/types.wado//Result<Array<String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_16 };
         }
         "core:internal/unreachable"();
@@ -3694,51 +3795,58 @@ fn "wado-compiler/tests/fixtures/serde_json_default.wado/Array<String>^Deseriali
 }
 
 fn "core:json/JsonSeqAccess^DeserializeSeq::next_element<String>"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let elem: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let v: ref "core:prelude/string.wado//String";
-    let e_5: ref "core:serde//DeserializeError";
-    let __local_9: ref "core:prelude/string.wado//String";
-    let __local_10: i64;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i32;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __local_3: ref "core:prelude/string.wado//String";
+    let __local_4: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_9 = self.de.input;
-        break __inline_String__len_0: __local_9.used;
+        __local_5 = self.de.input;
+        break __inline_String__len_0: __local_5.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_10 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_10 };
-        });
+        return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_6 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_11 = self.de.input;
-        __local_12 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_11.repr, __local_12);
+        __local_7 = self.de.input;
+        __local_8 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_7.repr, __local_8);
     } == 93 {
-        return 0, ref.null none, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: ref.null none };
     }
     if self.first == 0 {
-        r = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r) == 0 {
-            e_2 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-            return 1, ref.null none, e_2;
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
-    elem = "wado-compiler/tests/fixtures/serde_json_default.wado/String^Deserialize::deserialize<JsonDeserializer>"(self.de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(elem) {
-        v = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(elem).payload_0);
-        return 0, v, ref.null none;
-    }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(elem) {
-        e_5 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(elem).payload_0);
-        return 1, ref.null none, e_5;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return let __match_scrut_1: ref "core:prelude/types.wado//Result<String,DeserializeError>", __match_scrut_1 = "wado-compiler/tests/fixtures/serde_json_default.wado/String^Deserialize::deserialize<JsonDeserializer>"(self.de), (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>" {
+        let __cast_3: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_3 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1);
+        __local_3 = __cast_3.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_3 };
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1);
+        __local_4 = __cast_2.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_4 };
+    } else {
+        unreachable;
+    });
 }
 
 fn "core:prelude/array.wado/Array<String>::push"(self, value) {
@@ -3770,13 +3878,13 @@ fn "core:prelude/array.wado/Array<String>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l422: loop {
+            l445: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
                 i = i + 1;
-                continue l422;
+                continue l445;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/serde_json_deser_error.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_deser_error.wir.wado
@@ -51,253 +51,284 @@ struct wado-compiler/tests/fixtures/serde_json_deser_error.wado//User {  // Type
     mut active: bool,
 }
 
-variant core:prelude/types.wado//Option<i32> {  // TypeId(9)
+variant core:prelude/types.wado//Option<char> {  // TypeId(9)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(10)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<i32> {  // TypeId(11)
     Some(i32),
     None,
 }
 
-struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(10)
+struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(12)
     discriminant: i32,
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Result<User,DeserializeError> {  // TypeId(11)
+variant core:prelude/types.wado//Result<User,DeserializeError> {  // TypeId(13)
     Ok(ref "wado-compiler/tests/fixtures/serde_json_deser_error.wado//User"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<User,DeserializeError>::Ok {  // TypeId(12)
+struct core:prelude/types.wado//Result<User,DeserializeError>::Ok {  // TypeId(14)
     discriminant: i32,
     payload_0: ref "wado-compiler/tests/fixtures/serde_json_deser_error.wado//User",
 }
 
-struct core:prelude/types.wado//Result<User,DeserializeError>::Err {  // TypeId(13)
+struct core:prelude/types.wado//Result<User,DeserializeError>::Err {  // TypeId(15)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(14)
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(16)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(15)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(17)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(16)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(18)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(17)
+variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(19)
     Ok(bool),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(18)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(20)
     discriminant: i32,
     payload_0: bool,
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(19)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(21)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(20)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(22)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(23)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(24)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(25)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(21)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(26)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(22)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(27)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(23)
+variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(28)
     Ok(ref "core:prelude/types.wado//Option<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(24)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(29)
     discriminant: i32,
     payload_0: ref "core:prelude/types.wado//Option<i32>",
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(25)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(30)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(26)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(31)
 
-type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(27)
+type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(32)
 
-struct canonical//CanonicalClosure_0 {  // TypeId(28)
+struct canonical//CanonicalClosure_0 {  // TypeId(33)
     env: ref null struct,
     func: ref "functype/$canonical_closure_fn_0",
 }
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(29)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(34)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(30)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(35)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(31)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(36)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(32)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(37)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(33)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(38)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(34)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(39)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(35)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(40)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(36)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(41)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_0_invalid_json___not_an_object" = fn();  // TypeId(37)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_0_invalid_json___not_an_object" = fn();  // TypeId(42)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_1_invalid_json___empty_string" = fn();  // TypeId(38)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_1_invalid_json___empty_string" = fn();  // TypeId(43)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_2_invalid_json___truncated_string" = fn();  // TypeId(39)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_2_invalid_json___truncated_string" = fn();  // TypeId(44)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_3_missing_required_field" = fn();  // TypeId(40)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_3_missing_required_field" = fn();  // TypeId(45)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_4_type_mismatch___string_where_number_expected" = fn();  // TypeId(41)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_4_type_mismatch___string_where_number_expected" = fn();  // TypeId(46)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_5_type_mismatch___number_where_string_expected" = fn();  // TypeId(42)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_5_type_mismatch___number_where_string_expected" = fn();  // TypeId(47)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_6_type_mismatch___number_where_bool_expected" = fn();  // TypeId(43)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_6_type_mismatch___number_where_bool_expected" = fn();  // TypeId(48)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_7_trailing_data_after_valid_json" = fn();  // TypeId(44)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_7_trailing_data_after_valid_json" = fn();  // TypeId(49)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_8_valid_input_still_works" = fn();  // TypeId(45)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__test_8_valid_input_still_works" = fn();  // TypeId(50)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/_user_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(46)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/_user_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(51)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_0_invalid_json___not_an_object" = fn();  // TypeId(47)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_0_invalid_json___not_an_object" = fn();  // TypeId(52)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_1_invalid_json___empty_string" = fn();  // TypeId(48)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_1_invalid_json___empty_string" = fn();  // TypeId(53)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_2_invalid_json___truncated_string" = fn();  // TypeId(49)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_2_invalid_json___truncated_string" = fn();  // TypeId(54)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_3_missing_required_field" = fn();  // TypeId(50)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_3_missing_required_field" = fn();  // TypeId(55)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_4_type_mismatch___string_where_number_expected" = fn();  // TypeId(51)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_4_type_mismatch___string_where_number_expected" = fn();  // TypeId(56)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_5_type_mismatch___number_where_string_expected" = fn();  // TypeId(52)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_5_type_mismatch___number_where_string_expected" = fn();  // TypeId(57)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_6_type_mismatch___number_where_bool_expected" = fn();  // TypeId(53)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_6_type_mismatch___number_where_bool_expected" = fn();  // TypeId(58)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_7_trailing_data_after_valid_json" = fn();  // TypeId(54)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_7_trailing_data_after_valid_json" = fn();  // TypeId(59)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_8_valid_input_still_works" = fn();  // TypeId(55)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__cm_export____test_8_valid_input_still_works" = fn();  // TypeId(60)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(56)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(61)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(57)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(62)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(58)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(63)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(59)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(64)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(60)
+type "functype//core:internal/unreachable" = fn();  // TypeId(65)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(61)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(66)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(62)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(67)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(63)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(68)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(64)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(69)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(65)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(70)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(66)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(71)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(67)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(72)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(68)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(73)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(69)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(74)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(70)
+type "functype//core:json/core/json/from_string<User>" = fn(ref "core:prelude/string.wado//String") -> ref "core:prelude/types.wado//Result<User,DeserializeError>";  // TypeId(75)
 
-type "functype//core:json/core/json/from_string<User>" = fn(ref "core:prelude/string.wado//String") -> ref "core:prelude/types.wado//Result<User,DeserializeError>";  // TypeId(71)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(76)
 
-type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(72)
+type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(77)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(73)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(78)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(74)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(79)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(75)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(80)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(76)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(81)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(77)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(82)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(78)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(83)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(79)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(84)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(80)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(85)
 
-type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(81)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(86)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(82)
+type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(87)
 
-type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(83)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(88)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(84)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(89)
 
-type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(85)
+type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(90)
 
-type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(86)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(91)
 
-type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(87)
+type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(92)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(88)
+type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(93)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(89)
+type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(94)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(90)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(95)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(91)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(96)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(92)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(97)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(93)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(98)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(94)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(99)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(95)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/User^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<User,DeserializeError>";  // TypeId(100)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(96)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(101)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(97)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(102)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(98)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(103)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(99)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(104)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(100)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(105)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/User^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_deser_error.wado//User", ref null "core:serde//DeserializeError"];  // TypeId(101)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(106)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(102)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(107)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(103)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(108)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(104)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(109)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(105)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(110)
+
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(111)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(112)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(113)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -1398,64 +1429,120 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/core/json/from_string<User>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_json_deser_error.wado//User";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_json_deser_error.wado//User";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_json_deser_error.wado//User";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_deser_error.wado/User^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            }) };
-        }
-        return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Ok" { discriminant: 0, payload_0: v };
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<User,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_deser_error.wado/User^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<User,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_deser_error.wado//User" {
+        let __cast_2: ref "core:prelude/types.wado//Result<User,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<User,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<User,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_deser_error.wado//User" {
+        let __cast_1: ref "core:prelude/types.wado//Result<User,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<User,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        }) };
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: e };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Ok" { discriminant: 0, payload_0: v };
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1558,7 +1645,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l131: loop {
+            l142: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -1566,7 +1653,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l131;
+                continue l142;
             };
         };
     };
@@ -1617,6 +1704,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     return 0, code_10;
 }
 
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
+}
+
 fn "core:prelude/string.wado/String::push"(self, c) {
     let code: u32;
     code = c;
@@ -1655,10 +1791,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b142: block {
-        l143: loop {
+    b160: block {
+        l161: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b142;
+                break b160;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -1682,7 +1818,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l143;
+            continue l161;
         };
     };
     self.pos = _hfs_pos_8;
@@ -1761,11 +1897,11 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b151: block {
-        l152: loop {
+    b169: block {
+        l170: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= _licm_used_19 {
-                    break b151;
+                    break b169;
                 }
                 byte = builtin::array_get_u8(_licm_repr_20, __sroa___iter_3_index);
                 __sroa___iter_3_index = __sroa___iter_3_index + 1;
@@ -1800,7 +1936,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
                 _hfs_pos_27 = _hfs_pos_27 + 1;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l152;
+            continue l170;
         };
     };
     self.pos = _hfs_pos_27;
@@ -1819,130 +1955,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b158: block {
-        l159: loop {
-            if scan_pos >= _licm_used_90 {
-                break b158;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b176: block {
+        l177: loop {
+            if scan_pos >= _licm_used_56 {
+                break b176;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b158;
+                break b176;
             }
             scan_pos = scan_pos + 1;
-            continue l159;
+            continue l177;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -1951,22 +2059,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l166: loop {
+                l184: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l166;
+                    continue l184;
                 };
             };
         };
@@ -1974,71 +2082,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l169: loop {
+            l187: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l169;
+                continue l187;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b171: block {
-        l172: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b189: block {
+        l190: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b171;
+                break b189;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -2056,125 +2165,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l172;
+            continue l190;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -2182,87 +2234,71 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l197: loop {
+            l210: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l197;
+                continue l210;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -2317,25 +2353,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b208: block {
-        l209: loop {
+    b217: block {
+        l218: loop {
             if _hfs_pos_36 >= _licm_used_28 {
-                break b208;
+                break b217;
             }
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
                 break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr_29, __local_11);
             };
-            if (if b_1 >= 48 -> i32 {
+            if (if 48 <= b_1 -> i32 {
                 b_1 <= 57;
             } else {
                 0;
             }) {
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
-                break b208;
+                break b217;
             }
-            continue l209;
+            continue l218;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2356,25 +2392,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b215: block {
-            l216: loop {
+        b224: block {
+            l225: loop {
                 if _hfs_pos_37 >= _licm_used_31 {
-                    break b215;
+                    break b224;
                 }
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
                     break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_32, __local_17);
                 };
-                if (if b_2 >= 48 -> i32 {
+                if (if 48 <= b_2 -> i32 {
                     b_2 <= 57;
                 } else {
                     0;
                 }) {
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
-                    break b215;
+                    break b224;
                 }
-                continue l216;
+                continue l225;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2415,25 +2451,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b226: block {
-                l227: loop {
+            b235: block {
+                l236: loop {
                     if _hfs_pos_38 >= _licm_used_34 {
-                        break b226;
+                        break b235;
                     }
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
                         break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_35, __local_26);
                     };
-                    if (if b2 >= 48 -> i32 {
+                    if (if 48 <= b2 -> i32 {
                         b2 <= 57;
                     } else {
                         0;
                     }) {
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
-                        break b226;
+                        break b235;
                     }
-                    continue l227;
+                    continue l236;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -2527,16 +2563,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b236: block {
-        l237: loop {
+    b245: block {
+        l246: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b236;
+                break b245;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -2557,17 +2593,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b245: block {
-                        l246: loop {
+                    b254: block {
+                        l255: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b245;
+                                break b254;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -2577,9 +2613,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b245;
+                                break b254;
                             }
-                            continue l246;
+                            continue l255;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -2610,17 +2646,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b255: block {
-                            l256: loop {
+                        b264: block {
+                            l265: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b255;
+                                    break b264;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -2629,9 +2665,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b255;
+                                    break b264;
                                 }
-                                continue l256;
+                                continue l265;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -2669,9 +2705,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b236;
+                break b245;
             }
-            continue l237;
+            continue l246;
         };
     };
     self.pos = _hfs_pos_51;
@@ -2697,10 +2733,10 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b266: block {
-        l267: loop {
+    b275: block {
+        l276: loop {
             if _hfs_pos_14 >= _licm_used_12 {
-                break b266;
+                break b275;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -2730,7 +2766,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
                 }
             }
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l267;
+            continue l276;
         };
     };
     self.pos = _hfs_pos_14;
@@ -2741,19 +2777,284 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
 }
 
 fn "core:json/JsonDeserializer::skip_value"(self) {
-    let b: i32;
-    let r: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let c_4: i32;
-    let kr: ref null "core:serde//DeserializeError";
-    let e_6: ref "core:serde//DeserializeError";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let vr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let c_11: i32;
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: char;
+    let __local_6: ref "core:serde//DeserializeError";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_10: ref "core:serde//DeserializeError";
+    let __local_11: char;
     let __local_12: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/format.wado//Formatter";
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i64;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i32;
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
+    let __local_20: i32;
+    let __local_21: ref "core:prelude/string.wado//String";
+    let __local_22: i64;
+    let __local_23: ref "core:prelude/string.wado//String";
+    let __local_24: i32;
+    let __local_25: ref "core:prelude/string.wado//String";
+    let __local_26: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let __local_30: ref "core:prelude/string.wado//String";
+    let __local_31: ref "core:prelude/string.wado//String";
+    let __local_32: i32;
+    let __local_33: ref "core:prelude/string.wado//String";
+    let __local_34: i64;
+    let __local_35: ref "core:prelude/string.wado//String";
+    let __local_36: i64;
+    let __local_37: ref "core:prelude/string.wado//String";
+    let __local_38: i32;
+    let __local_39: ref "core:prelude/string.wado//String";
+    let __local_40: i64;
+    let __local_43: ref "core:prelude/string.wado//String";
+    let __local_44: i64;
+    "core:json/JsonDeserializer::skip_whitespace"(self);
+    if self.pos >= __inline_String__len_0: block -> i32 {
+        __local_14 = self.input;
+        break __inline_String__len_0: __local_14.used;
+    } {
+        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_15 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_15 };
+        });
+    }
+    b = __inline_String__get_byte_2: block -> u8 {
+        __local_16 = self.input;
+        __local_17 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_16.repr, __local_17);
+    } & 255;
+    if b == 34 {
+        return "core:json/JsonDeserializer::skip_string"(self);
+        unreachable;
+    } else if b == 116 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        unreachable;
+    } else if b == 102 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        unreachable;
+    } else if b == 110 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
+        unreachable;
+    } else if b == 91 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_3: block -> i32 {
+            __local_18 = self.input;
+            break __inline_String__len_3: __local_18.used;
+        } -> i32 {
+            __inline_String__get_byte_4: block -> u8 {
+                __local_19 = self.input;
+                __local_20 = self.pos;
+                break __inline_String__get_byte_4: builtin::array_get_u8(__local_19.repr, __local_20);
+            } == 93;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l291: loop {
+                let __match_scrut_5: ref null "core:serde//DeserializeError";
+                __match_scrut_5 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_5) {
+                } else if ref.is_null(__match_scrut_5) == 0 {
+                    let __cast_4: ref null "core:serde//DeserializeError";
+                    __cast_4 = ref.as_non_null(__match_scrut_5);
+                    __local_3 = ref.as_non_null(__cast_4);
+                    return __local_3;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_5: block -> i32 {
+                    __local_21 = self.input;
+                    break __inline_String__len_5: __local_21.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
+                        __local_22 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_22 };
+                    });
+                }
+                __local_4 = __inline_String__get_byte_7: block -> u8 {
+                    __local_23 = self.input;
+                    __local_24 = self.pos;
+                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_23.repr, __local_24);
+                } & 255;
+                if __local_4 == 93 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_4 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
+                        __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
+                        __local_26 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_25, offset: __local_26 };
+                    });
+                    unreachable;
+                }
+                continue l291;
+            };
+        };
+    } else if b == 123 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_9: block -> i32 {
+            __local_27 = self.input;
+            break __inline_String__len_9: __local_27.used;
+        } -> i32 {
+            __inline_String__get_byte_10: block -> u8 {
+                __local_28 = self.input;
+                __local_29 = self.pos;
+                break __inline_String__get_byte_10: builtin::array_get_u8(__local_28.repr, __local_29);
+            } == 125;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l301: loop {
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if (if self.pos >= __inline_String__len_11: block -> i32 {
+                    __local_30 = self.input;
+                    break __inline_String__len_11: __local_30.used;
+                } -> i32 {
+                    1;
+                } else {
+                    __inline_String__get_byte_12: block -> u8 {
+                        __local_31 = self.input;
+                        __local_32 = self.pos;
+                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_31.repr, __local_32);
+                    } != 34;
+                }) {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
+                        __local_33 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+                        __local_34 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_33, offset: __local_34 };
+                    });
+                }
+                let __match_scrut_1: ref null "core:serde//DeserializeError";
+                __match_scrut_1 = "core:json/JsonDeserializer::skip_string"(self);
+                if ref.is_null(__match_scrut_1) {
+                } else if ref.is_null(__match_scrut_1) == 0 {
+                    let __cast_1: ref null "core:serde//DeserializeError";
+                    __cast_1 = ref.as_non_null(__match_scrut_1);
+                    __local_6 = ref.as_non_null(__cast_1);
+                    return __local_6;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_2: ref null "core:serde//DeserializeError";
+                __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+                if ref.is_null(__match_scrut_2) {
+                } else if ref.is_null(__match_scrut_2) == 0 {
+                    let __cast_2: ref null "core:serde//DeserializeError";
+                    __cast_2 = ref.as_non_null(__match_scrut_2);
+                    __local_8 = ref.as_non_null(__cast_2);
+                    return __local_8;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_3: ref null "core:serde//DeserializeError";
+                __match_scrut_3 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_3) {
+                } else if ref.is_null(__match_scrut_3) == 0 {
+                    let __cast_3: ref null "core:serde//DeserializeError";
+                    __cast_3 = ref.as_non_null(__match_scrut_3);
+                    __local_10 = ref.as_non_null(__cast_3);
+                    return __local_10;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_14: block -> i32 {
+                    __local_35 = self.input;
+                    break __inline_String__len_14: __local_35.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
+                        __local_36 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_36 };
+                    });
+                }
+                __local_11 = __inline_String__get_byte_16: block -> u8 {
+                    __local_37 = self.input;
+                    __local_38 = self.pos;
+                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_37.repr, __local_38);
+                } & 255;
+                if __local_11 == 125 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_11 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
+                        __local_39 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
+                        __local_40 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_39, offset: __local_40 };
+                    });
+                    unreachable;
+                }
+                continue l301;
+            };
+        };
+    } else {
+        if (if b == 45 -> i32 {
+            1;
+        } else if 48 <= b -> i32 {
+            b <= 57;
+        } else {
+            0;
+        }) {
+            "core:json/JsonDeserializer::skip_number"(self);
+            return ref.null none;
+        }
+        return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
+            __local_43 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
+                "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
+                __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
+                "core:prelude/primitive.wado/char^Display::fmt"(b, __local_13);
+                "core:prelude/string.wado/String::push"(__local_12, 39);
+                break __tmpl: __local_12;
+            };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
+        });
+        unreachable;
+    }
+}
+
+fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
+    let __local_2: ref "core:serde//DeserializeError";
+    let key_start: i32;
+    let has_escape: bool;
+    let b: i32;
+    let key_end: i32;
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: i32;
+    let idx_10: i32;
+    let __local_11: ref "core:prelude/string.wado//String";
+    let __local_12: ref "core:serde//DeserializeError";
+    let key: ref "core:prelude/string.wado//String";
+    let __local_15: ref "core:serde//DeserializeError";
+    let __local_16: i32;
+    let idx_17: i32;
     let __local_18: ref "core:prelude/string.wado//String";
     let __local_19: i64;
     let __local_20: ref "core:prelude/string.wado//String";
@@ -2764,464 +3065,244 @@ fn "core:json/JsonDeserializer::skip_value"(self) {
     let __local_25: ref "core:prelude/string.wado//String";
     let __local_26: i64;
     let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: i64;
-    let __local_31: ref "core:prelude/string.wado//String";
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i32;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
-    let __local_37: ref "core:prelude/string.wado//String";
-    let __local_38: i64;
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
-    let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_47: ref "core:prelude/string.wado//String";
-    let __local_48: i64;
-    let _hfs_pos_49: i32;
-    let _hfs_pos_50: i32;
-    "core:json/JsonDeserializer::skip_whitespace"(self);
-    if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_18 = self.input;
-        break __inline_String__len_0: __local_18.used;
-    } {
-        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_19 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
-        });
-    }
-    b = __inline_String__get_byte_2: block -> u8 {
-        __local_20 = self.input;
-        __local_21 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
-    };
-    if b == 34 {
-        return "core:json/JsonDeserializer::skip_string"(self);
-    }
-    if b == 116 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-    }
-    if b == 102 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-    }
-    if b == 110 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
-    }
-    if b == 91 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_3: block -> i32 {
-            __local_22 = self.input;
-            break __inline_String__len_3: __local_22.used;
-        } -> i32 {
-            __inline_String__get_byte_4: block -> u8 {
-                __local_23 = self.input;
-                __local_24 = self.pos;
-                break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
-            } == 93;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_49 = self.pos;
-        block {
-            l282: loop {
-                self.pos = _hfs_pos_49;
-                r = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_49 = self.pos;
-                if ref.is_null(r) == 0 {
-                    e_3 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-                    self.pos = _hfs_pos_49;
-                    return e_3;
-                }
-                self.pos = _hfs_pos_49;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_49 = self.pos;
-                if _hfs_pos_49 >= __inline_String__len_5: block -> i32 {
-                    __local_25 = self.input;
-                    self.pos = _hfs_pos_49;
-                    break __inline_String__len_5: __local_25.used;
-                } {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
-                        __local_26 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
-                    });
-                }
-                c_4 = __inline_String__get_byte_7: block -> u8 {
-                    __local_27 = self.input;
-                    __local_28 = _hfs_pos_49;
-                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_27.repr, __local_28);
-                };
-                if c_4 == 93 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                    self.pos = _hfs_pos_49;
-                    return ref.null none;
-                }
-                if c_4 == 44 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                } else {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
-                        __local_29 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
-                        __local_30 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_29, offset: __local_30 };
-                    });
-                }
-                continue l282;
-            };
-        };
-        self.pos = _hfs_pos_49;
-    }
-    if b == 123 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_9: block -> i32 {
-            __local_31 = self.input;
-            break __inline_String__len_9: __local_31.used;
-        } -> i32 {
-            __inline_String__get_byte_10: block -> u8 {
-                __local_32 = self.input;
-                __local_33 = self.pos;
-                break __inline_String__get_byte_10: builtin::array_get_u8(__local_32.repr, __local_33);
-            } == 125;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_50 = self.pos;
-        block {
-            l291: loop {
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if (if _hfs_pos_50 >= __inline_String__len_11: block -> i32 {
-                    __local_34 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_11: __local_34.used;
-                } -> i32 {
-                    1;
-                } else {
-                    __inline_String__get_byte_12: block -> u8 {
-                        __local_35 = self.input;
-                        __local_36 = _hfs_pos_50;
-                        self.pos = _hfs_pos_50;
-                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_35.repr, __local_36);
-                    } != 34;
-                }) {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
-                        __local_37 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-                        __local_38 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_37, offset: __local_38 };
-                    });
-                }
-                self.pos = _hfs_pos_50;
-                kr = "core:json/JsonDeserializer::skip_string"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(kr) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(kr));
-                    self.pos = _hfs_pos_50;
-                    return e_6;
-                }
-                self.pos = _hfs_pos_50;
-                cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(cr) == 0 {
-                    e_8 = value_copy "core:serde//DeserializeError"(ref.as_non_null(cr));
-                    self.pos = _hfs_pos_50;
-                    return e_8;
-                }
-                self.pos = _hfs_pos_50;
-                vr = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(vr) == 0 {
-                    e_10 = value_copy "core:serde//DeserializeError"(ref.as_non_null(vr));
-                    self.pos = _hfs_pos_50;
-                    return e_10;
-                }
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if _hfs_pos_50 >= __inline_String__len_14: block -> i32 {
-                    __local_39 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_14: __local_39.used;
-                } {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
-                        __local_40 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-                    });
-                }
-                c_11 = __inline_String__get_byte_16: block -> u8 {
-                    __local_41 = self.input;
-                    __local_42 = _hfs_pos_50;
-                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_41.repr, __local_42);
-                };
-                if c_11 == 125 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                    self.pos = _hfs_pos_50;
-                    return ref.null none;
-                }
-                if c_11 == 44 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                } else {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
-                        __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
-                        __local_44 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
-                    });
-                }
-                continue l291;
-            };
-        };
-        self.pos = _hfs_pos_50;
-    }
-    if (if b == 45 -> i32 {
-        1;
-    } else if b >= 48 -> i32 {
-        b <= 57;
-    } else {
-        0;
-    }) {
-        "core:json/JsonDeserializer::skip_number"(self);
-        return ref.null none;
-    }
-    return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
-        __local_47 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-            __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
-            "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
-            __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
-            "core:prelude/primitive.wado/char^Display::fmt"(b & 255, __local_13);
-            "core:prelude/string.wado/String::push"(__local_12, 39);
-            break __tmpl: __local_12;
-        };
-        __local_48 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_47, offset: __local_48 };
-    });
-}
-
-fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
-    let r_1: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let key_start: i32;
-    let has_escape: bool;
-    let b: i32;
-    let key_end: i32;
-    let r_7: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let idx_9: ref "core:prelude/types.wado//Option<i32>";
-    let i_10: i32;
-    let key_r: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let key: ref "core:prelude/string.wado//String";
-    let r_13: ref null "core:serde//DeserializeError";
-    let e_14: ref "core:serde//DeserializeError";
-    let idx_15: ref "core:prelude/types.wado//Option<i32>";
-    let i_16: i32;
-    let e_17: ref "core:serde//DeserializeError";
-    let __local_25: ref "core:prelude/string.wado//String";
-    let __local_26: i64;
-    let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: ref "core:prelude/string.wado//String";
-    let __local_31: i32;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i64;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_25 = self.de.input;
-        break __inline_String__len_0: __local_25.used;
+        __local_18 = self.de.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
+            __local_19 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_27 = self.de.input;
-        __local_28 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_27.repr, __local_28);
+        __local_20 = self.de.input;
+        __local_21 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } == 125 {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r_1 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r_1) == 0 {
-            e_2 = ref.as_non_null(r_1);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if (if self.de.pos >= __inline_String__len_3: block -> i32 {
-        __local_29 = self.de.input;
-        break __inline_String__len_3: __local_29.used;
+        __local_22 = self.de.input;
+        break __inline_String__len_3: __local_22.used;
     } -> i32 {
         1;
     } else {
         __inline_String__get_byte_4: block -> u8 {
-            __local_30 = self.de.input;
-            __local_31 = self.de.pos;
-            break __inline_String__get_byte_4: builtin::array_get_u8(__local_30.repr, __local_31);
+            __local_23 = self.de.input;
+            __local_24 = self.de.pos;
+            break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
         } != 34;
     }) {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_5: block -> ref "core:serde//DeserializeError" {
-            __local_32 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-            __local_33 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_32, offset: __local_33 };
+            __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_25, offset: __local_26 };
         }) };
     }
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b309: block {
-        l310: loop {
+    b323: block {
+        l324: loop {
             if self.de.pos >= __inline_String__len_6: block -> i32 {
-                __local_34 = self.de.input;
-                break __inline_String__len_6: __local_34.used;
+                __local_27 = self.de.input;
+                break __inline_String__len_6: __local_27.used;
             } {
-                break b309;
+                break b323;
             }
             b = __inline_String__get_byte_7: block -> u8 {
-                __local_35 = self.de.input;
-                __local_36 = self.de.pos;
-                break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
+                __local_28 = self.de.input;
+                __local_29 = self.de.pos;
+                break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
             };
             if b == 34 {
-                break b309;
+                break b323;
             }
             if b == 92 {
                 has_escape = 1;
-                break b309;
+                break b323;
             }
             self.de.pos = self.de.pos + 1;
-            continue l310;
+            continue l324;
         };
     };
     if has_escape == 0 {
         key_end = self.de.pos;
         self.de.pos = self.de.pos + 1;
-        r_7 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_7) == 0 {
-            e_8 = ref.as_non_null(r_7);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_8 };
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_1);
+            __local_8 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        idx_9 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_0: ref "canonical//CanonicalClosure_0";
-            __indirect_call_0 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_0.func, __indirect_call_0.env, self.de.input, key_start, key_end);
+        let __match_scrut_2: ref "core:prelude/types.wado//Option<i32>";
+        __match_scrut_2 = block -> ref "core:prelude/types.wado//Option<i32>" {
+            let __indirect_call_2: ref "canonical//CanonicalClosure_0";
+            __indirect_call_2 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_2.func, __indirect_call_2.env, self.de.input, key_start, key_end);
         };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_9) {
-            i_10 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_9).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_10 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+        idx_10 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2) -> i32 {
+            let __cast_4: ref "core:prelude/types.wado//Option<i32>::Some";
+            __cast_4 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2);
+            __local_9 = __cast_4.payload_0;
+            __local_9;
+        } else if __match_scrut_2.discriminant == 1 -> i32 {
+            -1;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_10 } };
     }
     self.de.pos = key_start - 1;
-    key_r = "core:json/JsonDeserializer::read_json_string"(self.de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r) {
-        key = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r).payload_0);
-        r_13 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_13) == 0 {
-            e_14 = ref.as_non_null(r_13);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_14 };
-        }
-        idx_15 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_1: ref "canonical//CanonicalClosure_0";
-            __indirect_call_1 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_1.func, __indirect_call_1.env, key, 0, key.used);
-        };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_15) {
-            i_16 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_15).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_16 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+    key = value_copy "core:prelude/string.wado//String"(let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self.de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_6: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_6 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+        __local_11 = __cast_6.payload_0;
+        __local_11;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+        __local_12 = __cast_5.payload_0;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_12 };
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    let __match_scrut_4: ref null "core:serde//DeserializeError";
+    __match_scrut_4 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+    if ref.is_null(__match_scrut_4) {
+    } else if ref.is_null(__match_scrut_4) == 0 {
+        let __cast_7: ref null "core:serde//DeserializeError";
+        __cast_7 = ref.as_non_null(__match_scrut_4);
+        __local_15 = ref.as_non_null(__cast_7);
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_15 };
+        unreachable;
+    } else {
+        unreachable;
     }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r) {
-        e_17 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    let __match_scrut_5: ref "core:prelude/types.wado//Option<i32>";
+    __match_scrut_5 = block -> ref "core:prelude/types.wado//Option<i32>" {
+        let __indirect_call_7: ref "canonical//CanonicalClosure_0";
+        __indirect_call_7 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+        call_ref "functype/$canonical_closure_fn_0"(__indirect_call_7.func, __indirect_call_7.env, key, 0, key.used);
+    };
+    idx_17 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5) -> i32 {
+        let __cast_9: ref "core:prelude/types.wado//Option<i32>::Some";
+        __cast_9 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5);
+        __local_16 = __cast_9.payload_0;
+        __local_16;
+    } else if __match_scrut_5.discriminant == 1 -> i32 {
+        -1;
+    } else {
+        unreachable;
+    });
+    return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_17 } };
 }
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_bool"(self) {
-    let b: i32;
-    let r_2: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let r_4: ref null "core:serde//DeserializeError";
-    let e_5: ref "core:serde//DeserializeError";
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:serde//DeserializeError";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
     let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i64;
+    let __local_9: i32;
     let __local_10: ref "core:prelude/string.wado//String";
-    let __local_11: i32;
-    let __local_12: ref "core:prelude/string.wado//String";
-    let __local_13: i64;
+    let __local_11: i64;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_8 = self.input;
-        break __inline_String__len_0: __local_8.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_9 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_9 };
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
         }) };
     }
     b = __inline_String__get_byte_2: block -> u8 {
-        __local_10 = self.input;
-        __local_11 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_10.repr, __local_11);
-    };
+        __local_8 = self.input;
+        __local_9 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_8.repr, __local_9);
+    } & 255;
     if b == 116 {
-        r_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-        if ref.is_null(r_2) == 0 {
-            e_3 = ref.as_non_null(r_2);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_3 };
+        let __match_scrut_2: ref null "core:serde//DeserializeError";
+        __match_scrut_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        if ref.is_null(__match_scrut_2) {
+        } else if ref.is_null(__match_scrut_2) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_2);
+            __local_3 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 1 };
-    }
-    if b == 102 {
-        r_4 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-        if ref.is_null(r_4) == 0 {
-            e_5 = ref.as_non_null(r_4);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
+        unreachable;
+    } else if b == 102 {
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_1);
+            __local_5 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_5 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 0 };
+        unreachable;
+    } else {
+        return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
+            __local_11 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_10, offset: __local_11 };
+        }) };
+        unreachable;
     }
-    return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-        __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
-        __local_13 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_12, offset: __local_13 };
-    }) };
+    unreachable;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_struct"(self, lookup) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 123);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_5: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 123);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_5 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_5;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonStructAccess" { de: self, lookup: lookup, first: 1 }, ref.null none;
 }
@@ -3233,13 +3314,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l330: loop {
+            l351: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l330;
+                continue l351;
             };
         };
     };
@@ -3376,8 +3457,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b353: block {
-        l354: loop {
+    b374: block {
+        l375: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3402,9 +3483,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b353;
+                break b374;
             }
-            continue l354;
+            continue l375;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -3442,8 +3523,8 @@ fn "wado-compiler/tests/fixtures/serde_json_deser_error.wado/User^Deserialize::d
         name = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
         age = 0;
         active = 0;
-        b362: block {
-            l363: loop {
+        b383: block {
+            l384: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -3461,7 +3542,7 @@ fn "wado-compiler/tests/fixtures/serde_json_deser_error.wado/User^Deserialize::d
                                 name = __local_11;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_10).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_10).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_12 = __inline_i32_Deserialize__deserialize_JsonDeserializer__6: block -> ref "core:prelude/types.wado//Result<i32,DeserializeError>" {
@@ -3474,7 +3555,7 @@ fn "wado-compiler/tests/fixtures/serde_json_deser_error.wado/User^Deserialize::d
                                 age = __local_13;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_12).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_12).payload_0 };
                             }
                         } else if __idx == 2 {
                             __local_14 = __inline_bool_Deserialize__deserialize_JsonDeserializer__8: block -> ref "core:prelude/types.wado//Result<bool,DeserializeError>" {
@@ -3487,27 +3568,27 @@ fn "wado-compiler/tests/fixtures/serde_json_deser_error.wado/User^Deserialize::d
                                 active = __local_15;
                                 seen = seen | 4;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__local_14).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__local_14).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b362;
+                        break b383;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l363;
+                continue l384;
             };
         };
         if (seen & 7) != 7 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_json_deser_error.wado//User" { name: name, age: age, active: active }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_json_deser_error.wado//User" { name: name, age: age, active: active } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 

--- a/wado-compiler/tests/fixtures.golden/serde_json_deser_error_edge.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_deser_error_edge.wir.wado
@@ -82,433 +82,509 @@ array builtin::array<u64> (mut u64);  // TypeId(15)
 
 array builtin::array<i32> (mut i32);  // TypeId(16)
 
-variant core:prelude/types.wado//Option<i32> {  // TypeId(17)
+variant core:prelude/types.wado//Option<char> {  // TypeId(17)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(18)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<i32> {  // TypeId(19)
     Some(i32),
     None,
 }
 
-struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(18)
+struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(20)
     discriminant: i32,
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(19)
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(21)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(20)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(22)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(21)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(23)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(22)
+variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(24)
     Ok(bool),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(23)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(25)
     discriminant: i32,
     payload_0: bool,
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(24)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(26)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(25)
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(27)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(26)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(28)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(27)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(29)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<u32,DeserializeError> {  // TypeId(28)
+variant core:prelude/types.wado//Result<u32,DeserializeError> {  // TypeId(30)
     Ok(u32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<u32,DeserializeError>::Ok {  // TypeId(29)
+struct core:prelude/types.wado//Result<u32,DeserializeError>::Ok {  // TypeId(31)
     discriminant: i32,
     payload_0: u32,
 }
 
-struct core:prelude/types.wado//Result<u32,DeserializeError>::Err {  // TypeId(30)
+struct core:prelude/types.wado//Result<u32,DeserializeError>::Err {  // TypeId(32)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Color,DeserializeError> {  // TypeId(31)
+variant core:prelude/types.wado//Result<Point,DeserializeError> {  // TypeId(33)
+    Ok(ref "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//Point"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Point,DeserializeError>::Ok {  // TypeId(34)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//Point",
+}
+
+struct core:prelude/types.wado//Result<Point,DeserializeError>::Err {  // TypeId(35)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<Color,DeserializeError> {  // TypeId(36)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Color,DeserializeError>::Ok {  // TypeId(32)
+struct core:prelude/types.wado//Result<Color,DeserializeError>::Ok {  // TypeId(37)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<Color,DeserializeError>::Err {  // TypeId(33)
+struct core:prelude/types.wado//Result<Color,DeserializeError>::Err {  // TypeId(38)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError> {  // TypeId(34)
+variant core:prelude/types.wado//Result<i64,DeserializeError> {  // TypeId(39)
+    Ok(i64),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<i64,DeserializeError>::Ok {  // TypeId(40)
+    discriminant: i32,
+    payload_0: i64,
+}
+
+struct core:prelude/types.wado//Result<i64,DeserializeError>::Err {  // TypeId(41)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(42)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(43)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(44)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError> {  // TypeId(45)
     Ok(ref "core:json//JsonVariantAccess"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok {  // TypeId(35)
+struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok {  // TypeId(46)
     discriminant: i32,
     payload_0: ref "core:json//JsonVariantAccess",
 }
 
-struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err {  // TypeId(36)
+struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err {  // TypeId(47)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(37)
+variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(48)
     Ok(ref "core:prelude/types.wado//Option<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(38)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(49)
     discriminant: i32,
     payload_0: ref "core:prelude/types.wado//Option<i32>",
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(39)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(50)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-struct core:prelude//Array<u64> {  // TypeId(40)
+struct core:prelude//Array<u64> {  // TypeId(51)
     mut repr: ref builtin::array<u64>,
     mut used: i32,
 }
 
-struct core:prelude//Array<i32> {  // TypeId(41)
+struct core:prelude//Array<i32> {  // TypeId(52)
     mut repr: ref builtin::array<i32>,
     mut used: i32,
 }
 
-enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(42)
+variant core:prelude/types.wado//Result<Array<i32>,DeserializeError> {  // TypeId(53)
+    Ok(ref "core:prelude//Array<i32>"),
+    Err(ref "core:serde//DeserializeError"),
+}
 
-enum wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//enum:Color { Red = 0, Green = 1, Blue = 2 };  // TypeId(43)
+struct core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Ok {  // TypeId(54)
+    discriminant: i32,
+    payload_0: ref "core:prelude//Array<i32>",
+}
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(44)
+struct core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err {  // TypeId(55)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
 
-type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(45)
+enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(56)
 
-struct canonical//CanonicalClosure_0 {  // TypeId(46)
+enum wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//enum:Color { Red = 0, Green = 1, Blue = 2 };  // TypeId(57)
+
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(58)
+
+type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(59)
+
+struct canonical//CanonicalClosure_0 {  // TypeId(60)
     env: ref null struct,
     func: ref "functype/$canonical_closure_fn_0",
 }
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(47)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(61)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(48)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(62)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(49)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(63)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(50)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(64)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(51)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(65)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(52)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(66)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(53)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(67)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(54)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(68)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_2_number_where_bool_expected" = fn();  // TypeId(55)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_2_number_where_bool_expected" = fn();  // TypeId(69)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_3_number_where_string_expected" = fn();  // TypeId(56)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_3_number_where_string_expected" = fn();  // TypeId(70)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_9_truncated_string" = fn();  // TypeId(57)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_9_truncated_string" = fn();  // TypeId(71)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_10_trailing_garbage" = fn();  // TypeId(58)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_10_trailing_garbage" = fn();  // TypeId(72)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_11_multiple_values" = fn();  // TypeId(59)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_11_multiple_values" = fn();  // TypeId(73)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_13_u32_too_large" = fn();  // TypeId(60)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_13_u32_too_large" = fn();  // TypeId(74)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_14_f64_nan_serialize_error" = fn();  // TypeId(61)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_14_f64_nan_serialize_error" = fn();  // TypeId(75)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_15_f64_infinity_serialize_error" = fn();  // TypeId(62)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_15_f64_infinity_serialize_error" = fn();  // TypeId(76)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_16_f64_negative_infinity_serialize_error" = fn();  // TypeId(63)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_16_f64_negative_infinity_serialize_error" = fn();  // TypeId(77)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_17_f32_nan_serialize_error" = fn();  // TypeId(64)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_17_f32_nan_serialize_error" = fn();  // TypeId(78)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_18_f32_infinity_serialize_error" = fn();  // TypeId(65)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_18_f32_infinity_serialize_error" = fn();  // TypeId(79)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_21_struct_missing_required_field" = fn();  // TypeId(66)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_21_struct_missing_required_field" = fn();  // TypeId(80)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_26_option_some_deserialize" = fn();  // TypeId(67)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_26_option_some_deserialize" = fn();  // TypeId(81)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_27_enum_unknown_variant" = fn();  // TypeId(68)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__test_27_enum_unknown_variant" = fn();  // TypeId(82)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/_point_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(69)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/_point_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(83)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_0_string_where_i32_expected" = fn();  // TypeId(70)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_0_string_where_i32_expected" = fn();  // TypeId(84)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_1_bool_where_i32_expected" = fn();  // TypeId(71)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_1_bool_where_i32_expected" = fn();  // TypeId(85)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_2_number_where_bool_expected" = fn();  // TypeId(72)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_2_number_where_bool_expected" = fn();  // TypeId(86)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_3_number_where_string_expected" = fn();  // TypeId(73)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_3_number_where_string_expected" = fn();  // TypeId(87)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_4_null_where_i32_expected" = fn();  // TypeId(74)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_4_null_where_i32_expected" = fn();  // TypeId(88)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_5_array_where_i32_expected" = fn();  // TypeId(75)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_5_array_where_i32_expected" = fn();  // TypeId(89)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_6_object_where_i32_expected" = fn();  // TypeId(76)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_6_object_where_i32_expected" = fn();  // TypeId(90)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_7_empty_input" = fn();  // TypeId(77)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_7_empty_input" = fn();  // TypeId(91)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_8_whitespace_only" = fn();  // TypeId(78)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_8_whitespace_only" = fn();  // TypeId(92)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_9_truncated_string" = fn();  // TypeId(79)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_9_truncated_string" = fn();  // TypeId(93)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_10_trailing_garbage" = fn();  // TypeId(80)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_10_trailing_garbage" = fn();  // TypeId(94)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_11_multiple_values" = fn();  // TypeId(81)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_11_multiple_values" = fn();  // TypeId(95)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_12_u32_negative_value" = fn();  // TypeId(82)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_12_u32_negative_value" = fn();  // TypeId(96)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_13_u32_too_large" = fn();  // TypeId(83)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_13_u32_too_large" = fn();  // TypeId(97)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_14_f64_nan_serialize_error" = fn();  // TypeId(84)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_14_f64_nan_serialize_error" = fn();  // TypeId(98)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_15_f64_infinity_serialize_error" = fn();  // TypeId(85)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_15_f64_infinity_serialize_error" = fn();  // TypeId(99)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_16_f64_negative_infinity_serialize_error" = fn();  // TypeId(86)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_16_f64_negative_infinity_serialize_error" = fn();  // TypeId(100)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_17_f32_nan_serialize_error" = fn();  // TypeId(87)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_17_f32_nan_serialize_error" = fn();  // TypeId(101)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_18_f32_infinity_serialize_error" = fn();  // TypeId(88)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_18_f32_infinity_serialize_error" = fn();  // TypeId(102)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_19_struct_from_non_object" = fn();  // TypeId(89)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_19_struct_from_non_object" = fn();  // TypeId(103)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_20_struct_from_array" = fn();  // TypeId(90)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_20_struct_from_array" = fn();  // TypeId(104)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_21_struct_missing_required_field" = fn();  // TypeId(91)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_21_struct_missing_required_field" = fn();  // TypeId(105)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_22_struct_wrong_field_type" = fn();  // TypeId(92)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_22_struct_wrong_field_type" = fn();  // TypeId(106)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_23_array_malformed" = fn();  // TypeId(93)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_23_array_malformed" = fn();  // TypeId(107)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_24_array_wrong_element_type" = fn();  // TypeId(94)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_24_array_wrong_element_type" = fn();  // TypeId(108)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_25_option_null_deserialize" = fn();  // TypeId(95)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_25_option_null_deserialize" = fn();  // TypeId(109)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_26_option_some_deserialize" = fn();  // TypeId(96)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_26_option_some_deserialize" = fn();  // TypeId(110)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_27_enum_unknown_variant" = fn();  // TypeId(97)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_27_enum_unknown_variant" = fn();  // TypeId(111)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_28_enum_non_string_value" = fn();  // TypeId(98)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__cm_export____test_28_enum_non_string_value" = fn();  // TypeId(112)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__initialize_module" = fn();  // TypeId(99)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__initialize_module" = fn();  // TypeId(113)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(100)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(114)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(101)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(115)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(102)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(116)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(103)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(117)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(104)
+type "functype//core:internal/unreachable" = fn();  // TypeId(118)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(105)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(119)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(106)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(120)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(107)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(121)
 
-type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(108)
+type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(122)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(109)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(123)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(110)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(124)
 
-type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(111)
+type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(125)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(112)
+type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(126)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(113)
+type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(127)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(114)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(128)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(115)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(129)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(116)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(130)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(117)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(131)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(118)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(132)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(119)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(133)
 
-type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(120)
+type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(134)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(121)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(135)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(122)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(136)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(123)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(137)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(124)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(138)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(125)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(139)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(126)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(140)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(127)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(141)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(128)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(142)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(129)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(143)
 
-type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(130)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(144)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(131)
+type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(145)
 
-type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(132)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(146)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(133)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(147)
 
-type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(134)
+type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(148)
 
-type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(135)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(149)
 
-type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(136)
+type "functype//core:json/JsonDeserializer::parse_i64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(150)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_u32" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u32,DeserializeError>";  // TypeId(137)
+type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(151)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(138)
+type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(152)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(139)
+type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(153)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(140)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_u32" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u32,DeserializeError>";  // TypeId(154)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(141)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(155)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(142)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(156)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(143)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(157)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(144)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(158)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(145)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(159)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Color^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Color,DeserializeError>";  // TypeId(146)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(160)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(147)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(161)
 
-type "functype//core:prelude/array.wado/Array<i32>::push" = fn(ref "core:prelude//Array<i32>", i32);  // TypeId(148)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(162)
 
-type "functype//core:prelude/array.wado/Array<i32>::grow" = fn(ref "core:prelude//Array<i32>");  // TypeId(149)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Color^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Color,DeserializeError>";  // TypeId(163)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/u32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u32,DeserializeError>";  // TypeId(150)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Option<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(164)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(151)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(165)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/bool^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(152)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Array<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Array<i32>,DeserializeError>";  // TypeId(166)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(153)
+type "functype//core:prelude/array.wado/Array<i32>::push" = fn(ref "core:prelude//Array<i32>", i32);  // TypeId(167)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(154)
+type "functype//core:prelude/array.wado/Array<i32>::grow" = fn(ref "core:prelude//Array<i32>");  // TypeId(168)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(155)
+type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(169)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(156)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Point^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Point,DeserializeError>";  // TypeId(170)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(157)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/u32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u32,DeserializeError>";  // TypeId(171)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(158)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(172)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(159)
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/bool^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(173)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(160)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(174)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(161)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(175)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(162)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(176)
 
-type "functype//core:json/core/json/from_string<Color>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(163)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(177)
 
-type "functype//core:json/core/json/from_string<Option<i32>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/types.wado//Option<i32>", ref null "core:serde//DeserializeError"];  // TypeId(164)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(178)
 
-type "functype//core:json/core/json/from_string<Array<i32>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude//Array<i32>", ref null "core:serde//DeserializeError"];  // TypeId(165)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(179)
 
-type "functype//core:json/core/json/from_string<Point>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//Point", ref null "core:serde//DeserializeError"];  // TypeId(166)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(180)
 
-type "functype//core:json/core/json/from_string<u32>" = fn(ref "core:prelude/string.wado//String") -> [i32, u32, ref null "core:serde//DeserializeError"];  // TypeId(167)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(181)
 
-type "functype//core:json/core/json/from_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(168)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(182)
 
-type "functype//core:json/core/json/from_string<bool>" = fn(ref "core:prelude/string.wado//String") -> [i32, bool, ref null "core:serde//DeserializeError"];  // TypeId(169)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(183)
 
-type "functype//core:json/core/json/from_string<i32>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(170)
+type "functype//core:json/core/json/from_string<Color>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(184)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(171)
+type "functype//core:json/core/json/from_string<Option<i32>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/types.wado//Option<i32>", ref null "core:serde//DeserializeError"];  // TypeId(185)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(172)
+type "functype//core:json/core/json/from_string<Array<i32>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude//Array<i32>", ref null "core:serde//DeserializeError"];  // TypeId(186)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(173)
+type "functype//core:json/core/json/from_string<Point>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//Point", ref null "core:serde//DeserializeError"];  // TypeId(187)
 
-type "functype//core:json/JsonDeserializer::parse_i64_direct" = fn(ref "core:json//JsonDeserializer") -> [i32, i64, ref null "core:serde//DeserializeError"];  // TypeId(174)
+type "functype//core:json/core/json/from_string<u32>" = fn(ref "core:prelude/string.wado//String") -> [i32, u32, ref null "core:serde//DeserializeError"];  // TypeId(188)
 
-type "functype//core:json/JsonDeserializer^Deserializer::is_null" = fn(ref "core:json//JsonDeserializer") -> [i32, bool, ref null "core:serde//DeserializeError"];  // TypeId(175)
+type "functype//core:json/core/json/from_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(189)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_seq" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:json//JsonSeqAccess", ref null "core:serde//DeserializeError"];  // TypeId(176)
+type "functype//core:json/core/json/from_string<bool>" = fn(ref "core:prelude/string.wado//String") -> [i32, bool, ref null "core:serde//DeserializeError"];  // TypeId(190)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Option<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude/types.wado//Option<i32>", ref null "core:serde//DeserializeError"];  // TypeId(177)
+type "functype//core:json/core/json/from_string<i32>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(191)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Array<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude//Array<i32>", ref null "core:serde//DeserializeError"];  // TypeId(178)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(192)
 
-type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>" = fn(ref "core:json//JsonSeqAccess") -> [i32, ref null "core:prelude/types.wado//Option<i32>", ref null "core:serde//DeserializeError"];  // TypeId(179)
+type "functype//core:json/JsonDeserializer^Deserializer::is_null" = fn(ref "core:json//JsonDeserializer") -> [i32, bool, ref null "core:serde//DeserializeError"];  // TypeId(193)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Point^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//Point", ref null "core:serde//DeserializeError"];  // TypeId(180)
+type "functype//core:json/JsonDeserializer^Deserializer::begin_seq" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:json//JsonSeqAccess", ref null "core:serde//DeserializeError"];  // TypeId(194)
 
-type "functype//core:json/core/json/to_string<f32>" = fn(f32) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(181)
+type "functype//core:json/core/json/to_string<f32>" = fn(f32) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(195)
 
-type "functype//core:json/core/json/to_string<f64>" = fn(f64) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(182)
+type "functype//core:json/core/json/to_string<f64>" = fn(f64) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(196)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(183)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(197)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(184)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(198)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(185)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(199)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(186)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(200)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f32" = fn(ref "core:prelude/string.wado//String", f32) -> ref null "core:serde//SerializeError";  // TypeId(187)
+type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(201)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(188)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(202)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(189)
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(203)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_variant" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>";  // TypeId(190)
+type "functype//core:json/JsonSerializer^Serializer::serialize_f32" = fn(ref "core:prelude/string.wado//String", f32) -> ref null "core:serde//SerializeError";  // TypeId(204)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(191)
+type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(205)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(206)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_variant" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>";  // TypeId(207)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(208)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -2656,311 +2732,409 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/core/json/from_string<Color>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<Color,DeserializeError>";
+    let __local_2: "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//enum:Color";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//enum:Color";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Color^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<Color,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<Color,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<Color,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Color^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<Color,DeserializeError>::Ok"(__match_scrut_0) -> "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//enum:Color" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Color,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Color,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Color,DeserializeError>::Err"(__match_scrut_0) -> "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//enum:Color" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Color,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Color,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<Color,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<Color,DeserializeError>::Err"(r).payload_0);
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/from_string<Option<i32>>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "core:prelude/types.wado//Option<i32>";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "core:prelude/types.wado//Option<i32>";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Option<i32>^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:prelude/types.wado//Option<i32>"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Option<i32>^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<i32>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/types.wado//Option<i32>" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/from_string<Array<i32>>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "core:prelude//Array<i32>";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "core:prelude//Array<i32>";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "core:prelude//Array<i32>";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Array<i32>^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:prelude//Array<i32>"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Array<i32>,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Array<i32>^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude//Array<i32>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude//Array<i32>" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/from_string<Point>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//Point";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//Point";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//Point";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Point^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//Point"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Point,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Point^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Point,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//Point" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Point,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Point,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Point,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//Point" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Point,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Point,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<f32>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_f32"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_f32"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<f64>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_f64"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_f64"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<u32>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<u32,DeserializeError>";
+    let __local_2: u32;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: u32;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/u32^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<u32,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<u32,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<u32,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/u32^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<u32,DeserializeError>::Ok"(__match_scrut_0) -> u32 {
+        let __cast_2: ref "core:prelude/types.wado//Result<u32,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<u32,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<u32,DeserializeError>::Err"(__match_scrut_0) -> u32 {
+        let __cast_1: ref "core:prelude/types.wado//Result<u32,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<u32,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<u32,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<u32,DeserializeError>::Err"(r).payload_0);
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/from_string<String>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+    let __local_2: ref "core:prelude/string.wado//String";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "core:prelude/string.wado//String";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/String^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r) {
-        v = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r).payload_0);
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:prelude/string.wado//String"(let __match_scrut_0: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/String^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+        let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+        let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r).payload_0);
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/from_string<bool>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<bool,DeserializeError>";
+    let __local_2: bool;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: bool;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/bool^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<bool,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<bool,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/bool^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<bool,DeserializeError>::Ok"(__match_scrut_0) -> bool {
+        let __cast_2: ref "core:prelude/types.wado//Result<bool,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__match_scrut_0) -> bool {
+        let __cast_1: ref "core:prelude/types.wado//Result<bool,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(r).payload_0);
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/from_string<i32>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
+    let __local_2: i32;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: i32;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/i32^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/i32^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_0) -> i32 {
+        let __cast_2: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_0) -> i32 {
+        let __cast_1: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(r).payload_0);
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -3240,7 +3414,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l256: loop {
+            l269: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -3248,7 +3422,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l256;
+                continue l269;
             };
         };
     };
@@ -3297,6 +3471,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -3381,10 +3604,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b271: block {
-        l272: loop {
+    b291: block {
+        l292: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b271;
+                break b291;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -3408,7 +3631,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l272;
+            continue l292;
         };
     };
     self.pos = _hfs_pos_8;
@@ -3487,11 +3710,11 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b280: block {
-        l281: loop {
+    b300: block {
+        l301: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= _licm_used_19 {
-                    break b280;
+                    break b300;
                 }
                 byte = builtin::array_get_u8(_licm_repr_20, __sroa___iter_3_index);
                 __sroa___iter_3_index = __sroa___iter_3_index + 1;
@@ -3526,7 +3749,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
                 _hfs_pos_27 = _hfs_pos_27 + 1;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l281;
+            continue l301;
         };
     };
     self.pos = _hfs_pos_27;
@@ -3545,130 +3768,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b287: block {
-        l288: loop {
-            if scan_pos >= _licm_used_90 {
-                break b287;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b307: block {
+        l308: loop {
+            if scan_pos >= _licm_used_56 {
+                break b307;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b287;
+                break b307;
             }
             scan_pos = scan_pos + 1;
-            continue l288;
+            continue l308;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -3677,22 +3872,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l295: loop {
+                l315: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l295;
+                    continue l315;
                 };
             };
         };
@@ -3700,71 +3895,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l298: loop {
+            l318: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l298;
+                continue l318;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b300: block {
-        l301: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b320: block {
+        l321: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b300;
+                break b320;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -3782,125 +3978,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l301;
+            continue l321;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -3908,87 +4047,71 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l326: loop {
+            l341: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l326;
+                continue l341;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -4043,25 +4166,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b337: block {
-        l338: loop {
+    b348: block {
+        l349: loop {
             if _hfs_pos_36 >= _licm_used_28 {
-                break b337;
+                break b348;
             }
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
                 break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr_29, __local_11);
             };
-            if (if b_1 >= 48 -> i32 {
+            if (if 48 <= b_1 -> i32 {
                 b_1 <= 57;
             } else {
                 0;
             }) {
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
-                break b337;
+                break b348;
             }
-            continue l338;
+            continue l349;
         };
     };
     self.pos = _hfs_pos_36;
@@ -4082,25 +4205,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b344: block {
-            l345: loop {
+        b355: block {
+            l356: loop {
                 if _hfs_pos_37 >= _licm_used_31 {
-                    break b344;
+                    break b355;
                 }
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
                     break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_32, __local_17);
                 };
-                if (if b_2 >= 48 -> i32 {
+                if (if 48 <= b_2 -> i32 {
                     b_2 <= 57;
                 } else {
                     0;
                 }) {
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
-                    break b344;
+                    break b355;
                 }
-                continue l345;
+                continue l356;
             };
         };
         self.pos = _hfs_pos_37;
@@ -4141,25 +4264,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b355: block {
-                l356: loop {
+            b366: block {
+                l367: loop {
                     if _hfs_pos_38 >= _licm_used_34 {
-                        break b355;
+                        break b366;
                     }
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
                         break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_35, __local_26);
                     };
-                    if (if b2 >= 48 -> i32 {
+                    if (if 48 <= b2 -> i32 {
                         b2 <= 57;
                     } else {
                         0;
                     }) {
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
-                        break b355;
+                        break b366;
                     }
-                    continue l356;
+                    continue l367;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -4253,16 +4376,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b365: block {
-        l366: loop {
+    b376: block {
+        l377: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b365;
+                break b376;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -4283,17 +4406,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b374: block {
-                        l375: loop {
+                    b385: block {
+                        l386: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b374;
+                                break b385;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -4303,9 +4426,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b374;
+                                break b385;
                             }
-                            continue l375;
+                            continue l386;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -4336,17 +4459,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b384: block {
-                            l385: loop {
+                        b395: block {
+                            l396: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b384;
+                                    break b395;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -4355,9 +4478,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b384;
+                                    break b395;
                                 }
-                                continue l385;
+                                continue l396;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -4395,9 +4518,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b365;
+                break b376;
             }
-            continue l366;
+            continue l377;
         };
     };
     self.pos = _hfs_pos_51;
@@ -4450,7 +4573,7 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
         __local_16 = self.input;
         break __inline_String__len_0: __local_16.used;
     } {
-        return 1, 0_i64, struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: start };
+        return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: start } };
     }
     neg = 0;
     if __inline_String__get_byte_2: block -> u8 {
@@ -4465,10 +4588,10 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
         __local_20 = self.input;
         break __inline_String__len_3: __local_20.used;
     } {
-        return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__eof_4: block -> ref "core:serde//DeserializeError" {
+        return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_4: block -> ref "core:serde//DeserializeError" {
             __local_21 = builtin::i64_extend_i32_s(self.pos);
             break __inline_DeserializeError__eof_4: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_21 };
-        });
+        }) };
     }
     first = __inline_String__get_byte_5: block -> u8 {
         __local_22 = self.input;
@@ -4480,11 +4603,11 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
     } else {
         first > 57;
     }) {
-        return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__unexpected_type_6: block -> ref "core:serde//DeserializeError" {
+        return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_6: block -> ref "core:serde//DeserializeError" {
             __local_24 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected number"), used: 15 };
             __local_25 = builtin::i64_extend_i32_s(self.pos);
             break __inline_DeserializeError__unexpected_type_6: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_24, offset: __local_25 };
-        });
+        }) };
     }
     result = builtin::i64_extend_i32_s(first - 48);
     self.pos = self.pos + 1;
@@ -4492,16 +4615,16 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b400: block {
-        l401: loop {
+    b411: block {
+        l412: loop {
             if _hfs_pos_49 >= _licm_used_45 {
-                break b400;
+                break b411;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_49;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_46, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -4522,17 +4645,17 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b409: block {
-                        l410: loop {
+                    b420: block {
+                        l421: loop {
                             if _hfs_pos_47 >= _licm_used_45 {
                                 self.pos = _hfs_pos_49;
-                                break b409;
+                                break b420;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_47;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_46, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -4542,9 +4665,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                                 _hfs_pos_47 = _hfs_pos_47 + 1;
                             } else {
                                 self.pos = _hfs_pos_49;
-                                break b409;
+                                break b420;
                             }
-                            continue l410;
+                            continue l421;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -4575,17 +4698,17 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                             }
                         }
                         _hfs_pos_48 = _hfs_pos_49;
-                        b419: block {
-                            l420: loop {
+                        b430: block {
+                            l431: loop {
                                 if _hfs_pos_48 >= _licm_used_45 {
                                     self.pos = _hfs_pos_49;
-                                    break b419;
+                                    break b430;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_48;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_46, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -4594,9 +4717,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                                     _hfs_pos_48 = _hfs_pos_48 + 1;
                                 } else {
                                     self.pos = _hfs_pos_49;
-                                    break b419;
+                                    break b430;
                                 }
-                                continue l420;
+                                continue l431;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -4613,25 +4736,25 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                 });
                 if v_signed != builtin::f64_floor(v_signed) {
                     self.pos = _hfs_pos_49;
-                    return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__unexpected_type_18: block -> ref "core:serde//DeserializeError" {
+                    return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_18: block -> ref "core:serde//DeserializeError" {
                         __local_42 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
                         self.pos = _hfs_pos_49;
                         break __inline_DeserializeError__unexpected_type_18: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_42, offset: start };
-                    });
+                    }) };
                 }
                 self.pos = _hfs_pos_49;
-                return 0, builtin::i64_trunc_f64_s(v_signed), ref.null none;
+                return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v_signed) };
             } else {
-                break b400;
+                break b411;
             }
-            continue l401;
+            continue l412;
         };
     };
     self.pos = _hfs_pos_49;
     if neg {
         result = 0_i64 - result;
     }
-    return 0, result, ref.null none;
+    return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Ok" { discriminant: 0, payload_0: result };
 }
 
 fn "core:json/JsonDeserializer::skip_string"(self) {
@@ -4650,10 +4773,10 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b428: block {
-        l429: loop {
+    b439: block {
+        l440: loop {
             if _hfs_pos_14 >= _licm_used_12 {
-                break b428;
+                break b439;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -4683,7 +4806,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
                 }
             }
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l429;
+            continue l440;
         };
     };
     self.pos = _hfs_pos_14;
@@ -4694,19 +4817,284 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
 }
 
 fn "core:json/JsonDeserializer::skip_value"(self) {
-    let b: i32;
-    let r: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let c_4: i32;
-    let kr: ref null "core:serde//DeserializeError";
-    let e_6: ref "core:serde//DeserializeError";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let vr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let c_11: i32;
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: char;
+    let __local_6: ref "core:serde//DeserializeError";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_10: ref "core:serde//DeserializeError";
+    let __local_11: char;
     let __local_12: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/format.wado//Formatter";
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i64;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i32;
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
+    let __local_20: i32;
+    let __local_21: ref "core:prelude/string.wado//String";
+    let __local_22: i64;
+    let __local_23: ref "core:prelude/string.wado//String";
+    let __local_24: i32;
+    let __local_25: ref "core:prelude/string.wado//String";
+    let __local_26: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let __local_30: ref "core:prelude/string.wado//String";
+    let __local_31: ref "core:prelude/string.wado//String";
+    let __local_32: i32;
+    let __local_33: ref "core:prelude/string.wado//String";
+    let __local_34: i64;
+    let __local_35: ref "core:prelude/string.wado//String";
+    let __local_36: i64;
+    let __local_37: ref "core:prelude/string.wado//String";
+    let __local_38: i32;
+    let __local_39: ref "core:prelude/string.wado//String";
+    let __local_40: i64;
+    let __local_43: ref "core:prelude/string.wado//String";
+    let __local_44: i64;
+    "core:json/JsonDeserializer::skip_whitespace"(self);
+    if self.pos >= __inline_String__len_0: block -> i32 {
+        __local_14 = self.input;
+        break __inline_String__len_0: __local_14.used;
+    } {
+        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_15 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_15 };
+        });
+    }
+    b = __inline_String__get_byte_2: block -> u8 {
+        __local_16 = self.input;
+        __local_17 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_16.repr, __local_17);
+    } & 255;
+    if b == 34 {
+        return "core:json/JsonDeserializer::skip_string"(self);
+        unreachable;
+    } else if b == 116 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        unreachable;
+    } else if b == 102 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        unreachable;
+    } else if b == 110 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
+        unreachable;
+    } else if b == 91 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_3: block -> i32 {
+            __local_18 = self.input;
+            break __inline_String__len_3: __local_18.used;
+        } -> i32 {
+            __inline_String__get_byte_4: block -> u8 {
+                __local_19 = self.input;
+                __local_20 = self.pos;
+                break __inline_String__get_byte_4: builtin::array_get_u8(__local_19.repr, __local_20);
+            } == 93;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l455: loop {
+                let __match_scrut_5: ref null "core:serde//DeserializeError";
+                __match_scrut_5 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_5) {
+                } else if ref.is_null(__match_scrut_5) == 0 {
+                    let __cast_4: ref null "core:serde//DeserializeError";
+                    __cast_4 = ref.as_non_null(__match_scrut_5);
+                    __local_3 = ref.as_non_null(__cast_4);
+                    return __local_3;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_5: block -> i32 {
+                    __local_21 = self.input;
+                    break __inline_String__len_5: __local_21.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
+                        __local_22 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_22 };
+                    });
+                }
+                __local_4 = __inline_String__get_byte_7: block -> u8 {
+                    __local_23 = self.input;
+                    __local_24 = self.pos;
+                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_23.repr, __local_24);
+                } & 255;
+                if __local_4 == 93 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_4 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
+                        __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
+                        __local_26 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_25, offset: __local_26 };
+                    });
+                    unreachable;
+                }
+                continue l455;
+            };
+        };
+    } else if b == 123 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_9: block -> i32 {
+            __local_27 = self.input;
+            break __inline_String__len_9: __local_27.used;
+        } -> i32 {
+            __inline_String__get_byte_10: block -> u8 {
+                __local_28 = self.input;
+                __local_29 = self.pos;
+                break __inline_String__get_byte_10: builtin::array_get_u8(__local_28.repr, __local_29);
+            } == 125;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l465: loop {
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if (if self.pos >= __inline_String__len_11: block -> i32 {
+                    __local_30 = self.input;
+                    break __inline_String__len_11: __local_30.used;
+                } -> i32 {
+                    1;
+                } else {
+                    __inline_String__get_byte_12: block -> u8 {
+                        __local_31 = self.input;
+                        __local_32 = self.pos;
+                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_31.repr, __local_32);
+                    } != 34;
+                }) {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
+                        __local_33 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+                        __local_34 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_33, offset: __local_34 };
+                    });
+                }
+                let __match_scrut_1: ref null "core:serde//DeserializeError";
+                __match_scrut_1 = "core:json/JsonDeserializer::skip_string"(self);
+                if ref.is_null(__match_scrut_1) {
+                } else if ref.is_null(__match_scrut_1) == 0 {
+                    let __cast_1: ref null "core:serde//DeserializeError";
+                    __cast_1 = ref.as_non_null(__match_scrut_1);
+                    __local_6 = ref.as_non_null(__cast_1);
+                    return __local_6;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_2: ref null "core:serde//DeserializeError";
+                __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+                if ref.is_null(__match_scrut_2) {
+                } else if ref.is_null(__match_scrut_2) == 0 {
+                    let __cast_2: ref null "core:serde//DeserializeError";
+                    __cast_2 = ref.as_non_null(__match_scrut_2);
+                    __local_8 = ref.as_non_null(__cast_2);
+                    return __local_8;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_3: ref null "core:serde//DeserializeError";
+                __match_scrut_3 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_3) {
+                } else if ref.is_null(__match_scrut_3) == 0 {
+                    let __cast_3: ref null "core:serde//DeserializeError";
+                    __cast_3 = ref.as_non_null(__match_scrut_3);
+                    __local_10 = ref.as_non_null(__cast_3);
+                    return __local_10;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_14: block -> i32 {
+                    __local_35 = self.input;
+                    break __inline_String__len_14: __local_35.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
+                        __local_36 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_36 };
+                    });
+                }
+                __local_11 = __inline_String__get_byte_16: block -> u8 {
+                    __local_37 = self.input;
+                    __local_38 = self.pos;
+                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_37.repr, __local_38);
+                } & 255;
+                if __local_11 == 125 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_11 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
+                        __local_39 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
+                        __local_40 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_39, offset: __local_40 };
+                    });
+                    unreachable;
+                }
+                continue l465;
+            };
+        };
+    } else {
+        if (if b == 45 -> i32 {
+            1;
+        } else if 48 <= b -> i32 {
+            b <= 57;
+        } else {
+            0;
+        }) {
+            "core:json/JsonDeserializer::skip_number"(self);
+            return ref.null none;
+        }
+        return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
+            __local_43 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
+                "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
+                __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
+                "core:prelude/primitive.wado/char^Display::fmt"(b, __local_13);
+                "core:prelude/string.wado/String::push"(__local_12, 39);
+                break __tmpl: __local_12;
+            };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
+        });
+        unreachable;
+    }
+}
+
+fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
+    let __local_2: ref "core:serde//DeserializeError";
+    let key_start: i32;
+    let has_escape: bool;
+    let b: i32;
+    let key_end: i32;
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: i32;
+    let idx_10: i32;
+    let __local_11: ref "core:prelude/string.wado//String";
+    let __local_12: ref "core:serde//DeserializeError";
+    let key: ref "core:prelude/string.wado//String";
+    let __local_15: ref "core:serde//DeserializeError";
+    let __local_16: i32;
+    let idx_17: i32;
     let __local_18: ref "core:prelude/string.wado//String";
     let __local_19: i64;
     let __local_20: ref "core:prelude/string.wado//String";
@@ -4717,487 +5105,265 @@ fn "core:json/JsonDeserializer::skip_value"(self) {
     let __local_25: ref "core:prelude/string.wado//String";
     let __local_26: i64;
     let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: i64;
-    let __local_31: ref "core:prelude/string.wado//String";
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i32;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
-    let __local_37: ref "core:prelude/string.wado//String";
-    let __local_38: i64;
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
-    let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_47: ref "core:prelude/string.wado//String";
-    let __local_48: i64;
-    let _hfs_pos_49: i32;
-    let _hfs_pos_50: i32;
-    "core:json/JsonDeserializer::skip_whitespace"(self);
-    if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_18 = self.input;
-        break __inline_String__len_0: __local_18.used;
-    } {
-        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_19 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
-        });
-    }
-    b = __inline_String__get_byte_2: block -> u8 {
-        __local_20 = self.input;
-        __local_21 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
-    };
-    if b == 34 {
-        return "core:json/JsonDeserializer::skip_string"(self);
-    }
-    if b == 116 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-    }
-    if b == 102 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-    }
-    if b == 110 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
-    }
-    if b == 91 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_3: block -> i32 {
-            __local_22 = self.input;
-            break __inline_String__len_3: __local_22.used;
-        } -> i32 {
-            __inline_String__get_byte_4: block -> u8 {
-                __local_23 = self.input;
-                __local_24 = self.pos;
-                break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
-            } == 93;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_49 = self.pos;
-        block {
-            l444: loop {
-                self.pos = _hfs_pos_49;
-                r = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_49 = self.pos;
-                if ref.is_null(r) == 0 {
-                    e_3 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-                    self.pos = _hfs_pos_49;
-                    return e_3;
-                }
-                self.pos = _hfs_pos_49;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_49 = self.pos;
-                if _hfs_pos_49 >= __inline_String__len_5: block -> i32 {
-                    __local_25 = self.input;
-                    self.pos = _hfs_pos_49;
-                    break __inline_String__len_5: __local_25.used;
-                } {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
-                        __local_26 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
-                    });
-                }
-                c_4 = __inline_String__get_byte_7: block -> u8 {
-                    __local_27 = self.input;
-                    __local_28 = _hfs_pos_49;
-                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_27.repr, __local_28);
-                };
-                if c_4 == 93 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                    self.pos = _hfs_pos_49;
-                    return ref.null none;
-                }
-                if c_4 == 44 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                } else {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
-                        __local_29 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
-                        __local_30 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_29, offset: __local_30 };
-                    });
-                }
-                continue l444;
-            };
-        };
-        self.pos = _hfs_pos_49;
-    }
-    if b == 123 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_9: block -> i32 {
-            __local_31 = self.input;
-            break __inline_String__len_9: __local_31.used;
-        } -> i32 {
-            __inline_String__get_byte_10: block -> u8 {
-                __local_32 = self.input;
-                __local_33 = self.pos;
-                break __inline_String__get_byte_10: builtin::array_get_u8(__local_32.repr, __local_33);
-            } == 125;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_50 = self.pos;
-        block {
-            l453: loop {
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if (if _hfs_pos_50 >= __inline_String__len_11: block -> i32 {
-                    __local_34 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_11: __local_34.used;
-                } -> i32 {
-                    1;
-                } else {
-                    __inline_String__get_byte_12: block -> u8 {
-                        __local_35 = self.input;
-                        __local_36 = _hfs_pos_50;
-                        self.pos = _hfs_pos_50;
-                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_35.repr, __local_36);
-                    } != 34;
-                }) {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
-                        __local_37 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-                        __local_38 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_37, offset: __local_38 };
-                    });
-                }
-                self.pos = _hfs_pos_50;
-                kr = "core:json/JsonDeserializer::skip_string"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(kr) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(kr));
-                    self.pos = _hfs_pos_50;
-                    return e_6;
-                }
-                self.pos = _hfs_pos_50;
-                cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(cr) == 0 {
-                    e_8 = value_copy "core:serde//DeserializeError"(ref.as_non_null(cr));
-                    self.pos = _hfs_pos_50;
-                    return e_8;
-                }
-                self.pos = _hfs_pos_50;
-                vr = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(vr) == 0 {
-                    e_10 = value_copy "core:serde//DeserializeError"(ref.as_non_null(vr));
-                    self.pos = _hfs_pos_50;
-                    return e_10;
-                }
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if _hfs_pos_50 >= __inline_String__len_14: block -> i32 {
-                    __local_39 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_14: __local_39.used;
-                } {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
-                        __local_40 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-                    });
-                }
-                c_11 = __inline_String__get_byte_16: block -> u8 {
-                    __local_41 = self.input;
-                    __local_42 = _hfs_pos_50;
-                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_41.repr, __local_42);
-                };
-                if c_11 == 125 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                    self.pos = _hfs_pos_50;
-                    return ref.null none;
-                }
-                if c_11 == 44 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                } else {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
-                        __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
-                        __local_44 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
-                    });
-                }
-                continue l453;
-            };
-        };
-        self.pos = _hfs_pos_50;
-    }
-    if (if b == 45 -> i32 {
-        1;
-    } else if b >= 48 -> i32 {
-        b <= 57;
-    } else {
-        0;
-    }) {
-        "core:json/JsonDeserializer::skip_number"(self);
-        return ref.null none;
-    }
-    return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
-        __local_47 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-            __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
-            "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
-            __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
-            "core:prelude/primitive.wado/char^Display::fmt"(b & 255, __local_13);
-            "core:prelude/string.wado/String::push"(__local_12, 39);
-            break __tmpl: __local_12;
-        };
-        __local_48 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_47, offset: __local_48 };
-    });
-}
-
-fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
-    let r_1: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let key_start: i32;
-    let has_escape: bool;
-    let b: i32;
-    let key_end: i32;
-    let r_7: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let idx_9: ref "core:prelude/types.wado//Option<i32>";
-    let i_10: i32;
-    let key_r: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let key: ref "core:prelude/string.wado//String";
-    let r_13: ref null "core:serde//DeserializeError";
-    let e_14: ref "core:serde//DeserializeError";
-    let idx_15: ref "core:prelude/types.wado//Option<i32>";
-    let i_16: i32;
-    let e_17: ref "core:serde//DeserializeError";
-    let __local_25: ref "core:prelude/string.wado//String";
-    let __local_26: i64;
-    let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: ref "core:prelude/string.wado//String";
-    let __local_31: i32;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i64;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_25 = self.de.input;
-        break __inline_String__len_0: __local_25.used;
+        __local_18 = self.de.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
+            __local_19 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_27 = self.de.input;
-        __local_28 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_27.repr, __local_28);
+        __local_20 = self.de.input;
+        __local_21 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } == 125 {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r_1 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r_1) == 0 {
-            e_2 = ref.as_non_null(r_1);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if (if self.de.pos >= __inline_String__len_3: block -> i32 {
-        __local_29 = self.de.input;
-        break __inline_String__len_3: __local_29.used;
+        __local_22 = self.de.input;
+        break __inline_String__len_3: __local_22.used;
     } -> i32 {
         1;
     } else {
         __inline_String__get_byte_4: block -> u8 {
-            __local_30 = self.de.input;
-            __local_31 = self.de.pos;
-            break __inline_String__get_byte_4: builtin::array_get_u8(__local_30.repr, __local_31);
+            __local_23 = self.de.input;
+            __local_24 = self.de.pos;
+            break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
         } != 34;
     }) {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_5: block -> ref "core:serde//DeserializeError" {
-            __local_32 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-            __local_33 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_32, offset: __local_33 };
+            __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_25, offset: __local_26 };
         }) };
     }
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b471: block {
-        l472: loop {
+    b487: block {
+        l488: loop {
             if self.de.pos >= __inline_String__len_6: block -> i32 {
-                __local_34 = self.de.input;
-                break __inline_String__len_6: __local_34.used;
+                __local_27 = self.de.input;
+                break __inline_String__len_6: __local_27.used;
             } {
-                break b471;
+                break b487;
             }
             b = __inline_String__get_byte_7: block -> u8 {
-                __local_35 = self.de.input;
-                __local_36 = self.de.pos;
-                break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
+                __local_28 = self.de.input;
+                __local_29 = self.de.pos;
+                break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
             };
             if b == 34 {
-                break b471;
+                break b487;
             }
             if b == 92 {
                 has_escape = 1;
-                break b471;
+                break b487;
             }
             self.de.pos = self.de.pos + 1;
-            continue l472;
+            continue l488;
         };
     };
     if has_escape == 0 {
         key_end = self.de.pos;
         self.de.pos = self.de.pos + 1;
-        r_7 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_7) == 0 {
-            e_8 = ref.as_non_null(r_7);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_8 };
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_1);
+            __local_8 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        idx_9 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_0: ref "canonical//CanonicalClosure_0";
-            __indirect_call_0 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_0.func, __indirect_call_0.env, self.de.input, key_start, key_end);
+        let __match_scrut_2: ref "core:prelude/types.wado//Option<i32>";
+        __match_scrut_2 = block -> ref "core:prelude/types.wado//Option<i32>" {
+            let __indirect_call_2: ref "canonical//CanonicalClosure_0";
+            __indirect_call_2 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_2.func, __indirect_call_2.env, self.de.input, key_start, key_end);
         };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_9) {
-            i_10 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_9).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_10 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+        idx_10 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2) -> i32 {
+            let __cast_4: ref "core:prelude/types.wado//Option<i32>::Some";
+            __cast_4 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2);
+            __local_9 = __cast_4.payload_0;
+            __local_9;
+        } else if __match_scrut_2.discriminant == 1 -> i32 {
+            -1;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_10 } };
     }
     self.de.pos = key_start - 1;
-    key_r = "core:json/JsonDeserializer::read_json_string"(self.de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r) {
-        key = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r).payload_0);
-        r_13 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_13) == 0 {
-            e_14 = ref.as_non_null(r_13);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_14 };
-        }
-        idx_15 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_1: ref "canonical//CanonicalClosure_0";
-            __indirect_call_1 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_1.func, __indirect_call_1.env, key, 0, key.used);
-        };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_15) {
-            i_16 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_15).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_16 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+    key = value_copy "core:prelude/string.wado//String"(let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self.de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_6: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_6 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+        __local_11 = __cast_6.payload_0;
+        __local_11;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+        __local_12 = __cast_5.payload_0;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_12 };
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    let __match_scrut_4: ref null "core:serde//DeserializeError";
+    __match_scrut_4 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+    if ref.is_null(__match_scrut_4) {
+    } else if ref.is_null(__match_scrut_4) == 0 {
+        let __cast_7: ref null "core:serde//DeserializeError";
+        __cast_7 = ref.as_non_null(__match_scrut_4);
+        __local_15 = ref.as_non_null(__cast_7);
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_15 };
+        unreachable;
+    } else {
+        unreachable;
     }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r) {
-        e_17 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    let __match_scrut_5: ref "core:prelude/types.wado//Option<i32>";
+    __match_scrut_5 = block -> ref "core:prelude/types.wado//Option<i32>" {
+        let __indirect_call_7: ref "canonical//CanonicalClosure_0";
+        __indirect_call_7 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+        call_ref "functype/$canonical_closure_fn_0"(__indirect_call_7.func, __indirect_call_7.env, key, 0, key.used);
+    };
+    idx_17 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5) -> i32 {
+        let __cast_9: ref "core:prelude/types.wado//Option<i32>::Some";
+        __cast_9 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5);
+        __local_16 = __cast_9.payload_0;
+        __local_16;
+    } else if __match_scrut_5.discriminant == 1 -> i32 {
+        -1;
+    } else {
+        unreachable;
+    });
+    return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_17 } };
 }
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_u32"(self) {
     let start: i64;
+    let __local_2: i64;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: i64;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_5: ref "core:prelude/string.wado//String";
     start = builtin::i64_extend_i32_s(self.pos);
-    let __sroa_ir_discriminant: i32;
-    let __sroa_ir_case0_payload_0: i64;
-    let __sroa_ir_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_ir_discriminant, __sroa_ir_case0_payload_0, __sroa_ir_case1_payload_0] = "core:json/JsonDeserializer::parse_i64_direct"(self);
-    if __sroa_ir_discriminant == 0 {
-        v = __sroa_ir_case0_payload_0;
-        if (if v < 0_i64 -> i32 {
-            1;
-        } else {
-            v > 4294967295_i64;
-        }) {
-            return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__overflow_0: block -> ref "core:serde//DeserializeError" {
-                __local_7 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("value out of range for u32"), used: 26 };
-                break __inline_DeserializeError__overflow_0: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_7, offset: start };
-            }) };
-        }
-        return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_wrap_i64(v) };
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<i64,DeserializeError>";
+    __match_scrut_0 = "core:json/JsonDeserializer::parse_i64_direct"(self);
+    v = (if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(__match_scrut_0) -> i64 {
+        let __cast_2: ref "core:prelude/types.wado//Result<i64,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(__match_scrut_0) -> i64 {
+        let __cast_1: ref "core:prelude/types.wado//Result<i64,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+        unreachable;
+    } else {
+        unreachable;
+    });
+    if (if v < 0_i64 -> i32 {
+        1;
+    } else {
+        v > 4294967295_i64;
+    }) {
+        return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__overflow_0: block -> ref "core:serde//DeserializeError" {
+            __local_5 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("value out of range for u32"), used: 26 };
+            break __inline_DeserializeError__overflow_0: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_5, offset: start };
+        }) };
     }
-    if __sroa_ir_discriminant == 1 {
-        e = __sroa_ir_case1_payload_0;
-        return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Err" { discriminant: 1, payload_0: e };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_wrap_i64(v) };
 }
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_bool"(self) {
-    let b: i32;
-    let r_2: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let r_4: ref null "core:serde//DeserializeError";
-    let e_5: ref "core:serde//DeserializeError";
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:serde//DeserializeError";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
     let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i64;
+    let __local_9: i32;
     let __local_10: ref "core:prelude/string.wado//String";
-    let __local_11: i32;
-    let __local_12: ref "core:prelude/string.wado//String";
-    let __local_13: i64;
+    let __local_11: i64;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_8 = self.input;
-        break __inline_String__len_0: __local_8.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_9 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_9 };
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
         }) };
     }
     b = __inline_String__get_byte_2: block -> u8 {
-        __local_10 = self.input;
-        __local_11 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_10.repr, __local_11);
-    };
+        __local_8 = self.input;
+        __local_9 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_8.repr, __local_9);
+    } & 255;
     if b == 116 {
-        r_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-        if ref.is_null(r_2) == 0 {
-            e_3 = ref.as_non_null(r_2);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_3 };
+        let __match_scrut_2: ref null "core:serde//DeserializeError";
+        __match_scrut_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        if ref.is_null(__match_scrut_2) {
+        } else if ref.is_null(__match_scrut_2) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_2);
+            __local_3 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 1 };
-    }
-    if b == 102 {
-        r_4 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-        if ref.is_null(r_4) == 0 {
-            e_5 = ref.as_non_null(r_4);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
+        unreachable;
+    } else if b == 102 {
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_1);
+            __local_5 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_5 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 0 };
+        unreachable;
+    } else {
+        return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
+            __local_11 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_10, offset: __local_11 };
+        }) };
+        unreachable;
     }
-    return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-        __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
-        __local_13 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_12, offset: __local_13 };
-    }) };
+    unreachable;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::is_null"(self) {
@@ -5252,91 +5418,129 @@ fn "core:json/JsonDeserializer^Deserializer::is_null"(self) {
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_seq"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 91);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 91);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_2 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_2;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonSeqAccess" { de: self, first: 1 }, ref.null none;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_struct"(self, lookup) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 123);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_5: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 123);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_5 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_5;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonStructAccess" { de: self, lookup: lookup, first: 1 }, ref.null none;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_variant"(self) {
-    let b: i32;
-    let r_4: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let name_5: ref "core:prelude/string.wado//String";
-    let e_6: ref "core:serde//DeserializeError";
-    let r_7: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let name_8: ref "core:prelude/string.wado//String";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let e_11: ref "core:serde//DeserializeError";
-    let __local_17: ref "core:prelude/string.wado//String";
-    let __local_18: i64;
-    let __local_19: ref "core:prelude/string.wado//String";
-    let __local_20: i32;
-    let __local_21: ref "core:prelude/string.wado//String";
-    let __local_22: i64;
+    let b: char;
+    let __local_4: ref "core:prelude/string.wado//String";
+    let __local_5: ref "core:serde//DeserializeError";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: ref "core:prelude/string.wado//String";
+    let __local_11: ref "core:serde//DeserializeError";
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i32;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i64;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_17 = self.input;
-        break __inline_String__len_0: __local_17.used;
+        __local_12 = self.input;
+        break __inline_String__len_0: __local_12.used;
     } {
         return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_18 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_18 };
+            __local_13 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_13 };
         }) };
     }
     b = __inline_String__get_byte_2: block -> u8 {
-        __local_19 = self.input;
-        __local_20 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_19.repr, __local_20);
-    };
+        __local_14 = self.input;
+        __local_15 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_14.repr, __local_15);
+    } & 255;
     if b == 34 {
-        r_4 = "core:json/JsonDeserializer::read_json_string"(self);
-        if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r_4) {
-            name_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r_4).payload_0;
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: name_5, is_object: 0 } };
-        }
-        if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r_4) {
-            e_6 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r_4).payload_0;
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e_6 };
-        }
-    }
-    if b == 123 {
+        let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+        __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self);
+        __local_6 = (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+            let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+            __local_4 = __cast_5.payload_0;
+            __local_4;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+            let __cast_4: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_4 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+            __local_5 = __cast_4.payload_0;
+            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_5 };
+            unreachable;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: __local_6, is_object: 0 } };
+        unreachable;
+    } else if b == 123 {
         self.pos = self.pos + 1;
-        r_7 = "core:json/JsonDeserializer::read_json_string"(self);
-        if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r_7) {
-            name_8 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r_7).payload_0;
-            cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-            if ref.is_null(cr) == 0 {
-                e_10 = ref.as_non_null(cr);
-                return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e_10 };
-            }
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: name_8, is_object: 1 } };
+        let __match_scrut_1: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+        __match_scrut_1 = "core:json/JsonDeserializer::read_json_string"(self);
+        __local_9 = (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/string.wado//String" {
+            let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1);
+            __local_7 = __cast_2.payload_0;
+            __local_7;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/string.wado//String" {
+            let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1);
+            __local_8 = __cast_1.payload_0;
+            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
+        });
+        let __match_scrut_2: ref null "core:serde//DeserializeError";
+        __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+        if ref.is_null(__match_scrut_2) {
+        } else if ref.is_null(__match_scrut_2) == 0 {
+            let __cast_3: ref null "core:serde//DeserializeError";
+            __cast_3 = ref.as_non_null(__match_scrut_2);
+            __local_11 = ref.as_non_null(__cast_3);
+            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_11 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r_7) {
-            e_11 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r_7).payload_0;
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e_11 };
-        }
+        return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: __local_9, is_object: 1 } };
+        unreachable;
+    } else {
+        return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_16 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string or object for variant"), used: 37 };
+            __local_17 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_16, offset: __local_17 };
+        }) };
+        unreachable;
     }
-    return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-        __local_21 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string or object for variant"), used: 37 };
-        __local_22 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_21, offset: __local_22 };
-    }) };
+    unreachable;
 }
 
 fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
@@ -5346,13 +5550,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l510: loop {
+            l535: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l510;
+                continue l535;
             };
         };
     };
@@ -5445,10 +5649,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b520: block {
-            l521: loop {
+        b545: block {
+            l546: loop {
                 if i_8 < 0 {
-                    break b520;
+                    break b545;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -5457,7 +5661,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l521;
+                continue l546;
             };
         };
         __for_1: block {
@@ -5465,14 +5669,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l524: loop {
+                l549: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l524;
+                    continue l549;
                 };
             };
         };
@@ -5482,10 +5686,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b526: block {
-            l527: loop {
+        b551: block {
+            l552: loop {
                 if i_10 < 0 {
-                    break b526;
+                    break b551;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -5494,7 +5698,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l527;
+                continue l552;
             };
         };
         __for_2: block {
@@ -5502,14 +5706,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l530: loop {
+                l555: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l530;
+                    continue l555;
                 };
             };
         };
@@ -5613,8 +5817,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b549: block {
-        l550: loop {
+    b574: block {
+        l575: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -5639,9 +5843,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b549;
+                break b574;
             }
-            continue l550;
+            continue l575;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -5676,13 +5880,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l559: loop {
+            l584: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l559;
+                continue l584;
             };
         };
     };
@@ -5788,21 +5992,21 @@ fn "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Option<i32>^De
     if __sroa_null_check_discriminant == 0 {
         is_null = __sroa_null_check_case0_payload_0;
         if is_null {
-            return 0, struct.new "core:prelude/types.wado//Option<i32>" { 1 }, ref.null none;
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
         }
         inner = "core:json/JsonDeserializer::parse_i32_direct"(d);
         if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(inner) {
             v = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(inner).payload_0;
-            return 0, struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: v }, ref.null none;
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: v } };
         }
         if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(inner) {
-            e_5 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(inner).payload_0);
-            return 1, ref.null none, e_5;
+            e_5 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(inner).payload_0;
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
         }
     }
     if __sroa_null_check_discriminant == 1 {
         e_6 = __sroa_null_check_case1_payload_0;
-        return 1, ref.null none, e_6;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_6 };
     }
     "core:internal/unreachable"();
     unreachable;
@@ -5814,12 +6018,14 @@ fn "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/i32^Deserializ
 
 fn "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Array<i32>^Deserialize::deserialize<JsonDeserializer>"(d) {
     let seq: ref "core:json//JsonSeqAccess";
+    let first: ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";
     let first_opt: ref "core:prelude/types.wado//Option<i32>";
     let end_result_5: ref null "core:serde//DeserializeError";
     let e_6: ref "core:serde//DeserializeError";
     let __local_7: ref "core:prelude//Array<i32>";
     let first_elem: i32;
     let items: ref "core:prelude//Array<i32>";
+    let next: ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";
     let next_opt: ref "core:prelude/types.wado//Option<i32>";
     let end_result_12: ref null "core:serde//DeserializeError";
     let e_13: ref "core:serde//DeserializeError";
@@ -5833,65 +6039,59 @@ fn "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Array<i32>^Des
     multivalue_bind [__sroa_seq_result_discriminant, __sroa_seq_result_case0_payload_0, __sroa_seq_result_case1_payload_0] = "core:json/JsonDeserializer^Deserializer::begin_seq"(d);
     if __sroa_seq_result_discriminant == 0 {
         seq = __sroa_seq_result_case0_payload_0;
-        let __sroa_first_discriminant: i32;
-        let __sroa_first_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
-        let __sroa_first_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_first_discriminant, __sroa_first_case0_payload_0, __sroa_first_case1_payload_0] = "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(seq);
-        if __sroa_first_discriminant == 0 {
-            first_opt = __sroa_first_case0_payload_0;
+        first = "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(seq);
+        if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(first) {
+            first_opt = ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(first).payload_0;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(first_opt) {
                 first_elem = ref.cast "core:prelude/types.wado//Option<i32>::Some"(first_opt).payload_0;
                 items = struct.new "core:prelude//Array<i32>" { repr: builtin::array_new<i32>(2), used: 0 };
                 "core:prelude/array.wado/Array<i32>::push"(items, first_elem);
                 block {
-                    l585: loop {
-                        let __sroa_next_discriminant: i32;
-                        let __sroa_next_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
-                        let __sroa_next_case1_payload_0: ref null "core:serde//DeserializeError";
-                        multivalue_bind [__sroa_next_discriminant, __sroa_next_case0_payload_0, __sroa_next_case1_payload_0] = "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(seq);
-                        if __sroa_next_discriminant == 0 {
-                            next_opt = __sroa_next_case0_payload_0;
+                    l610: loop {
+                        next = "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(seq);
+                        if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(next) {
+                            next_opt = ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(next).payload_0;
                             if ref.test "core:prelude/types.wado//Option<i32>::Some"(next_opt) {
                                 item = ref.cast "core:prelude/types.wado//Option<i32>::Some"(next_opt).payload_0;
                                 "core:prelude/array.wado/Array<i32>::push"(items, item);
                             } else {
                                 end_result_12 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
                                 if ref.is_null(end_result_12) == 0 {
-                                    e_13 = value_copy "core:serde//DeserializeError"(ref.as_non_null(end_result_12));
-                                    return 1, ref.null none, e_13;
+                                    e_13 = ref.as_non_null(end_result_12);
+                                    return struct.new "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_13 };
                                 }
-                                return 0, items, ref.null none;
+                                return struct.new "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: items };
                             }
                         }
-                        if __sroa_next_discriminant == 1 {
-                            e_15 = __sroa_next_case1_payload_0;
-                            return 1, ref.null none, e_15;
+                        if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(next) {
+                            e_15 = ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(next).payload_0;
+                            return struct.new "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_15 };
                         }
-                        continue l585;
+                        continue l610;
                     };
                 };
             } else {
                 end_result_5 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
                 if ref.is_null(end_result_5) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(end_result_5));
-                    return 1, ref.null none, e_6;
+                    e_6 = ref.as_non_null(end_result_5);
+                    return struct.new "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_6 };
                 }
-                return 0, ref.as_non_null(__seq_lit: block -> ref "core:prelude//Array<i32>" {
+                return struct.new "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: ref.as_non_null(__seq_lit: block -> ref "core:prelude//Array<i32>" {
                     __local_7 = struct.new "core:prelude//Array<i32>" { repr: builtin::array_new<i32>(0), used: 0 };
                     break __seq_lit: __local_7;
-                }), ref.null none;
+                }) };
             }
         }
-        if __sroa_first_discriminant == 1 {
-            e_16 = __sroa_first_case1_payload_0;
-            return 1, ref.null none, e_16;
+        if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(first) {
+            e_16 = ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(first).payload_0;
+            return struct.new "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_16 };
         }
         "core:internal/unreachable"();
         unreachable;
     }
     if __sroa_seq_result_discriminant == 1 {
         e_17 = __sroa_seq_result_case1_payload_0;
-        return 1, ref.null none, e_17;
+        return struct.new "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
     }
     "core:internal/unreachable"();
     unreachable;
@@ -5926,13 +6126,13 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l595: loop {
+            l620: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
                 i = i + 1;
-                continue l595;
+                continue l620;
             };
         };
     };
@@ -5940,51 +6140,58 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
 }
 
 fn "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let elem: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
-    let v: i32;
-    let e_5: ref "core:serde//DeserializeError";
-    let __local_9: ref "core:prelude/string.wado//String";
-    let __local_10: i64;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i32;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __local_3: i32;
+    let __local_4: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_9 = self.de.input;
-        break __inline_String__len_0: __local_9.used;
+        __local_5 = self.de.input;
+        break __inline_String__len_0: __local_5.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_10 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_10 };
-        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_6 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_11 = self.de.input;
-        __local_12 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_11.repr, __local_12);
+        __local_7 = self.de.input;
+        __local_8 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_7.repr, __local_8);
     } == 93 {
-        return 0, struct.new "core:prelude/types.wado//Option<i32>" { 1 }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r) == 0 {
-            e_2 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-            return 1, ref.null none, e_2;
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
-    elem = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/i32^Deserialize::deserialize<JsonDeserializer>"(self.de);
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(elem) {
-        v = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(elem).payload_0;
-        return 0, struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: v }, ref.null none;
-    }
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(elem) {
-        e_5 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(elem).payload_0);
-        return 1, ref.null none, e_5;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return let __match_scrut_1: ref "core:prelude/types.wado//Result<i32,DeserializeError>", __match_scrut_1 = "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/i32^Deserialize::deserialize<JsonDeserializer>"(self.de), (if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>" {
+        let __cast_3: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Ok";
+        __cast_3 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_1);
+        __local_3 = __cast_3.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: __local_3 } };
+    } else if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Err";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_1);
+        __local_4 = __cast_2.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_4 };
+    } else {
+        unreachable;
+    });
 }
 
 fn "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Point^Deserialize::deserialize<JsonDeserializer>"(d) {
@@ -6013,8 +6220,8 @@ fn "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Point^Deserial
         seen = 0;
         x = 0;
         y = 0;
-        b604: block {
-            l605: loop {
+        b630: block {
+            l631: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -6032,7 +6239,7 @@ fn "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Point^Deserial
                                 x = __local_10;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_9).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_9).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_11 = __inline_i32_Deserialize__deserialize_JsonDeserializer__5: block -> ref "core:prelude/types.wado//Result<i32,DeserializeError>" {
@@ -6045,27 +6252,27 @@ fn "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado/Point^Deserial
                                 y = __local_12;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_11).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_11).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b604;
+                        break b630;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l605;
+                continue l631;
             };
         };
         if (seen & 3) != 3 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//Point" { x: x, y: y }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_json_deser_error_edge.wado//Point" { x: x, y: y } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 

--- a/wado-compiler/tests/fixtures.golden/serde_json_duplicate_fields.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_duplicate_fields.wir.wado
@@ -46,209 +46,270 @@ struct wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado//Point {  /
 
 array builtin::array<u64> (mut u64);  // TypeId(8)
 
-variant core:prelude/types.wado//Option<i32> {  // TypeId(9)
+variant core:prelude/types.wado//Option<char> {  // TypeId(9)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(10)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<i32> {  // TypeId(11)
     Some(i32),
     None,
 }
 
-struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(10)
+struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(12)
     discriminant: i32,
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(11)
+variant core:prelude/types.wado//Result<Point,DeserializeError> {  // TypeId(13)
+    Ok(ref "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado//Point"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Point,DeserializeError>::Ok {  // TypeId(14)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado//Point",
+}
+
+struct core:prelude/types.wado//Result<Point,DeserializeError>::Err {  // TypeId(15)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(16)
     Ok(f64),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(12)
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(17)
     discriminant: i32,
     payload_0: f64,
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(13)
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(18)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(14)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(19)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(20)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(21)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(22)
+    Ok(ref "core:prelude/string.wado//String"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(23)
+    discriminant: i32,
+    payload_0: ref "core:prelude/string.wado//String",
+}
+
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(24)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(25)
     Ok(ref "core:prelude/types.wado//Option<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(15)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(26)
     discriminant: i32,
     payload_0: ref "core:prelude/types.wado//Option<i32>",
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(16)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(27)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-struct core:prelude//Array<u64> {  // TypeId(17)
+struct core:prelude//Array<u64> {  // TypeId(28)
     mut repr: ref builtin::array<u64>,
     mut used: i32,
 }
 
-enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(18)
+enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(29)
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(19)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(30)
 
-type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(20)
+type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(31)
 
-struct canonical//CanonicalClosure_0 {  // TypeId(21)
+struct canonical//CanonicalClosure_0 {  // TypeId(32)
     env: ref null struct,
     func: ref "functype/$canonical_closure_fn_0",
 }
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(22)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(33)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(23)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(34)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(24)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(35)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(25)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(36)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(26)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(37)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(27)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(38)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(28)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(39)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(29)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(40)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/__test_0_duplicate_field_last_value_wins" = fn();  // TypeId(30)
+type "functype//wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/__test_0_duplicate_field_last_value_wins" = fn();  // TypeId(41)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/_point_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(31)
+type "functype//wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/_point_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(42)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/__cm_export____test_0_duplicate_field_last_value_wins" = fn();  // TypeId(32)
+type "functype//wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/__cm_export____test_0_duplicate_field_last_value_wins" = fn();  // TypeId(43)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/__initialize_module" = fn();  // TypeId(33)
+type "functype//wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/__initialize_module" = fn();  // TypeId(44)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(34)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(45)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(35)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(46)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(36)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(47)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(37)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(48)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(38)
+type "functype//core:internal/unreachable" = fn();  // TypeId(49)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(39)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(50)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(40)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(51)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(41)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(52)
 
-type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(42)
+type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(53)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(43)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(54)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(44)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(55)
 
-type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(45)
+type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(56)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(46)
+type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(57)
 
-type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(47)
+type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(58)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(48)
+type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(59)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(49)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(60)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(50)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(61)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(51)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(62)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(52)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(63)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(53)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(64)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(54)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(65)
 
-type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(55)
+type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(66)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(56)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(67)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(57)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(68)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(58)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(69)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(59)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(70)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(60)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(71)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(61)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(72)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(62)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(73)
 
-type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(63)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(74)
 
-type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(64)
+type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(75)
 
-type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(65)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(76)
 
-type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(66)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(77)
 
-type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(67)
+type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(78)
 
-type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(68)
+type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(79)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(69)
+type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(80)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(70)
+type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(81)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(71)
+type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(82)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(72)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(83)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(73)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(84)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(74)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(85)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(75)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(86)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(76)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(87)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(77)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(88)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(78)
+type "functype//wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/Point^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Point,DeserializeError>";  // TypeId(89)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(79)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(90)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(80)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(91)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(81)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(92)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(82)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(93)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(83)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(94)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(84)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(95)
 
-type "functype//core:json/core/json/from_string<Point>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado//Point", ref null "core:serde//DeserializeError"];  // TypeId(85)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(96)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(86)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(97)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(87)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(98)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(88)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(99)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/Point^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado//Point", ref null "core:serde//DeserializeError"];  // TypeId(89)
+type "functype//core:json/core/json/from_string<Point>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado//Point", ref null "core:serde//DeserializeError"];  // TypeId(100)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(90)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(101)
 
-type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(91)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(102)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(92)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(103)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(93)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(104)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(94)
+type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(105)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(95)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(106)
+
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(107)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(108)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(109)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -1452,64 +1513,118 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/core/json/from_string<Point>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado//Point";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado//Point";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado//Point";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/Point^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado//Point"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Point,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/Point^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Point,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado//Point" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Point,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Point,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Point,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado//Point" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Point,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Point,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1789,6 +1904,55 @@ fn "core:prelude/string.wado/String::push_str"(self, other) {
     self.used = new_used;
 }
 
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
+}
+
 fn "core:prelude/string.wado/String::push"(self, c) {
     let code: u32;
     code = c;
@@ -1827,10 +1991,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b174: block {
-        l175: loop {
+    b192: block {
+        l193: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b174;
+                break b192;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -1854,7 +2018,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l175;
+            continue l193;
         };
     };
     self.pos = _hfs_pos_8;
@@ -1933,11 +2097,11 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b183: block {
-        l184: loop {
+    b201: block {
+        l202: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= _licm_used_19 {
-                    break b183;
+                    break b201;
                 }
                 byte = builtin::array_get_u8(_licm_repr_20, __sroa___iter_3_index);
                 __sroa___iter_3_index = __sroa___iter_3_index + 1;
@@ -1972,7 +2136,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
                 _hfs_pos_27 = _hfs_pos_27 + 1;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l184;
+            continue l202;
         };
     };
     self.pos = _hfs_pos_27;
@@ -1991,130 +2155,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
+        }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b190: block {
-        l191: loop {
-            if scan_pos >= _licm_used_90 {
-                break b190;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b208: block {
+        l209: loop {
+            if scan_pos >= _licm_used_56 {
+                break b208;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b190;
+                break b208;
             }
             scan_pos = scan_pos + 1;
-            continue l191;
+            continue l209;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -2123,94 +2259,95 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l198: loop {
+                l216: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l198;
+                    continue l216;
                 };
             };
         };
         self.pos = scan_pos + 1;
-        return 0, result_5, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l201: loop {
+            l219: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l201;
+                continue l219;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b203: block {
-        l204: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b221: block {
+        l222: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b203;
+                break b221;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
-                return 0, result_8, ref.null none;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
+                return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
-                    });
+                    self.pos = _hfs_pos_64;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
+                    }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -2228,213 +2365,140 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return 1, ref.null none, e;
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
-                    });
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
+                    }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
-                    });
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
+                    }) };
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l204;
+            continue l222;
         };
     };
-    self.pos = _hfs_pos_98;
-    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
-    });
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
+    }) };
 }
 
 fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l229: loop {
+            l242: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l229;
+                continue l242;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -2489,25 +2553,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b240: block {
-        l241: loop {
+    b249: block {
+        l250: loop {
             if _hfs_pos_36 >= _licm_used_28 {
-                break b240;
+                break b249;
             }
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
                 break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr_29, __local_11);
             };
-            if (if b_1 >= 48 -> i32 {
+            if (if 48 <= b_1 -> i32 {
                 b_1 <= 57;
             } else {
                 0;
             }) {
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
-                break b240;
+                break b249;
             }
-            continue l241;
+            continue l250;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2528,25 +2592,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b247: block {
-            l248: loop {
+        b256: block {
+            l257: loop {
                 if _hfs_pos_37 >= _licm_used_31 {
-                    break b247;
+                    break b256;
                 }
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
                     break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_32, __local_17);
                 };
-                if (if b_2 >= 48 -> i32 {
+                if (if 48 <= b_2 -> i32 {
                     b_2 <= 57;
                 } else {
                     0;
                 }) {
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
-                    break b247;
+                    break b256;
                 }
-                continue l248;
+                continue l257;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2587,25 +2651,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b258: block {
-                l259: loop {
+            b267: block {
+                l268: loop {
                     if _hfs_pos_38 >= _licm_used_34 {
-                        break b258;
+                        break b267;
                     }
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
                         break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_35, __local_26);
                     };
-                    if (if b2 >= 48 -> i32 {
+                    if (if 48 <= b2 -> i32 {
                         b2 <= 57;
                     } else {
                         0;
                     }) {
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
-                        break b258;
+                        break b267;
                     }
-                    continue l259;
+                    continue l268;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -2715,16 +2779,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b268: block {
-        l269: loop {
+    b277: block {
+        l278: loop {
             if _hfs_pos_57 >= _licm_used_49 {
-                break b268;
+                break b277;
             }
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_50, __local_32);
             };
-            if (if b_6 >= 48 -> i32 {
+            if (if 48 <= b_6 -> i32 {
                 b_6 <= 57;
             } else {
                 0;
@@ -2735,9 +2799,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                 total_digits = total_digits + 1;
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
-                break b268;
+                break b277;
             }
-            continue l269;
+            continue l278;
         };
     };
     self.pos = _hfs_pos_57;
@@ -2759,16 +2823,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b276: block {
-            l277: loop {
+        b285: block {
+            l286: loop {
                 if _hfs_pos_58 >= _licm_used_52 {
-                    break b276;
+                    break b285;
                 }
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
                     break __inline_String__get_byte_12: builtin::array_get_u8(_licm_repr_53, __local_38);
                 };
-                if (if b_8 >= 48 -> i32 {
+                if (if 48 <= b_8 -> i32 {
                     b_8 <= 57;
                 } else {
                     0;
@@ -2780,9 +2844,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                     total_digits = total_digits + 1;
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
-                    break b276;
+                    break b285;
                 }
-                continue l277;
+                continue l286;
             };
         };
         self.pos = _hfs_pos_58;
@@ -2824,16 +2888,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b288: block {
-                l289: loop {
+            b297: block {
+                l298: loop {
                     if _hfs_pos_59 >= _licm_used_55 {
-                        break b288;
+                        break b297;
                     }
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
                         break __inline_String__get_byte_18: builtin::array_get_u8(_licm_repr_56, __local_47);
                     };
-                    if (if b3 >= 48 -> i32 {
+                    if (if 48 <= b3 -> i32 {
                         b3 <= 57;
                     } else {
                         0;
@@ -2841,9 +2905,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                         exp = (exp * 10) + (b3 - 48);
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
-                        break b288;
+                        break b297;
                     }
-                    continue l289;
+                    continue l298;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -2893,10 +2957,10 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b299: block {
-        l300: loop {
+    b308: block {
+        l309: loop {
             if _hfs_pos_14 >= _licm_used_12 {
-                break b299;
+                break b308;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -2926,7 +2990,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
                 }
             }
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l300;
+            continue l309;
         };
     };
     self.pos = _hfs_pos_14;
@@ -2937,19 +3001,284 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
 }
 
 fn "core:json/JsonDeserializer::skip_value"(self) {
-    let b: i32;
-    let r: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let c_4: i32;
-    let kr: ref null "core:serde//DeserializeError";
-    let e_6: ref "core:serde//DeserializeError";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let vr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let c_11: i32;
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: char;
+    let __local_6: ref "core:serde//DeserializeError";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_10: ref "core:serde//DeserializeError";
+    let __local_11: char;
     let __local_12: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/format.wado//Formatter";
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i64;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i32;
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
+    let __local_20: i32;
+    let __local_21: ref "core:prelude/string.wado//String";
+    let __local_22: i64;
+    let __local_23: ref "core:prelude/string.wado//String";
+    let __local_24: i32;
+    let __local_25: ref "core:prelude/string.wado//String";
+    let __local_26: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let __local_30: ref "core:prelude/string.wado//String";
+    let __local_31: ref "core:prelude/string.wado//String";
+    let __local_32: i32;
+    let __local_33: ref "core:prelude/string.wado//String";
+    let __local_34: i64;
+    let __local_35: ref "core:prelude/string.wado//String";
+    let __local_36: i64;
+    let __local_37: ref "core:prelude/string.wado//String";
+    let __local_38: i32;
+    let __local_39: ref "core:prelude/string.wado//String";
+    let __local_40: i64;
+    let __local_43: ref "core:prelude/string.wado//String";
+    let __local_44: i64;
+    "core:json/JsonDeserializer::skip_whitespace"(self);
+    if self.pos >= __inline_String__len_0: block -> i32 {
+        __local_14 = self.input;
+        break __inline_String__len_0: __local_14.used;
+    } {
+        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_15 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_15 };
+        });
+    }
+    b = __inline_String__get_byte_2: block -> u8 {
+        __local_16 = self.input;
+        __local_17 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_16.repr, __local_17);
+    } & 255;
+    if b == 34 {
+        return "core:json/JsonDeserializer::skip_string"(self);
+        unreachable;
+    } else if b == 116 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        unreachable;
+    } else if b == 102 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        unreachable;
+    } else if b == 110 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
+        unreachable;
+    } else if b == 91 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_3: block -> i32 {
+            __local_18 = self.input;
+            break __inline_String__len_3: __local_18.used;
+        } -> i32 {
+            __inline_String__get_byte_4: block -> u8 {
+                __local_19 = self.input;
+                __local_20 = self.pos;
+                break __inline_String__get_byte_4: builtin::array_get_u8(__local_19.repr, __local_20);
+            } == 93;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l324: loop {
+                let __match_scrut_5: ref null "core:serde//DeserializeError";
+                __match_scrut_5 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_5) {
+                } else if ref.is_null(__match_scrut_5) == 0 {
+                    let __cast_4: ref null "core:serde//DeserializeError";
+                    __cast_4 = ref.as_non_null(__match_scrut_5);
+                    __local_3 = ref.as_non_null(__cast_4);
+                    return __local_3;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_5: block -> i32 {
+                    __local_21 = self.input;
+                    break __inline_String__len_5: __local_21.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
+                        __local_22 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_22 };
+                    });
+                }
+                __local_4 = __inline_String__get_byte_7: block -> u8 {
+                    __local_23 = self.input;
+                    __local_24 = self.pos;
+                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_23.repr, __local_24);
+                } & 255;
+                if __local_4 == 93 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_4 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
+                        __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
+                        __local_26 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_25, offset: __local_26 };
+                    });
+                    unreachable;
+                }
+                continue l324;
+            };
+        };
+    } else if b == 123 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_9: block -> i32 {
+            __local_27 = self.input;
+            break __inline_String__len_9: __local_27.used;
+        } -> i32 {
+            __inline_String__get_byte_10: block -> u8 {
+                __local_28 = self.input;
+                __local_29 = self.pos;
+                break __inline_String__get_byte_10: builtin::array_get_u8(__local_28.repr, __local_29);
+            } == 125;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l334: loop {
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if (if self.pos >= __inline_String__len_11: block -> i32 {
+                    __local_30 = self.input;
+                    break __inline_String__len_11: __local_30.used;
+                } -> i32 {
+                    1;
+                } else {
+                    __inline_String__get_byte_12: block -> u8 {
+                        __local_31 = self.input;
+                        __local_32 = self.pos;
+                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_31.repr, __local_32);
+                    } != 34;
+                }) {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
+                        __local_33 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+                        __local_34 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_33, offset: __local_34 };
+                    });
+                }
+                let __match_scrut_1: ref null "core:serde//DeserializeError";
+                __match_scrut_1 = "core:json/JsonDeserializer::skip_string"(self);
+                if ref.is_null(__match_scrut_1) {
+                } else if ref.is_null(__match_scrut_1) == 0 {
+                    let __cast_1: ref null "core:serde//DeserializeError";
+                    __cast_1 = ref.as_non_null(__match_scrut_1);
+                    __local_6 = ref.as_non_null(__cast_1);
+                    return __local_6;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_2: ref null "core:serde//DeserializeError";
+                __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+                if ref.is_null(__match_scrut_2) {
+                } else if ref.is_null(__match_scrut_2) == 0 {
+                    let __cast_2: ref null "core:serde//DeserializeError";
+                    __cast_2 = ref.as_non_null(__match_scrut_2);
+                    __local_8 = ref.as_non_null(__cast_2);
+                    return __local_8;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_3: ref null "core:serde//DeserializeError";
+                __match_scrut_3 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_3) {
+                } else if ref.is_null(__match_scrut_3) == 0 {
+                    let __cast_3: ref null "core:serde//DeserializeError";
+                    __cast_3 = ref.as_non_null(__match_scrut_3);
+                    __local_10 = ref.as_non_null(__cast_3);
+                    return __local_10;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_14: block -> i32 {
+                    __local_35 = self.input;
+                    break __inline_String__len_14: __local_35.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
+                        __local_36 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_36 };
+                    });
+                }
+                __local_11 = __inline_String__get_byte_16: block -> u8 {
+                    __local_37 = self.input;
+                    __local_38 = self.pos;
+                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_37.repr, __local_38);
+                } & 255;
+                if __local_11 == 125 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_11 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
+                        __local_39 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
+                        __local_40 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_39, offset: __local_40 };
+                    });
+                    unreachable;
+                }
+                continue l334;
+            };
+        };
+    } else {
+        if (if b == 45 -> i32 {
+            1;
+        } else if 48 <= b -> i32 {
+            b <= 57;
+        } else {
+            0;
+        }) {
+            "core:json/JsonDeserializer::skip_number"(self);
+            return ref.null none;
+        }
+        return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
+            __local_43 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
+                "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
+                __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
+                "core:prelude/primitive.wado/char^Display::fmt"(b, __local_13);
+                "core:prelude/string.wado/String::push"(__local_12, 39);
+                break __tmpl: __local_12;
+            };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
+        });
+        unreachable;
+    }
+}
+
+fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
+    let __local_2: ref "core:serde//DeserializeError";
+    let key_start: i32;
+    let has_escape: bool;
+    let b: i32;
+    let key_end: i32;
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: i32;
+    let idx_10: i32;
+    let __local_11: ref "core:prelude/string.wado//String";
+    let __local_12: ref "core:serde//DeserializeError";
+    let key: ref "core:prelude/string.wado//String";
+    let __local_15: ref "core:serde//DeserializeError";
+    let __local_16: i32;
+    let idx_17: i32;
     let __local_18: ref "core:prelude/string.wado//String";
     let __local_19: i64;
     let __local_20: ref "core:prelude/string.wado//String";
@@ -2960,416 +3289,178 @@ fn "core:json/JsonDeserializer::skip_value"(self) {
     let __local_25: ref "core:prelude/string.wado//String";
     let __local_26: i64;
     let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: i64;
-    let __local_31: ref "core:prelude/string.wado//String";
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i32;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
-    let __local_37: ref "core:prelude/string.wado//String";
-    let __local_38: i64;
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
-    let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_47: ref "core:prelude/string.wado//String";
-    let __local_48: i64;
-    let _hfs_pos_49: i32;
-    let _hfs_pos_50: i32;
-    "core:json/JsonDeserializer::skip_whitespace"(self);
-    if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_18 = self.input;
-        break __inline_String__len_0: __local_18.used;
-    } {
-        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_19 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
-        });
-    }
-    b = __inline_String__get_byte_2: block -> u8 {
-        __local_20 = self.input;
-        __local_21 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
-    };
-    if b == 34 {
-        return "core:json/JsonDeserializer::skip_string"(self);
-    }
-    if b == 116 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-    }
-    if b == 102 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-    }
-    if b == 110 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
-    }
-    if b == 91 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_3: block -> i32 {
-            __local_22 = self.input;
-            break __inline_String__len_3: __local_22.used;
-        } -> i32 {
-            __inline_String__get_byte_4: block -> u8 {
-                __local_23 = self.input;
-                __local_24 = self.pos;
-                break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
-            } == 93;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_49 = self.pos;
-        block {
-            l315: loop {
-                self.pos = _hfs_pos_49;
-                r = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_49 = self.pos;
-                if ref.is_null(r) == 0 {
-                    e_3 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-                    self.pos = _hfs_pos_49;
-                    return e_3;
-                }
-                self.pos = _hfs_pos_49;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_49 = self.pos;
-                if _hfs_pos_49 >= __inline_String__len_5: block -> i32 {
-                    __local_25 = self.input;
-                    self.pos = _hfs_pos_49;
-                    break __inline_String__len_5: __local_25.used;
-                } {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
-                        __local_26 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
-                    });
-                }
-                c_4 = __inline_String__get_byte_7: block -> u8 {
-                    __local_27 = self.input;
-                    __local_28 = _hfs_pos_49;
-                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_27.repr, __local_28);
-                };
-                if c_4 == 93 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                    self.pos = _hfs_pos_49;
-                    return ref.null none;
-                }
-                if c_4 == 44 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                } else {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
-                        __local_29 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
-                        __local_30 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_29, offset: __local_30 };
-                    });
-                }
-                continue l315;
-            };
-        };
-        self.pos = _hfs_pos_49;
-    }
-    if b == 123 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_9: block -> i32 {
-            __local_31 = self.input;
-            break __inline_String__len_9: __local_31.used;
-        } -> i32 {
-            __inline_String__get_byte_10: block -> u8 {
-                __local_32 = self.input;
-                __local_33 = self.pos;
-                break __inline_String__get_byte_10: builtin::array_get_u8(__local_32.repr, __local_33);
-            } == 125;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_50 = self.pos;
-        block {
-            l324: loop {
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if (if _hfs_pos_50 >= __inline_String__len_11: block -> i32 {
-                    __local_34 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_11: __local_34.used;
-                } -> i32 {
-                    1;
-                } else {
-                    __inline_String__get_byte_12: block -> u8 {
-                        __local_35 = self.input;
-                        __local_36 = _hfs_pos_50;
-                        self.pos = _hfs_pos_50;
-                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_35.repr, __local_36);
-                    } != 34;
-                }) {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
-                        __local_37 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-                        __local_38 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_37, offset: __local_38 };
-                    });
-                }
-                self.pos = _hfs_pos_50;
-                kr = "core:json/JsonDeserializer::skip_string"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(kr) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(kr));
-                    self.pos = _hfs_pos_50;
-                    return e_6;
-                }
-                self.pos = _hfs_pos_50;
-                cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(cr) == 0 {
-                    e_8 = value_copy "core:serde//DeserializeError"(ref.as_non_null(cr));
-                    self.pos = _hfs_pos_50;
-                    return e_8;
-                }
-                self.pos = _hfs_pos_50;
-                vr = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(vr) == 0 {
-                    e_10 = value_copy "core:serde//DeserializeError"(ref.as_non_null(vr));
-                    self.pos = _hfs_pos_50;
-                    return e_10;
-                }
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if _hfs_pos_50 >= __inline_String__len_14: block -> i32 {
-                    __local_39 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_14: __local_39.used;
-                } {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
-                        __local_40 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-                    });
-                }
-                c_11 = __inline_String__get_byte_16: block -> u8 {
-                    __local_41 = self.input;
-                    __local_42 = _hfs_pos_50;
-                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_41.repr, __local_42);
-                };
-                if c_11 == 125 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                    self.pos = _hfs_pos_50;
-                    return ref.null none;
-                }
-                if c_11 == 44 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                } else {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
-                        __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
-                        __local_44 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
-                    });
-                }
-                continue l324;
-            };
-        };
-        self.pos = _hfs_pos_50;
-    }
-    if (if b == 45 -> i32 {
-        1;
-    } else if b >= 48 -> i32 {
-        b <= 57;
-    } else {
-        0;
-    }) {
-        "core:json/JsonDeserializer::skip_number"(self);
-        return ref.null none;
-    }
-    return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
-        __local_47 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-            __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
-            "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
-            __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
-            "core:prelude/primitive.wado/char^Display::fmt"(b & 255, __local_13);
-            "core:prelude/string.wado/String::push"(__local_12, 39);
-            break __tmpl: __local_12;
-        };
-        __local_48 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_47, offset: __local_48 };
-    });
-}
-
-fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
-    let r_1: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let key_start: i32;
-    let has_escape: bool;
-    let b: i32;
-    let key_end: i32;
-    let r_7: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let idx_9: ref "core:prelude/types.wado//Option<i32>";
-    let i_10: i32;
-    let key: ref "core:prelude/string.wado//String";
-    let r_13: ref null "core:serde//DeserializeError";
-    let e_14: ref "core:serde//DeserializeError";
-    let idx_15: ref "core:prelude/types.wado//Option<i32>";
-    let i_16: i32;
-    let e_17: ref "core:serde//DeserializeError";
-    let __local_25: ref "core:prelude/string.wado//String";
-    let __local_26: i64;
-    let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: ref "core:prelude/string.wado//String";
-    let __local_31: i32;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i64;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_25 = self.de.input;
-        break __inline_String__len_0: __local_25.used;
+        __local_18 = self.de.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
+            __local_19 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_27 = self.de.input;
-        __local_28 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_27.repr, __local_28);
+        __local_20 = self.de.input;
+        __local_21 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } == 125 {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r_1 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r_1) == 0 {
-            e_2 = ref.as_non_null(r_1);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if (if self.de.pos >= __inline_String__len_3: block -> i32 {
-        __local_29 = self.de.input;
-        break __inline_String__len_3: __local_29.used;
+        __local_22 = self.de.input;
+        break __inline_String__len_3: __local_22.used;
     } -> i32 {
         1;
     } else {
         __inline_String__get_byte_4: block -> u8 {
-            __local_30 = self.de.input;
-            __local_31 = self.de.pos;
-            break __inline_String__get_byte_4: builtin::array_get_u8(__local_30.repr, __local_31);
+            __local_23 = self.de.input;
+            __local_24 = self.de.pos;
+            break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
         } != 34;
     }) {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_5: block -> ref "core:serde//DeserializeError" {
-            __local_32 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-            __local_33 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_32, offset: __local_33 };
+            __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_25, offset: __local_26 };
         }) };
     }
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b342: block {
-        l343: loop {
+    b356: block {
+        l357: loop {
             if self.de.pos >= __inline_String__len_6: block -> i32 {
-                __local_34 = self.de.input;
-                break __inline_String__len_6: __local_34.used;
+                __local_27 = self.de.input;
+                break __inline_String__len_6: __local_27.used;
             } {
-                break b342;
+                break b356;
             }
             b = __inline_String__get_byte_7: block -> u8 {
-                __local_35 = self.de.input;
-                __local_36 = self.de.pos;
-                break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
+                __local_28 = self.de.input;
+                __local_29 = self.de.pos;
+                break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
             };
             if b == 34 {
-                break b342;
+                break b356;
             }
             if b == 92 {
                 has_escape = 1;
-                break b342;
+                break b356;
             }
             self.de.pos = self.de.pos + 1;
-            continue l343;
+            continue l357;
         };
     };
     if has_escape == 0 {
         key_end = self.de.pos;
         self.de.pos = self.de.pos + 1;
-        r_7 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_7) == 0 {
-            e_8 = ref.as_non_null(r_7);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_8 };
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_1);
+            __local_8 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        idx_9 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_0: ref "canonical//CanonicalClosure_0";
-            __indirect_call_0 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_0.func, __indirect_call_0.env, self.de.input, key_start, key_end);
+        let __match_scrut_2: ref "core:prelude/types.wado//Option<i32>";
+        __match_scrut_2 = block -> ref "core:prelude/types.wado//Option<i32>" {
+            let __indirect_call_2: ref "canonical//CanonicalClosure_0";
+            __indirect_call_2 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_2.func, __indirect_call_2.env, self.de.input, key_start, key_end);
         };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_9) {
-            i_10 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_9).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_10 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+        idx_10 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2) -> i32 {
+            let __cast_4: ref "core:prelude/types.wado//Option<i32>::Some";
+            __cast_4 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2);
+            __local_9 = __cast_4.payload_0;
+            __local_9;
+        } else if __match_scrut_2.discriminant == 1 -> i32 {
+            -1;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_10 } };
     }
     self.de.pos = key_start - 1;
-    let __sroa_key_r_discriminant: i32;
-    let __sroa_key_r_case0_payload_0: ref null "core:prelude/string.wado//String";
-    let __sroa_key_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_key_r_discriminant, __sroa_key_r_case0_payload_0, __sroa_key_r_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self.de);
-    if __sroa_key_r_discriminant == 0 {
-        key = __sroa_key_r_case0_payload_0;
-        r_13 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_13) == 0 {
-            e_14 = ref.as_non_null(r_13);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_14 };
-        }
-        idx_15 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_1: ref "canonical//CanonicalClosure_0";
-            __indirect_call_1 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_1.func, __indirect_call_1.env, key, 0, key.used);
-        };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_15) {
-            i_16 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_15).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_16 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+    key = value_copy "core:prelude/string.wado//String"(let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self.de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_6: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_6 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+        __local_11 = __cast_6.payload_0;
+        __local_11;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+        __local_12 = __cast_5.payload_0;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_12 };
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    let __match_scrut_4: ref null "core:serde//DeserializeError";
+    __match_scrut_4 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+    if ref.is_null(__match_scrut_4) {
+    } else if ref.is_null(__match_scrut_4) == 0 {
+        let __cast_7: ref null "core:serde//DeserializeError";
+        __cast_7 = ref.as_non_null(__match_scrut_4);
+        __local_15 = ref.as_non_null(__cast_7);
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_15 };
+        unreachable;
+    } else {
+        unreachable;
     }
-    if __sroa_key_r_discriminant == 1 {
-        e_17 = __sroa_key_r_case1_payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    let __match_scrut_5: ref "core:prelude/types.wado//Option<i32>";
+    __match_scrut_5 = block -> ref "core:prelude/types.wado//Option<i32>" {
+        let __indirect_call_7: ref "canonical//CanonicalClosure_0";
+        __indirect_call_7 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+        call_ref "functype/$canonical_closure_fn_0"(__indirect_call_7.func, __indirect_call_7.env, key, 0, key.used);
+    };
+    idx_17 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5) -> i32 {
+        let __cast_9: ref "core:prelude/types.wado//Option<i32>::Some";
+        __cast_9 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5);
+        __local_16 = __cast_9.payload_0;
+        __local_16;
+    } else if __match_scrut_5.discriminant == 1 -> i32 {
+        -1;
+    } else {
+        unreachable;
+    });
+    return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_17 } };
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_struct"(self, lookup) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 123);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_5: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 123);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_5 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_5;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonStructAccess" { de: self, lookup: lookup, first: 1 }, ref.null none;
 }
@@ -3381,13 +3472,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l358: loop {
+            l377: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l358;
+                continue l377;
             };
         };
     };
@@ -3480,10 +3571,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b368: block {
-            l369: loop {
+        b387: block {
+            l388: loop {
                 if i_8 < 0 {
-                    break b368;
+                    break b387;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -3492,7 +3583,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l369;
+                continue l388;
             };
         };
         __for_1: block {
@@ -3500,14 +3591,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l372: loop {
+                l391: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l372;
+                    continue l391;
                 };
             };
         };
@@ -3517,10 +3608,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b374: block {
-            l375: loop {
+        b393: block {
+            l394: loop {
                 if i_10 < 0 {
-                    break b374;
+                    break b393;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -3529,7 +3620,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l375;
+                continue l394;
             };
         };
         __for_2: block {
@@ -3537,14 +3628,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l378: loop {
+                l397: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l378;
+                    continue l397;
                 };
             };
         };
@@ -3662,13 +3753,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l399: loop {
+            l418: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l399;
+                continue l418;
             };
         };
     };
@@ -3701,8 +3792,8 @@ fn "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/Point^Deserial
         seen = 0;
         x = 0;
         y = 0;
-        b402: block {
-            l403: loop {
+        b421: block {
+            l422: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -3720,7 +3811,7 @@ fn "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/Point^Deserial
                                 x = __local_10;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__local_9).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__local_9).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_11 = __inline_f64_Deserialize__deserialize_JsonDeserializer__5: block -> ref "core:prelude/types.wado//Result<f64,DeserializeError>" {
@@ -3733,27 +3824,27 @@ fn "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado/Point^Deserial
                                 y = __local_12;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__local_11).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__local_11).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b402;
+                        break b421;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l403;
+                continue l422;
             };
         };
         if (seen & 3) != 3 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado//Point" { x: x, y: y }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_json_duplicate_fields.wado//Point" { x: x, y: y } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 

--- a/wado-compiler/tests/fixtures.golden/serde_json_error_kind.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_error_kind.wir.wado
@@ -731,33 +731,39 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
 
 fn "core:json/core/json/from_string<i32>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
+    let __local_2: i32;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: i32;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_error_kind.wado/i32^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            }) };
-        }
-        return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: v };
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_error_kind.wado/i32^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_0) -> i32 {
+        let __cast_2: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_0) -> i32 {
+        let __cast_1: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        }) };
     }
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(r) {
-        e = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(r).payload_0;
-        return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Err" { discriminant: 1, payload_0: e };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: v };
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1039,7 +1045,7 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -1070,7 +1076,7 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -1123,7 +1129,7 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;

--- a/wado-compiler/tests/fixtures.golden/serde_json_int_types.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_int_types.wir.wado
@@ -46,213 +46,269 @@ struct core:serde//SerializeError {  // TypeId(7)
     mut message: ref "core:prelude/string.wado//String",
 }
 
-variant core:prelude/types.wado//Result<i64,DeserializeError> {  // TypeId(8)
+variant core:prelude/types.wado//Option<char> {  // TypeId(8)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(9)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<f64> {  // TypeId(10)
+    Some(f64),
+    None,
+}
+
+struct core:prelude/types.wado//Option<f64>::Some {  // TypeId(11)
+    discriminant: i32,
+    payload_0: f64,
+}
+
+variant core:prelude/types.wado//Result<i64,DeserializeError> {  // TypeId(12)
     Ok(i64),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i64,DeserializeError>::Ok {  // TypeId(9)
+struct core:prelude/types.wado//Result<i64,DeserializeError>::Ok {  // TypeId(13)
     discriminant: i32,
     payload_0: i64,
 }
 
-struct core:prelude/types.wado//Result<i64,DeserializeError>::Err {  // TypeId(10)
+struct core:prelude/types.wado//Result<i64,DeserializeError>::Err {  // TypeId(14)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<u64,DeserializeError> {  // TypeId(11)
+variant core:prelude/types.wado//Result<u64,DeserializeError> {  // TypeId(15)
     Ok(u64),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<u64,DeserializeError>::Ok {  // TypeId(12)
+struct core:prelude/types.wado//Result<u64,DeserializeError>::Ok {  // TypeId(16)
     discriminant: i32,
     payload_0: u64,
 }
 
-struct core:prelude/types.wado//Result<u64,DeserializeError>::Err {  // TypeId(13)
+struct core:prelude/types.wado//Result<u64,DeserializeError>::Err {  // TypeId(17)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(14)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(18)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(15)
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(19)
+    discriminant: i32,
+    payload_0: char,
+}
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(16)
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(20)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(17)
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(21)
+    Ok(ref "core:prelude/string.wado//String"),
+    Err(ref "core:serde//DeserializeError"),
+}
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(18)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(22)
+    discriminant: i32,
+    payload_0: ref "core:prelude/string.wado//String",
+}
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(19)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(23)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(20)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(24)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(21)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(25)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(22)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(26)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_0_i8_max_and_min" = fn();  // TypeId(23)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(27)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_1_i16_max" = fn();  // TypeId(24)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(28)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_2_u8_max" = fn();  // TypeId(25)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(29)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_3_u16_max" = fn();  // TypeId(26)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(30)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_4_i64_at_safe_limit_as_number" = fn();  // TypeId(27)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(31)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_5_i64_above_safe_limit_as_string" = fn();  // TypeId(28)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(32)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_6_i64_deserialize_from_string" = fn();  // TypeId(29)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_0_i8_max_and_min" = fn();  // TypeId(33)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_7_u64_at_safe_limit_as_number" = fn();  // TypeId(30)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_1_i16_max" = fn();  // TypeId(34)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_8_u64_max_as_string" = fn();  // TypeId(31)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_2_u8_max" = fn();  // TypeId(35)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_0_i8_max_and_min" = fn();  // TypeId(32)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_3_u16_max" = fn();  // TypeId(36)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_1_i16_max" = fn();  // TypeId(33)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_4_i64_at_safe_limit_as_number" = fn();  // TypeId(37)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_2_u8_max" = fn();  // TypeId(34)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_5_i64_above_safe_limit_as_string" = fn();  // TypeId(38)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_3_u16_max" = fn();  // TypeId(35)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_6_i64_deserialize_from_string" = fn();  // TypeId(39)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_4_i64_at_safe_limit_as_number" = fn();  // TypeId(36)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_7_u64_at_safe_limit_as_number" = fn();  // TypeId(40)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_5_i64_above_safe_limit_as_string" = fn();  // TypeId(37)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__test_8_u64_max_as_string" = fn();  // TypeId(41)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_6_i64_deserialize_from_string" = fn();  // TypeId(38)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_0_i8_max_and_min" = fn();  // TypeId(42)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_7_u64_at_safe_limit_as_number" = fn();  // TypeId(39)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_1_i16_max" = fn();  // TypeId(43)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_8_u64_max_as_string" = fn();  // TypeId(40)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_2_u8_max" = fn();  // TypeId(44)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(41)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_3_u16_max" = fn();  // TypeId(45)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(42)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_4_i64_at_safe_limit_as_number" = fn();  // TypeId(46)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(43)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_5_i64_above_safe_limit_as_string" = fn();  // TypeId(47)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(44)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_6_i64_deserialize_from_string" = fn();  // TypeId(48)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(45)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_7_u64_at_safe_limit_as_number" = fn();  // TypeId(49)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(46)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/__cm_export____test_8_u64_max_as_string" = fn();  // TypeId(50)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(47)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(51)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(48)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(52)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(49)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(53)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(50)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(54)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(51)
+type "functype//core:internal/unreachable" = fn();  // TypeId(55)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(52)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(56)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(53)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(57)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(54)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(58)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(55)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(59)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(56)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(60)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(57)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(61)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(58)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(62)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(59)
+type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> ref "core:prelude/types.wado//Option<f64>";  // TypeId(63)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(60)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(64)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(61)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(65)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(62)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(66)
 
-type "functype//core:json/JsonDeserializer::parse_i64_from" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String", i64) -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(63)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(67)
 
-type "functype//core:json/JsonDeserializer::parse_u64_from" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String", i64) -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(64)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(68)
 
-type "functype//core:json/JsonDeserializer::parse_i64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(65)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(69)
 
-type "functype//core:json/JsonDeserializer::parse_u64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(66)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(70)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_i64" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(67)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(71)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_u64" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(68)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(72)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(69)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(73)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(70)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(74)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(71)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(75)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(72)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(76)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/u64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(73)
+type "functype//core:json/JsonDeserializer::parse_i64_from" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String", i64) -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(77)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/i64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(74)
+type "functype//core:json/JsonDeserializer::parse_u64_from" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String", i64) -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(78)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(75)
+type "functype//core:json/JsonDeserializer::parse_i64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(79)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(76)
+type "functype//core:json/JsonDeserializer::parse_u64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(80)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(77)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_i64" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(81)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(78)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_u64" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(82)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(79)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(83)
 
-type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(80)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(84)
 
-type "functype//core:json/core/json/from_string<u64>" = fn(ref "core:prelude/string.wado//String") -> [i32, u64, ref null "core:serde//DeserializeError"];  // TypeId(81)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(85)
 
-type "functype//core:json/core/json/from_string<i64>" = fn(ref "core:prelude/string.wado//String") -> [i32, i64, ref null "core:serde//DeserializeError"];  // TypeId(82)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(86)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(83)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/u64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(87)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(84)
+type "functype//wado-compiler/tests/fixtures/serde_json_int_types.wado/i64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(88)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(85)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(89)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(86)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(90)
 
-type "functype//core:json/core/json/to_string<u64>" = fn(u64) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(87)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(91)
 
-type "functype//core:json/core/json/to_string<i64>" = fn(i64) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(88)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(92)
 
-type "functype//core:json/core/json/to_string<u16>" = fn(u16) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(89)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(93)
 
-type "functype//core:json/core/json/to_string<u8>" = fn(u8) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(90)
+type "functype//core:json/core/json/from_string<u64>" = fn(ref "core:prelude/string.wado//String") -> [i32, u64, ref null "core:serde//DeserializeError"];  // TypeId(94)
 
-type "functype//core:json/core/json/to_string<i16>" = fn(i16) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(91)
+type "functype//core:json/core/json/from_string<i64>" = fn(ref "core:prelude/string.wado//String") -> [i32, i64, ref null "core:serde//DeserializeError"];  // TypeId(95)
 
-type "functype//core:json/core/json/to_string<i8>" = fn(i8) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(92)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(96)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(93)
+type "functype//core:json/core/json/to_string<u64>" = fn(u64) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(97)
 
-type "functype//core:prelude/primitive.wado/u32::fmt_decimal" = fn(u32, ref "core:prelude/format.wado//Formatter");  // TypeId(94)
+type "functype//core:json/core/json/to_string<i64>" = fn(i64) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(98)
 
-type "functype//core:prelude/primitive.wado/i64::fmt_decimal" = fn(i64, ref "core:prelude/format.wado//Formatter");  // TypeId(95)
+type "functype//core:json/core/json/to_string<u16>" = fn(u16) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(99)
 
-type "functype//core:prelude/primitive.wado/u64::fmt_decimal" = fn(u64, ref "core:prelude/format.wado//Formatter");  // TypeId(96)
+type "functype//core:json/core/json/to_string<u8>" = fn(u8) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(100)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(97)
+type "functype//core:json/core/json/to_string<i16>" = fn(i16) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(101)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(98)
+type "functype//core:json/core/json/to_string<i8>" = fn(i8) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(102)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i64" = fn(ref "core:prelude/string.wado//String", i64) -> ref null "core:serde//SerializeError";  // TypeId(99)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(103)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_u32" = fn(ref "core:prelude/string.wado//String", u32) -> ref null "core:serde//SerializeError";  // TypeId(100)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(104)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_u64" = fn(ref "core:prelude/string.wado//String", u64) -> ref null "core:serde//SerializeError";  // TypeId(101)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(105)
 
-type "functype//core:json/JsonDeserializer::has_exp_or_dot" = fn(ref "core:prelude/string.wado//String") -> bool;  // TypeId(102)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(106)
+
+type "functype//core:prelude/primitive.wado/u32::fmt_decimal" = fn(u32, ref "core:prelude/format.wado//Formatter");  // TypeId(107)
+
+type "functype//core:prelude/primitive.wado/i64::fmt_decimal" = fn(i64, ref "core:prelude/format.wado//Formatter");  // TypeId(108)
+
+type "functype//core:prelude/primitive.wado/u64::fmt_decimal" = fn(u64, ref "core:prelude/format.wado//Formatter");  // TypeId(109)
+
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(110)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(111)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_i64" = fn(ref "core:prelude/string.wado//String", i64) -> ref null "core:serde//SerializeError";  // TypeId(112)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_u32" = fn(ref "core:prelude/string.wado//String", u32) -> ref null "core:serde//SerializeError";  // TypeId(113)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_u64" = fn(ref "core:prelude/string.wado//String", u64) -> ref null "core:serde//SerializeError";  // TypeId(114)
+
+type "functype//core:json/JsonDeserializer::has_exp_or_dot" = fn(ref "core:prelude/string.wado//String") -> bool;  // TypeId(115)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -1307,7 +1363,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     let _licm_repr_81: ref builtin::array<u8>;
     len = s.used;
     if len == 0 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     sign = 1;
     i = 0;
@@ -1319,7 +1375,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         i = 1;
     }
     if i >= len {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     remaining = len - i;
     c0 = builtin::array_get_u8(s.repr, i);
@@ -1354,7 +1410,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
             0;
         }) {
             if remaining == 3 {
-                return 0, f64.copysign(inf, sign);
+                return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(inf, sign) };
             }
             if remaining == 8 {
                 c3 = __inline_String__get_byte_5: block -> u8 {
@@ -1414,11 +1470,11 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
                 } else {
                     0;
                 }) {
-                    return 0, f64.copysign(inf, sign);
+                    return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(inf, sign) };
                 }
             }
         }
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     if (if (if c0 == 110 -> i32 {
         1;
@@ -1450,9 +1506,9 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         } else {
             0;
         }) {
-            return 0, 0 / 0;
+            return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: 0 / 0 };
         }
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     d = 0_i64;
     frac = 0;
@@ -1485,7 +1541,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         0;
     }) {
         if int_digits == 0 {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
         i = i + 1;
         frac_start = i;
@@ -1512,7 +1568,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
             };
         };
         if i == frac_start {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
     }
     total_digits = int_digits + frac;
@@ -1521,7 +1577,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     } else {
         total_digits > 19;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     p = 0;
     if (if i < len -> i32 {
@@ -1549,7 +1605,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         } else {
             (len - i) > 3;
         }) {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
         __for_2: block {
             _licm_repr_81 = s.repr;
@@ -1573,25 +1629,25 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
             };
         };
         if i == exp_start {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
         p = p * exp_sign;
     }
     if i != len {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     if d == 0_i64 {
-        return 0, f64.copysign(0, sign);
+        return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(0, sign) };
     }
     eff_p = p - frac;
     if eff_p > 350 {
-        return 0, f64.copysign(inf, sign);
+        return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(inf, sign) };
     }
     if eff_p < -351 {
-        return 0, f64.copysign(0, sign);
+        return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(0, sign) };
     }
     val = "core:prelude/fpfmt.wado/parse"(d, eff_p);
-    return 0, f64.copysign(val, sign);
+    return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(val, sign) };
 }
 
 fn "core:prelude/primitive.wado/count_digits_i64"(val) {
@@ -1641,171 +1697,271 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/core/json/from_string<u64>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<u64,DeserializeError>";
+    let __local_2: u64;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: u64;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_int_types.wado/u64^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<u64,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<u64,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<u64,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_int_types.wado/u64^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<u64,DeserializeError>::Ok"(__match_scrut_0) -> u64 {
+        let __cast_2: ref "core:prelude/types.wado//Result<u64,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<u64,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<u64,DeserializeError>::Err"(__match_scrut_0) -> u64 {
+        let __cast_1: ref "core:prelude/types.wado//Result<u64,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<u64,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0_i64, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<u64,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<u64,DeserializeError>::Err"(r).payload_0);
-        return 1, 0_i64, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<u64>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_u64"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_u64"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<i64>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<i64,DeserializeError>";
+    let __local_2: i64;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: i64;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_int_types.wado/i64^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<i64,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_int_types.wado/i64^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(__match_scrut_0) -> i64 {
+        let __cast_2: ref "core:prelude/types.wado//Result<i64,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(__match_scrut_0) -> i64 {
+        let __cast_1: ref "core:prelude/types.wado//Result<i64,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0_i64, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(r).payload_0);
-        return 1, 0_i64, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<i64>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_i64"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_i64"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<u16>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_u32"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_u32"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<u8>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_u32"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_u32"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<i16>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_i32"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_i32"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<i8>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_i32"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_i32"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1917,10 +2073,10 @@ fn "core:prelude/primitive.wado/u64::fmt_decimal"(self, f) {
     }
     digit_count = 0;
     temp = val_i64;
-    b185: block {
-        l186: loop {
+    b202: block {
+        l203: loop {
             if temp == 0_i64 {
-                break b185;
+                break b202;
             }
             digit_count = digit_count + 1;
             if temp >= 0_i64 {
@@ -1935,7 +2091,7 @@ fn "core:prelude/primitive.wado/u64::fmt_decimal"(self, f) {
                 }
                 temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             }
-            continue l186;
+            continue l203;
         };
     };
     offset_11 = "core:prelude/format.wado/Formatter::prepare_int_write"(f, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
@@ -1945,10 +2101,10 @@ fn "core:prelude/primitive.wado/u64::fmt_decimal"(self, f) {
     };
     pos = offset_11 + digit_count;
     temp = val_i64;
-    b190: block {
-        l191: loop {
+    b207: block {
+        l208: loop {
             if temp == 0_i64 {
-                break b190;
+                break b207;
             }
             pos = pos - 1;
             digit = 0;
@@ -1971,7 +2127,7 @@ fn "core:prelude/primitive.wado/u64::fmt_decimal"(self, f) {
                 temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             }
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
-            continue l191;
+            continue l208;
         };
     };
 }
@@ -2052,7 +2208,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l203: loop {
+            l220: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -2060,7 +2216,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l203;
+                continue l220;
             };
         };
     };
@@ -2109,6 +2265,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -2227,10 +2432,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b217: block {
-        l218: loop {
+    b241: block {
+        l242: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b217;
+                break b241;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -2254,7 +2459,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l218;
+            continue l242;
         };
     };
     self.pos = _hfs_pos_8;
@@ -2272,130 +2477,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
+        }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b226: block {
-        l227: loop {
-            if scan_pos >= _licm_used_90 {
-                break b226;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b250: block {
+        l251: loop {
+            if scan_pos >= _licm_used_56 {
+                break b250;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b226;
+                break b250;
             }
             scan_pos = scan_pos + 1;
-            continue l227;
+            continue l251;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -2404,94 +2581,95 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l234: loop {
+                l258: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l234;
+                    continue l258;
                 };
             };
         };
         self.pos = scan_pos + 1;
-        return 0, result_5, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l237: loop {
+            l261: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l237;
+                continue l261;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b239: block {
-        l240: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b263: block {
+        l264: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b239;
+                break b263;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
-                return 0, result_8, ref.null none;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
+                return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
-                    });
+                    self.pos = _hfs_pos_64;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
+                    }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -2509,213 +2687,140 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return 1, ref.null none, e;
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
-                    });
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
+                    }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
-                    });
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
+                    }) };
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l240;
+            continue l264;
         };
     };
-    self.pos = _hfs_pos_98;
-    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
-    });
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
+    }) };
 }
 
 fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l265: loop {
+            l284: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l265;
+                continue l284;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -2729,7 +2834,7 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(raw) {
         _licm_used_7 = raw.used;
         _licm_repr_8 = raw.repr;
         block {
-            l275: loop {
+            l290: loop {
                 if i >= _licm_used_7 {
                     break __for_4;
                 }
@@ -2746,7 +2851,7 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(raw) {
                     return 1;
                 }
                 i = i + 1;
-                continue l275;
+                continue l290;
             };
         };
     };
@@ -2755,38 +2860,47 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(raw) {
 
 fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {
     let has_exp: bool;
-    let v: f64;
+    let __local_4: f64;
     let neg: bool;
     let idx: i32;
     let len: i32;
     let result: i64;
     let b: i32;
     let digit: i64;
+    let __local_11: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/string.wado//String";
     let __local_15: ref "core:prelude/string.wado//String";
-    let __local_17: ref "core:prelude/string.wado//String";
-    let __local_24: ref "core:prelude/string.wado//String";
-    let _licm_repr_26: ref builtin::array<u8>;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let _licm_repr_24: ref builtin::array<u8>;
     has_exp = "core:json/JsonDeserializer::has_exp_or_dot"(raw);
     if has_exp {
-        let __sroa_parsed_discriminant: i32;
-        let __sroa_parsed_payload_0: f64;
-        __local_13 = value_copy "core:prelude/string.wado//String"(raw);
-        multivalue_bind [__sroa_parsed_discriminant, __sroa_parsed_payload_0] = "core:prelude/fpfmt.wado/parse_text"(__local_13);
-        if __sroa_parsed_discriminant == 0 {
-            v = __sroa_parsed_payload_0;
-            if v != builtin::f64_floor(v) {
+        let __match_scrut_0: ref "core:prelude/types.wado//Option<f64>";
+        __match_scrut_0 = __inline_f64__parse_0: block -> ref "core:prelude/types.wado//Option<f64>" {
+            __local_11 = value_copy "core:prelude/string.wado//String"(raw);
+            break __inline_f64__parse_0: "core:prelude/fpfmt.wado/parse_text"(__local_11);
+        };
+        if ref.test "core:prelude/types.wado//Option<f64>::Some"(__match_scrut_0) {
+            let __cast_1: ref "core:prelude/types.wado//Option<f64>::Some";
+            __cast_1 = ref.cast "core:prelude/types.wado//Option<f64>::Some"(__match_scrut_0);
+            __local_4 = __cast_1.payload_0;
+            if __local_4 != builtin::f64_floor(__local_4) {
                 return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_2: block -> ref "core:serde//DeserializeError" {
-                    __local_15 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
-                    break __inline_DeserializeError__unexpected_type_2: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_15, offset: start };
+                    __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
+                    break __inline_DeserializeError__unexpected_type_2: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_13, offset: start };
                 }) };
             }
-            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v) };
+            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(__local_4) };
+            unreachable;
+        } else if __match_scrut_0.discriminant == 1 {
+            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_3: block -> ref "core:serde//DeserializeError" {
+                __local_15 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid number"), used: 14 };
+                break __inline_DeserializeError__invalid_value_3: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_15, offset: start };
+            }) };
+            unreachable;
+        } else {
+            unreachable;
         }
-        return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_3: block -> ref "core:serde//DeserializeError" {
-            __local_17 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid number"), used: 14 };
-            break __inline_DeserializeError__invalid_value_3: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_17, offset: start };
-        }) };
+        unreachable;
     }
     neg = 0;
     idx = 0;
@@ -2800,27 +2914,27 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {
         idx = 1;
     }
     result = 0_i64;
-    _licm_repr_26 = raw.repr;
-    b285: block {
-        l286: loop {
+    _licm_repr_24 = raw.repr;
+    b301: block {
+        l302: loop {
             if idx >= len {
-                break b285;
+                break b301;
             }
-            b = builtin::array_get_u8(_licm_repr_26, idx);
+            b = builtin::array_get_u8(_licm_repr_24, idx);
             if (if b < 48 -> i32 {
                 1;
             } else {
                 b > 57;
             }) {
                 return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_7: block -> ref "core:serde//DeserializeError" {
-                    __local_24 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid digit in number"), used: 23 };
-                    break __inline_DeserializeError__invalid_value_7: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_24, offset: start };
+                    __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid digit in number"), used: 23 };
+                    break __inline_DeserializeError__invalid_value_7: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_22, offset: start };
                 }) };
             }
             digit = builtin::i64_extend_i32_s(b - 48);
             result = (result * 10_i64) + digit;
             idx = idx + 1;
-            continue l286;
+            continue l302;
         };
     };
     if neg {
@@ -2831,80 +2945,89 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {
 
 fn "core:json/JsonDeserializer::parse_u64_from"(self, raw, start) {
     let has_exp: bool;
-    let v: f64;
+    let __local_4: f64;
     let idx: i32;
     let len: i32;
     let result: u64;
     let b: i32;
     let digit: u64;
+    let __local_13: ref "core:prelude/string.wado//String";
     let __local_15: ref "core:prelude/string.wado//String";
-    let __local_17: ref "core:prelude/string.wado//String";
-    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
     let __local_21: ref "core:prelude/string.wado//String";
-    let __local_23: ref "core:prelude/string.wado//String";
-    let __local_28: ref "core:prelude/string.wado//String";
-    let _licm_repr_30: ref builtin::array<u8>;
+    let __local_26: ref "core:prelude/string.wado//String";
+    let _licm_repr_28: ref builtin::array<u8>;
     if (if raw.used > 0 -> i32 {
         builtin::array_get_u8(raw.repr, 0) == 45;
     } else {
         0;
     }) {
         return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__overflow_2: block -> ref "core:serde//DeserializeError" {
-            __local_15 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative value for u64"), used: 22 };
-            break __inline_DeserializeError__overflow_2: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_15, offset: start };
+            __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative value for u64"), used: 22 };
+            break __inline_DeserializeError__overflow_2: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_13, offset: start };
         }) };
     }
     has_exp = "core:json/JsonDeserializer::has_exp_or_dot"(raw);
     if has_exp {
-        let __sroa_parsed_discriminant: i32;
-        let __sroa_parsed_payload_0: f64;
-        __local_17 = value_copy "core:prelude/string.wado//String"(raw);
-        multivalue_bind [__sroa_parsed_discriminant, __sroa_parsed_payload_0] = "core:prelude/fpfmt.wado/parse_text"(__local_17);
-        if __sroa_parsed_discriminant == 0 {
-            v = __sroa_parsed_payload_0;
-            if v < 0 {
+        let __match_scrut_0: ref "core:prelude/types.wado//Option<f64>";
+        __match_scrut_0 = __inline_f64__parse_3: block -> ref "core:prelude/types.wado//Option<f64>" {
+            __local_15 = value_copy "core:prelude/string.wado//String"(raw);
+            break __inline_f64__parse_3: "core:prelude/fpfmt.wado/parse_text"(__local_15);
+        };
+        if ref.test "core:prelude/types.wado//Option<f64>::Some"(__match_scrut_0) {
+            let __cast_1: ref "core:prelude/types.wado//Option<f64>::Some";
+            __cast_1 = ref.cast "core:prelude/types.wado//Option<f64>::Some"(__match_scrut_0);
+            __local_4 = __cast_1.payload_0;
+            if __local_4 < 0 {
                 return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__overflow_4: block -> ref "core:serde//DeserializeError" {
-                    __local_18 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative value for u64"), used: 22 };
-                    break __inline_DeserializeError__overflow_4: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_18, offset: start };
+                    __local_16 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative value for u64"), used: 22 };
+                    break __inline_DeserializeError__overflow_4: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_16, offset: start };
                 }) };
             }
-            if v != builtin::f64_floor(v) {
+            if __local_4 != builtin::f64_floor(__local_4) {
                 return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_6: block -> ref "core:serde//DeserializeError" {
-                    __local_21 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
-                    break __inline_DeserializeError__unexpected_type_6: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_21, offset: start };
+                    __local_19 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
+                    break __inline_DeserializeError__unexpected_type_6: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_19, offset: start };
                 }) };
             }
-            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_u(v) };
+            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_u(__local_4) };
+            unreachable;
+        } else if __match_scrut_0.discriminant == 1 {
+            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_7: block -> ref "core:serde//DeserializeError" {
+                __local_21 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid number"), used: 14 };
+                break __inline_DeserializeError__invalid_value_7: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_21, offset: start };
+            }) };
+            unreachable;
+        } else {
+            unreachable;
         }
-        return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_7: block -> ref "core:serde//DeserializeError" {
-            __local_23 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid number"), used: 14 };
-            break __inline_DeserializeError__invalid_value_7: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_23, offset: start };
-        }) };
+        unreachable;
     }
     idx = 0;
     len = raw.used;
     result = 0_i64;
-    _licm_repr_30 = raw.repr;
-    b297: block {
-        l298: loop {
+    _licm_repr_28 = raw.repr;
+    b314: block {
+        l315: loop {
             if idx >= len {
-                break b297;
+                break b314;
             }
-            b = builtin::array_get_u8(_licm_repr_30, idx);
+            b = builtin::array_get_u8(_licm_repr_28, idx);
             if (if b < 48 -> i32 {
                 1;
             } else {
                 b > 57;
             }) {
                 return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_10: block -> ref "core:serde//DeserializeError" {
-                    __local_28 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid digit"), used: 13 };
-                    break __inline_DeserializeError__invalid_value_10: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_28, offset: start };
+                    __local_26 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid digit"), used: 13 };
+                    break __inline_DeserializeError__invalid_value_10: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_26, offset: start };
                 }) };
             }
             digit = builtin::i64_extend_i32_s(b - 48);
             result = (result * 10_i64) + digit;
             idx = idx + 1;
-            continue l298;
+            continue l315;
         };
     };
     return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Ok" { discriminant: 0, payload_0: result };
@@ -2995,16 +3118,16 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b307: block {
-        l308: loop {
+    b324: block {
+        l325: loop {
             if _hfs_pos_49 >= _licm_used_45 {
-                break b307;
+                break b324;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_49;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_46, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -3025,17 +3148,17 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b316: block {
-                        l317: loop {
+                    b333: block {
+                        l334: loop {
                             if _hfs_pos_47 >= _licm_used_45 {
                                 self.pos = _hfs_pos_49;
-                                break b316;
+                                break b333;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_47;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_46, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -3045,9 +3168,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                                 _hfs_pos_47 = _hfs_pos_47 + 1;
                             } else {
                                 self.pos = _hfs_pos_49;
-                                break b316;
+                                break b333;
                             }
-                            continue l317;
+                            continue l334;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -3078,17 +3201,17 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                             }
                         }
                         _hfs_pos_48 = _hfs_pos_49;
-                        b326: block {
-                            l327: loop {
+                        b343: block {
+                            l344: loop {
                                 if _hfs_pos_48 >= _licm_used_45 {
                                     self.pos = _hfs_pos_49;
-                                    break b326;
+                                    break b343;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_48;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_46, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -3097,9 +3220,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                                     _hfs_pos_48 = _hfs_pos_48 + 1;
                                 } else {
                                     self.pos = _hfs_pos_49;
-                                    break b326;
+                                    break b343;
                                 }
-                                continue l327;
+                                continue l344;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -3125,9 +3248,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                 self.pos = _hfs_pos_49;
                 return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v_signed) };
             } else {
-                break b307;
+                break b324;
             }
-            continue l308;
+            continue l325;
         };
     };
     self.pos = _hfs_pos_49;
@@ -3212,16 +3335,16 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b339: block {
-        l340: loop {
+    b356: block {
+        l357: loop {
             if _hfs_pos_49 >= _licm_used_45 {
-                break b339;
+                break b356;
             }
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_26 = _hfs_pos_49;
                 break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_46, __local_26);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -3242,17 +3365,17 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b348: block {
-                        l349: loop {
+                    b365: block {
+                        l366: loop {
                             if _hfs_pos_47 >= _licm_used_45 {
                                 self.pos = _hfs_pos_49;
-                                break b348;
+                                break b365;
                             }
                             b2 = __inline_String__get_byte_9: block -> u8 {
                                 __local_29 = _hfs_pos_47;
                                 break __inline_String__get_byte_9: builtin::array_get_u8(_licm_repr_46, __local_29);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -3262,9 +3385,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                                 _hfs_pos_47 = _hfs_pos_47 + 1;
                             } else {
                                 self.pos = _hfs_pos_49;
-                                break b348;
+                                break b365;
                             }
-                            continue l349;
+                            continue l366;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -3295,17 +3418,17 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                             }
                         }
                         _hfs_pos_48 = _hfs_pos_49;
-                        b358: block {
-                            l359: loop {
+                        b375: block {
+                            l376: loop {
                                 if _hfs_pos_48 >= _licm_used_45 {
                                     self.pos = _hfs_pos_49;
-                                    break b358;
+                                    break b375;
                                 }
                                 b3 = __inline_String__get_byte_15: block -> u8 {
                                     __local_38 = _hfs_pos_48;
                                     break __inline_String__get_byte_15: builtin::array_get_u8(_licm_repr_46, __local_38);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -3314,9 +3437,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                                     _hfs_pos_48 = _hfs_pos_48 + 1;
                                 } else {
                                     self.pos = _hfs_pos_49;
-                                    break b358;
+                                    break b375;
                                 }
-                                continue l359;
+                                continue l376;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -3345,9 +3468,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                 self.pos = _hfs_pos_49;
                 return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_u(v) };
             } else {
-                break b339;
+                break b356;
             }
-            continue l340;
+            continue l357;
         };
     };
     self.pos = _hfs_pos_49;
@@ -3356,78 +3479,82 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_i64"(self) {
     let start: i64;
+    let __local_2: ref "core:prelude/string.wado//String";
+    let __local_3: ref "core:serde//DeserializeError";
     let s: ref "core:prelude/string.wado//String";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     start = builtin::i64_extend_i32_s(self.pos);
     if (if self.pos < __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_5 = self.input;
+        break __inline_String__len_0: __local_5.used;
     } -> i32 {
         __inline_String__get_byte_1: block -> u8 {
-            __local_8 = self.input;
-            __local_9 = self.pos;
-            break __inline_String__get_byte_1: builtin::array_get_u8(__local_8.repr, __local_9);
+            __local_6 = self.input;
+            __local_7 = self.pos;
+            break __inline_String__get_byte_1: builtin::array_get_u8(__local_6.repr, __local_7);
         } == 34;
     } else {
         0;
     }) {
-        let __sroa_sr_discriminant: i32;
-        let __sroa_sr_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_sr_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_sr_discriminant, __sroa_sr_case0_payload_0, __sroa_sr_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self);
-        if __sroa_sr_discriminant == 0 {
-            s = __sroa_sr_case0_payload_0;
-            return "core:json/JsonDeserializer::parse_i64_from"(self, s, start);
-        }
-        if __sroa_sr_discriminant == 1 {
-            e = __sroa_sr_case1_payload_0;
-            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: e };
-        }
-        "core:internal/unreachable"();
-        unreachable;
+        s = value_copy "core:prelude/string.wado//String"(let __match_scrut_0: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_0 = "core:json/JsonDeserializer::read_json_string"(self); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+            let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0);
+            __local_2 = __cast_2.payload_0;
+            __local_2;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+            let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0);
+            __local_3 = __cast_1.payload_0;
+            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
+        }));
+        return "core:json/JsonDeserializer::parse_i64_from"(self, s, start);
     }
     return "core:json/JsonDeserializer::parse_i64_direct"(self);
 }
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_u64"(self) {
     let start: i64;
+    let __local_2: ref "core:prelude/string.wado//String";
+    let __local_3: ref "core:serde//DeserializeError";
     let s: ref "core:prelude/string.wado//String";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     start = builtin::i64_extend_i32_s(self.pos);
     if (if self.pos < __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_5 = self.input;
+        break __inline_String__len_0: __local_5.used;
     } -> i32 {
         __inline_String__get_byte_1: block -> u8 {
-            __local_8 = self.input;
-            __local_9 = self.pos;
-            break __inline_String__get_byte_1: builtin::array_get_u8(__local_8.repr, __local_9);
+            __local_6 = self.input;
+            __local_7 = self.pos;
+            break __inline_String__get_byte_1: builtin::array_get_u8(__local_6.repr, __local_7);
         } == 34;
     } else {
         0;
     }) {
-        let __sroa_sr_discriminant: i32;
-        let __sroa_sr_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_sr_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_sr_discriminant, __sroa_sr_case0_payload_0, __sroa_sr_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self);
-        if __sroa_sr_discriminant == 0 {
-            s = __sroa_sr_case0_payload_0;
-            return "core:json/JsonDeserializer::parse_u64_from"(self, s, start);
-        }
-        if __sroa_sr_discriminant == 1 {
-            e = __sroa_sr_case1_payload_0;
-            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: e };
-        }
-        "core:internal/unreachable"();
-        unreachable;
+        s = value_copy "core:prelude/string.wado//String"(let __match_scrut_0: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_0 = "core:json/JsonDeserializer::read_json_string"(self); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+            let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0);
+            __local_2 = __cast_2.payload_0;
+            __local_2;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+            let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0);
+            __local_3 = __cast_1.payload_0;
+            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
+        }));
+        return "core:json/JsonDeserializer::parse_u64_from"(self, s, start);
     }
     return "core:json/JsonDeserializer::parse_u64_direct"(self);
 }
@@ -3439,13 +3566,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l375: loop {
+            l392: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l375;
+                continue l392;
             };
         };
     };
@@ -3582,8 +3709,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b398: block {
-        l399: loop {
+    b415: block {
+        l416: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3608,9 +3735,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b398;
+                break b415;
             }
-            continue l399;
+            continue l416;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_large_int.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_large_int.wir.wado
@@ -61,229 +61,285 @@ struct tuple//[u128, u128] {  // TypeId(10)
     mut 1: ref "core:prelude/int128.wado//u128",
 }
 
-variant core:prelude/types.wado//Result<i64,DeserializeError> {  // TypeId(11)
+variant core:prelude/types.wado//Option<char> {  // TypeId(11)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(12)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<f64> {  // TypeId(13)
+    Some(f64),
+    None,
+}
+
+struct core:prelude/types.wado//Option<f64>::Some {  // TypeId(14)
+    discriminant: i32,
+    payload_0: f64,
+}
+
+variant core:prelude/types.wado//Result<i64,DeserializeError> {  // TypeId(15)
     Ok(i64),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i64,DeserializeError>::Ok {  // TypeId(12)
+struct core:prelude/types.wado//Result<i64,DeserializeError>::Ok {  // TypeId(16)
     discriminant: i32,
     payload_0: i64,
 }
 
-struct core:prelude/types.wado//Result<i64,DeserializeError>::Err {  // TypeId(13)
+struct core:prelude/types.wado//Result<i64,DeserializeError>::Err {  // TypeId(17)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<u64,DeserializeError> {  // TypeId(14)
+variant core:prelude/types.wado//Result<u64,DeserializeError> {  // TypeId(18)
     Ok(u64),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<u64,DeserializeError>::Ok {  // TypeId(15)
+struct core:prelude/types.wado//Result<u64,DeserializeError>::Ok {  // TypeId(19)
     discriminant: i32,
     payload_0: u64,
 }
 
-struct core:prelude/types.wado//Result<u64,DeserializeError>::Err {  // TypeId(16)
+struct core:prelude/types.wado//Result<u64,DeserializeError>::Err {  // TypeId(20)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/traits.wado//enum:Ordering { Less = 0, Equal = 1, Greater = 2 };  // TypeId(17)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(21)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(18)
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(22)
+    discriminant: i32,
+    payload_0: char,
+}
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(19)
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(23)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(20)
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(24)
+    Ok(ref "core:prelude/string.wado//String"),
+    Err(ref "core:serde//DeserializeError"),
+}
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(21)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(25)
+    discriminant: i32,
+    payload_0: ref "core:prelude/string.wado//String",
+}
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(22)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(26)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(23)
+enum core:prelude/traits.wado//enum:Ordering { Less = 0, Equal = 1, Greater = 2 };  // TypeId(27)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(24)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(28)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(25)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(29)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(26)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(30)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_0_i64_small_value_as_number" = fn();  // TypeId(27)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(31)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_1_i64_at_max_safe_integer_as_number" = fn();  // TypeId(28)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(32)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_2_i64_above_max_safe_integer_as_string" = fn();  // TypeId(29)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(33)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_3_u64_large_value_as_string" = fn();  // TypeId(30)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(34)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_4_i64_negative_large_value_as_string" = fn();  // TypeId(31)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(35)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_5_deserialize_i64_from_string" = fn();  // TypeId(32)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(36)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_6_deserialize_u64_from_string" = fn();  // TypeId(33)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_0_i64_small_value_as_number" = fn();  // TypeId(37)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_7_i128_large_value_as_string" = fn();  // TypeId(34)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_1_i64_at_max_safe_integer_as_number" = fn();  // TypeId(38)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_8_u128_large_value_as_string" = fn();  // TypeId(35)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_2_i64_above_max_safe_integer_as_string" = fn();  // TypeId(39)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_0_i64_small_value_as_number" = fn();  // TypeId(36)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_3_u64_large_value_as_string" = fn();  // TypeId(40)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_1_i64_at_max_safe_integer_as_number" = fn();  // TypeId(37)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_4_i64_negative_large_value_as_string" = fn();  // TypeId(41)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_2_i64_above_max_safe_integer_as_string" = fn();  // TypeId(38)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_5_deserialize_i64_from_string" = fn();  // TypeId(42)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_3_u64_large_value_as_string" = fn();  // TypeId(39)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_6_deserialize_u64_from_string" = fn();  // TypeId(43)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_4_i64_negative_large_value_as_string" = fn();  // TypeId(40)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_7_i128_large_value_as_string" = fn();  // TypeId(44)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_5_deserialize_i64_from_string" = fn();  // TypeId(41)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__test_8_u128_large_value_as_string" = fn();  // TypeId(45)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_6_deserialize_u64_from_string" = fn();  // TypeId(42)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_0_i64_small_value_as_number" = fn();  // TypeId(46)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_7_i128_large_value_as_string" = fn();  // TypeId(43)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_1_i64_at_max_safe_integer_as_number" = fn();  // TypeId(47)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_8_u128_large_value_as_string" = fn();  // TypeId(44)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_2_i64_above_max_safe_integer_as_string" = fn();  // TypeId(48)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(45)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_3_u64_large_value_as_string" = fn();  // TypeId(49)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(46)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_4_i64_negative_large_value_as_string" = fn();  // TypeId(50)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(47)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_5_deserialize_i64_from_string" = fn();  // TypeId(51)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(48)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_6_deserialize_u64_from_string" = fn();  // TypeId(52)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(49)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_7_i128_large_value_as_string" = fn();  // TypeId(53)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(50)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/__cm_export____test_8_u128_large_value_as_string" = fn();  // TypeId(54)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(51)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(55)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(52)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(56)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(53)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(57)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(54)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(58)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(55)
+type "functype//core:internal/unreachable" = fn();  // TypeId(59)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(56)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(60)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(57)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(61)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(58)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(62)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(59)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(63)
 
-type "functype//core:prelude/int128.wado/u128::div_rem" = fn(ref "core:prelude/int128.wado//u128", ref "core:prelude/int128.wado//u128") -> ref "tuple//[u128, u128]";  // TypeId(60)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(64)
 
-type "functype//core:prelude/int128.wado/u128::get_bit" = fn(ref "core:prelude/int128.wado//u128", i32) -> bool;  // TypeId(61)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(65)
 
-type "functype//core:prelude/int128.wado/u128::set_bit" = fn(ref "core:prelude/int128.wado//u128", i32) -> ref "core:prelude/int128.wado//u128";  // TypeId(62)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(66)
 
-type "functype//core:prelude/int128.wado/u128::fmt_decimal" = fn(ref "core:prelude/int128.wado//u128", ref "core:prelude/format.wado//Formatter");  // TypeId(63)
+type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> ref "core:prelude/types.wado//Option<f64>";  // TypeId(67)
 
-type "functype//core:prelude/int128.wado/u128^Ord::cmp" = fn(ref "core:prelude/int128.wado//u128", ref "core:prelude/int128.wado//u128") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(64)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(68)
 
-type "functype//core:prelude/int128.wado/u128^Sub::sub" = fn(ref "core:prelude/int128.wado//u128", ref "core:prelude/int128.wado//u128") -> ref "core:prelude/int128.wado//u128";  // TypeId(65)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(69)
 
-type "functype//core:prelude/int128.wado/u128^Shl::shl" = fn(ref "core:prelude/int128.wado//u128", u32) -> ref "core:prelude/int128.wado//u128";  // TypeId(66)
+type "functype//core:prelude/int128.wado/u128::div_rem" = fn(ref "core:prelude/int128.wado//u128", ref "core:prelude/int128.wado//u128") -> ref "tuple//[u128, u128]";  // TypeId(70)
 
-type "functype//core:prelude/int128.wado/i128::abs_u128" = fn(ref "core:prelude/int128.wado//i128") -> ref "core:prelude/int128.wado//u128";  // TypeId(67)
+type "functype//core:prelude/int128.wado/u128::get_bit" = fn(ref "core:prelude/int128.wado//u128", i32) -> bool;  // TypeId(71)
 
-type "functype//core:prelude/int128.wado/i128::fmt_decimal" = fn(ref "core:prelude/int128.wado//i128", ref "core:prelude/format.wado//Formatter");  // TypeId(68)
+type "functype//core:prelude/int128.wado/u128::set_bit" = fn(ref "core:prelude/int128.wado//u128", i32) -> ref "core:prelude/int128.wado//u128";  // TypeId(72)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(69)
+type "functype//core:prelude/int128.wado/u128::fmt_decimal" = fn(ref "core:prelude/int128.wado//u128", ref "core:prelude/format.wado//Formatter");  // TypeId(73)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(70)
+type "functype//core:prelude/int128.wado/u128^Ord::cmp" = fn(ref "core:prelude/int128.wado//u128", ref "core:prelude/int128.wado//u128") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(74)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(71)
+type "functype//core:prelude/int128.wado/u128^Sub::sub" = fn(ref "core:prelude/int128.wado//u128", ref "core:prelude/int128.wado//u128") -> ref "core:prelude/int128.wado//u128";  // TypeId(75)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(72)
+type "functype//core:prelude/int128.wado/u128^Shl::shl" = fn(ref "core:prelude/int128.wado//u128", u32) -> ref "core:prelude/int128.wado//u128";  // TypeId(76)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(73)
+type "functype//core:prelude/int128.wado/i128::abs_u128" = fn(ref "core:prelude/int128.wado//i128") -> ref "core:prelude/int128.wado//u128";  // TypeId(77)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(74)
+type "functype//core:prelude/int128.wado/i128::fmt_decimal" = fn(ref "core:prelude/int128.wado//i128", ref "core:prelude/format.wado//Formatter");  // TypeId(78)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(75)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(79)
 
-type "functype//core:json/JsonDeserializer::parse_i64_from" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String", i64) -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(76)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(80)
 
-type "functype//core:json/JsonDeserializer::parse_u64_from" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String", i64) -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(77)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(81)
 
-type "functype//core:json/JsonDeserializer::parse_i64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(78)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(82)
 
-type "functype//core:json/JsonDeserializer::parse_u64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(79)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(83)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_i64" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(80)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(84)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_u64" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(81)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(85)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(82)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(86)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(83)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(87)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(84)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(88)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(85)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(89)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/u64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(86)
+type "functype//core:json/JsonDeserializer::parse_i64_from" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String", i64) -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(90)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/i64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(87)
+type "functype//core:json/JsonDeserializer::parse_u64_from" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String", i64) -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(91)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(88)
+type "functype//core:json/JsonDeserializer::parse_i64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(92)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(89)
+type "functype//core:json/JsonDeserializer::parse_u64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(93)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(90)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_i64" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(94)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(91)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_u64" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(95)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(92)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(96)
 
-type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(93)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(97)
 
-type "functype//core:json/core/json/to_string<u128>" = fn(ref "core:prelude/int128.wado//u128") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(94)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(98)
 
-type "functype//core:json/core/json/to_string<i128>" = fn(ref "core:prelude/int128.wado//i128") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(95)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(99)
 
-type "functype//core:json/core/json/from_string<u64>" = fn(ref "core:prelude/string.wado//String") -> [i32, u64, ref null "core:serde//DeserializeError"];  // TypeId(96)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/u64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(100)
 
-type "functype//core:json/core/json/from_string<i64>" = fn(ref "core:prelude/string.wado//String") -> [i32, i64, ref null "core:serde//DeserializeError"];  // TypeId(97)
+type "functype//wado-compiler/tests/fixtures/serde_json_large_int.wado/i64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(101)
 
-type "functype//core:prelude/int128.wado/i128::sub" = fn(ref "core:prelude/int128.wado//i128", ref "core:prelude/int128.wado//i128") -> [u64, i64];  // TypeId(98)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(102)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(99)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(103)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(100)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(104)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(101)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(105)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(102)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(106)
 
-type "functype//core:json/core/json/to_string<u64>" = fn(u64) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(103)
+type "functype//core:json/core/json/to_string<u128>" = fn(ref "core:prelude/int128.wado//u128") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(107)
 
-type "functype//core:json/core/json/to_string<i64>" = fn(i64) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(104)
+type "functype//core:json/core/json/to_string<i128>" = fn(ref "core:prelude/int128.wado//i128") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(108)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(105)
+type "functype//core:json/core/json/from_string<u64>" = fn(ref "core:prelude/string.wado//String") -> [i32, u64, ref null "core:serde//DeserializeError"];  // TypeId(109)
 
-type "functype//core:prelude/primitive.wado/i64::fmt_decimal" = fn(i64, ref "core:prelude/format.wado//Formatter");  // TypeId(106)
+type "functype//core:json/core/json/from_string<i64>" = fn(ref "core:prelude/string.wado//String") -> [i32, i64, ref null "core:serde//DeserializeError"];  // TypeId(110)
 
-type "functype//core:prelude/primitive.wado/u64::fmt_decimal" = fn(u64, ref "core:prelude/format.wado//Formatter");  // TypeId(107)
+type "functype//core:prelude/int128.wado/i128::sub" = fn(ref "core:prelude/int128.wado//i128", ref "core:prelude/int128.wado//i128") -> [u64, i64];  // TypeId(111)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(108)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(112)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i64" = fn(ref "core:prelude/string.wado//String", i64) -> ref null "core:serde//SerializeError";  // TypeId(109)
+type "functype//core:json/core/json/to_string<u64>" = fn(u64) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(113)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_u64" = fn(ref "core:prelude/string.wado//String", u64) -> ref null "core:serde//SerializeError";  // TypeId(110)
+type "functype//core:json/core/json/to_string<i64>" = fn(i64) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(114)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i128" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/int128.wado//i128") -> ref null "core:serde//SerializeError";  // TypeId(111)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(115)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_u128" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/int128.wado//u128") -> ref null "core:serde//SerializeError";  // TypeId(112)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(116)
 
-type "functype//core:json/JsonDeserializer::has_exp_or_dot" = fn(ref "core:prelude/string.wado//String") -> bool;  // TypeId(113)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(117)
+
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(118)
+
+type "functype//core:prelude/primitive.wado/i64::fmt_decimal" = fn(i64, ref "core:prelude/format.wado//Formatter");  // TypeId(119)
+
+type "functype//core:prelude/primitive.wado/u64::fmt_decimal" = fn(u64, ref "core:prelude/format.wado//Formatter");  // TypeId(120)
+
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(121)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_i64" = fn(ref "core:prelude/string.wado//String", i64) -> ref null "core:serde//SerializeError";  // TypeId(122)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_u64" = fn(ref "core:prelude/string.wado//String", u64) -> ref null "core:serde//SerializeError";  // TypeId(123)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_i128" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/int128.wado//i128") -> ref null "core:serde//SerializeError";  // TypeId(124)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_u128" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/int128.wado//u128") -> ref null "core:serde//SerializeError";  // TypeId(125)
+
+type "functype//core:json/JsonDeserializer::has_exp_or_dot" = fn(ref "core:prelude/string.wado//String") -> bool;  // TypeId(126)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -1250,7 +1306,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     let _licm_repr_81: ref builtin::array<u8>;
     len = s.used;
     if len == 0 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     sign = 1;
     i = 0;
@@ -1262,7 +1318,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         i = 1;
     }
     if i >= len {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     remaining = len - i;
     c0 = builtin::array_get_u8(s.repr, i);
@@ -1297,7 +1353,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
             0;
         }) {
             if remaining == 3 {
-                return 0, f64.copysign(inf, sign);
+                return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(inf, sign) };
             }
             if remaining == 8 {
                 c3 = __inline_String__get_byte_5: block -> u8 {
@@ -1357,11 +1413,11 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
                 } else {
                     0;
                 }) {
-                    return 0, f64.copysign(inf, sign);
+                    return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(inf, sign) };
                 }
             }
         }
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     if (if (if c0 == 110 -> i32 {
         1;
@@ -1393,9 +1449,9 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         } else {
             0;
         }) {
-            return 0, 0 / 0;
+            return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: 0 / 0 };
         }
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     d = 0_i64;
     frac = 0;
@@ -1428,7 +1484,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         0;
     }) {
         if int_digits == 0 {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
         i = i + 1;
         frac_start = i;
@@ -1455,7 +1511,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
             };
         };
         if i == frac_start {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
     }
     total_digits = int_digits + frac;
@@ -1464,7 +1520,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     } else {
         total_digits > 19;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     p = 0;
     if (if i < len -> i32 {
@@ -1492,7 +1548,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         } else {
             (len - i) > 3;
         }) {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
         __for_2: block {
             _licm_repr_81 = s.repr;
@@ -1516,25 +1572,25 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
             };
         };
         if i == exp_start {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
         p = p * exp_sign;
     }
     if i != len {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     if d == 0_i64 {
-        return 0, f64.copysign(0, sign);
+        return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(0, sign) };
     }
     eff_p = p - frac;
     if eff_p > 350 {
-        return 0, f64.copysign(inf, sign);
+        return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(inf, sign) };
     }
     if eff_p < -351 {
-        return 0, f64.copysign(0, sign);
+        return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(0, sign) };
     }
     val = "core:prelude/fpfmt.wado/parse"(d, eff_p);
-    return 0, f64.copysign(val, sign);
+    return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(val, sign) };
 }
 
 fn "core:prelude/primitive.wado/count_digits_i64"(val) {
@@ -1584,129 +1640,152 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/core/json/to_string<u128>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_u128"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_u128"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<i128>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_i128"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_i128"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<u64>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<u64,DeserializeError>";
+    let __local_2: u64;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: u64;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_large_int.wado/u64^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<u64,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<u64,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<u64,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_large_int.wado/u64^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<u64,DeserializeError>::Ok"(__match_scrut_0) -> u64 {
+        let __cast_2: ref "core:prelude/types.wado//Result<u64,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<u64,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<u64,DeserializeError>::Err"(__match_scrut_0) -> u64 {
+        let __cast_1: ref "core:prelude/types.wado//Result<u64,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<u64,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0_i64, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<u64,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<u64,DeserializeError>::Err"(r).payload_0);
-        return 1, 0_i64, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/from_string<i64>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<i64,DeserializeError>";
+    let __local_2: i64;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: i64;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_large_int.wado/i64^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<i64,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_large_int.wado/i64^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(__match_scrut_0) -> i64 {
+        let __cast_2: ref "core:prelude/types.wado//Result<i64,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(__match_scrut_0) -> i64 {
+        let __cast_1: ref "core:prelude/types.wado//Result<i64,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0_i64, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(r).payload_0);
-        return 1, 0_i64, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<u64>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_u64"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_u64"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<i64>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_i64"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_i64"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
@@ -1744,10 +1823,10 @@ fn "core:prelude/int128.wado/u128::div_rem"(self, divisor) {
     quotient = struct.new "core:prelude/int128.wado//u128" { low: 0_i64, high: 0_i64 };
     remainder = struct.new "core:prelude/int128.wado//u128" { low: 0_i64, high: 0_i64 };
     i = 127;
-    b176: block {
-        l177: loop {
+    b177: block {
+        l178: loop {
             if i < 0 {
-                break b176;
+                break b177;
             }
             remainder = "core:prelude/int128.wado/u128^Shl::shl"(remainder, 1);
             bit = "core:prelude/int128.wado/u128::get_bit"(self, i);
@@ -1759,7 +1838,7 @@ fn "core:prelude/int128.wado/u128::div_rem"(self, divisor) {
                 quotient = "core:prelude/int128.wado/u128::set_bit"(quotient, i);
             }
             i = i - 1;
-            continue l177;
+            continue l178;
         };
     };
     return struct.new "tuple//[u128, u128]" { 0: quotient, 1: remainder };
@@ -1834,7 +1913,7 @@ fn "core:prelude/int128.wado/u128::fmt_decimal"(self, f) {
     __for_0: block {
         temp_7 = value_copy "core:prelude/int128.wado//u128"(self);
         block {
-            l186: loop {
+            l187: loop {
                 if "core:prelude/int128.wado/u128^Ord::cmp"(temp_7, struct.new "core:prelude/int128.wado//u128" { low: 0_i64, high: 0_i64 }) != 2 {
                     break __for_0;
                 }
@@ -1844,7 +1923,7 @@ fn "core:prelude/int128.wado/u128::fmt_decimal"(self, f) {
                     __local_21 = "core:prelude/int128.wado/u128::div_rem"(__local_19, ten);
                     break __inline_u128_Div__div_5: __local_21.0;
                 };
-                continue l186;
+                continue l187;
             };
         };
     };
@@ -1857,7 +1936,7 @@ fn "core:prelude/int128.wado/u128::fmt_decimal"(self, f) {
     __for_1: block {
         temp_11 = value_copy "core:prelude/int128.wado//u128"(self);
         block {
-            l189: loop {
+            l190: loop {
                 if "core:prelude/int128.wado/u128^Ord::cmp"(temp_11, struct.new "core:prelude/int128.wado//u128" { low: 0_i64, high: 0_i64 }) != 2 {
                     break __for_1;
                 }
@@ -1876,7 +1955,7 @@ fn "core:prelude/int128.wado/u128::fmt_decimal"(self, f) {
                     __local_30 = "core:prelude/int128.wado/u128::div_rem"(__local_28, ten);
                     break __inline_u128_Div__div_10: __local_30.0;
                 };
-                continue l189;
+                continue l190;
             };
         };
     };
@@ -1985,7 +2064,7 @@ fn "core:prelude/int128.wado/i128::fmt_decimal"(self, f) {
     __for_2: block {
         temp_9 = value_copy "core:prelude/int128.wado//u128"(abs_val);
         block {
-            l202: loop {
+            l203: loop {
                 if "core:prelude/int128.wado/u128^Ord::cmp"(temp_9, struct.new "core:prelude/int128.wado//u128" { low: 0_i64, high: 0_i64 }) != 2 {
                     break __for_2;
                 }
@@ -1995,7 +2074,7 @@ fn "core:prelude/int128.wado/i128::fmt_decimal"(self, f) {
                     __local_21 = "core:prelude/int128.wado/u128::div_rem"(__local_19, ten);
                     break __inline_u128_Div__div_4: __local_21.0;
                 };
-                continue l202;
+                continue l203;
             };
         };
     };
@@ -2008,7 +2087,7 @@ fn "core:prelude/int128.wado/i128::fmt_decimal"(self, f) {
     __for_3: block {
         temp_13 = value_copy "core:prelude/int128.wado//u128"(abs_val);
         block {
-            l205: loop {
+            l206: loop {
                 if "core:prelude/int128.wado/u128^Ord::cmp"(temp_13, struct.new "core:prelude/int128.wado//u128" { low: 0_i64, high: 0_i64 }) != 2 {
                     break __for_3;
                 }
@@ -2027,7 +2106,7 @@ fn "core:prelude/int128.wado/i128::fmt_decimal"(self, f) {
                     __local_30 = "core:prelude/int128.wado/u128::div_rem"(__local_28, ten);
                     break __inline_u128_Div__div_9: __local_30.0;
                 };
-                continue l205;
+                continue l206;
             };
         };
     };
@@ -2035,16 +2114,81 @@ fn "core:prelude/int128.wado/i128::fmt_decimal"(self, f) {
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -2136,10 +2280,10 @@ fn "core:prelude/primitive.wado/u64::fmt_decimal"(self, f) {
     }
     digit_count = 0;
     temp = val_i64;
-    b214: block {
-        l215: loop {
+    b229: block {
+        l230: loop {
             if temp == 0_i64 {
-                break b214;
+                break b229;
             }
             digit_count = digit_count + 1;
             if temp >= 0_i64 {
@@ -2154,7 +2298,7 @@ fn "core:prelude/primitive.wado/u64::fmt_decimal"(self, f) {
                 }
                 temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             }
-            continue l215;
+            continue l230;
         };
     };
     offset_11 = "core:prelude/format.wado/Formatter::prepare_int_write"(f, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
@@ -2164,10 +2308,10 @@ fn "core:prelude/primitive.wado/u64::fmt_decimal"(self, f) {
     };
     pos = offset_11 + digit_count;
     temp = val_i64;
-    b219: block {
-        l220: loop {
+    b234: block {
+        l235: loop {
             if temp == 0_i64 {
-                break b219;
+                break b234;
             }
             pos = pos - 1;
             digit = 0;
@@ -2190,7 +2334,7 @@ fn "core:prelude/primitive.wado/u64::fmt_decimal"(self, f) {
                 temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             }
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
-            continue l220;
+            continue l235;
         };
     };
 }
@@ -2271,7 +2415,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l232: loop {
+            l247: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -2279,7 +2423,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l232;
+                continue l247;
             };
         };
     };
@@ -2328,6 +2472,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -2450,10 +2643,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b246: block {
-        l247: loop {
+    b268: block {
+        l269: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b246;
+                break b268;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -2477,7 +2670,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l247;
+            continue l269;
         };
     };
     self.pos = _hfs_pos_8;
@@ -2495,130 +2688,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
+        }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b255: block {
-        l256: loop {
-            if scan_pos >= _licm_used_90 {
-                break b255;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b277: block {
+        l278: loop {
+            if scan_pos >= _licm_used_56 {
+                break b277;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b255;
+                break b277;
             }
             scan_pos = scan_pos + 1;
-            continue l256;
+            continue l278;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -2627,94 +2792,95 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l263: loop {
+                l285: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l263;
+                    continue l285;
                 };
             };
         };
         self.pos = scan_pos + 1;
-        return 0, result_5, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l266: loop {
+            l288: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l266;
+                continue l288;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b268: block {
-        l269: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b290: block {
+        l291: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b268;
+                break b290;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
-                return 0, result_8, ref.null none;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
+                return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
-                    });
+                    self.pos = _hfs_pos_64;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
+                    }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -2732,213 +2898,140 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return 1, ref.null none, e;
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
-                    });
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
+                    }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
-                    });
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
+                    }) };
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l269;
+            continue l291;
         };
     };
-    self.pos = _hfs_pos_98;
-    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
-    });
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
+    }) };
 }
 
 fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l294: loop {
+            l311: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l294;
+                continue l311;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -2952,7 +3045,7 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(raw) {
         _licm_used_7 = raw.used;
         _licm_repr_8 = raw.repr;
         block {
-            l304: loop {
+            l317: loop {
                 if i >= _licm_used_7 {
                     break __for_4;
                 }
@@ -2969,7 +3062,7 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(raw) {
                     return 1;
                 }
                 i = i + 1;
-                continue l304;
+                continue l317;
             };
         };
     };
@@ -2978,38 +3071,47 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(raw) {
 
 fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {
     let has_exp: bool;
-    let v: f64;
+    let __local_4: f64;
     let neg: bool;
     let idx: i32;
     let len: i32;
     let result: i64;
     let b: i32;
     let digit: i64;
+    let __local_11: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/string.wado//String";
     let __local_15: ref "core:prelude/string.wado//String";
-    let __local_17: ref "core:prelude/string.wado//String";
-    let __local_24: ref "core:prelude/string.wado//String";
-    let _licm_repr_26: ref builtin::array<u8>;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let _licm_repr_24: ref builtin::array<u8>;
     has_exp = "core:json/JsonDeserializer::has_exp_or_dot"(raw);
     if has_exp {
-        let __sroa_parsed_discriminant: i32;
-        let __sroa_parsed_payload_0: f64;
-        __local_13 = value_copy "core:prelude/string.wado//String"(raw);
-        multivalue_bind [__sroa_parsed_discriminant, __sroa_parsed_payload_0] = "core:prelude/fpfmt.wado/parse_text"(__local_13);
-        if __sroa_parsed_discriminant == 0 {
-            v = __sroa_parsed_payload_0;
-            if v != builtin::f64_floor(v) {
+        let __match_scrut_0: ref "core:prelude/types.wado//Option<f64>";
+        __match_scrut_0 = __inline_f64__parse_0: block -> ref "core:prelude/types.wado//Option<f64>" {
+            __local_11 = value_copy "core:prelude/string.wado//String"(raw);
+            break __inline_f64__parse_0: "core:prelude/fpfmt.wado/parse_text"(__local_11);
+        };
+        if ref.test "core:prelude/types.wado//Option<f64>::Some"(__match_scrut_0) {
+            let __cast_1: ref "core:prelude/types.wado//Option<f64>::Some";
+            __cast_1 = ref.cast "core:prelude/types.wado//Option<f64>::Some"(__match_scrut_0);
+            __local_4 = __cast_1.payload_0;
+            if __local_4 != builtin::f64_floor(__local_4) {
                 return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_2: block -> ref "core:serde//DeserializeError" {
-                    __local_15 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
-                    break __inline_DeserializeError__unexpected_type_2: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_15, offset: start };
+                    __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
+                    break __inline_DeserializeError__unexpected_type_2: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_13, offset: start };
                 }) };
             }
-            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v) };
+            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(__local_4) };
+            unreachable;
+        } else if __match_scrut_0.discriminant == 1 {
+            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_3: block -> ref "core:serde//DeserializeError" {
+                __local_15 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid number"), used: 14 };
+                break __inline_DeserializeError__invalid_value_3: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_15, offset: start };
+            }) };
+            unreachable;
+        } else {
+            unreachable;
         }
-        return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_3: block -> ref "core:serde//DeserializeError" {
-            __local_17 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid number"), used: 14 };
-            break __inline_DeserializeError__invalid_value_3: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_17, offset: start };
-        }) };
+        unreachable;
     }
     neg = 0;
     idx = 0;
@@ -3023,27 +3125,27 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {
         idx = 1;
     }
     result = 0_i64;
-    _licm_repr_26 = raw.repr;
-    b314: block {
-        l315: loop {
+    _licm_repr_24 = raw.repr;
+    b328: block {
+        l329: loop {
             if idx >= len {
-                break b314;
+                break b328;
             }
-            b = builtin::array_get_u8(_licm_repr_26, idx);
+            b = builtin::array_get_u8(_licm_repr_24, idx);
             if (if b < 48 -> i32 {
                 1;
             } else {
                 b > 57;
             }) {
                 return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_7: block -> ref "core:serde//DeserializeError" {
-                    __local_24 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid digit in number"), used: 23 };
-                    break __inline_DeserializeError__invalid_value_7: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_24, offset: start };
+                    __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid digit in number"), used: 23 };
+                    break __inline_DeserializeError__invalid_value_7: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_22, offset: start };
                 }) };
             }
             digit = builtin::i64_extend_i32_s(b - 48);
             result = (result * 10_i64) + digit;
             idx = idx + 1;
-            continue l315;
+            continue l329;
         };
     };
     if neg {
@@ -3054,80 +3156,89 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {
 
 fn "core:json/JsonDeserializer::parse_u64_from"(self, raw, start) {
     let has_exp: bool;
-    let v: f64;
+    let __local_4: f64;
     let idx: i32;
     let len: i32;
     let result: u64;
     let b: i32;
     let digit: u64;
+    let __local_13: ref "core:prelude/string.wado//String";
     let __local_15: ref "core:prelude/string.wado//String";
-    let __local_17: ref "core:prelude/string.wado//String";
-    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
     let __local_21: ref "core:prelude/string.wado//String";
-    let __local_23: ref "core:prelude/string.wado//String";
-    let __local_28: ref "core:prelude/string.wado//String";
-    let _licm_repr_30: ref builtin::array<u8>;
+    let __local_26: ref "core:prelude/string.wado//String";
+    let _licm_repr_28: ref builtin::array<u8>;
     if (if raw.used > 0 -> i32 {
         builtin::array_get_u8(raw.repr, 0) == 45;
     } else {
         0;
     }) {
         return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__overflow_2: block -> ref "core:serde//DeserializeError" {
-            __local_15 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative value for u64"), used: 22 };
-            break __inline_DeserializeError__overflow_2: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_15, offset: start };
+            __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative value for u64"), used: 22 };
+            break __inline_DeserializeError__overflow_2: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_13, offset: start };
         }) };
     }
     has_exp = "core:json/JsonDeserializer::has_exp_or_dot"(raw);
     if has_exp {
-        let __sroa_parsed_discriminant: i32;
-        let __sroa_parsed_payload_0: f64;
-        __local_17 = value_copy "core:prelude/string.wado//String"(raw);
-        multivalue_bind [__sroa_parsed_discriminant, __sroa_parsed_payload_0] = "core:prelude/fpfmt.wado/parse_text"(__local_17);
-        if __sroa_parsed_discriminant == 0 {
-            v = __sroa_parsed_payload_0;
-            if v < 0 {
+        let __match_scrut_0: ref "core:prelude/types.wado//Option<f64>";
+        __match_scrut_0 = __inline_f64__parse_3: block -> ref "core:prelude/types.wado//Option<f64>" {
+            __local_15 = value_copy "core:prelude/string.wado//String"(raw);
+            break __inline_f64__parse_3: "core:prelude/fpfmt.wado/parse_text"(__local_15);
+        };
+        if ref.test "core:prelude/types.wado//Option<f64>::Some"(__match_scrut_0) {
+            let __cast_1: ref "core:prelude/types.wado//Option<f64>::Some";
+            __cast_1 = ref.cast "core:prelude/types.wado//Option<f64>::Some"(__match_scrut_0);
+            __local_4 = __cast_1.payload_0;
+            if __local_4 < 0 {
                 return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__overflow_4: block -> ref "core:serde//DeserializeError" {
-                    __local_18 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative value for u64"), used: 22 };
-                    break __inline_DeserializeError__overflow_4: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_18, offset: start };
+                    __local_16 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative value for u64"), used: 22 };
+                    break __inline_DeserializeError__overflow_4: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_16, offset: start };
                 }) };
             }
-            if v != builtin::f64_floor(v) {
+            if __local_4 != builtin::f64_floor(__local_4) {
                 return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_6: block -> ref "core:serde//DeserializeError" {
-                    __local_21 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
-                    break __inline_DeserializeError__unexpected_type_6: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_21, offset: start };
+                    __local_19 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
+                    break __inline_DeserializeError__unexpected_type_6: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_19, offset: start };
                 }) };
             }
-            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_u(v) };
+            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_u(__local_4) };
+            unreachable;
+        } else if __match_scrut_0.discriminant == 1 {
+            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_7: block -> ref "core:serde//DeserializeError" {
+                __local_21 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid number"), used: 14 };
+                break __inline_DeserializeError__invalid_value_7: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_21, offset: start };
+            }) };
+            unreachable;
+        } else {
+            unreachable;
         }
-        return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_7: block -> ref "core:serde//DeserializeError" {
-            __local_23 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid number"), used: 14 };
-            break __inline_DeserializeError__invalid_value_7: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_23, offset: start };
-        }) };
+        unreachable;
     }
     idx = 0;
     len = raw.used;
     result = 0_i64;
-    _licm_repr_30 = raw.repr;
-    b326: block {
-        l327: loop {
+    _licm_repr_28 = raw.repr;
+    b341: block {
+        l342: loop {
             if idx >= len {
-                break b326;
+                break b341;
             }
-            b = builtin::array_get_u8(_licm_repr_30, idx);
+            b = builtin::array_get_u8(_licm_repr_28, idx);
             if (if b < 48 -> i32 {
                 1;
             } else {
                 b > 57;
             }) {
                 return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_10: block -> ref "core:serde//DeserializeError" {
-                    __local_28 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid digit"), used: 13 };
-                    break __inline_DeserializeError__invalid_value_10: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_28, offset: start };
+                    __local_26 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid digit"), used: 13 };
+                    break __inline_DeserializeError__invalid_value_10: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_26, offset: start };
                 }) };
             }
             digit = builtin::i64_extend_i32_s(b - 48);
             result = (result * 10_i64) + digit;
             idx = idx + 1;
-            continue l327;
+            continue l342;
         };
     };
     return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Ok" { discriminant: 0, payload_0: result };
@@ -3218,16 +3329,16 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b336: block {
-        l337: loop {
+    b351: block {
+        l352: loop {
             if _hfs_pos_49 >= _licm_used_45 {
-                break b336;
+                break b351;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_49;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_46, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -3248,17 +3359,17 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b345: block {
-                        l346: loop {
+                    b360: block {
+                        l361: loop {
                             if _hfs_pos_47 >= _licm_used_45 {
                                 self.pos = _hfs_pos_49;
-                                break b345;
+                                break b360;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_47;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_46, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -3268,9 +3379,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                                 _hfs_pos_47 = _hfs_pos_47 + 1;
                             } else {
                                 self.pos = _hfs_pos_49;
-                                break b345;
+                                break b360;
                             }
-                            continue l346;
+                            continue l361;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -3301,17 +3412,17 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                             }
                         }
                         _hfs_pos_48 = _hfs_pos_49;
-                        b355: block {
-                            l356: loop {
+                        b370: block {
+                            l371: loop {
                                 if _hfs_pos_48 >= _licm_used_45 {
                                     self.pos = _hfs_pos_49;
-                                    break b355;
+                                    break b370;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_48;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_46, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -3320,9 +3431,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                                     _hfs_pos_48 = _hfs_pos_48 + 1;
                                 } else {
                                     self.pos = _hfs_pos_49;
-                                    break b355;
+                                    break b370;
                                 }
-                                continue l356;
+                                continue l371;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -3348,9 +3459,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                 self.pos = _hfs_pos_49;
                 return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v_signed) };
             } else {
-                break b336;
+                break b351;
             }
-            continue l337;
+            continue l352;
         };
     };
     self.pos = _hfs_pos_49;
@@ -3435,16 +3546,16 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b368: block {
-        l369: loop {
+    b383: block {
+        l384: loop {
             if _hfs_pos_49 >= _licm_used_45 {
-                break b368;
+                break b383;
             }
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_26 = _hfs_pos_49;
                 break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_46, __local_26);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -3465,17 +3576,17 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b377: block {
-                        l378: loop {
+                    b392: block {
+                        l393: loop {
                             if _hfs_pos_47 >= _licm_used_45 {
                                 self.pos = _hfs_pos_49;
-                                break b377;
+                                break b392;
                             }
                             b2 = __inline_String__get_byte_9: block -> u8 {
                                 __local_29 = _hfs_pos_47;
                                 break __inline_String__get_byte_9: builtin::array_get_u8(_licm_repr_46, __local_29);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -3485,9 +3596,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                                 _hfs_pos_47 = _hfs_pos_47 + 1;
                             } else {
                                 self.pos = _hfs_pos_49;
-                                break b377;
+                                break b392;
                             }
-                            continue l378;
+                            continue l393;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -3518,17 +3629,17 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                             }
                         }
                         _hfs_pos_48 = _hfs_pos_49;
-                        b387: block {
-                            l388: loop {
+                        b402: block {
+                            l403: loop {
                                 if _hfs_pos_48 >= _licm_used_45 {
                                     self.pos = _hfs_pos_49;
-                                    break b387;
+                                    break b402;
                                 }
                                 b3 = __inline_String__get_byte_15: block -> u8 {
                                     __local_38 = _hfs_pos_48;
                                     break __inline_String__get_byte_15: builtin::array_get_u8(_licm_repr_46, __local_38);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -3537,9 +3648,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                                     _hfs_pos_48 = _hfs_pos_48 + 1;
                                 } else {
                                     self.pos = _hfs_pos_49;
-                                    break b387;
+                                    break b402;
                                 }
-                                continue l388;
+                                continue l403;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -3568,9 +3679,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                 self.pos = _hfs_pos_49;
                 return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_u(v) };
             } else {
-                break b368;
+                break b383;
             }
-            continue l369;
+            continue l384;
         };
     };
     self.pos = _hfs_pos_49;
@@ -3579,78 +3690,82 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_i64"(self) {
     let start: i64;
+    let __local_2: ref "core:prelude/string.wado//String";
+    let __local_3: ref "core:serde//DeserializeError";
     let s: ref "core:prelude/string.wado//String";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     start = builtin::i64_extend_i32_s(self.pos);
     if (if self.pos < __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_5 = self.input;
+        break __inline_String__len_0: __local_5.used;
     } -> i32 {
         __inline_String__get_byte_1: block -> u8 {
-            __local_8 = self.input;
-            __local_9 = self.pos;
-            break __inline_String__get_byte_1: builtin::array_get_u8(__local_8.repr, __local_9);
+            __local_6 = self.input;
+            __local_7 = self.pos;
+            break __inline_String__get_byte_1: builtin::array_get_u8(__local_6.repr, __local_7);
         } == 34;
     } else {
         0;
     }) {
-        let __sroa_sr_discriminant: i32;
-        let __sroa_sr_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_sr_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_sr_discriminant, __sroa_sr_case0_payload_0, __sroa_sr_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self);
-        if __sroa_sr_discriminant == 0 {
-            s = __sroa_sr_case0_payload_0;
-            return "core:json/JsonDeserializer::parse_i64_from"(self, s, start);
-        }
-        if __sroa_sr_discriminant == 1 {
-            e = __sroa_sr_case1_payload_0;
-            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: e };
-        }
-        "core:internal/unreachable"();
-        unreachable;
+        s = value_copy "core:prelude/string.wado//String"(let __match_scrut_0: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_0 = "core:json/JsonDeserializer::read_json_string"(self); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+            let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0);
+            __local_2 = __cast_2.payload_0;
+            __local_2;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+            let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0);
+            __local_3 = __cast_1.payload_0;
+            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
+        }));
+        return "core:json/JsonDeserializer::parse_i64_from"(self, s, start);
     }
     return "core:json/JsonDeserializer::parse_i64_direct"(self);
 }
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_u64"(self) {
     let start: i64;
+    let __local_2: ref "core:prelude/string.wado//String";
+    let __local_3: ref "core:serde//DeserializeError";
     let s: ref "core:prelude/string.wado//String";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     start = builtin::i64_extend_i32_s(self.pos);
     if (if self.pos < __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_5 = self.input;
+        break __inline_String__len_0: __local_5.used;
     } -> i32 {
         __inline_String__get_byte_1: block -> u8 {
-            __local_8 = self.input;
-            __local_9 = self.pos;
-            break __inline_String__get_byte_1: builtin::array_get_u8(__local_8.repr, __local_9);
+            __local_6 = self.input;
+            __local_7 = self.pos;
+            break __inline_String__get_byte_1: builtin::array_get_u8(__local_6.repr, __local_7);
         } == 34;
     } else {
         0;
     }) {
-        let __sroa_sr_discriminant: i32;
-        let __sroa_sr_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_sr_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_sr_discriminant, __sroa_sr_case0_payload_0, __sroa_sr_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self);
-        if __sroa_sr_discriminant == 0 {
-            s = __sroa_sr_case0_payload_0;
-            return "core:json/JsonDeserializer::parse_u64_from"(self, s, start);
-        }
-        if __sroa_sr_discriminant == 1 {
-            e = __sroa_sr_case1_payload_0;
-            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: e };
-        }
-        "core:internal/unreachable"();
-        unreachable;
+        s = value_copy "core:prelude/string.wado//String"(let __match_scrut_0: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_0 = "core:json/JsonDeserializer::read_json_string"(self); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+            let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0);
+            __local_2 = __cast_2.payload_0;
+            __local_2;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+            let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0);
+            __local_3 = __cast_1.payload_0;
+            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
+        }));
+        return "core:json/JsonDeserializer::parse_u64_from"(self, s, start);
     }
     return "core:json/JsonDeserializer::parse_u64_direct"(self);
 }
@@ -3662,13 +3777,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l404: loop {
+            l419: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l404;
+                continue l419;
             };
         };
     };
@@ -3805,8 +3920,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b427: block {
-        l428: loop {
+    b442: block {
+        l443: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3831,9 +3946,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b427;
+                break b442;
             }
-            continue l428;
+            continue l443;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_multi_type_deser.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_multi_type_deser.wir.wado
@@ -31,141 +31,172 @@ struct core:serde//DeserializeError {  // TypeId(4)
     mut offset: i64,
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(5)
+variant core:prelude/types.wado//Option<char> {  // TypeId(5)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(6)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(7)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(6)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(8)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(7)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(9)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(8)
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(10)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(9)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(11)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(10)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(12)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(11)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(13)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(12)
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(14)
+    discriminant: i32,
+    payload_0: char,
+}
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(13)
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(15)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(14)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(16)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(15)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(17)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(16)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(18)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(17)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(19)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(18)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(20)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(19)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(21)
 
-type "functype//wasi/wasi:cli/Stdout::write_via_stream" = fn(i32) -> i32;  // TypeId(20)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(22)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_multi_type_deser.wado/run" = fn();  // TypeId(21)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(23)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_multi_type_deser.wado/__cm_binding__Stdout_write_via_stream" = fn(i32) -> i32;  // TypeId(22)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(24)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_multi_type_deser.wado/__cm_export__run" = fn();  // TypeId(23)
+type "functype//wasi/wasi:cli/Stdout::write_via_stream" = fn(i32) -> i32;  // TypeId(25)
 
-type "functype//core:cli/write_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(24)
+type "functype//wado-compiler/tests/fixtures/serde_json_multi_type_deser.wado/run" = fn();  // TypeId(26)
 
-type "functype//core:cli/println" = fn(ref "core:prelude/string.wado//String");  // TypeId(25)
+type "functype//wado-compiler/tests/fixtures/serde_json_multi_type_deser.wado/__cm_binding__Stdout_write_via_stream" = fn(i32) -> i32;  // TypeId(27)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(26)
+type "functype//wado-compiler/tests/fixtures/serde_json_multi_type_deser.wado/__cm_export__run" = fn();  // TypeId(28)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(27)
+type "functype//core:cli/write_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(29)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(28)
+type "functype//core:cli/println" = fn(ref "core:prelude/string.wado//String");  // TypeId(30)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(29)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(31)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(30)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(32)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(31)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(33)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(32)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(34)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(33)
+type "functype//core:internal/unreachable" = fn();  // TypeId(35)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(34)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(36)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(35)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(37)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(36)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(38)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(37)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(39)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(38)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(40)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(39)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(41)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(40)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(42)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(41)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(43)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(42)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(44)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(43)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(45)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(44)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(46)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(45)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(47)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(46)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(48)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(47)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(49)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(48)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(50)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(49)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(51)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(50)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(52)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_multi_type_deser.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(51)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(53)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_multi_type_deser.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(52)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(54)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(53)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(55)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(54)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(56)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(55)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(57)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(56)
+type "functype//wado-compiler/tests/fixtures/serde_json_multi_type_deser.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(58)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(57)
+type "functype//wado-compiler/tests/fixtures/serde_json_multi_type_deser.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(59)
 
-type "functype//core:json/core/json/from_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(58)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(60)
 
-type "functype//core:json/core/json/from_string<i32>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(59)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(61)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(60)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(62)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(61)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(63)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(62)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(64)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(63)
+type "functype//core:json/core/json/from_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(65)
+
+type "functype//core:json/core/json/from_string<i32>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(66)
+
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(67)
+
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(68)
+
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(69)
+
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(70)
+
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(71)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -749,93 +780,155 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/core/json/from_string<String>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+    let __local_2: ref "core:prelude/string.wado//String";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "core:prelude/string.wado//String";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_multi_type_deser.wado/String^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r) {
-        v = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r).payload_0);
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:prelude/string.wado//String"(let __match_scrut_0: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_multi_type_deser.wado/String^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+        let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+        let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r).payload_0);
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/from_string<i32>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
+    let __local_2: i32;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: i32;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_multi_type_deser.wado/i32^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_multi_type_deser.wado/i32^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_0) -> i32 {
+        let __cast_2: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_0) -> i32 {
+        let __cast_1: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(r).payload_0);
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -920,6 +1013,55 @@ fn "core:prelude/string.wado/String::push_str"(self, other) {
     self.used = new_used;
 }
 
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
+}
+
 fn "core:prelude/string.wado/String::push"(self, c) {
     let code: u32;
     code = c;
@@ -958,10 +1100,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b102: block {
-        l103: loop {
+    b120: block {
+        l121: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b102;
+                break b120;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -985,7 +1127,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l103;
+            continue l121;
         };
     };
     self.pos = _hfs_pos_8;
@@ -1003,130 +1145,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b111: block {
-        l112: loop {
-            if scan_pos >= _licm_used_90 {
-                break b111;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b129: block {
+        l130: loop {
+            if scan_pos >= _licm_used_56 {
+                break b129;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b111;
+                break b129;
             }
             scan_pos = scan_pos + 1;
-            continue l112;
+            continue l130;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -1135,22 +1249,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l119: loop {
+                l137: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l119;
+                    continue l137;
                 };
             };
         };
@@ -1158,71 +1272,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l122: loop {
+            l140: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l122;
+                continue l140;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b124: block {
-        l125: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b142: block {
+        l143: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b124;
+                break b142;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -1240,125 +1355,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l125;
+            continue l143;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -1366,87 +1424,71 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l150: loop {
+            l163: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l150;
+                continue l163;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -1536,16 +1578,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b164: block {
-        l165: loop {
+    b173: block {
+        l174: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b164;
+                break b173;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -1566,17 +1608,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b173: block {
-                        l174: loop {
+                    b182: block {
+                        l183: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b173;
+                                break b182;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -1586,9 +1628,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b173;
+                                break b182;
                             }
-                            continue l174;
+                            continue l183;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -1619,17 +1661,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b183: block {
-                            l184: loop {
+                        b192: block {
+                            l193: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b183;
+                                    break b192;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -1638,9 +1680,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b183;
+                                    break b192;
                                 }
-                                continue l184;
+                                continue l193;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -1678,9 +1720,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b164;
+                break b173;
             }
-            continue l165;
+            continue l174;
         };
     };
     self.pos = _hfs_pos_51;
@@ -1697,13 +1739,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l195: loop {
+            l204: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l195;
+                continue l204;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/serde_json_nested_struct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_nested_struct.wir.wado
@@ -77,260 +77,327 @@ struct wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line {  // Ty
 
 array builtin::array<u64> (mut u64);  // TypeId(15)
 
-variant core:prelude/types.wado//Option<i32> {  // TypeId(16)
+variant core:prelude/types.wado//Option<char> {  // TypeId(16)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(17)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<i32> {  // TypeId(18)
     Some(i32),
     None,
 }
 
-struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(17)
+struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(19)
     discriminant: i32,
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(18)
+variant core:prelude/types.wado//Result<Line,DeserializeError> {  // TypeId(20)
+    Ok(ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Line,DeserializeError>::Ok {  // TypeId(21)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line",
+}
+
+struct core:prelude/types.wado//Result<Line,DeserializeError>::Err {  // TypeId(22)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(23)
     Ok(f64),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(19)
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(24)
     discriminant: i32,
     payload_0: f64,
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(20)
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(25)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Point,DeserializeError> {  // TypeId(21)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(26)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(27)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(28)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(29)
+    Ok(ref "core:prelude/string.wado//String"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(30)
+    discriminant: i32,
+    payload_0: ref "core:prelude/string.wado//String",
+}
+
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(31)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<Point,DeserializeError> {  // TypeId(32)
     Ok(ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Point"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Point,DeserializeError>::Ok {  // TypeId(22)
+struct core:prelude/types.wado//Result<Point,DeserializeError>::Ok {  // TypeId(33)
     discriminant: i32,
     payload_0: ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Point",
 }
 
-struct core:prelude/types.wado//Result<Point,DeserializeError>::Err {  // TypeId(23)
+struct core:prelude/types.wado//Result<Point,DeserializeError>::Err {  // TypeId(34)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(24)
+variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(35)
     Ok(ref "core:prelude/types.wado//Option<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(25)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(36)
     discriminant: i32,
     payload_0: ref "core:prelude/types.wado//Option<i32>",
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(26)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(37)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-struct core:prelude//Array<u64> {  // TypeId(27)
+struct core:prelude//Array<u64> {  // TypeId(38)
     mut repr: ref builtin::array<u64>,
     mut used: i32,
 }
 
-enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(28)
+enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(39)
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(29)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(40)
 
-type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(30)
+type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(41)
 
-struct canonical//CanonicalClosure_0 {  // TypeId(31)
+struct canonical//CanonicalClosure_0 {  // TypeId(42)
     env: ref null struct,
     func: ref "functype/$canonical_closure_fn_0",
 }
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(32)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(43)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(33)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(44)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(34)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(45)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(35)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(46)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(36)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(47)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(37)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(48)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(38)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(49)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(39)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(50)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/__test_0_nested_struct_serialize" = fn();  // TypeId(40)
+type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/__test_0_nested_struct_serialize" = fn();  // TypeId(51)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/__test_1_nested_struct_roundtrip" = fn();  // TypeId(41)
+type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/__test_1_nested_struct_roundtrip" = fn();  // TypeId(52)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/_point_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(42)
+type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/_point_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(53)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/_line_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(43)
+type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/_line_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(54)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/__cm_export____test_0_nested_struct_serialize" = fn();  // TypeId(44)
+type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/__cm_export____test_0_nested_struct_serialize" = fn();  // TypeId(55)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/__cm_export____test_1_nested_struct_roundtrip" = fn();  // TypeId(45)
+type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/__cm_export____test_1_nested_struct_roundtrip" = fn();  // TypeId(56)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/__initialize_module" = fn();  // TypeId(46)
+type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/__initialize_module" = fn();  // TypeId(57)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(47)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(58)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(48)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(59)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(49)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(60)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(50)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(61)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(51)
+type "functype//core:internal/unreachable" = fn();  // TypeId(62)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(52)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(63)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(53)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(64)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(54)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(65)
 
-type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(55)
+type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(66)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(56)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(67)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(57)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(68)
 
-type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(58)
+type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(69)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(59)
+type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(70)
 
-type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(60)
+type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(71)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(61)
+type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(72)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(62)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(73)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(63)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(74)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(64)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(75)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(65)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(76)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(66)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(77)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(67)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(78)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(68)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(79)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(69)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(80)
 
-type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(70)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(81)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(71)
+type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(82)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(72)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(83)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(73)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(84)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(74)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(85)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(75)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(86)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(76)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(87)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(77)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(88)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(78)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(89)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(79)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(90)
 
-type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(80)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(91)
 
-type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(81)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(92)
 
-type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(82)
+type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(93)
 
-type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(83)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(94)
 
-type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(84)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(95)
 
-type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(85)
+type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(96)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(86)
+type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(97)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(87)
+type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(98)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(88)
+type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(99)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(89)
+type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(100)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(90)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(101)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(91)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(102)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(92)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(103)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Point^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Point,DeserializeError>";  // TypeId(93)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(104)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<Point>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Point") -> ref null "core:serde//SerializeError";  // TypeId(94)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(105)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(95)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(106)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(96)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(107)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(97)
+type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Line^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Line,DeserializeError>";  // TypeId(108)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(98)
+type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Point^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Point,DeserializeError>";  // TypeId(109)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(99)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<Point>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Point") -> ref null "core:serde//SerializeError";  // TypeId(110)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(100)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(111)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(101)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(112)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(102)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(113)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(103)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(114)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(104)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(115)
 
-type "functype//core:json/core/json/from_string<Line>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line", ref null "core:serde//DeserializeError"];  // TypeId(105)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(116)
 
-type "functype//core:json/core/json/to_string<Line>" = fn(ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(106)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(117)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(107)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(118)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(108)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(119)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(109)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(120)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(110)
+type "functype//core:json/core/json/from_string<Line>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line", ref null "core:serde//DeserializeError"];  // TypeId(121)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Line^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line", ref null "core:serde//DeserializeError"];  // TypeId(111)
+type "functype//core:json/core/json/to_string<Line>" = fn(ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(122)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(112)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(123)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(113)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(124)
 
-type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(114)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(125)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(115)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(126)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(116)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(127)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(117)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(128)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Line^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(118)
+type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(129)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Point^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Point", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(119)
+type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(130)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<f64>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(120)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(131)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(121)
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(132)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(122)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(133)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/__Closure_3::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(123)
+type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(134)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Line^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(135)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Point^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Point", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(136)
+
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<f64>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(137)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(138)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(139)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_nested_struct.wado/__Closure_3::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(140)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -1725,6 +1792,67 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l156: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l156;
+                };
+            };
+        };
+    }
+}
+
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
+        return 1;
+    }
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l162: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l162;
+            };
+        };
+    };
+    return n;
+}
+
 fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     let mark: i32;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -1753,36 +1881,16 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
-    }
-    return ((97 + v) - 10) & 255;
-}
-
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b162: block {
-        l163: loop {
+    b168: block {
+        l169: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -1803,23 +1911,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b162;
+                break b168;
             }
-            continue l163;
+            continue l169;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -1827,62 +1937,135 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/from_string<Line>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Line^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Line,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Line^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Line,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Line,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Line,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Line,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Line,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Line,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Line>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Line^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Line^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1903,6 +2086,20 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
         __local_6 = f.buf;
         break __inline_String__internal_raw_bytes_0: __local_6.repr;
     }, offset, abs_val, digit_count);
+}
+
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
 }
 
 fn "core:prelude/primitive.wado/f64::fmt_into"(self, f) {
@@ -2163,6 +2360,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     }
 }
 
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
+}
+
 fn "core:prelude/string.wado/String::get_byte"(self, index) {
     return builtin::array_get_u8(self.repr, index);
 }
@@ -2243,7 +2454,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l215: loop {
+            l237: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -2251,7 +2462,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l215;
+                continue l237;
             };
         };
     };
@@ -2300,6 +2511,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -2362,10 +2622,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b228: block {
-        l229: loop {
+    b257: block {
+        l258: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b228;
+                break b257;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -2389,7 +2649,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l229;
+            continue l258;
         };
     };
     self.pos = _hfs_pos_8;
@@ -2468,11 +2728,11 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b237: block {
-        l238: loop {
+    b266: block {
+        l267: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= _licm_used_19 {
-                    break b237;
+                    break b266;
                 }
                 byte = builtin::array_get_u8(_licm_repr_20, __sroa___iter_3_index);
                 __sroa___iter_3_index = __sroa___iter_3_index + 1;
@@ -2507,7 +2767,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
                 _hfs_pos_27 = _hfs_pos_27 + 1;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l238;
+            continue l267;
         };
     };
     self.pos = _hfs_pos_27;
@@ -2526,130 +2786,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
+        }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b244: block {
-        l245: loop {
-            if scan_pos >= _licm_used_90 {
-                break b244;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b273: block {
+        l274: loop {
+            if scan_pos >= _licm_used_56 {
+                break b273;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b244;
+                break b273;
             }
             scan_pos = scan_pos + 1;
-            continue l245;
+            continue l274;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -2658,94 +2890,95 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l252: loop {
+                l281: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l252;
+                    continue l281;
                 };
             };
         };
         self.pos = scan_pos + 1;
-        return 0, result_5, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l255: loop {
+            l284: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l255;
+                continue l284;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b257: block {
-        l258: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b286: block {
+        l287: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b257;
+                break b286;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
-                return 0, result_8, ref.null none;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
+                return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
-                    });
+                    self.pos = _hfs_pos_64;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
+                    }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -2763,213 +2996,140 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return 1, ref.null none, e;
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
-                    });
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
+                    }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
-                    });
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
+                    }) };
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l258;
+            continue l287;
         };
     };
-    self.pos = _hfs_pos_98;
-    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
-    });
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
+    }) };
 }
 
 fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l283: loop {
+            l307: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l283;
+                continue l307;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -3024,25 +3184,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b294: block {
-        l295: loop {
+    b314: block {
+        l315: loop {
             if _hfs_pos_36 >= _licm_used_28 {
-                break b294;
+                break b314;
             }
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
                 break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr_29, __local_11);
             };
-            if (if b_1 >= 48 -> i32 {
+            if (if 48 <= b_1 -> i32 {
                 b_1 <= 57;
             } else {
                 0;
             }) {
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
-                break b294;
+                break b314;
             }
-            continue l295;
+            continue l315;
         };
     };
     self.pos = _hfs_pos_36;
@@ -3063,25 +3223,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b301: block {
-            l302: loop {
+        b321: block {
+            l322: loop {
                 if _hfs_pos_37 >= _licm_used_31 {
-                    break b301;
+                    break b321;
                 }
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
                     break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_32, __local_17);
                 };
-                if (if b_2 >= 48 -> i32 {
+                if (if 48 <= b_2 -> i32 {
                     b_2 <= 57;
                 } else {
                     0;
                 }) {
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
-                    break b301;
+                    break b321;
                 }
-                continue l302;
+                continue l322;
             };
         };
         self.pos = _hfs_pos_37;
@@ -3122,25 +3282,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b312: block {
-                l313: loop {
+            b332: block {
+                l333: loop {
                     if _hfs_pos_38 >= _licm_used_34 {
-                        break b312;
+                        break b332;
                     }
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
                         break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_35, __local_26);
                     };
-                    if (if b2 >= 48 -> i32 {
+                    if (if 48 <= b2 -> i32 {
                         b2 <= 57;
                     } else {
                         0;
                     }) {
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
-                        break b312;
+                        break b332;
                     }
-                    continue l313;
+                    continue l333;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -3250,16 +3410,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b322: block {
-        l323: loop {
+    b342: block {
+        l343: loop {
             if _hfs_pos_57 >= _licm_used_49 {
-                break b322;
+                break b342;
             }
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_50, __local_32);
             };
-            if (if b_6 >= 48 -> i32 {
+            if (if 48 <= b_6 -> i32 {
                 b_6 <= 57;
             } else {
                 0;
@@ -3270,9 +3430,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                 total_digits = total_digits + 1;
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
-                break b322;
+                break b342;
             }
-            continue l323;
+            continue l343;
         };
     };
     self.pos = _hfs_pos_57;
@@ -3294,16 +3454,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b330: block {
-            l331: loop {
+        b350: block {
+            l351: loop {
                 if _hfs_pos_58 >= _licm_used_52 {
-                    break b330;
+                    break b350;
                 }
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
                     break __inline_String__get_byte_12: builtin::array_get_u8(_licm_repr_53, __local_38);
                 };
-                if (if b_8 >= 48 -> i32 {
+                if (if 48 <= b_8 -> i32 {
                     b_8 <= 57;
                 } else {
                     0;
@@ -3315,9 +3475,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                     total_digits = total_digits + 1;
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
-                    break b330;
+                    break b350;
                 }
-                continue l331;
+                continue l351;
             };
         };
         self.pos = _hfs_pos_58;
@@ -3359,16 +3519,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b342: block {
-                l343: loop {
+            b362: block {
+                l363: loop {
                     if _hfs_pos_59 >= _licm_used_55 {
-                        break b342;
+                        break b362;
                     }
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
                         break __inline_String__get_byte_18: builtin::array_get_u8(_licm_repr_56, __local_47);
                     };
-                    if (if b3 >= 48 -> i32 {
+                    if (if 48 <= b3 -> i32 {
                         b3 <= 57;
                     } else {
                         0;
@@ -3376,9 +3536,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                         exp = (exp * 10) + (b3 - 48);
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
-                        break b342;
+                        break b362;
                     }
-                    continue l343;
+                    continue l363;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -3428,10 +3588,10 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b353: block {
-        l354: loop {
+    b373: block {
+        l374: loop {
             if _hfs_pos_14 >= _licm_used_12 {
-                break b353;
+                break b373;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -3461,7 +3621,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
                 }
             }
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l354;
+            continue l374;
         };
     };
     self.pos = _hfs_pos_14;
@@ -3472,19 +3632,284 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
 }
 
 fn "core:json/JsonDeserializer::skip_value"(self) {
-    let b: i32;
-    let r: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let c_4: i32;
-    let kr: ref null "core:serde//DeserializeError";
-    let e_6: ref "core:serde//DeserializeError";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let vr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let c_11: i32;
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: char;
+    let __local_6: ref "core:serde//DeserializeError";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_10: ref "core:serde//DeserializeError";
+    let __local_11: char;
     let __local_12: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/format.wado//Formatter";
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i64;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i32;
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
+    let __local_20: i32;
+    let __local_21: ref "core:prelude/string.wado//String";
+    let __local_22: i64;
+    let __local_23: ref "core:prelude/string.wado//String";
+    let __local_24: i32;
+    let __local_25: ref "core:prelude/string.wado//String";
+    let __local_26: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let __local_30: ref "core:prelude/string.wado//String";
+    let __local_31: ref "core:prelude/string.wado//String";
+    let __local_32: i32;
+    let __local_33: ref "core:prelude/string.wado//String";
+    let __local_34: i64;
+    let __local_35: ref "core:prelude/string.wado//String";
+    let __local_36: i64;
+    let __local_37: ref "core:prelude/string.wado//String";
+    let __local_38: i32;
+    let __local_39: ref "core:prelude/string.wado//String";
+    let __local_40: i64;
+    let __local_43: ref "core:prelude/string.wado//String";
+    let __local_44: i64;
+    "core:json/JsonDeserializer::skip_whitespace"(self);
+    if self.pos >= __inline_String__len_0: block -> i32 {
+        __local_14 = self.input;
+        break __inline_String__len_0: __local_14.used;
+    } {
+        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_15 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_15 };
+        });
+    }
+    b = __inline_String__get_byte_2: block -> u8 {
+        __local_16 = self.input;
+        __local_17 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_16.repr, __local_17);
+    } & 255;
+    if b == 34 {
+        return "core:json/JsonDeserializer::skip_string"(self);
+        unreachable;
+    } else if b == 116 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        unreachable;
+    } else if b == 102 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        unreachable;
+    } else if b == 110 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
+        unreachable;
+    } else if b == 91 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_3: block -> i32 {
+            __local_18 = self.input;
+            break __inline_String__len_3: __local_18.used;
+        } -> i32 {
+            __inline_String__get_byte_4: block -> u8 {
+                __local_19 = self.input;
+                __local_20 = self.pos;
+                break __inline_String__get_byte_4: builtin::array_get_u8(__local_19.repr, __local_20);
+            } == 93;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l389: loop {
+                let __match_scrut_5: ref null "core:serde//DeserializeError";
+                __match_scrut_5 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_5) {
+                } else if ref.is_null(__match_scrut_5) == 0 {
+                    let __cast_4: ref null "core:serde//DeserializeError";
+                    __cast_4 = ref.as_non_null(__match_scrut_5);
+                    __local_3 = ref.as_non_null(__cast_4);
+                    return __local_3;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_5: block -> i32 {
+                    __local_21 = self.input;
+                    break __inline_String__len_5: __local_21.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
+                        __local_22 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_22 };
+                    });
+                }
+                __local_4 = __inline_String__get_byte_7: block -> u8 {
+                    __local_23 = self.input;
+                    __local_24 = self.pos;
+                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_23.repr, __local_24);
+                } & 255;
+                if __local_4 == 93 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_4 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
+                        __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
+                        __local_26 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_25, offset: __local_26 };
+                    });
+                    unreachable;
+                }
+                continue l389;
+            };
+        };
+    } else if b == 123 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_9: block -> i32 {
+            __local_27 = self.input;
+            break __inline_String__len_9: __local_27.used;
+        } -> i32 {
+            __inline_String__get_byte_10: block -> u8 {
+                __local_28 = self.input;
+                __local_29 = self.pos;
+                break __inline_String__get_byte_10: builtin::array_get_u8(__local_28.repr, __local_29);
+            } == 125;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l399: loop {
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if (if self.pos >= __inline_String__len_11: block -> i32 {
+                    __local_30 = self.input;
+                    break __inline_String__len_11: __local_30.used;
+                } -> i32 {
+                    1;
+                } else {
+                    __inline_String__get_byte_12: block -> u8 {
+                        __local_31 = self.input;
+                        __local_32 = self.pos;
+                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_31.repr, __local_32);
+                    } != 34;
+                }) {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
+                        __local_33 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+                        __local_34 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_33, offset: __local_34 };
+                    });
+                }
+                let __match_scrut_1: ref null "core:serde//DeserializeError";
+                __match_scrut_1 = "core:json/JsonDeserializer::skip_string"(self);
+                if ref.is_null(__match_scrut_1) {
+                } else if ref.is_null(__match_scrut_1) == 0 {
+                    let __cast_1: ref null "core:serde//DeserializeError";
+                    __cast_1 = ref.as_non_null(__match_scrut_1);
+                    __local_6 = ref.as_non_null(__cast_1);
+                    return __local_6;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_2: ref null "core:serde//DeserializeError";
+                __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+                if ref.is_null(__match_scrut_2) {
+                } else if ref.is_null(__match_scrut_2) == 0 {
+                    let __cast_2: ref null "core:serde//DeserializeError";
+                    __cast_2 = ref.as_non_null(__match_scrut_2);
+                    __local_8 = ref.as_non_null(__cast_2);
+                    return __local_8;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_3: ref null "core:serde//DeserializeError";
+                __match_scrut_3 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_3) {
+                } else if ref.is_null(__match_scrut_3) == 0 {
+                    let __cast_3: ref null "core:serde//DeserializeError";
+                    __cast_3 = ref.as_non_null(__match_scrut_3);
+                    __local_10 = ref.as_non_null(__cast_3);
+                    return __local_10;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_14: block -> i32 {
+                    __local_35 = self.input;
+                    break __inline_String__len_14: __local_35.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
+                        __local_36 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_36 };
+                    });
+                }
+                __local_11 = __inline_String__get_byte_16: block -> u8 {
+                    __local_37 = self.input;
+                    __local_38 = self.pos;
+                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_37.repr, __local_38);
+                } & 255;
+                if __local_11 == 125 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_11 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
+                        __local_39 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
+                        __local_40 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_39, offset: __local_40 };
+                    });
+                    unreachable;
+                }
+                continue l399;
+            };
+        };
+    } else {
+        if (if b == 45 -> i32 {
+            1;
+        } else if 48 <= b -> i32 {
+            b <= 57;
+        } else {
+            0;
+        }) {
+            "core:json/JsonDeserializer::skip_number"(self);
+            return ref.null none;
+        }
+        return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
+            __local_43 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
+                "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
+                __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
+                "core:prelude/primitive.wado/char^Display::fmt"(b, __local_13);
+                "core:prelude/string.wado/String::push"(__local_12, 39);
+                break __tmpl: __local_12;
+            };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
+        });
+        unreachable;
+    }
+}
+
+fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
+    let __local_2: ref "core:serde//DeserializeError";
+    let key_start: i32;
+    let has_escape: bool;
+    let b: i32;
+    let key_end: i32;
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: i32;
+    let idx_10: i32;
+    let __local_11: ref "core:prelude/string.wado//String";
+    let __local_12: ref "core:serde//DeserializeError";
+    let key: ref "core:prelude/string.wado//String";
+    let __local_15: ref "core:serde//DeserializeError";
+    let __local_16: i32;
+    let idx_17: i32;
     let __local_18: ref "core:prelude/string.wado//String";
     let __local_19: i64;
     let __local_20: ref "core:prelude/string.wado//String";
@@ -3495,416 +3920,178 @@ fn "core:json/JsonDeserializer::skip_value"(self) {
     let __local_25: ref "core:prelude/string.wado//String";
     let __local_26: i64;
     let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: i64;
-    let __local_31: ref "core:prelude/string.wado//String";
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i32;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
-    let __local_37: ref "core:prelude/string.wado//String";
-    let __local_38: i64;
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
-    let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_47: ref "core:prelude/string.wado//String";
-    let __local_48: i64;
-    let _hfs_pos_49: i32;
-    let _hfs_pos_50: i32;
-    "core:json/JsonDeserializer::skip_whitespace"(self);
-    if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_18 = self.input;
-        break __inline_String__len_0: __local_18.used;
-    } {
-        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_19 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
-        });
-    }
-    b = __inline_String__get_byte_2: block -> u8 {
-        __local_20 = self.input;
-        __local_21 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
-    };
-    if b == 34 {
-        return "core:json/JsonDeserializer::skip_string"(self);
-    }
-    if b == 116 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-    }
-    if b == 102 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-    }
-    if b == 110 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
-    }
-    if b == 91 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_3: block -> i32 {
-            __local_22 = self.input;
-            break __inline_String__len_3: __local_22.used;
-        } -> i32 {
-            __inline_String__get_byte_4: block -> u8 {
-                __local_23 = self.input;
-                __local_24 = self.pos;
-                break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
-            } == 93;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_49 = self.pos;
-        block {
-            l369: loop {
-                self.pos = _hfs_pos_49;
-                r = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_49 = self.pos;
-                if ref.is_null(r) == 0 {
-                    e_3 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-                    self.pos = _hfs_pos_49;
-                    return e_3;
-                }
-                self.pos = _hfs_pos_49;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_49 = self.pos;
-                if _hfs_pos_49 >= __inline_String__len_5: block -> i32 {
-                    __local_25 = self.input;
-                    self.pos = _hfs_pos_49;
-                    break __inline_String__len_5: __local_25.used;
-                } {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
-                        __local_26 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
-                    });
-                }
-                c_4 = __inline_String__get_byte_7: block -> u8 {
-                    __local_27 = self.input;
-                    __local_28 = _hfs_pos_49;
-                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_27.repr, __local_28);
-                };
-                if c_4 == 93 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                    self.pos = _hfs_pos_49;
-                    return ref.null none;
-                }
-                if c_4 == 44 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                } else {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
-                        __local_29 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
-                        __local_30 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_29, offset: __local_30 };
-                    });
-                }
-                continue l369;
-            };
-        };
-        self.pos = _hfs_pos_49;
-    }
-    if b == 123 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_9: block -> i32 {
-            __local_31 = self.input;
-            break __inline_String__len_9: __local_31.used;
-        } -> i32 {
-            __inline_String__get_byte_10: block -> u8 {
-                __local_32 = self.input;
-                __local_33 = self.pos;
-                break __inline_String__get_byte_10: builtin::array_get_u8(__local_32.repr, __local_33);
-            } == 125;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_50 = self.pos;
-        block {
-            l378: loop {
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if (if _hfs_pos_50 >= __inline_String__len_11: block -> i32 {
-                    __local_34 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_11: __local_34.used;
-                } -> i32 {
-                    1;
-                } else {
-                    __inline_String__get_byte_12: block -> u8 {
-                        __local_35 = self.input;
-                        __local_36 = _hfs_pos_50;
-                        self.pos = _hfs_pos_50;
-                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_35.repr, __local_36);
-                    } != 34;
-                }) {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
-                        __local_37 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-                        __local_38 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_37, offset: __local_38 };
-                    });
-                }
-                self.pos = _hfs_pos_50;
-                kr = "core:json/JsonDeserializer::skip_string"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(kr) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(kr));
-                    self.pos = _hfs_pos_50;
-                    return e_6;
-                }
-                self.pos = _hfs_pos_50;
-                cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(cr) == 0 {
-                    e_8 = value_copy "core:serde//DeserializeError"(ref.as_non_null(cr));
-                    self.pos = _hfs_pos_50;
-                    return e_8;
-                }
-                self.pos = _hfs_pos_50;
-                vr = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(vr) == 0 {
-                    e_10 = value_copy "core:serde//DeserializeError"(ref.as_non_null(vr));
-                    self.pos = _hfs_pos_50;
-                    return e_10;
-                }
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if _hfs_pos_50 >= __inline_String__len_14: block -> i32 {
-                    __local_39 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_14: __local_39.used;
-                } {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
-                        __local_40 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-                    });
-                }
-                c_11 = __inline_String__get_byte_16: block -> u8 {
-                    __local_41 = self.input;
-                    __local_42 = _hfs_pos_50;
-                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_41.repr, __local_42);
-                };
-                if c_11 == 125 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                    self.pos = _hfs_pos_50;
-                    return ref.null none;
-                }
-                if c_11 == 44 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                } else {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
-                        __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
-                        __local_44 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
-                    });
-                }
-                continue l378;
-            };
-        };
-        self.pos = _hfs_pos_50;
-    }
-    if (if b == 45 -> i32 {
-        1;
-    } else if b >= 48 -> i32 {
-        b <= 57;
-    } else {
-        0;
-    }) {
-        "core:json/JsonDeserializer::skip_number"(self);
-        return ref.null none;
-    }
-    return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
-        __local_47 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-            __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
-            "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
-            __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
-            "core:prelude/primitive.wado/char^Display::fmt"(b & 255, __local_13);
-            "core:prelude/string.wado/String::push"(__local_12, 39);
-            break __tmpl: __local_12;
-        };
-        __local_48 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_47, offset: __local_48 };
-    });
-}
-
-fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
-    let r_1: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let key_start: i32;
-    let has_escape: bool;
-    let b: i32;
-    let key_end: i32;
-    let r_7: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let idx_9: ref "core:prelude/types.wado//Option<i32>";
-    let i_10: i32;
-    let key: ref "core:prelude/string.wado//String";
-    let r_13: ref null "core:serde//DeserializeError";
-    let e_14: ref "core:serde//DeserializeError";
-    let idx_15: ref "core:prelude/types.wado//Option<i32>";
-    let i_16: i32;
-    let e_17: ref "core:serde//DeserializeError";
-    let __local_25: ref "core:prelude/string.wado//String";
-    let __local_26: i64;
-    let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: ref "core:prelude/string.wado//String";
-    let __local_31: i32;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i64;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_25 = self.de.input;
-        break __inline_String__len_0: __local_25.used;
+        __local_18 = self.de.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
+            __local_19 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_27 = self.de.input;
-        __local_28 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_27.repr, __local_28);
+        __local_20 = self.de.input;
+        __local_21 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } == 125 {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r_1 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r_1) == 0 {
-            e_2 = ref.as_non_null(r_1);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if (if self.de.pos >= __inline_String__len_3: block -> i32 {
-        __local_29 = self.de.input;
-        break __inline_String__len_3: __local_29.used;
+        __local_22 = self.de.input;
+        break __inline_String__len_3: __local_22.used;
     } -> i32 {
         1;
     } else {
         __inline_String__get_byte_4: block -> u8 {
-            __local_30 = self.de.input;
-            __local_31 = self.de.pos;
-            break __inline_String__get_byte_4: builtin::array_get_u8(__local_30.repr, __local_31);
+            __local_23 = self.de.input;
+            __local_24 = self.de.pos;
+            break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
         } != 34;
     }) {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_5: block -> ref "core:serde//DeserializeError" {
-            __local_32 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-            __local_33 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_32, offset: __local_33 };
+            __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_25, offset: __local_26 };
         }) };
     }
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b396: block {
-        l397: loop {
+    b421: block {
+        l422: loop {
             if self.de.pos >= __inline_String__len_6: block -> i32 {
-                __local_34 = self.de.input;
-                break __inline_String__len_6: __local_34.used;
+                __local_27 = self.de.input;
+                break __inline_String__len_6: __local_27.used;
             } {
-                break b396;
+                break b421;
             }
             b = __inline_String__get_byte_7: block -> u8 {
-                __local_35 = self.de.input;
-                __local_36 = self.de.pos;
-                break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
+                __local_28 = self.de.input;
+                __local_29 = self.de.pos;
+                break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
             };
             if b == 34 {
-                break b396;
+                break b421;
             }
             if b == 92 {
                 has_escape = 1;
-                break b396;
+                break b421;
             }
             self.de.pos = self.de.pos + 1;
-            continue l397;
+            continue l422;
         };
     };
     if has_escape == 0 {
         key_end = self.de.pos;
         self.de.pos = self.de.pos + 1;
-        r_7 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_7) == 0 {
-            e_8 = ref.as_non_null(r_7);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_8 };
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_1);
+            __local_8 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        idx_9 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_0: ref "canonical//CanonicalClosure_0";
-            __indirect_call_0 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_0.func, __indirect_call_0.env, self.de.input, key_start, key_end);
+        let __match_scrut_2: ref "core:prelude/types.wado//Option<i32>";
+        __match_scrut_2 = block -> ref "core:prelude/types.wado//Option<i32>" {
+            let __indirect_call_2: ref "canonical//CanonicalClosure_0";
+            __indirect_call_2 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_2.func, __indirect_call_2.env, self.de.input, key_start, key_end);
         };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_9) {
-            i_10 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_9).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_10 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+        idx_10 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2) -> i32 {
+            let __cast_4: ref "core:prelude/types.wado//Option<i32>::Some";
+            __cast_4 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2);
+            __local_9 = __cast_4.payload_0;
+            __local_9;
+        } else if __match_scrut_2.discriminant == 1 -> i32 {
+            -1;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_10 } };
     }
     self.de.pos = key_start - 1;
-    let __sroa_key_r_discriminant: i32;
-    let __sroa_key_r_case0_payload_0: ref null "core:prelude/string.wado//String";
-    let __sroa_key_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_key_r_discriminant, __sroa_key_r_case0_payload_0, __sroa_key_r_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self.de);
-    if __sroa_key_r_discriminant == 0 {
-        key = __sroa_key_r_case0_payload_0;
-        r_13 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_13) == 0 {
-            e_14 = ref.as_non_null(r_13);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_14 };
-        }
-        idx_15 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_1: ref "canonical//CanonicalClosure_0";
-            __indirect_call_1 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_1.func, __indirect_call_1.env, key, 0, key.used);
-        };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_15) {
-            i_16 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_15).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_16 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+    key = value_copy "core:prelude/string.wado//String"(let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self.de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_6: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_6 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+        __local_11 = __cast_6.payload_0;
+        __local_11;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+        __local_12 = __cast_5.payload_0;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_12 };
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    let __match_scrut_4: ref null "core:serde//DeserializeError";
+    __match_scrut_4 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+    if ref.is_null(__match_scrut_4) {
+    } else if ref.is_null(__match_scrut_4) == 0 {
+        let __cast_7: ref null "core:serde//DeserializeError";
+        __cast_7 = ref.as_non_null(__match_scrut_4);
+        __local_15 = ref.as_non_null(__cast_7);
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_15 };
+        unreachable;
+    } else {
+        unreachable;
     }
-    if __sroa_key_r_discriminant == 1 {
-        e_17 = __sroa_key_r_case1_payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    let __match_scrut_5: ref "core:prelude/types.wado//Option<i32>";
+    __match_scrut_5 = block -> ref "core:prelude/types.wado//Option<i32>" {
+        let __indirect_call_7: ref "canonical//CanonicalClosure_0";
+        __indirect_call_7 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+        call_ref "functype/$canonical_closure_fn_0"(__indirect_call_7.func, __indirect_call_7.env, key, 0, key.used);
+    };
+    idx_17 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5) -> i32 {
+        let __cast_9: ref "core:prelude/types.wado//Option<i32>::Some";
+        __cast_9 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5);
+        __local_16 = __cast_9.payload_0;
+        __local_16;
+    } else if __match_scrut_5.discriminant == 1 -> i32 {
+        -1;
+    } else {
+        unreachable;
+    });
+    return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_17 } };
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_struct"(self, lookup) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 123);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_5: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 123);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_5 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_5;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonStructAccess" { de: self, lookup: lookup, first: 1 }, ref.null none;
 }
@@ -3916,13 +4103,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l412: loop {
+            l442: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l412;
+                continue l442;
             };
         };
     };
@@ -4015,10 +4202,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b422: block {
-            l423: loop {
+        b452: block {
+            l453: loop {
                 if i_8 < 0 {
-                    break b422;
+                    break b452;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -4027,7 +4214,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l423;
+                continue l453;
             };
         };
         __for_1: block {
@@ -4035,14 +4222,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l426: loop {
+                l456: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l426;
+                    continue l456;
                 };
             };
         };
@@ -4052,10 +4239,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b428: block {
-            l429: loop {
+        b458: block {
+            l459: loop {
                 if i_10 < 0 {
-                    break b428;
+                    break b458;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -4064,7 +4251,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l429;
+                continue l459;
             };
         };
         __for_2: block {
@@ -4072,14 +4259,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l432: loop {
+                l462: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l432;
+                    continue l462;
                 };
             };
         };
@@ -4183,8 +4370,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b451: block {
-        l452: loop {
+    b481: block {
+        l482: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -4209,9 +4396,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b451;
+                break b481;
             }
-            continue l452;
+            continue l482;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -4246,13 +4433,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l461: loop {
+            l491: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l461;
+                continue l491;
             };
         };
     };
@@ -4283,8 +4470,8 @@ fn "wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Line^Deserialize:
         seen = 0;
         start_point = ref.null none;
         end_point = ref.null none;
-        b464: block {
-            l465: loop {
+        b494: block {
+            l495: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -4299,7 +4486,7 @@ fn "wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Line^Deserialize:
                                 start_point = __local_10;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Point,DeserializeError>::Err"(__local_9).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Line,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Point,DeserializeError>::Err"(__local_9).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_11 = "wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Point^Deserialize::deserialize<JsonDeserializer>"(sd.de);
@@ -4309,27 +4496,27 @@ fn "wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Line^Deserialize:
                                 end_point = __local_12;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Point,DeserializeError>::Err"(__local_11).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Line,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Point,DeserializeError>::Err"(__local_11).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b464;
+                        break b494;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<Line,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l465;
+                continue l495;
             };
         };
         if (seen & 3) != 3 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<Line,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line" { start_point: start_point, end_point: end_point }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Line,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_json_nested_struct.wado//Line" { start_point: start_point, end_point: end_point } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<Line,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 
@@ -4359,8 +4546,8 @@ fn "wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Point^Deserialize
         seen = 0;
         x = 0;
         y = 0;
-        b474: block {
-            l475: loop {
+        b504: block {
+            l505: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -4397,12 +4584,12 @@ fn "wado-compiler/tests/fixtures/serde_json_nested_struct.wado/Point^Deserialize
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b474;
+                        break b504;
                     }
                 } else {
                     return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l475;
+                continue l505;
             };
         };
         if (seen & 3) != 3 {

--- a/wado-compiler/tests/fixtures.golden/serde_json_option_array_fields.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_option_array_fields.wir.wado
@@ -88,289 +88,341 @@ variant core:prelude/types.wado//Option<String> {  // TypeId(16)
     None,
 }
 
-variant core:prelude/types.wado//Option<i32> {  // TypeId(17)
+variant core:prelude/types.wado//Option<char> {  // TypeId(17)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(18)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<i32> {  // TypeId(19)
     Some(i32),
     None,
 }
 
-struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(18)
+struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(20)
     discriminant: i32,
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(19)
+variant core:prelude/types.wado//Result<User,DeserializeError> {  // TypeId(21)
+    Ok(ref "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<User,DeserializeError>::Ok {  // TypeId(22)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User",
+}
+
+struct core:prelude/types.wado//Result<User,DeserializeError>::Err {  // TypeId(23)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(24)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(20)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(25)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(21)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(26)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(22)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(27)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(28)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(29)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(30)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(23)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(31)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(24)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(32)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError> {  // TypeId(25)
+variant core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError> {  // TypeId(33)
     Ok(ref "core:json//JsonSeqSerializer"),
     Err(ref "core:serde//SerializeError"),
 }
 
-struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Ok {  // TypeId(26)
+struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Ok {  // TypeId(34)
     discriminant: i32,
     payload_0: ref "core:json//JsonSeqSerializer",
 }
 
-struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Err {  // TypeId(27)
+struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Err {  // TypeId(35)
     discriminant: i32,
     payload_0: ref "core:serde//SerializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(28)
+variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(36)
     Ok(ref "core:prelude/types.wado//Option<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(29)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(37)
     discriminant: i32,
     payload_0: ref "core:prelude/types.wado//Option<i32>",
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(30)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(38)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<String>,DeserializeError> {  // TypeId(31)
+variant core:prelude/types.wado//Result<Option<String>,DeserializeError> {  // TypeId(39)
     Ok(ref null "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok {  // TypeId(32)
+struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok {  // TypeId(40)
     discriminant: i32,
     payload_0: ref null "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err {  // TypeId(33)
+struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err {  // TypeId(41)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-struct core:prelude//Array<i32> {  // TypeId(34)
+struct core:prelude//Array<i32> {  // TypeId(42)
     mut repr: ref builtin::array<i32>,
     mut used: i32,
 }
 
-variant core:prelude/types.wado//Result<Array<i32>,DeserializeError> {  // TypeId(35)
+variant core:prelude/types.wado//Result<Array<i32>,DeserializeError> {  // TypeId(43)
     Ok(ref "core:prelude//Array<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Ok {  // TypeId(36)
+struct core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Ok {  // TypeId(44)
     discriminant: i32,
     payload_0: ref "core:prelude//Array<i32>",
 }
 
-struct core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err {  // TypeId(37)
+struct core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err {  // TypeId(45)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(38)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(46)
 
-type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(39)
+type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(47)
 
-struct canonical//CanonicalClosure_0 {  // TypeId(40)
+struct canonical//CanonicalClosure_0 {  // TypeId(48)
     env: ref null struct,
     func: ref "functype/$canonical_closure_fn_0",
 }
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(41)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(49)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(42)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(50)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(43)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(51)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(44)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(52)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(45)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(53)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(46)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(54)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(47)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(55)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(48)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(56)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__test_0_serialize_with_some_and_non_empty_array" = fn();  // TypeId(49)
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__test_0_serialize_with_some_and_non_empty_array" = fn();  // TypeId(57)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__test_1_serialize_with_none_and_empty_array" = fn();  // TypeId(50)
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__test_1_serialize_with_none_and_empty_array" = fn();  // TypeId(58)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__test_2_roundtrip_with_some" = fn();  // TypeId(51)
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__test_2_roundtrip_with_some" = fn();  // TypeId(59)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__test_3_roundtrip_with_none" = fn();  // TypeId(52)
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__test_3_roundtrip_with_none" = fn();  // TypeId(60)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/_user_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(53)
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/_user_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(61)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__cm_export____test_0_serialize_with_some_and_non_empty_array" = fn();  // TypeId(54)
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__cm_export____test_0_serialize_with_some_and_non_empty_array" = fn();  // TypeId(62)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__cm_export____test_1_serialize_with_none_and_empty_array" = fn();  // TypeId(55)
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__cm_export____test_1_serialize_with_none_and_empty_array" = fn();  // TypeId(63)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__cm_export____test_2_roundtrip_with_some" = fn();  // TypeId(56)
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__cm_export____test_2_roundtrip_with_some" = fn();  // TypeId(64)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__cm_export____test_3_roundtrip_with_none" = fn();  // TypeId(57)
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__cm_export____test_3_roundtrip_with_none" = fn();  // TypeId(65)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(58)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(66)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(59)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(67)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(60)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(68)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(61)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(69)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(62)
+type "functype//core:internal/unreachable" = fn();  // TypeId(70)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(63)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(71)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(64)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(72)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(65)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(73)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(66)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(74)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(67)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(75)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(68)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(76)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(69)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(77)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(70)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(78)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(71)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(79)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(72)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(80)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(73)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(81)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(74)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(82)
 
-type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(75)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(83)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(76)
+type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(84)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(77)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(85)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(78)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(86)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(79)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(87)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(80)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(88)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(81)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(89)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(82)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(90)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(83)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(91)
 
-type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(84)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(92)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(85)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(93)
 
-type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(86)
+type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(94)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(87)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(95)
 
-type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(88)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(96)
 
-type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(89)
+type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(97)
 
-type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(90)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(98)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(91)
+type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(99)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(92)
+type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(100)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(93)
+type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(101)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(94)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(102)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/Array<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Array<i32>,DeserializeError>";  // TypeId(95)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(103)
 
-type "functype//core:prelude/array.wado/Array<i32>::push" = fn(ref "core:prelude//Array<i32>", i32);  // TypeId(96)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(104)
 
-type "functype//core:prelude/array.wado/Array<i32>::grow" = fn(ref "core:prelude//Array<i32>");  // TypeId(97)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(105)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(98)
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/User^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<User,DeserializeError>";  // TypeId(106)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/Option<String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";  // TypeId(99)
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/Array<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Array<i32>,DeserializeError>";  // TypeId(107)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<Array<i32>>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude//Array<i32>") -> ref null "core:serde//SerializeError";  // TypeId(100)
+type "functype//core:prelude/array.wado/Array<i32>::push" = fn(ref "core:prelude//Array<i32>", i32);  // TypeId(108)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<String>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(101)
+type "functype//core:prelude/array.wado/Array<i32>::grow" = fn(ref "core:prelude//Array<i32>");  // TypeId(109)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(102)
+type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(110)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(103)
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(111)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(104)
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/Option<String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";  // TypeId(112)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(105)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<Array<i32>>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude//Array<i32>") -> ref null "core:serde//SerializeError";  // TypeId(113)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(106)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<String>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(114)
 
-type "functype//core:json/core/json/from_string<User>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User", ref null "core:serde//DeserializeError"];  // TypeId(107)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(115)
 
-type "functype//core:json/core/json/to_string<User>" = fn(ref "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(108)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(116)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(109)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(117)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(110)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(118)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(111)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(119)
 
-type "functype//core:json/JsonDeserializer^Deserializer::is_null" = fn(ref "core:json//JsonDeserializer") -> [i32, bool, ref null "core:serde//DeserializeError"];  // TypeId(112)
+type "functype//core:json/core/json/from_string<User>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User", ref null "core:serde//DeserializeError"];  // TypeId(120)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_seq" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:json//JsonSeqAccess", ref null "core:serde//DeserializeError"];  // TypeId(113)
+type "functype//core:json/core/json/to_string<User>" = fn(ref "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(121)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/User^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User", ref null "core:serde//DeserializeError"];  // TypeId(114)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(122)
 
-type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>" = fn(ref "core:json//JsonSeqAccess") -> [i32, ref null "core:prelude/types.wado//Option<i32>", ref null "core:serde//DeserializeError"];  // TypeId(115)
+type "functype//core:json/JsonDeserializer^Deserializer::is_null" = fn(ref "core:json//JsonDeserializer") -> [i32, bool, ref null "core:serde//DeserializeError"];  // TypeId(123)
 
-type "functype//core:prelude/array.wado/ArrayIter<i32>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<i32>") -> [i32, i32];  // TypeId(116)
+type "functype//core:json/JsonDeserializer^Deserializer::begin_seq" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:json//JsonSeqAccess", ref null "core:serde//DeserializeError"];  // TypeId(124)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(117)
+type "functype//core:prelude/array.wado/ArrayIter<i32>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<i32>") -> [i32, i32];  // TypeId(125)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(118)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(126)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(119)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(127)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/User^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(120)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(128)
 
-type "functype//core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<i32>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(121)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(129)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<i32>" = fn(ref "core:json//JsonSeqSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(122)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(130)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<Option<String>>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref null "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(123)
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(131)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(124)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(132)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(125)
+type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(133)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/User^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(134)
+
+type "functype//core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<i32>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(135)
+
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<i32>" = fn(ref "core:json//JsonSeqSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(136)
+
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<Option<String>>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref null "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(137)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(138)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(139)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -1359,36 +1411,77 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l114: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l114;
+                };
+            };
+        };
     }
-    return ((97 + v) - 10) & 255;
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
         return 1;
     }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l120: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l120;
+            };
+        };
+    };
+    return n;
 }
 
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b116: block {
-        l117: loop {
+    b122: block {
+        l123: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -1409,23 +1502,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b116;
+                break b122;
             }
-            continue l117;
+            continue l123;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -1433,62 +1528,135 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/from_string<User>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/User^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User"(let __match_scrut_0: ref "core:prelude/types.wado//Result<User,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/User^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<User,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User" {
+        let __cast_2: ref "core:prelude/types.wado//Result<User,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<User,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<User,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User" {
+        let __cast_1: ref "core:prelude/types.wado//Result<User,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<User,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<User>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/User^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/User^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1511,6 +1679,20 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     }, offset, abs_val, digit_count);
 }
 
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
+}
+
 fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     let s: ref "core:prelude/string.wado//String";
     let c: char;
@@ -1522,6 +1704,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
         "core:prelude/string.wado/String::push"(s, self);
         "core:prelude/format.wado/Formatter::pad"(f, s);
     }
+}
+
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
 }
 
 fn "core:prelude/string.wado/String::get_byte"(self, index) {
@@ -1591,7 +1787,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l140: loop {
+            l162: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -1599,7 +1795,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l140;
+                continue l162;
             };
         };
     };
@@ -1648,6 +1844,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -1700,10 +1945,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b151: block {
-        l152: loop {
+    b180: block {
+        l181: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b151;
+                break b180;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -1727,7 +1972,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l152;
+            continue l181;
         };
     };
     self.pos = _hfs_pos_8;
@@ -1806,11 +2051,11 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b160: block {
-        l161: loop {
+    b189: block {
+        l190: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= _licm_used_19 {
-                    break b160;
+                    break b189;
                 }
                 byte = builtin::array_get_u8(_licm_repr_20, __sroa___iter_3_index);
                 __sroa___iter_3_index = __sroa___iter_3_index + 1;
@@ -1845,7 +2090,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
                 _hfs_pos_27 = _hfs_pos_27 + 1;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l161;
+            continue l190;
         };
     };
     self.pos = _hfs_pos_27;
@@ -1864,130 +2109,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b167: block {
-        l168: loop {
-            if scan_pos >= _licm_used_90 {
-                break b167;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b196: block {
+        l197: loop {
+            if scan_pos >= _licm_used_56 {
+                break b196;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b167;
+                break b196;
             }
             scan_pos = scan_pos + 1;
-            continue l168;
+            continue l197;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -1996,22 +2213,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l175: loop {
+                l204: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l175;
+                    continue l204;
                 };
             };
         };
@@ -2019,71 +2236,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l178: loop {
+            l207: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l178;
+                continue l207;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b180: block {
-        l181: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b209: block {
+        l210: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b180;
+                break b209;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -2101,125 +2319,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l181;
+            continue l210;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -2227,87 +2388,71 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l206: loop {
+            l230: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l206;
+                continue l230;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -2362,25 +2507,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b217: block {
-        l218: loop {
+    b237: block {
+        l238: loop {
             if _hfs_pos_36 >= _licm_used_28 {
-                break b217;
+                break b237;
             }
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
                 break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr_29, __local_11);
             };
-            if (if b_1 >= 48 -> i32 {
+            if (if 48 <= b_1 -> i32 {
                 b_1 <= 57;
             } else {
                 0;
             }) {
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
-                break b217;
+                break b237;
             }
-            continue l218;
+            continue l238;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2401,25 +2546,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b224: block {
-            l225: loop {
+        b244: block {
+            l245: loop {
                 if _hfs_pos_37 >= _licm_used_31 {
-                    break b224;
+                    break b244;
                 }
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
                     break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_32, __local_17);
                 };
-                if (if b_2 >= 48 -> i32 {
+                if (if 48 <= b_2 -> i32 {
                     b_2 <= 57;
                 } else {
                     0;
                 }) {
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
-                    break b224;
+                    break b244;
                 }
-                continue l225;
+                continue l245;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2460,25 +2605,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b235: block {
-                l236: loop {
+            b255: block {
+                l256: loop {
                     if _hfs_pos_38 >= _licm_used_34 {
-                        break b235;
+                        break b255;
                     }
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
                         break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_35, __local_26);
                     };
-                    if (if b2 >= 48 -> i32 {
+                    if (if 48 <= b2 -> i32 {
                         b2 <= 57;
                     } else {
                         0;
                     }) {
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
-                        break b235;
+                        break b255;
                     }
-                    continue l236;
+                    continue l256;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -2572,16 +2717,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b245: block {
-        l246: loop {
+    b265: block {
+        l266: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b245;
+                break b265;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -2602,17 +2747,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b254: block {
-                        l255: loop {
+                    b274: block {
+                        l275: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b254;
+                                break b274;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -2622,9 +2767,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b254;
+                                break b274;
                             }
-                            continue l255;
+                            continue l275;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -2655,17 +2800,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b264: block {
-                            l265: loop {
+                        b284: block {
+                            l285: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b264;
+                                    break b284;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -2674,9 +2819,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b264;
+                                    break b284;
                                 }
-                                continue l265;
+                                continue l285;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -2714,9 +2859,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b245;
+                break b265;
             }
-            continue l246;
+            continue l266;
         };
     };
     self.pos = _hfs_pos_51;
@@ -2742,10 +2887,10 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b275: block {
-        l276: loop {
+    b295: block {
+        l296: loop {
             if _hfs_pos_14 >= _licm_used_12 {
-                break b275;
+                break b295;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -2775,7 +2920,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
                 }
             }
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l276;
+            continue l296;
         };
     };
     self.pos = _hfs_pos_14;
@@ -2786,19 +2931,284 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
 }
 
 fn "core:json/JsonDeserializer::skip_value"(self) {
-    let b: i32;
-    let r: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let c_4: i32;
-    let kr: ref null "core:serde//DeserializeError";
-    let e_6: ref "core:serde//DeserializeError";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let vr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let c_11: i32;
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: char;
+    let __local_6: ref "core:serde//DeserializeError";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_10: ref "core:serde//DeserializeError";
+    let __local_11: char;
     let __local_12: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/format.wado//Formatter";
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i64;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i32;
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
+    let __local_20: i32;
+    let __local_21: ref "core:prelude/string.wado//String";
+    let __local_22: i64;
+    let __local_23: ref "core:prelude/string.wado//String";
+    let __local_24: i32;
+    let __local_25: ref "core:prelude/string.wado//String";
+    let __local_26: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let __local_30: ref "core:prelude/string.wado//String";
+    let __local_31: ref "core:prelude/string.wado//String";
+    let __local_32: i32;
+    let __local_33: ref "core:prelude/string.wado//String";
+    let __local_34: i64;
+    let __local_35: ref "core:prelude/string.wado//String";
+    let __local_36: i64;
+    let __local_37: ref "core:prelude/string.wado//String";
+    let __local_38: i32;
+    let __local_39: ref "core:prelude/string.wado//String";
+    let __local_40: i64;
+    let __local_43: ref "core:prelude/string.wado//String";
+    let __local_44: i64;
+    "core:json/JsonDeserializer::skip_whitespace"(self);
+    if self.pos >= __inline_String__len_0: block -> i32 {
+        __local_14 = self.input;
+        break __inline_String__len_0: __local_14.used;
+    } {
+        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_15 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_15 };
+        });
+    }
+    b = __inline_String__get_byte_2: block -> u8 {
+        __local_16 = self.input;
+        __local_17 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_16.repr, __local_17);
+    } & 255;
+    if b == 34 {
+        return "core:json/JsonDeserializer::skip_string"(self);
+        unreachable;
+    } else if b == 116 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        unreachable;
+    } else if b == 102 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        unreachable;
+    } else if b == 110 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
+        unreachable;
+    } else if b == 91 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_3: block -> i32 {
+            __local_18 = self.input;
+            break __inline_String__len_3: __local_18.used;
+        } -> i32 {
+            __inline_String__get_byte_4: block -> u8 {
+                __local_19 = self.input;
+                __local_20 = self.pos;
+                break __inline_String__get_byte_4: builtin::array_get_u8(__local_19.repr, __local_20);
+            } == 93;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l311: loop {
+                let __match_scrut_5: ref null "core:serde//DeserializeError";
+                __match_scrut_5 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_5) {
+                } else if ref.is_null(__match_scrut_5) == 0 {
+                    let __cast_4: ref null "core:serde//DeserializeError";
+                    __cast_4 = ref.as_non_null(__match_scrut_5);
+                    __local_3 = ref.as_non_null(__cast_4);
+                    return __local_3;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_5: block -> i32 {
+                    __local_21 = self.input;
+                    break __inline_String__len_5: __local_21.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
+                        __local_22 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_22 };
+                    });
+                }
+                __local_4 = __inline_String__get_byte_7: block -> u8 {
+                    __local_23 = self.input;
+                    __local_24 = self.pos;
+                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_23.repr, __local_24);
+                } & 255;
+                if __local_4 == 93 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_4 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
+                        __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
+                        __local_26 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_25, offset: __local_26 };
+                    });
+                    unreachable;
+                }
+                continue l311;
+            };
+        };
+    } else if b == 123 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_9: block -> i32 {
+            __local_27 = self.input;
+            break __inline_String__len_9: __local_27.used;
+        } -> i32 {
+            __inline_String__get_byte_10: block -> u8 {
+                __local_28 = self.input;
+                __local_29 = self.pos;
+                break __inline_String__get_byte_10: builtin::array_get_u8(__local_28.repr, __local_29);
+            } == 125;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l321: loop {
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if (if self.pos >= __inline_String__len_11: block -> i32 {
+                    __local_30 = self.input;
+                    break __inline_String__len_11: __local_30.used;
+                } -> i32 {
+                    1;
+                } else {
+                    __inline_String__get_byte_12: block -> u8 {
+                        __local_31 = self.input;
+                        __local_32 = self.pos;
+                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_31.repr, __local_32);
+                    } != 34;
+                }) {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
+                        __local_33 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+                        __local_34 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_33, offset: __local_34 };
+                    });
+                }
+                let __match_scrut_1: ref null "core:serde//DeserializeError";
+                __match_scrut_1 = "core:json/JsonDeserializer::skip_string"(self);
+                if ref.is_null(__match_scrut_1) {
+                } else if ref.is_null(__match_scrut_1) == 0 {
+                    let __cast_1: ref null "core:serde//DeserializeError";
+                    __cast_1 = ref.as_non_null(__match_scrut_1);
+                    __local_6 = ref.as_non_null(__cast_1);
+                    return __local_6;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_2: ref null "core:serde//DeserializeError";
+                __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+                if ref.is_null(__match_scrut_2) {
+                } else if ref.is_null(__match_scrut_2) == 0 {
+                    let __cast_2: ref null "core:serde//DeserializeError";
+                    __cast_2 = ref.as_non_null(__match_scrut_2);
+                    __local_8 = ref.as_non_null(__cast_2);
+                    return __local_8;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_3: ref null "core:serde//DeserializeError";
+                __match_scrut_3 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_3) {
+                } else if ref.is_null(__match_scrut_3) == 0 {
+                    let __cast_3: ref null "core:serde//DeserializeError";
+                    __cast_3 = ref.as_non_null(__match_scrut_3);
+                    __local_10 = ref.as_non_null(__cast_3);
+                    return __local_10;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_14: block -> i32 {
+                    __local_35 = self.input;
+                    break __inline_String__len_14: __local_35.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
+                        __local_36 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_36 };
+                    });
+                }
+                __local_11 = __inline_String__get_byte_16: block -> u8 {
+                    __local_37 = self.input;
+                    __local_38 = self.pos;
+                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_37.repr, __local_38);
+                } & 255;
+                if __local_11 == 125 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_11 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
+                        __local_39 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
+                        __local_40 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_39, offset: __local_40 };
+                    });
+                    unreachable;
+                }
+                continue l321;
+            };
+        };
+    } else {
+        if (if b == 45 -> i32 {
+            1;
+        } else if 48 <= b -> i32 {
+            b <= 57;
+        } else {
+            0;
+        }) {
+            "core:json/JsonDeserializer::skip_number"(self);
+            return ref.null none;
+        }
+        return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
+            __local_43 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
+                "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
+                __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
+                "core:prelude/primitive.wado/char^Display::fmt"(b, __local_13);
+                "core:prelude/string.wado/String::push"(__local_12, 39);
+                break __tmpl: __local_12;
+            };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
+        });
+        unreachable;
+    }
+}
+
+fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
+    let __local_2: ref "core:serde//DeserializeError";
+    let key_start: i32;
+    let has_escape: bool;
+    let b: i32;
+    let key_end: i32;
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: i32;
+    let idx_10: i32;
+    let __local_11: ref "core:prelude/string.wado//String";
+    let __local_12: ref "core:serde//DeserializeError";
+    let key: ref "core:prelude/string.wado//String";
+    let __local_15: ref "core:serde//DeserializeError";
+    let __local_16: i32;
+    let idx_17: i32;
     let __local_18: ref "core:prelude/string.wado//String";
     let __local_19: i64;
     let __local_20: ref "core:prelude/string.wado//String";
@@ -2809,405 +3219,163 @@ fn "core:json/JsonDeserializer::skip_value"(self) {
     let __local_25: ref "core:prelude/string.wado//String";
     let __local_26: i64;
     let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: i64;
-    let __local_31: ref "core:prelude/string.wado//String";
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i32;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
-    let __local_37: ref "core:prelude/string.wado//String";
-    let __local_38: i64;
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
-    let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_47: ref "core:prelude/string.wado//String";
-    let __local_48: i64;
-    let _hfs_pos_49: i32;
-    let _hfs_pos_50: i32;
-    "core:json/JsonDeserializer::skip_whitespace"(self);
-    if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_18 = self.input;
-        break __inline_String__len_0: __local_18.used;
-    } {
-        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_19 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
-        });
-    }
-    b = __inline_String__get_byte_2: block -> u8 {
-        __local_20 = self.input;
-        __local_21 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
-    };
-    if b == 34 {
-        return "core:json/JsonDeserializer::skip_string"(self);
-    }
-    if b == 116 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-    }
-    if b == 102 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-    }
-    if b == 110 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
-    }
-    if b == 91 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_3: block -> i32 {
-            __local_22 = self.input;
-            break __inline_String__len_3: __local_22.used;
-        } -> i32 {
-            __inline_String__get_byte_4: block -> u8 {
-                __local_23 = self.input;
-                __local_24 = self.pos;
-                break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
-            } == 93;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_49 = self.pos;
-        block {
-            l291: loop {
-                self.pos = _hfs_pos_49;
-                r = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_49 = self.pos;
-                if ref.is_null(r) == 0 {
-                    e_3 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-                    self.pos = _hfs_pos_49;
-                    return e_3;
-                }
-                self.pos = _hfs_pos_49;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_49 = self.pos;
-                if _hfs_pos_49 >= __inline_String__len_5: block -> i32 {
-                    __local_25 = self.input;
-                    self.pos = _hfs_pos_49;
-                    break __inline_String__len_5: __local_25.used;
-                } {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
-                        __local_26 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
-                    });
-                }
-                c_4 = __inline_String__get_byte_7: block -> u8 {
-                    __local_27 = self.input;
-                    __local_28 = _hfs_pos_49;
-                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_27.repr, __local_28);
-                };
-                if c_4 == 93 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                    self.pos = _hfs_pos_49;
-                    return ref.null none;
-                }
-                if c_4 == 44 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                } else {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
-                        __local_29 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
-                        __local_30 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_29, offset: __local_30 };
-                    });
-                }
-                continue l291;
-            };
-        };
-        self.pos = _hfs_pos_49;
-    }
-    if b == 123 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_9: block -> i32 {
-            __local_31 = self.input;
-            break __inline_String__len_9: __local_31.used;
-        } -> i32 {
-            __inline_String__get_byte_10: block -> u8 {
-                __local_32 = self.input;
-                __local_33 = self.pos;
-                break __inline_String__get_byte_10: builtin::array_get_u8(__local_32.repr, __local_33);
-            } == 125;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_50 = self.pos;
-        block {
-            l300: loop {
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if (if _hfs_pos_50 >= __inline_String__len_11: block -> i32 {
-                    __local_34 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_11: __local_34.used;
-                } -> i32 {
-                    1;
-                } else {
-                    __inline_String__get_byte_12: block -> u8 {
-                        __local_35 = self.input;
-                        __local_36 = _hfs_pos_50;
-                        self.pos = _hfs_pos_50;
-                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_35.repr, __local_36);
-                    } != 34;
-                }) {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
-                        __local_37 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-                        __local_38 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_37, offset: __local_38 };
-                    });
-                }
-                self.pos = _hfs_pos_50;
-                kr = "core:json/JsonDeserializer::skip_string"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(kr) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(kr));
-                    self.pos = _hfs_pos_50;
-                    return e_6;
-                }
-                self.pos = _hfs_pos_50;
-                cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(cr) == 0 {
-                    e_8 = value_copy "core:serde//DeserializeError"(ref.as_non_null(cr));
-                    self.pos = _hfs_pos_50;
-                    return e_8;
-                }
-                self.pos = _hfs_pos_50;
-                vr = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(vr) == 0 {
-                    e_10 = value_copy "core:serde//DeserializeError"(ref.as_non_null(vr));
-                    self.pos = _hfs_pos_50;
-                    return e_10;
-                }
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if _hfs_pos_50 >= __inline_String__len_14: block -> i32 {
-                    __local_39 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_14: __local_39.used;
-                } {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
-                        __local_40 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-                    });
-                }
-                c_11 = __inline_String__get_byte_16: block -> u8 {
-                    __local_41 = self.input;
-                    __local_42 = _hfs_pos_50;
-                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_41.repr, __local_42);
-                };
-                if c_11 == 125 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                    self.pos = _hfs_pos_50;
-                    return ref.null none;
-                }
-                if c_11 == 44 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                } else {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
-                        __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
-                        __local_44 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
-                    });
-                }
-                continue l300;
-            };
-        };
-        self.pos = _hfs_pos_50;
-    }
-    if (if b == 45 -> i32 {
-        1;
-    } else if b >= 48 -> i32 {
-        b <= 57;
-    } else {
-        0;
-    }) {
-        "core:json/JsonDeserializer::skip_number"(self);
-        return ref.null none;
-    }
-    return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
-        __local_47 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-            __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
-            "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
-            __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
-            "core:prelude/primitive.wado/char^Display::fmt"(b & 255, __local_13);
-            "core:prelude/string.wado/String::push"(__local_12, 39);
-            break __tmpl: __local_12;
-        };
-        __local_48 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_47, offset: __local_48 };
-    });
-}
-
-fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
-    let r_1: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let key_start: i32;
-    let has_escape: bool;
-    let b: i32;
-    let key_end: i32;
-    let r_7: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let idx_9: ref "core:prelude/types.wado//Option<i32>";
-    let i_10: i32;
-    let key_r: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let key: ref "core:prelude/string.wado//String";
-    let r_13: ref null "core:serde//DeserializeError";
-    let e_14: ref "core:serde//DeserializeError";
-    let idx_15: ref "core:prelude/types.wado//Option<i32>";
-    let i_16: i32;
-    let e_17: ref "core:serde//DeserializeError";
-    let __local_25: ref "core:prelude/string.wado//String";
-    let __local_26: i64;
-    let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: ref "core:prelude/string.wado//String";
-    let __local_31: i32;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i64;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_25 = self.de.input;
-        break __inline_String__len_0: __local_25.used;
+        __local_18 = self.de.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
+            __local_19 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_27 = self.de.input;
-        __local_28 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_27.repr, __local_28);
+        __local_20 = self.de.input;
+        __local_21 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } == 125 {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r_1 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r_1) == 0 {
-            e_2 = ref.as_non_null(r_1);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if (if self.de.pos >= __inline_String__len_3: block -> i32 {
-        __local_29 = self.de.input;
-        break __inline_String__len_3: __local_29.used;
+        __local_22 = self.de.input;
+        break __inline_String__len_3: __local_22.used;
     } -> i32 {
         1;
     } else {
         __inline_String__get_byte_4: block -> u8 {
-            __local_30 = self.de.input;
-            __local_31 = self.de.pos;
-            break __inline_String__get_byte_4: builtin::array_get_u8(__local_30.repr, __local_31);
+            __local_23 = self.de.input;
+            __local_24 = self.de.pos;
+            break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
         } != 34;
     }) {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_5: block -> ref "core:serde//DeserializeError" {
-            __local_32 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-            __local_33 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_32, offset: __local_33 };
+            __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_25, offset: __local_26 };
         }) };
     }
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b318: block {
-        l319: loop {
+    b343: block {
+        l344: loop {
             if self.de.pos >= __inline_String__len_6: block -> i32 {
-                __local_34 = self.de.input;
-                break __inline_String__len_6: __local_34.used;
+                __local_27 = self.de.input;
+                break __inline_String__len_6: __local_27.used;
             } {
-                break b318;
+                break b343;
             }
             b = __inline_String__get_byte_7: block -> u8 {
-                __local_35 = self.de.input;
-                __local_36 = self.de.pos;
-                break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
+                __local_28 = self.de.input;
+                __local_29 = self.de.pos;
+                break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
             };
             if b == 34 {
-                break b318;
+                break b343;
             }
             if b == 92 {
                 has_escape = 1;
-                break b318;
+                break b343;
             }
             self.de.pos = self.de.pos + 1;
-            continue l319;
+            continue l344;
         };
     };
     if has_escape == 0 {
         key_end = self.de.pos;
         self.de.pos = self.de.pos + 1;
-        r_7 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_7) == 0 {
-            e_8 = ref.as_non_null(r_7);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_8 };
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_1);
+            __local_8 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        idx_9 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_0: ref "canonical//CanonicalClosure_0";
-            __indirect_call_0 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_0.func, __indirect_call_0.env, self.de.input, key_start, key_end);
+        let __match_scrut_2: ref "core:prelude/types.wado//Option<i32>";
+        __match_scrut_2 = block -> ref "core:prelude/types.wado//Option<i32>" {
+            let __indirect_call_2: ref "canonical//CanonicalClosure_0";
+            __indirect_call_2 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_2.func, __indirect_call_2.env, self.de.input, key_start, key_end);
         };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_9) {
-            i_10 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_9).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_10 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+        idx_10 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2) -> i32 {
+            let __cast_4: ref "core:prelude/types.wado//Option<i32>::Some";
+            __cast_4 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2);
+            __local_9 = __cast_4.payload_0;
+            __local_9;
+        } else if __match_scrut_2.discriminant == 1 -> i32 {
+            -1;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_10 } };
     }
     self.de.pos = key_start - 1;
-    key_r = "core:json/JsonDeserializer::read_json_string"(self.de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r) {
-        key = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r).payload_0);
-        r_13 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_13) == 0 {
-            e_14 = ref.as_non_null(r_13);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_14 };
-        }
-        idx_15 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_1: ref "canonical//CanonicalClosure_0";
-            __indirect_call_1 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_1.func, __indirect_call_1.env, key, 0, key.used);
-        };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_15) {
-            i_16 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_15).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_16 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+    key = value_copy "core:prelude/string.wado//String"(let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self.de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_6: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_6 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+        __local_11 = __cast_6.payload_0;
+        __local_11;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+        __local_12 = __cast_5.payload_0;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_12 };
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    let __match_scrut_4: ref null "core:serde//DeserializeError";
+    __match_scrut_4 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+    if ref.is_null(__match_scrut_4) {
+    } else if ref.is_null(__match_scrut_4) == 0 {
+        let __cast_7: ref null "core:serde//DeserializeError";
+        __cast_7 = ref.as_non_null(__match_scrut_4);
+        __local_15 = ref.as_non_null(__cast_7);
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_15 };
+        unreachable;
+    } else {
+        unreachable;
     }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r) {
-        e_17 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    let __match_scrut_5: ref "core:prelude/types.wado//Option<i32>";
+    __match_scrut_5 = block -> ref "core:prelude/types.wado//Option<i32>" {
+        let __indirect_call_7: ref "canonical//CanonicalClosure_0";
+        __indirect_call_7 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+        call_ref "functype/$canonical_closure_fn_0"(__indirect_call_7.func, __indirect_call_7.env, key, 0, key.used);
+    };
+    idx_17 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5) -> i32 {
+        let __cast_9: ref "core:prelude/types.wado//Option<i32>::Some";
+        __cast_9 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5);
+        __local_16 = __cast_9.payload_0;
+        __local_16;
+    } else if __match_scrut_5.discriminant == 1 -> i32 {
+        -1;
+    } else {
+        unreachable;
+    });
+    return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_17 } };
 }
 
 fn "core:json/JsonDeserializer^Deserializer::is_null"(self) {
@@ -3262,23 +3430,35 @@ fn "core:json/JsonDeserializer^Deserializer::is_null"(self) {
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_seq"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 91);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 91);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_2 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_2;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonSeqAccess" { de: self, first: 1 }, ref.null none;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_struct"(self, lookup) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 123);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_5: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 123);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_5 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_5;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonStructAccess" { de: self, lookup: lookup, first: 1 }, ref.null none;
 }
@@ -3290,13 +3470,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l340: loop {
+            l371: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l340;
+                continue l371;
             };
         };
     };
@@ -3433,8 +3613,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b363: block {
-        l364: loop {
+    b394: block {
+        l395: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3459,9 +3639,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b363;
+                break b394;
             }
-            continue l364;
+            continue l395;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -3501,8 +3681,8 @@ fn "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/User^Deseri
             __local_22 = struct.new "core:prelude//Array<i32>" { repr: builtin::array_new<i32>(0), used: 0 };
             break __seq_lit: __local_22;
         };
-        b372: block {
-            l373: loop {
+        b403: block {
+            l404: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -3520,7 +3700,7 @@ fn "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/User^Deseri
                                 name = __local_11;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_10).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_10).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_12 = "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/Option<String>^Deserialize::deserialize<JsonDeserializer>"(sd.de);
@@ -3530,7 +3710,7 @@ fn "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/User^Deseri
                                 email = __local_13;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(__local_12).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(__local_12).payload_0 };
                             }
                         } else if __idx == 2 {
                             __local_14 = "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/Array<i32>^Deserialize::deserialize<JsonDeserializer>"(sd.de);
@@ -3540,38 +3720,40 @@ fn "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/User^Deseri
                                 scores = __local_15;
                                 seen = seen | 4;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err"(__local_14).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err"(__local_14).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b372;
+                        break b403;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l373;
+                continue l404;
             };
         };
         if (seen & 7) != 7 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User" { name: name, email: email, scores: scores }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado//User" { name: name, email: email, scores: scores } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 
 fn "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/Array<i32>^Deserialize::deserialize<JsonDeserializer>"(d) {
     let seq: ref "core:json//JsonSeqAccess";
+    let first: ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";
     let first_opt: ref "core:prelude/types.wado//Option<i32>";
     let end_result_5: ref null "core:serde//DeserializeError";
     let e_6: ref "core:serde//DeserializeError";
     let __local_7: ref "core:prelude//Array<i32>";
     let first_elem: i32;
     let items: ref "core:prelude//Array<i32>";
+    let next: ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";
     let next_opt: ref "core:prelude/types.wado//Option<i32>";
     let end_result_12: ref null "core:serde//DeserializeError";
     let e_13: ref "core:serde//DeserializeError";
@@ -3585,24 +3767,18 @@ fn "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/Array<i32>^
     multivalue_bind [__sroa_seq_result_discriminant, __sroa_seq_result_case0_payload_0, __sroa_seq_result_case1_payload_0] = "core:json/JsonDeserializer^Deserializer::begin_seq"(d);
     if __sroa_seq_result_discriminant == 0 {
         seq = __sroa_seq_result_case0_payload_0;
-        let __sroa_first_discriminant: i32;
-        let __sroa_first_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
-        let __sroa_first_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_first_discriminant, __sroa_first_case0_payload_0, __sroa_first_case1_payload_0] = "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(seq);
-        if __sroa_first_discriminant == 0 {
-            first_opt = __sroa_first_case0_payload_0;
+        first = "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(seq);
+        if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(first) {
+            first_opt = ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(first).payload_0;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(first_opt) {
                 first_elem = ref.cast "core:prelude/types.wado//Option<i32>::Some"(first_opt).payload_0;
                 items = struct.new "core:prelude//Array<i32>" { repr: builtin::array_new<i32>(2), used: 0 };
                 "core:prelude/array.wado/Array<i32>::push"(items, first_elem);
                 block {
-                    l387: loop {
-                        let __sroa_next_discriminant: i32;
-                        let __sroa_next_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
-                        let __sroa_next_case1_payload_0: ref null "core:serde//DeserializeError";
-                        multivalue_bind [__sroa_next_discriminant, __sroa_next_case0_payload_0, __sroa_next_case1_payload_0] = "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(seq);
-                        if __sroa_next_discriminant == 0 {
-                            next_opt = __sroa_next_case0_payload_0;
+                    l418: loop {
+                        next = "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(seq);
+                        if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(next) {
+                            next_opt = ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(next).payload_0;
                             if ref.test "core:prelude/types.wado//Option<i32>::Some"(next_opt) {
                                 item = ref.cast "core:prelude/types.wado//Option<i32>::Some"(next_opt).payload_0;
                                 "core:prelude/array.wado/Array<i32>::push"(items, item);
@@ -3615,11 +3791,11 @@ fn "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/Array<i32>^
                                 return struct.new "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: items };
                             }
                         }
-                        if __sroa_next_discriminant == 1 {
-                            e_15 = __sroa_next_case1_payload_0;
+                        if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(next) {
+                            e_15 = ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(next).payload_0;
                             return struct.new "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_15 };
                         }
-                        continue l387;
+                        continue l418;
                     };
                 };
             } else {
@@ -3634,8 +3810,8 @@ fn "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/Array<i32>^
                 }) };
             }
         }
-        if __sroa_first_discriminant == 1 {
-            e_16 = __sroa_first_case1_payload_0;
+        if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(first) {
+            e_16 = ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(first).payload_0;
             return struct.new "core:prelude/types.wado//Result<Array<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_16 };
         }
         "core:internal/unreachable"();
@@ -3678,13 +3854,13 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l397: loop {
+            l428: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
                 i = i + 1;
-                continue l397;
+                continue l428;
             };
         };
     };
@@ -3692,51 +3868,58 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
 }
 
 fn "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let elem: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
-    let v: i32;
-    let e_5: ref "core:serde//DeserializeError";
-    let __local_9: ref "core:prelude/string.wado//String";
-    let __local_10: i64;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i32;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __local_3: i32;
+    let __local_4: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_9 = self.de.input;
-        break __inline_String__len_0: __local_9.used;
+        __local_5 = self.de.input;
+        break __inline_String__len_0: __local_5.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_10 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_10 };
-        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_6 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_11 = self.de.input;
-        __local_12 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_11.repr, __local_12);
+        __local_7 = self.de.input;
+        __local_8 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_7.repr, __local_8);
     } == 93 {
-        return 0, struct.new "core:prelude/types.wado//Option<i32>" { 1 }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r) == 0 {
-            e_2 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-            return 1, ref.null none, e_2;
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
-    elem = "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/i32^Deserialize::deserialize<JsonDeserializer>"(self.de);
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(elem) {
-        v = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(elem).payload_0;
-        return 0, struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: v }, ref.null none;
-    }
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(elem) {
-        e_5 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(elem).payload_0);
-        return 1, ref.null none, e_5;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return let __match_scrut_1: ref "core:prelude/types.wado//Result<i32,DeserializeError>", __match_scrut_1 = "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/i32^Deserialize::deserialize<JsonDeserializer>"(self.de), (if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>" {
+        let __cast_3: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Ok";
+        __cast_3 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_1);
+        __local_3 = __cast_3.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: __local_3 } };
+    } else if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Err";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_1);
+        __local_4 = __cast_2.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_4 };
+    } else {
+        unreachable;
+    });
 }
 
 fn "wado-compiler/tests/fixtures/serde_json_option_array_fields.wado/i32^Deserialize::deserialize<JsonDeserializer>"(d) {
@@ -3824,8 +4007,8 @@ fn "core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>"(sel
             __local_16 = self;
             break __inline_Array_i32__IntoIterator__into_iter_2: struct.new "core:prelude/array.wado//ArrayIter<i32>" { repr: __local_16.repr, used: __local_16.used, index: 0 };
         };
-        b412: block {
-            l413: loop {
+        b444: block {
+            l445: loop {
                 let __sroa___pattern_temp_1_discriminant: i32;
                 let __sroa___pattern_temp_1_payload_0: i32;
                 multivalue_bind [__sroa___pattern_temp_1_discriminant, __sroa___pattern_temp_1_payload_0] = "core:prelude/array.wado/ArrayIter<i32>^Iterator::next"(__iter_4);
@@ -3836,9 +4019,9 @@ fn "core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>"(sel
                         return e_7;
                     }
                 } else {
-                    break b412;
+                    break b444;
                 }
-                continue l413;
+                continue l445;
             };
         };
         return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref null "core:serde//SerializeError" {

--- a/wado-compiler/tests/fixtures.golden/serde_json_primitives.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_primitives.wir.wado
@@ -56,364 +56,399 @@ struct core:serde//SerializeError {  // TypeId(9)
 
 array builtin::array<u64> (mut u64);  // TypeId(10)
 
-variant core:prelude/types.wado//Option<i32> {  // TypeId(11)
+variant core:prelude/types.wado//Option<char> {  // TypeId(11)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(12)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<i32> {  // TypeId(13)
     Some(i32),
     None,
 }
 
-struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(12)
+struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(14)
     discriminant: i32,
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Option<String> {  // TypeId(13)
+variant core:prelude/types.wado//Option<String> {  // TypeId(15)
     Some(ref "core:prelude/string.wado//String"),
     None,
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(14)
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(16)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(15)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(17)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(16)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(18)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(17)
+variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(19)
     Ok(f64),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(18)
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(20)
     discriminant: i32,
     payload_0: f64,
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(19)
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(21)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<f32,DeserializeError> {  // TypeId(20)
+variant core:prelude/types.wado//Result<f32,DeserializeError> {  // TypeId(22)
     Ok(f32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<f32,DeserializeError>::Ok {  // TypeId(21)
+struct core:prelude/types.wado//Result<f32,DeserializeError>::Ok {  // TypeId(23)
     discriminant: i32,
     payload_0: f32,
 }
 
-struct core:prelude/types.wado//Result<f32,DeserializeError>::Err {  // TypeId(22)
+struct core:prelude/types.wado//Result<f32,DeserializeError>::Err {  // TypeId(24)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(23)
+variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(25)
     Ok(bool),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(24)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(26)
     discriminant: i32,
     payload_0: bool,
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(25)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(27)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(26)
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(28)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(27)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(29)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(28)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(30)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-struct core:prelude//Array<u64> {  // TypeId(29)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(31)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(32)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(33)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+struct core:prelude//Array<u64> {  // TypeId(34)
     mut repr: ref builtin::array<u64>,
     mut used: i32,
 }
 
-enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(30)
+enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(35)
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(31)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(36)
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(32)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(37)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(33)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(38)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(34)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(39)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(35)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(40)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(36)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(41)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(37)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(42)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(38)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(43)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(39)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(44)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_0_i32_zero_roundtrip" = fn();  // TypeId(40)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_0_i32_zero_roundtrip" = fn();  // TypeId(45)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_1_i32_max" = fn();  // TypeId(41)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_1_i32_max" = fn();  // TypeId(46)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_2_i32_min" = fn();  // TypeId(42)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_2_i32_min" = fn();  // TypeId(47)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_3_u32_zero_and_max" = fn();  // TypeId(43)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_3_u32_zero_and_max" = fn();  // TypeId(48)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_4_f64_positive_and_negative" = fn();  // TypeId(44)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_4_f64_positive_and_negative" = fn();  // TypeId(49)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_5_f64_integer_value" = fn();  // TypeId(45)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_5_f64_integer_value" = fn();  // TypeId(50)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_6_f64_deserialize_with_exponent" = fn();  // TypeId(46)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_6_f64_deserialize_with_exponent" = fn();  // TypeId(51)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_7_f32_roundtrip" = fn();  // TypeId(47)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_7_f32_roundtrip" = fn();  // TypeId(52)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_8_f32_zero_and_negative" = fn();  // TypeId(48)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_8_f32_zero_and_negative" = fn();  // TypeId(53)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_9_bool_true_roundtrip" = fn();  // TypeId(49)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_9_bool_true_roundtrip" = fn();  // TypeId(54)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_10_bool_false_roundtrip" = fn();  // TypeId(50)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_10_bool_false_roundtrip" = fn();  // TypeId(55)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_11_char_ascii_and_special" = fn();  // TypeId(51)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_11_char_ascii_and_special" = fn();  // TypeId(56)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_12_string_empty_roundtrip" = fn();  // TypeId(52)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_12_string_empty_roundtrip" = fn();  // TypeId(57)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_13_string_with_escapes_roundtrip" = fn();  // TypeId(53)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_13_string_with_escapes_roundtrip" = fn();  // TypeId(58)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_14_option_some_and_none" = fn();  // TypeId(54)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__test_14_option_some_and_none" = fn();  // TypeId(59)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_0_i32_zero_roundtrip" = fn();  // TypeId(55)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_0_i32_zero_roundtrip" = fn();  // TypeId(60)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_1_i32_max" = fn();  // TypeId(56)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_1_i32_max" = fn();  // TypeId(61)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_2_i32_min" = fn();  // TypeId(57)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_2_i32_min" = fn();  // TypeId(62)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_3_u32_zero_and_max" = fn();  // TypeId(58)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_3_u32_zero_and_max" = fn();  // TypeId(63)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_4_f64_positive_and_negative" = fn();  // TypeId(59)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_4_f64_positive_and_negative" = fn();  // TypeId(64)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_5_f64_integer_value" = fn();  // TypeId(60)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_5_f64_integer_value" = fn();  // TypeId(65)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_6_f64_deserialize_with_exponent" = fn();  // TypeId(61)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_6_f64_deserialize_with_exponent" = fn();  // TypeId(66)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_7_f32_roundtrip" = fn();  // TypeId(62)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_7_f32_roundtrip" = fn();  // TypeId(67)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_8_f32_zero_and_negative" = fn();  // TypeId(63)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_8_f32_zero_and_negative" = fn();  // TypeId(68)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_9_bool_true_roundtrip" = fn();  // TypeId(64)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_9_bool_true_roundtrip" = fn();  // TypeId(69)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_10_bool_false_roundtrip" = fn();  // TypeId(65)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_10_bool_false_roundtrip" = fn();  // TypeId(70)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_11_char_ascii_and_special" = fn();  // TypeId(66)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_11_char_ascii_and_special" = fn();  // TypeId(71)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_12_string_empty_roundtrip" = fn();  // TypeId(67)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_12_string_empty_roundtrip" = fn();  // TypeId(72)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_13_string_with_escapes_roundtrip" = fn();  // TypeId(68)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_13_string_with_escapes_roundtrip" = fn();  // TypeId(73)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_14_option_some_and_none" = fn();  // TypeId(69)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__cm_export____test_14_option_some_and_none" = fn();  // TypeId(74)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__initialize_module" = fn();  // TypeId(70)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/__initialize_module" = fn();  // TypeId(75)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(71)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(76)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(72)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(77)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(73)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(78)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(74)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(79)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(75)
+type "functype//core:internal/unreachable" = fn();  // TypeId(80)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(76)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(81)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(77)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(82)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(78)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(83)
 
-type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(79)
+type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(84)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(80)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(85)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(81)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(86)
 
-type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(82)
+type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(87)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(83)
+type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(88)
 
-type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(84)
+type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(89)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(85)
+type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(90)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(86)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(91)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(87)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(92)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(88)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(93)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(89)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(94)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(90)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(95)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(91)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(96)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(92)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(97)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(93)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(98)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(94)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(99)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(95)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(100)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(96)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(101)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(97)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(102)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(98)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(103)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(99)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(104)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(100)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(105)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(101)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(106)
 
-type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(102)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(107)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(103)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(108)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(104)
+type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(109)
 
-type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(105)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(110)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_f32" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f32,DeserializeError>";  // TypeId(106)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(111)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(107)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(112)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(108)
+type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(113)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(109)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(114)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(110)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(115)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(111)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(116)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(112)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(117)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(113)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(118)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(114)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(119)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(115)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(120)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/bool^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(116)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(121)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/f32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f32,DeserializeError>";  // TypeId(117)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(122)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/f64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(118)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/bool^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(123)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(119)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/f32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f32,DeserializeError>";  // TypeId(124)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(120)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/f64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(125)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(121)
+type "functype//wado-compiler/tests/fixtures/serde_json_primitives.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(126)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(122)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(127)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(123)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(128)
 
-type "functype//core:prelude/fpfmt.wado/unpack32" = fn(f32) -> [u64, i32];  // TypeId(124)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(129)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(125)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(130)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(126)
+type "functype//core:prelude/fpfmt.wado/unpack32" = fn(f32) -> [u64, i32];  // TypeId(131)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(127)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(132)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(128)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(133)
 
-type "functype//core:prelude/fpfmt.wado/short32" = fn(f32) -> [u64, i32];  // TypeId(129)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(134)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(130)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(135)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(131)
+type "functype//core:prelude/fpfmt.wado/short32" = fn(f32) -> [u64, i32];  // TypeId(136)
 
-type "functype//core:json/core/json/from_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(132)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(137)
 
-type "functype//core:json/core/json/to_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(133)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(138)
 
-type "functype//core:json/core/json/from_string<bool>" = fn(ref "core:prelude/string.wado//String") -> [i32, bool, ref null "core:serde//DeserializeError"];  // TypeId(134)
+type "functype//core:json/core/json/from_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(139)
 
-type "functype//core:json/core/json/from_string<f32>" = fn(ref "core:prelude/string.wado//String") -> [i32, f32, ref null "core:serde//DeserializeError"];  // TypeId(135)
+type "functype//core:json/core/json/to_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(140)
 
-type "functype//core:json/core/json/from_string<f64>" = fn(ref "core:prelude/string.wado//String") -> [i32, f64, ref null "core:serde//DeserializeError"];  // TypeId(136)
+type "functype//core:json/core/json/from_string<bool>" = fn(ref "core:prelude/string.wado//String") -> [i32, bool, ref null "core:serde//DeserializeError"];  // TypeId(141)
 
-type "functype//core:json/core/json/from_string<i32>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(137)
+type "functype//core:json/core/json/from_string<f32>" = fn(ref "core:prelude/string.wado//String") -> [i32, f32, ref null "core:serde//DeserializeError"];  // TypeId(142)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(138)
+type "functype//core:json/core/json/from_string<f64>" = fn(ref "core:prelude/string.wado//String") -> [i32, f64, ref null "core:serde//DeserializeError"];  // TypeId(143)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(139)
+type "functype//core:json/core/json/from_string<i32>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(144)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(140)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(145)
 
-type "functype//core:json/core/json/to_string<Option<String>>" = fn(ref null "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(141)
+type "functype//core:json/core/json/to_string<Option<String>>" = fn(ref null "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(146)
 
-type "functype//core:json/core/json/to_string<Option<i32>>" = fn(ref "core:prelude/types.wado//Option<i32>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(142)
+type "functype//core:json/core/json/to_string<Option<i32>>" = fn(ref "core:prelude/types.wado//Option<i32>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(147)
 
-type "functype//core:json/core/json/to_string<char>" = fn(char) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(143)
+type "functype//core:json/core/json/to_string<char>" = fn(char) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(148)
 
-type "functype//core:json/core/json/to_string<bool>" = fn(bool) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(144)
+type "functype//core:json/core/json/to_string<bool>" = fn(bool) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(149)
 
-type "functype//core:json/core/json/to_string<f32>" = fn(f32) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(145)
+type "functype//core:json/core/json/to_string<f32>" = fn(f32) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(150)
 
-type "functype//core:json/core/json/to_string<f64>" = fn(f64) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(146)
+type "functype//core:json/core/json/to_string<f64>" = fn(f64) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(151)
 
-type "functype//core:json/core/json/to_string<u32>" = fn(u32) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(147)
+type "functype//core:json/core/json/to_string<u32>" = fn(u32) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(152)
 
-type "functype//core:json/core/json/to_string<i32>" = fn(i32) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(148)
+type "functype//core:json/core/json/to_string<i32>" = fn(i32) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(153)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(149)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(154)
 
-type "functype//core:prelude/primitive.wado/u32::fmt_decimal" = fn(u32, ref "core:prelude/format.wado//Formatter");  // TypeId(150)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(155)
 
-type "functype//core:prelude/primitive.wado/f32::inspect_into" = fn(f32, ref "core:prelude/format.wado//Formatter");  // TypeId(151)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(156)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(152)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(157)
 
-type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(153)
+type "functype//core:prelude/primitive.wado/u32::fmt_decimal" = fn(u32, ref "core:prelude/format.wado//Formatter");  // TypeId(158)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(154)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(159)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(155)
+type "functype//core:prelude/primitive.wado/f32::inspect_into" = fn(f32, ref "core:prelude/format.wado//Formatter");  // TypeId(160)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(156)
+type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(161)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_u32" = fn(ref "core:prelude/string.wado//String", u32) -> ref null "core:serde//SerializeError";  // TypeId(157)
+type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(162)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f32" = fn(ref "core:prelude/string.wado//String", f32) -> ref null "core:serde//SerializeError";  // TypeId(158)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(163)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(159)
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(164)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(160)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(165)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_char" = fn(ref "core:prelude/string.wado//String", char) -> ref null "core:serde//SerializeError";  // TypeId(161)
+type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(166)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_u32" = fn(ref "core:prelude/string.wado//String", u32) -> ref null "core:serde//SerializeError";  // TypeId(167)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_f32" = fn(ref "core:prelude/string.wado//String", f32) -> ref null "core:serde//SerializeError";  // TypeId(168)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(169)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(170)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_char" = fn(ref "core:prelude/string.wado//String", char) -> ref null "core:serde//SerializeError";  // TypeId(171)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -3167,6 +3202,67 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l205: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l205;
+                };
+            };
+        };
+    }
+}
+
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
+        return 1;
+    }
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l211: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l211;
+            };
+        };
+    };
+    return n;
+}
+
 fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     let mark: i32;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -3195,36 +3291,16 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
-    }
-    return ((97 + v) - 10) & 255;
-}
-
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b211: block {
-        l212: loop {
+    b217: block {
+        l218: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3245,353 +3321,502 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b211;
+                break b217;
             }
-            continue l212;
+            continue l218;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
 }
 
 fn "core:json/core/json/to_string<Option<String>>"(value) {
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: ref null "core:prelude/string.wado//String";
+    let __local_3: ref "core:serde//SerializeError";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: ref null "core:prelude/string.wado//String";
     let __sroa_ser_buf: ref "core:prelude/string.wado//String";
     __sroa_ser_buf = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
-    r = __inline_Option_String__Serialize__serialize_JsonSerializer__0: block -> ref null "core:serde//SerializeError" {
-        __local_8 = value_copy "core:prelude/types.wado//Option<String>"(value);
-        if ref.is_null(__local_8) == 0 {
-            __local_7 = ref.as_non_null(__local_8);
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = __inline_Option_String__Serialize__serialize_JsonSerializer__0: block -> ref null "core:serde//SerializeError" {
+        __local_7 = value_copy "core:prelude/types.wado//Option<String>"(value);
+        if ref.is_null(__local_7) == 0 {
+            __local_6 = ref.as_non_null(__local_7);
             __inline_JsonSerializer_Serializer__serialize_string_0: block -> ref null "core:serde//SerializeError" {
-                "core:json/write_escaped_string"(__sroa_ser_buf, __local_7);
+                "core:json/write_escaped_string"(__sroa_ser_buf, __local_6);
                 break __inline_JsonSerializer_Serializer__serialize_string_0: ref.null none;
             };
             break __inline_Option_String__Serialize__serialize_JsonSerializer__0;
         }
-        __inline_JsonSerializer_Serializer__serialize_null_2: block -> ref null "core:serde//SerializeError" {
+        __inline_JsonSerializer_Serializer__serialize_null_1: block -> ref null "core:serde//SerializeError" {
             "core:prelude/string.wado/String::push"(__sroa_ser_buf, 110);
             "core:prelude/string.wado/String::push"(__sroa_ser_buf, 117);
             "core:prelude/string.wado/String::push"(__sroa_ser_buf, 108);
             "core:prelude/string.wado/String::push"(__sroa_ser_buf, 108);
-            break __inline_JsonSerializer_Serializer__serialize_null_2: ref.null none;
+            break __inline_JsonSerializer_Serializer__serialize_null_1: ref.null none;
         };
         break __inline_Option_String__Serialize__serialize_JsonSerializer__0;
     };
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, __sroa_ser_buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Option<i32>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
-    let __local_6: ref "core:json//JsonSerializer";
-    let __local_8: ref "core:prelude/types.wado//Option<i32>";
-    let __local_12: i32;
+    let __local_3: ref "core:serde//SerializeError";
+    let __local_5: ref "core:json//JsonSerializer";
+    let __local_7: ref "core:prelude/types.wado//Option<i32>";
+    let __local_11: i32;
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = __inline_Option_i32__Serialize__serialize_JsonSerializer__0: block -> ref null "core:serde//SerializeError" {
-        __local_6 = ser;
-        __local_8 = value;
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(__local_8) {
-            __local_12 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__local_8).payload_0;
-            break __inline_Option_i32__Serialize__serialize_JsonSerializer__0: "core:json/JsonSerializer^Serializer::serialize_i32"(__local_6.buf, __local_12);
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = __inline_Option_i32__Serialize__serialize_JsonSerializer__0: block -> ref null "core:serde//SerializeError" {
+        __local_5 = ser;
+        __local_7 = value;
+        if ref.test "core:prelude/types.wado//Option<i32>::Some"(__local_7) {
+            __local_11 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__local_7).payload_0;
+            break __inline_Option_i32__Serialize__serialize_JsonSerializer__0: "core:json/JsonSerializer^Serializer::serialize_i32"(__local_5.buf, __local_11);
         }
-        __inline_JsonSerializer_Serializer__serialize_null_2: block -> ref null "core:serde//SerializeError" {
-            "core:prelude/string.wado/String::push"(__local_6.buf, 110);
-            "core:prelude/string.wado/String::push"(__local_6.buf, 117);
-            "core:prelude/string.wado/String::push"(__local_6.buf, 108);
-            "core:prelude/string.wado/String::push"(__local_6.buf, 108);
-            break __inline_JsonSerializer_Serializer__serialize_null_2: ref.null none;
+        __inline_JsonSerializer_Serializer__serialize_null_1: block -> ref null "core:serde//SerializeError" {
+            "core:prelude/string.wado/String::push"(__local_5.buf, 110);
+            "core:prelude/string.wado/String::push"(__local_5.buf, 117);
+            "core:prelude/string.wado/String::push"(__local_5.buf, 108);
+            "core:prelude/string.wado/String::push"(__local_5.buf, 108);
+            break __inline_JsonSerializer_Serializer__serialize_null_1: ref.null none;
         };
         break __inline_Option_i32__Serialize__serialize_JsonSerializer__0;
     };
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<String>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+    let __local_2: ref "core:prelude/string.wado//String";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "core:prelude/string.wado//String";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_primitives.wado/String^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r) {
-        v = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r).payload_0);
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:prelude/string.wado//String"(let __match_scrut_0: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_primitives.wado/String^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+        let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+        let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r).payload_0);
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<String>"(value) {
-    let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
-    ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = __inline_JsonSerializer_Serializer__serialize_string_1: block -> ref null "core:serde//SerializeError" {
-        "core:json/write_escaped_string"(ser.buf, value);
-        break __inline_JsonSerializer_Serializer__serialize_string_1: ref.null none;
+    let __local_3: ref "core:serde//SerializeError";
+    let __sroa_ser_buf: ref "core:prelude/string.wado//String";
+    __sroa_ser_buf = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = __inline_JsonSerializer_Serializer__serialize_string_0: block -> ref null "core:serde//SerializeError" {
+        "core:json/write_escaped_string"(__sroa_ser_buf, value);
+        break __inline_JsonSerializer_Serializer__serialize_string_0: ref.null none;
     };
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
-    return 0, ser.buf, ref.null none;
+    return 0, __sroa_ser_buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<char>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_char"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_char"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<bool>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<bool,DeserializeError>";
+    let __local_2: bool;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: bool;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_primitives.wado/bool^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<bool,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<bool,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_primitives.wado/bool^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<bool,DeserializeError>::Ok"(__match_scrut_0) -> bool {
+        let __cast_2: ref "core:prelude/types.wado//Result<bool,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__match_scrut_0) -> bool {
+        let __cast_1: ref "core:prelude/types.wado//Result<bool,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(r).payload_0);
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<bool>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_bool"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_bool"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<f32>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<f32,DeserializeError>";
+    let __local_2: f32;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: f32;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_primitives.wado/f32^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<f32,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<f32,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0_f32, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<f32,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_primitives.wado/f32^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<f32,DeserializeError>::Ok"(__match_scrut_0) -> f32 {
+        let __cast_2: ref "core:prelude/types.wado//Result<f32,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<f32,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<f32,DeserializeError>::Err"(__match_scrut_0) -> f32 {
+        let __cast_1: ref "core:prelude/types.wado//Result<f32,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<f32,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0_f32, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0_f32, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<f32,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<f32,DeserializeError>::Err"(r).payload_0);
-        return 1, 0_f32, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<f32>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_f32"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_f32"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<f64>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<f64,DeserializeError>";
+    let __local_2: f64;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: f64;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_primitives.wado/f64^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<f64,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_primitives.wado/f64^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(__match_scrut_0) -> f64 {
+        let __cast_2: ref "core:prelude/types.wado//Result<f64,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__match_scrut_0) -> f64 {
+        let __cast_1: ref "core:prelude/types.wado//Result<f64,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(r).payload_0);
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<f64>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_f64"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_f64"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<u32>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_u32"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_u32"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<i32>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
+    let __local_2: i32;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: i32;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_primitives.wado/i32^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_primitives.wado/i32^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_0) -> i32 {
+        let __cast_2: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_0) -> i32 {
+        let __cast_1: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(r).payload_0);
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<i32>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_i32"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_i32"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -3632,6 +3857,20 @@ fn "core:prelude/primitive.wado/u32::fmt_decimal"(self, f) {
         __local_6 = f.buf;
         break __inline_String__internal_raw_bytes_0: __local_6.repr;
     }, offset, abs_val, digit_count);
+}
+
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
 }
 
 fn "core:prelude/primitive.wado/f32::inspect_into"(self, f) {
@@ -3975,6 +4214,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     }
 }
 
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
+}
+
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     let capacity: i32;
     let new_capacity: i32;
@@ -4051,7 +4304,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l296: loop {
+            l326: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -4059,7 +4312,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l296;
+                continue l326;
             };
         };
     };
@@ -4108,6 +4361,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -4246,10 +4548,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b312: block {
-        l313: loop {
+    b349: block {
+        l350: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b312;
+                break b349;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -4273,7 +4575,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l313;
+            continue l350;
         };
     };
     self.pos = _hfs_pos_8;
@@ -4306,11 +4608,11 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b319: block {
-        l320: loop {
+    b356: block {
+        l357: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= _licm_used_19 {
-                    break b319;
+                    break b356;
                 }
                 byte = builtin::array_get_u8(_licm_repr_20, __sroa___iter_3_index);
                 __sroa___iter_3_index = __sroa___iter_3_index + 1;
@@ -4345,7 +4647,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
                 _hfs_pos_27 = _hfs_pos_27 + 1;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l320;
+            continue l357;
         };
     };
     self.pos = _hfs_pos_27;
@@ -4364,130 +4666,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b326: block {
-        l327: loop {
-            if scan_pos >= _licm_used_90 {
-                break b326;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b363: block {
+        l364: loop {
+            if scan_pos >= _licm_used_56 {
+                break b363;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b326;
+                break b363;
             }
             scan_pos = scan_pos + 1;
-            continue l327;
+            continue l364;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -4496,22 +4770,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l334: loop {
+                l371: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l334;
+                    continue l371;
                 };
             };
         };
@@ -4519,71 +4793,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l337: loop {
+            l374: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l337;
+                continue l374;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b339: block {
-        l340: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b376: block {
+        l377: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b339;
+                break b376;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -4601,125 +4876,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l340;
+            continue l377;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -4727,87 +4945,71 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l365: loop {
+            l397: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l365;
+                continue l397;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -4897,16 +5099,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b379: block {
-        l380: loop {
+    b407: block {
+        l408: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b379;
+                break b407;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -4927,17 +5129,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b388: block {
-                        l389: loop {
+                    b416: block {
+                        l417: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b388;
+                                break b416;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -4947,9 +5149,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b388;
+                                break b416;
                             }
-                            continue l389;
+                            continue l417;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -4980,17 +5182,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b398: block {
-                            l399: loop {
+                        b426: block {
+                            l427: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b398;
+                                    break b426;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -4999,9 +5201,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b398;
+                                    break b426;
                                 }
-                                continue l399;
+                                continue l427;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -5039,9 +5241,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b379;
+                break b407;
             }
-            continue l380;
+            continue l408;
         };
     };
     self.pos = _hfs_pos_51;
@@ -5153,16 +5355,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b414: block {
-        l415: loop {
+    b442: block {
+        l443: loop {
             if _hfs_pos_57 >= _licm_used_49 {
-                break b414;
+                break b442;
             }
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_50, __local_32);
             };
-            if (if b_6 >= 48 -> i32 {
+            if (if 48 <= b_6 -> i32 {
                 b_6 <= 57;
             } else {
                 0;
@@ -5173,9 +5375,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                 total_digits = total_digits + 1;
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
-                break b414;
+                break b442;
             }
-            continue l415;
+            continue l443;
         };
     };
     self.pos = _hfs_pos_57;
@@ -5197,16 +5399,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b422: block {
-            l423: loop {
+        b450: block {
+            l451: loop {
                 if _hfs_pos_58 >= _licm_used_52 {
-                    break b422;
+                    break b450;
                 }
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
                     break __inline_String__get_byte_12: builtin::array_get_u8(_licm_repr_53, __local_38);
                 };
-                if (if b_8 >= 48 -> i32 {
+                if (if 48 <= b_8 -> i32 {
                     b_8 <= 57;
                 } else {
                     0;
@@ -5218,9 +5420,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                     total_digits = total_digits + 1;
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
-                    break b422;
+                    break b450;
                 }
-                continue l423;
+                continue l451;
             };
         };
         self.pos = _hfs_pos_58;
@@ -5262,16 +5464,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b434: block {
-                l435: loop {
+            b462: block {
+                l463: loop {
                     if _hfs_pos_59 >= _licm_used_55 {
-                        break b434;
+                        break b462;
                     }
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
                         break __inline_String__get_byte_18: builtin::array_get_u8(_licm_repr_56, __local_47);
                     };
-                    if (if b3 >= 48 -> i32 {
+                    if (if 48 <= b3 -> i32 {
                         b3 <= 57;
                     } else {
                         0;
@@ -5279,9 +5481,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                         exp = (exp * 10) + (b3 - 48);
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
-                        break b434;
+                        break b462;
                     }
-                    continue l435;
+                    continue l463;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -5315,71 +5517,70 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
     return struct.new "core:prelude/types.wado//Result<f64,DeserializeError>::Ok" { discriminant: 0, payload_0: v_19 };
 }
 
-fn "core:json/JsonDeserializer^Deserializer::deserialize_f32"(self) {
-    let r: ref "core:prelude/types.wado//Result<f64,DeserializeError>";
-    let v: f64;
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::parse_f64_direct"(self);
-    if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(r).payload_0;
-        return struct.new "core:prelude/types.wado//Result<f32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::f32_demote_f64(v) };
-    }
-    if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(r) {
-        e = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(r).payload_0;
-        return struct.new "core:prelude/types.wado//Result<f32,DeserializeError>::Err" { discriminant: 1, payload_0: e };
-    }
-    "core:internal/unreachable"();
-    unreachable;
-}
-
 fn "core:json/JsonDeserializer^Deserializer::deserialize_bool"(self) {
-    let b: i32;
-    let r_2: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let r_4: ref null "core:serde//DeserializeError";
-    let e_5: ref "core:serde//DeserializeError";
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:serde//DeserializeError";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
     let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i64;
+    let __local_9: i32;
     let __local_10: ref "core:prelude/string.wado//String";
-    let __local_11: i32;
-    let __local_12: ref "core:prelude/string.wado//String";
-    let __local_13: i64;
+    let __local_11: i64;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_8 = self.input;
-        break __inline_String__len_0: __local_8.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_9 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_9 };
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
         }) };
     }
     b = __inline_String__get_byte_2: block -> u8 {
-        __local_10 = self.input;
-        __local_11 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_10.repr, __local_11);
-    };
+        __local_8 = self.input;
+        __local_9 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_8.repr, __local_9);
+    } & 255;
     if b == 116 {
-        r_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-        if ref.is_null(r_2) == 0 {
-            e_3 = ref.as_non_null(r_2);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_3 };
+        let __match_scrut_2: ref null "core:serde//DeserializeError";
+        __match_scrut_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        if ref.is_null(__match_scrut_2) {
+        } else if ref.is_null(__match_scrut_2) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_2);
+            __local_3 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 1 };
-    }
-    if b == 102 {
-        r_4 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-        if ref.is_null(r_4) == 0 {
-            e_5 = ref.as_non_null(r_4);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
+        unreachable;
+    } else if b == 102 {
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_1);
+            __local_5 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_5 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 0 };
+        unreachable;
+    } else {
+        return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
+            __local_11 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_10, offset: __local_11 };
+        }) };
+        unreachable;
     }
-    return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-        __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
-        __local_13 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_12, offset: __local_13 };
-    }) };
+    unreachable;
 }
 
 fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
@@ -5389,13 +5590,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l453: loop {
+            l481: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l453;
+                continue l481;
             };
         };
     };
@@ -5488,10 +5689,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b463: block {
-            l464: loop {
+        b491: block {
+            l492: loop {
                 if i_8 < 0 {
-                    break b463;
+                    break b491;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -5500,7 +5701,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l464;
+                continue l492;
             };
         };
         __for_1: block {
@@ -5508,14 +5709,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l467: loop {
+                l495: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l467;
+                    continue l495;
                 };
             };
         };
@@ -5525,10 +5726,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b469: block {
-            l470: loop {
+        b497: block {
+            l498: loop {
                 if i_10 < 0 {
-                    break b469;
+                    break b497;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -5537,7 +5738,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l470;
+                continue l498;
             };
         };
         __for_2: block {
@@ -5545,14 +5746,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l473: loop {
+                l501: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l473;
+                    continue l501;
                 };
             };
         };
@@ -5656,8 +5857,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b492: block {
-        l493: loop {
+    b520: block {
+        l521: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -5682,9 +5883,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b492;
+                break b520;
             }
-            continue l493;
+            continue l521;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -5719,13 +5920,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l502: loop {
+            l530: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l502;
+                continue l530;
             };
         };
     };
@@ -5741,7 +5942,28 @@ fn "wado-compiler/tests/fixtures/serde_json_primitives.wado/bool^Deserialize::de
 }
 
 fn "wado-compiler/tests/fixtures/serde_json_primitives.wado/f32^Deserialize::deserialize<JsonDeserializer>"(d) {
-    return "core:json/JsonDeserializer^Deserializer::deserialize_f32"(d);
+    let __local_2: f64;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: f64;
+    return __inline_JsonDeserializer_Deserializer__deserialize_f32_0: block -> ref "core:prelude/types.wado//Result<f32,DeserializeError>" {
+        let __match_scrut_0: ref "core:prelude/types.wado//Result<f64,DeserializeError>";
+        __match_scrut_0 = "core:json/JsonDeserializer::parse_f64_direct"(d);
+        __local_4 = (if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(__match_scrut_0) -> f64 {
+            let __cast_2: ref "core:prelude/types.wado//Result<f64,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(__match_scrut_0);
+            __local_2 = __cast_2.payload_0;
+            __local_2;
+        } else if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__match_scrut_0) -> f64 {
+            let __cast_1: ref "core:prelude/types.wado//Result<f64,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__match_scrut_0);
+            __local_3 = __cast_1.payload_0;
+            break __inline_JsonDeserializer_Deserializer__deserialize_f32_0: struct.new "core:prelude/types.wado//Result<f32,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
+        });
+        break __inline_JsonDeserializer_Deserializer__deserialize_f32_0: struct.new "core:prelude/types.wado//Result<f32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::f32_demote_f64(__local_4) };
+    };
 }
 
 fn "wado-compiler/tests/fixtures/serde_json_primitives.wado/f64^Deserialize::deserialize<JsonDeserializer>"(d) {

--- a/wado-compiler/tests/fixtures.golden/serde_json_rename.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_rename.wir.wado
@@ -64,211 +64,263 @@ struct wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse {  // Ty
     mut response_data: ref "core:prelude/string.wado//String",
 }
 
-variant core:prelude/types.wado//Option<i32> {  // TypeId(12)
+variant core:prelude/types.wado//Option<char> {  // TypeId(12)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(13)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<i32> {  // TypeId(14)
     Some(i32),
     None,
 }
 
-struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(13)
+struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(15)
     discriminant: i32,
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(14)
+variant core:prelude/types.wado//Result<ApiResponse,DeserializeError> {  // TypeId(16)
+    Ok(ref "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<ApiResponse,DeserializeError>::Ok {  // TypeId(17)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse",
+}
+
+struct core:prelude/types.wado//Result<ApiResponse,DeserializeError>::Err {  // TypeId(18)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(19)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(15)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(20)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(16)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(21)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(17)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(22)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(23)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(24)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(25)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(18)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(26)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(19)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(27)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(20)
+variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(28)
     Ok(ref "core:prelude/types.wado//Option<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(21)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(29)
     discriminant: i32,
     payload_0: ref "core:prelude/types.wado//Option<i32>",
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(22)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(30)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(23)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(31)
 
-type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(24)
+type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(32)
 
-struct canonical//CanonicalClosure_0 {  // TypeId(25)
+struct canonical//CanonicalClosure_0 {  // TypeId(33)
     env: ref null struct,
     func: ref "functype/$canonical_closure_fn_0",
 }
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(26)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(34)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(27)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(35)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(28)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(36)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(29)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(37)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(30)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(38)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(31)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(39)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(32)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(40)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(33)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(41)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/__test_0_serialize_with_rename" = fn();  // TypeId(34)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/__test_0_serialize_with_rename" = fn();  // TypeId(42)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/__test_1_deserialize_with_rename" = fn();  // TypeId(35)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/__test_1_deserialize_with_rename" = fn();  // TypeId(43)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/__test_2_roundtrip_with_rename" = fn();  // TypeId(36)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/__test_2_roundtrip_with_rename" = fn();  // TypeId(44)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/_apiresponse_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(37)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/_apiresponse_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(45)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/__cm_export____test_0_serialize_with_rename" = fn();  // TypeId(38)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/__cm_export____test_0_serialize_with_rename" = fn();  // TypeId(46)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/__cm_export____test_1_deserialize_with_rename" = fn();  // TypeId(39)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/__cm_export____test_1_deserialize_with_rename" = fn();  // TypeId(47)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/__cm_export____test_2_roundtrip_with_rename" = fn();  // TypeId(40)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/__cm_export____test_2_roundtrip_with_rename" = fn();  // TypeId(48)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(41)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(49)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(42)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(50)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(43)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(51)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(44)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(52)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(45)
+type "functype//core:internal/unreachable" = fn();  // TypeId(53)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(46)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(54)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(47)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(55)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(48)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(56)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(49)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(57)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(50)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(58)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(51)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(59)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(52)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(60)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(53)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(61)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(54)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(62)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(55)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(63)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(56)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(64)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(57)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(65)
 
-type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(58)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(66)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(59)
+type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(67)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(60)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(68)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(61)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(69)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(62)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(70)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(63)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(71)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(64)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(72)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(65)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(73)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(66)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(74)
 
-type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(67)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(75)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(68)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(76)
 
-type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(69)
+type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(77)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(70)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(78)
 
-type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(71)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(79)
 
-type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(72)
+type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(80)
 
-type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(73)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(81)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(74)
+type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(82)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(75)
+type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(83)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(76)
+type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(84)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(77)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(85)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<String>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(78)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(86)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(79)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(87)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(80)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(88)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(81)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/ApiResponse^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<ApiResponse,DeserializeError>";  // TypeId(89)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(82)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<String>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(90)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(83)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(91)
 
-type "functype//core:json/core/json/from_string<ApiResponse>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse", ref null "core:serde//DeserializeError"];  // TypeId(84)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(92)
 
-type "functype//core:json/core/json/to_string<ApiResponse>" = fn(ref "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(85)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(93)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(86)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(94)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(87)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(95)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(88)
+type "functype//core:json/core/json/from_string<ApiResponse>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse", ref null "core:serde//DeserializeError"];  // TypeId(96)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/ApiResponse^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse", ref null "core:serde//DeserializeError"];  // TypeId(89)
+type "functype//core:json/core/json/to_string<ApiResponse>" = fn(ref "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(97)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(90)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(98)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(91)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(99)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(92)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(100)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/ApiResponse^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(93)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(101)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<i32>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(94)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(102)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(95)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(103)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(96)
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(104)
+
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(105)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(106)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/ApiResponse^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(107)
+
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<i32>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(108)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(109)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_rename.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(110)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -1070,36 +1122,77 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l105: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l105;
+                };
+            };
+        };
     }
-    return ((97 + v) - 10) & 255;
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
         return 1;
     }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l111: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l111;
+            };
+        };
+    };
+    return n;
 }
 
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b107: block {
-        l108: loop {
+    b113: block {
+        l114: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -1120,23 +1213,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b107;
+                break b113;
             }
-            continue l108;
+            continue l114;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -1144,62 +1239,135 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/from_string<ApiResponse>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_rename.wado/ApiResponse^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse"(let __match_scrut_0: ref "core:prelude/types.wado//Result<ApiResponse,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_rename.wado/ApiResponse^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<ApiResponse,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse" {
+        let __cast_2: ref "core:prelude/types.wado//Result<ApiResponse,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<ApiResponse,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<ApiResponse,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse" {
+        let __cast_1: ref "core:prelude/types.wado//Result<ApiResponse,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<ApiResponse,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<ApiResponse>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_json_rename.wado/ApiResponse^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_rename.wado/ApiResponse^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1222,6 +1390,20 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     }, offset, abs_val, digit_count);
 }
 
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
+}
+
 fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     let s: ref "core:prelude/string.wado//String";
     let c: char;
@@ -1233,6 +1415,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
         "core:prelude/string.wado/String::push"(s, self);
         "core:prelude/format.wado/Formatter::pad"(f, s);
     }
+}
+
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
 }
 
 fn "core:prelude/string.wado/String::get_byte"(self, index) {
@@ -1302,7 +1498,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l131: loop {
+            l153: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -1310,7 +1506,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l131;
+                continue l153;
             };
         };
     };
@@ -1359,6 +1555,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -1411,10 +1656,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b142: block {
-        l143: loop {
+    b171: block {
+        l172: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b142;
+                break b171;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -1438,7 +1683,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l143;
+            continue l172;
         };
     };
     self.pos = _hfs_pos_8;
@@ -1517,11 +1762,11 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b151: block {
-        l152: loop {
+    b180: block {
+        l181: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= _licm_used_19 {
-                    break b151;
+                    break b180;
                 }
                 byte = builtin::array_get_u8(_licm_repr_20, __sroa___iter_3_index);
                 __sroa___iter_3_index = __sroa___iter_3_index + 1;
@@ -1556,7 +1801,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
                 _hfs_pos_27 = _hfs_pos_27 + 1;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l152;
+            continue l181;
         };
     };
     self.pos = _hfs_pos_27;
@@ -1575,130 +1820,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b158: block {
-        l159: loop {
-            if scan_pos >= _licm_used_90 {
-                break b158;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b187: block {
+        l188: loop {
+            if scan_pos >= _licm_used_56 {
+                break b187;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b158;
+                break b187;
             }
             scan_pos = scan_pos + 1;
-            continue l159;
+            continue l188;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -1707,22 +1924,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l166: loop {
+                l195: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l166;
+                    continue l195;
                 };
             };
         };
@@ -1730,71 +1947,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l169: loop {
+            l198: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l169;
+                continue l198;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b171: block {
-        l172: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b200: block {
+        l201: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b171;
+                break b200;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -1812,125 +2030,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l172;
+            continue l201;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -1938,87 +2099,71 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l197: loop {
+            l221: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l197;
+                continue l221;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -2073,25 +2218,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b208: block {
-        l209: loop {
+    b228: block {
+        l229: loop {
             if _hfs_pos_36 >= _licm_used_28 {
-                break b208;
+                break b228;
             }
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
                 break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr_29, __local_11);
             };
-            if (if b_1 >= 48 -> i32 {
+            if (if 48 <= b_1 -> i32 {
                 b_1 <= 57;
             } else {
                 0;
             }) {
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
-                break b208;
+                break b228;
             }
-            continue l209;
+            continue l229;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2112,25 +2257,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b215: block {
-            l216: loop {
+        b235: block {
+            l236: loop {
                 if _hfs_pos_37 >= _licm_used_31 {
-                    break b215;
+                    break b235;
                 }
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
                     break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_32, __local_17);
                 };
-                if (if b_2 >= 48 -> i32 {
+                if (if 48 <= b_2 -> i32 {
                     b_2 <= 57;
                 } else {
                     0;
                 }) {
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
-                    break b215;
+                    break b235;
                 }
-                continue l216;
+                continue l236;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2171,25 +2316,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b226: block {
-                l227: loop {
+            b246: block {
+                l247: loop {
                     if _hfs_pos_38 >= _licm_used_34 {
-                        break b226;
+                        break b246;
                     }
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
                         break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_35, __local_26);
                     };
-                    if (if b2 >= 48 -> i32 {
+                    if (if 48 <= b2 -> i32 {
                         b2 <= 57;
                     } else {
                         0;
                     }) {
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
-                        break b226;
+                        break b246;
                     }
-                    continue l227;
+                    continue l247;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -2283,16 +2428,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b236: block {
-        l237: loop {
+    b256: block {
+        l257: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b236;
+                break b256;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -2313,17 +2458,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b245: block {
-                        l246: loop {
+                    b265: block {
+                        l266: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b245;
+                                break b265;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -2333,9 +2478,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b245;
+                                break b265;
                             }
-                            continue l246;
+                            continue l266;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -2366,17 +2511,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b255: block {
-                            l256: loop {
+                        b275: block {
+                            l276: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b255;
+                                    break b275;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -2385,9 +2530,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b255;
+                                    break b275;
                                 }
-                                continue l256;
+                                continue l276;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -2425,9 +2570,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b236;
+                break b256;
             }
-            continue l237;
+            continue l257;
         };
     };
     self.pos = _hfs_pos_51;
@@ -2453,10 +2598,10 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b266: block {
-        l267: loop {
+    b286: block {
+        l287: loop {
             if _hfs_pos_14 >= _licm_used_12 {
-                break b266;
+                break b286;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -2486,7 +2631,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
                 }
             }
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l267;
+            continue l287;
         };
     };
     self.pos = _hfs_pos_14;
@@ -2497,19 +2642,284 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
 }
 
 fn "core:json/JsonDeserializer::skip_value"(self) {
-    let b: i32;
-    let r: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let c_4: i32;
-    let kr: ref null "core:serde//DeserializeError";
-    let e_6: ref "core:serde//DeserializeError";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let vr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let c_11: i32;
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: char;
+    let __local_6: ref "core:serde//DeserializeError";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_10: ref "core:serde//DeserializeError";
+    let __local_11: char;
     let __local_12: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/format.wado//Formatter";
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i64;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i32;
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
+    let __local_20: i32;
+    let __local_21: ref "core:prelude/string.wado//String";
+    let __local_22: i64;
+    let __local_23: ref "core:prelude/string.wado//String";
+    let __local_24: i32;
+    let __local_25: ref "core:prelude/string.wado//String";
+    let __local_26: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let __local_30: ref "core:prelude/string.wado//String";
+    let __local_31: ref "core:prelude/string.wado//String";
+    let __local_32: i32;
+    let __local_33: ref "core:prelude/string.wado//String";
+    let __local_34: i64;
+    let __local_35: ref "core:prelude/string.wado//String";
+    let __local_36: i64;
+    let __local_37: ref "core:prelude/string.wado//String";
+    let __local_38: i32;
+    let __local_39: ref "core:prelude/string.wado//String";
+    let __local_40: i64;
+    let __local_43: ref "core:prelude/string.wado//String";
+    let __local_44: i64;
+    "core:json/JsonDeserializer::skip_whitespace"(self);
+    if self.pos >= __inline_String__len_0: block -> i32 {
+        __local_14 = self.input;
+        break __inline_String__len_0: __local_14.used;
+    } {
+        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_15 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_15 };
+        });
+    }
+    b = __inline_String__get_byte_2: block -> u8 {
+        __local_16 = self.input;
+        __local_17 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_16.repr, __local_17);
+    } & 255;
+    if b == 34 {
+        return "core:json/JsonDeserializer::skip_string"(self);
+        unreachable;
+    } else if b == 116 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        unreachable;
+    } else if b == 102 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        unreachable;
+    } else if b == 110 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
+        unreachable;
+    } else if b == 91 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_3: block -> i32 {
+            __local_18 = self.input;
+            break __inline_String__len_3: __local_18.used;
+        } -> i32 {
+            __inline_String__get_byte_4: block -> u8 {
+                __local_19 = self.input;
+                __local_20 = self.pos;
+                break __inline_String__get_byte_4: builtin::array_get_u8(__local_19.repr, __local_20);
+            } == 93;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l302: loop {
+                let __match_scrut_5: ref null "core:serde//DeserializeError";
+                __match_scrut_5 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_5) {
+                } else if ref.is_null(__match_scrut_5) == 0 {
+                    let __cast_4: ref null "core:serde//DeserializeError";
+                    __cast_4 = ref.as_non_null(__match_scrut_5);
+                    __local_3 = ref.as_non_null(__cast_4);
+                    return __local_3;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_5: block -> i32 {
+                    __local_21 = self.input;
+                    break __inline_String__len_5: __local_21.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
+                        __local_22 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_22 };
+                    });
+                }
+                __local_4 = __inline_String__get_byte_7: block -> u8 {
+                    __local_23 = self.input;
+                    __local_24 = self.pos;
+                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_23.repr, __local_24);
+                } & 255;
+                if __local_4 == 93 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_4 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
+                        __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
+                        __local_26 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_25, offset: __local_26 };
+                    });
+                    unreachable;
+                }
+                continue l302;
+            };
+        };
+    } else if b == 123 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_9: block -> i32 {
+            __local_27 = self.input;
+            break __inline_String__len_9: __local_27.used;
+        } -> i32 {
+            __inline_String__get_byte_10: block -> u8 {
+                __local_28 = self.input;
+                __local_29 = self.pos;
+                break __inline_String__get_byte_10: builtin::array_get_u8(__local_28.repr, __local_29);
+            } == 125;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l312: loop {
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if (if self.pos >= __inline_String__len_11: block -> i32 {
+                    __local_30 = self.input;
+                    break __inline_String__len_11: __local_30.used;
+                } -> i32 {
+                    1;
+                } else {
+                    __inline_String__get_byte_12: block -> u8 {
+                        __local_31 = self.input;
+                        __local_32 = self.pos;
+                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_31.repr, __local_32);
+                    } != 34;
+                }) {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
+                        __local_33 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+                        __local_34 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_33, offset: __local_34 };
+                    });
+                }
+                let __match_scrut_1: ref null "core:serde//DeserializeError";
+                __match_scrut_1 = "core:json/JsonDeserializer::skip_string"(self);
+                if ref.is_null(__match_scrut_1) {
+                } else if ref.is_null(__match_scrut_1) == 0 {
+                    let __cast_1: ref null "core:serde//DeserializeError";
+                    __cast_1 = ref.as_non_null(__match_scrut_1);
+                    __local_6 = ref.as_non_null(__cast_1);
+                    return __local_6;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_2: ref null "core:serde//DeserializeError";
+                __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+                if ref.is_null(__match_scrut_2) {
+                } else if ref.is_null(__match_scrut_2) == 0 {
+                    let __cast_2: ref null "core:serde//DeserializeError";
+                    __cast_2 = ref.as_non_null(__match_scrut_2);
+                    __local_8 = ref.as_non_null(__cast_2);
+                    return __local_8;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_3: ref null "core:serde//DeserializeError";
+                __match_scrut_3 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_3) {
+                } else if ref.is_null(__match_scrut_3) == 0 {
+                    let __cast_3: ref null "core:serde//DeserializeError";
+                    __cast_3 = ref.as_non_null(__match_scrut_3);
+                    __local_10 = ref.as_non_null(__cast_3);
+                    return __local_10;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_14: block -> i32 {
+                    __local_35 = self.input;
+                    break __inline_String__len_14: __local_35.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
+                        __local_36 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_36 };
+                    });
+                }
+                __local_11 = __inline_String__get_byte_16: block -> u8 {
+                    __local_37 = self.input;
+                    __local_38 = self.pos;
+                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_37.repr, __local_38);
+                } & 255;
+                if __local_11 == 125 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_11 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
+                        __local_39 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
+                        __local_40 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_39, offset: __local_40 };
+                    });
+                    unreachable;
+                }
+                continue l312;
+            };
+        };
+    } else {
+        if (if b == 45 -> i32 {
+            1;
+        } else if 48 <= b -> i32 {
+            b <= 57;
+        } else {
+            0;
+        }) {
+            "core:json/JsonDeserializer::skip_number"(self);
+            return ref.null none;
+        }
+        return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
+            __local_43 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
+                "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
+                __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
+                "core:prelude/primitive.wado/char^Display::fmt"(b, __local_13);
+                "core:prelude/string.wado/String::push"(__local_12, 39);
+                break __tmpl: __local_12;
+            };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
+        });
+        unreachable;
+    }
+}
+
+fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
+    let __local_2: ref "core:serde//DeserializeError";
+    let key_start: i32;
+    let has_escape: bool;
+    let b: i32;
+    let key_end: i32;
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: i32;
+    let idx_10: i32;
+    let __local_11: ref "core:prelude/string.wado//String";
+    let __local_12: ref "core:serde//DeserializeError";
+    let key: ref "core:prelude/string.wado//String";
+    let __local_15: ref "core:serde//DeserializeError";
+    let __local_16: i32;
+    let idx_17: i32;
     let __local_18: ref "core:prelude/string.wado//String";
     let __local_19: i64;
     let __local_20: ref "core:prelude/string.wado//String";
@@ -2520,414 +2930,178 @@ fn "core:json/JsonDeserializer::skip_value"(self) {
     let __local_25: ref "core:prelude/string.wado//String";
     let __local_26: i64;
     let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: i64;
-    let __local_31: ref "core:prelude/string.wado//String";
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i32;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
-    let __local_37: ref "core:prelude/string.wado//String";
-    let __local_38: i64;
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
-    let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_47: ref "core:prelude/string.wado//String";
-    let __local_48: i64;
-    let _hfs_pos_49: i32;
-    let _hfs_pos_50: i32;
-    "core:json/JsonDeserializer::skip_whitespace"(self);
-    if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_18 = self.input;
-        break __inline_String__len_0: __local_18.used;
-    } {
-        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_19 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
-        });
-    }
-    b = __inline_String__get_byte_2: block -> u8 {
-        __local_20 = self.input;
-        __local_21 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
-    };
-    if b == 34 {
-        return "core:json/JsonDeserializer::skip_string"(self);
-    }
-    if b == 116 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-    }
-    if b == 102 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-    }
-    if b == 110 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
-    }
-    if b == 91 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_3: block -> i32 {
-            __local_22 = self.input;
-            break __inline_String__len_3: __local_22.used;
-        } -> i32 {
-            __inline_String__get_byte_4: block -> u8 {
-                __local_23 = self.input;
-                __local_24 = self.pos;
-                break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
-            } == 93;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_49 = self.pos;
-        block {
-            l282: loop {
-                self.pos = _hfs_pos_49;
-                r = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_49 = self.pos;
-                if ref.is_null(r) == 0 {
-                    e_3 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-                    self.pos = _hfs_pos_49;
-                    return e_3;
-                }
-                self.pos = _hfs_pos_49;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_49 = self.pos;
-                if _hfs_pos_49 >= __inline_String__len_5: block -> i32 {
-                    __local_25 = self.input;
-                    self.pos = _hfs_pos_49;
-                    break __inline_String__len_5: __local_25.used;
-                } {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
-                        __local_26 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
-                    });
-                }
-                c_4 = __inline_String__get_byte_7: block -> u8 {
-                    __local_27 = self.input;
-                    __local_28 = _hfs_pos_49;
-                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_27.repr, __local_28);
-                };
-                if c_4 == 93 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                    self.pos = _hfs_pos_49;
-                    return ref.null none;
-                }
-                if c_4 == 44 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                } else {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
-                        __local_29 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
-                        __local_30 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_29, offset: __local_30 };
-                    });
-                }
-                continue l282;
-            };
-        };
-        self.pos = _hfs_pos_49;
-    }
-    if b == 123 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_9: block -> i32 {
-            __local_31 = self.input;
-            break __inline_String__len_9: __local_31.used;
-        } -> i32 {
-            __inline_String__get_byte_10: block -> u8 {
-                __local_32 = self.input;
-                __local_33 = self.pos;
-                break __inline_String__get_byte_10: builtin::array_get_u8(__local_32.repr, __local_33);
-            } == 125;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_50 = self.pos;
-        block {
-            l291: loop {
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if (if _hfs_pos_50 >= __inline_String__len_11: block -> i32 {
-                    __local_34 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_11: __local_34.used;
-                } -> i32 {
-                    1;
-                } else {
-                    __inline_String__get_byte_12: block -> u8 {
-                        __local_35 = self.input;
-                        __local_36 = _hfs_pos_50;
-                        self.pos = _hfs_pos_50;
-                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_35.repr, __local_36);
-                    } != 34;
-                }) {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
-                        __local_37 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-                        __local_38 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_37, offset: __local_38 };
-                    });
-                }
-                self.pos = _hfs_pos_50;
-                kr = "core:json/JsonDeserializer::skip_string"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(kr) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(kr));
-                    self.pos = _hfs_pos_50;
-                    return e_6;
-                }
-                self.pos = _hfs_pos_50;
-                cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(cr) == 0 {
-                    e_8 = value_copy "core:serde//DeserializeError"(ref.as_non_null(cr));
-                    self.pos = _hfs_pos_50;
-                    return e_8;
-                }
-                self.pos = _hfs_pos_50;
-                vr = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(vr) == 0 {
-                    e_10 = value_copy "core:serde//DeserializeError"(ref.as_non_null(vr));
-                    self.pos = _hfs_pos_50;
-                    return e_10;
-                }
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if _hfs_pos_50 >= __inline_String__len_14: block -> i32 {
-                    __local_39 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_14: __local_39.used;
-                } {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
-                        __local_40 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-                    });
-                }
-                c_11 = __inline_String__get_byte_16: block -> u8 {
-                    __local_41 = self.input;
-                    __local_42 = _hfs_pos_50;
-                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_41.repr, __local_42);
-                };
-                if c_11 == 125 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                    self.pos = _hfs_pos_50;
-                    return ref.null none;
-                }
-                if c_11 == 44 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                } else {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
-                        __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
-                        __local_44 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
-                    });
-                }
-                continue l291;
-            };
-        };
-        self.pos = _hfs_pos_50;
-    }
-    if (if b == 45 -> i32 {
-        1;
-    } else if b >= 48 -> i32 {
-        b <= 57;
-    } else {
-        0;
-    }) {
-        "core:json/JsonDeserializer::skip_number"(self);
-        return ref.null none;
-    }
-    return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
-        __local_47 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-            __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
-            "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
-            __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
-            "core:prelude/primitive.wado/char^Display::fmt"(b & 255, __local_13);
-            "core:prelude/string.wado/String::push"(__local_12, 39);
-            break __tmpl: __local_12;
-        };
-        __local_48 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_47, offset: __local_48 };
-    });
-}
-
-fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
-    let r_1: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let key_start: i32;
-    let has_escape: bool;
-    let b: i32;
-    let key_end: i32;
-    let r_7: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let idx_9: ref "core:prelude/types.wado//Option<i32>";
-    let i_10: i32;
-    let key_r: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let key: ref "core:prelude/string.wado//String";
-    let r_13: ref null "core:serde//DeserializeError";
-    let e_14: ref "core:serde//DeserializeError";
-    let idx_15: ref "core:prelude/types.wado//Option<i32>";
-    let i_16: i32;
-    let e_17: ref "core:serde//DeserializeError";
-    let __local_25: ref "core:prelude/string.wado//String";
-    let __local_26: i64;
-    let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: ref "core:prelude/string.wado//String";
-    let __local_31: i32;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i64;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_25 = self.de.input;
-        break __inline_String__len_0: __local_25.used;
+        __local_18 = self.de.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
+            __local_19 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_27 = self.de.input;
-        __local_28 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_27.repr, __local_28);
+        __local_20 = self.de.input;
+        __local_21 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } == 125 {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r_1 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r_1) == 0 {
-            e_2 = ref.as_non_null(r_1);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if (if self.de.pos >= __inline_String__len_3: block -> i32 {
-        __local_29 = self.de.input;
-        break __inline_String__len_3: __local_29.used;
+        __local_22 = self.de.input;
+        break __inline_String__len_3: __local_22.used;
     } -> i32 {
         1;
     } else {
         __inline_String__get_byte_4: block -> u8 {
-            __local_30 = self.de.input;
-            __local_31 = self.de.pos;
-            break __inline_String__get_byte_4: builtin::array_get_u8(__local_30.repr, __local_31);
+            __local_23 = self.de.input;
+            __local_24 = self.de.pos;
+            break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
         } != 34;
     }) {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_5: block -> ref "core:serde//DeserializeError" {
-            __local_32 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-            __local_33 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_32, offset: __local_33 };
+            __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_25, offset: __local_26 };
         }) };
     }
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b309: block {
-        l310: loop {
+    b334: block {
+        l335: loop {
             if self.de.pos >= __inline_String__len_6: block -> i32 {
-                __local_34 = self.de.input;
-                break __inline_String__len_6: __local_34.used;
+                __local_27 = self.de.input;
+                break __inline_String__len_6: __local_27.used;
             } {
-                break b309;
+                break b334;
             }
             b = __inline_String__get_byte_7: block -> u8 {
-                __local_35 = self.de.input;
-                __local_36 = self.de.pos;
-                break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
+                __local_28 = self.de.input;
+                __local_29 = self.de.pos;
+                break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
             };
             if b == 34 {
-                break b309;
+                break b334;
             }
             if b == 92 {
                 has_escape = 1;
-                break b309;
+                break b334;
             }
             self.de.pos = self.de.pos + 1;
-            continue l310;
+            continue l335;
         };
     };
     if has_escape == 0 {
         key_end = self.de.pos;
         self.de.pos = self.de.pos + 1;
-        r_7 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_7) == 0 {
-            e_8 = ref.as_non_null(r_7);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_8 };
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_1);
+            __local_8 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        idx_9 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_0: ref "canonical//CanonicalClosure_0";
-            __indirect_call_0 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_0.func, __indirect_call_0.env, self.de.input, key_start, key_end);
+        let __match_scrut_2: ref "core:prelude/types.wado//Option<i32>";
+        __match_scrut_2 = block -> ref "core:prelude/types.wado//Option<i32>" {
+            let __indirect_call_2: ref "canonical//CanonicalClosure_0";
+            __indirect_call_2 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_2.func, __indirect_call_2.env, self.de.input, key_start, key_end);
         };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_9) {
-            i_10 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_9).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_10 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+        idx_10 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2) -> i32 {
+            let __cast_4: ref "core:prelude/types.wado//Option<i32>::Some";
+            __cast_4 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2);
+            __local_9 = __cast_4.payload_0;
+            __local_9;
+        } else if __match_scrut_2.discriminant == 1 -> i32 {
+            -1;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_10 } };
     }
     self.de.pos = key_start - 1;
-    key_r = "core:json/JsonDeserializer::read_json_string"(self.de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r) {
-        key = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r).payload_0);
-        r_13 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_13) == 0 {
-            e_14 = ref.as_non_null(r_13);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_14 };
-        }
-        idx_15 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_1: ref "canonical//CanonicalClosure_0";
-            __indirect_call_1 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_1.func, __indirect_call_1.env, key, 0, key.used);
-        };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_15) {
-            i_16 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_15).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_16 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+    key = value_copy "core:prelude/string.wado//String"(let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self.de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_6: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_6 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+        __local_11 = __cast_6.payload_0;
+        __local_11;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+        __local_12 = __cast_5.payload_0;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_12 };
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    let __match_scrut_4: ref null "core:serde//DeserializeError";
+    __match_scrut_4 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+    if ref.is_null(__match_scrut_4) {
+    } else if ref.is_null(__match_scrut_4) == 0 {
+        let __cast_7: ref null "core:serde//DeserializeError";
+        __cast_7 = ref.as_non_null(__match_scrut_4);
+        __local_15 = ref.as_non_null(__cast_7);
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_15 };
+        unreachable;
+    } else {
+        unreachable;
     }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r) {
-        e_17 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    let __match_scrut_5: ref "core:prelude/types.wado//Option<i32>";
+    __match_scrut_5 = block -> ref "core:prelude/types.wado//Option<i32>" {
+        let __indirect_call_7: ref "canonical//CanonicalClosure_0";
+        __indirect_call_7 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+        call_ref "functype/$canonical_closure_fn_0"(__indirect_call_7.func, __indirect_call_7.env, key, 0, key.used);
+    };
+    idx_17 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5) -> i32 {
+        let __cast_9: ref "core:prelude/types.wado//Option<i32>::Some";
+        __cast_9 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5);
+        __local_16 = __cast_9.payload_0;
+        __local_16;
+    } else if __match_scrut_5.discriminant == 1 -> i32 {
+        -1;
+    } else {
+        unreachable;
+    });
+    return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_17 } };
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_struct"(self, lookup) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 123);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_5: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 123);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_5 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_5;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonStructAccess" { de: self, lookup: lookup, first: 1 }, ref.null none;
 }
@@ -2939,13 +3113,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l325: loop {
+            l355: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l325;
+                continue l355;
             };
         };
     };
@@ -3082,8 +3256,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b348: block {
-        l349: loop {
+    b378: block {
+        l379: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3108,9 +3282,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b348;
+                break b378;
             }
-            continue l349;
+            continue l379;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -3142,8 +3316,8 @@ fn "wado-compiler/tests/fixtures/serde_json_rename.wado/ApiResponse^Deserialize:
         seen = 0;
         status_code = 0;
         response_data = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
-        b357: block {
-            l358: loop {
+        b387: block {
+            l388: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -3161,7 +3335,7 @@ fn "wado-compiler/tests/fixtures/serde_json_rename.wado/ApiResponse^Deserialize:
                                 status_code = __local_10;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_9).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<ApiResponse,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_9).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_11 = __inline_String_Deserialize__deserialize_JsonDeserializer__5: block -> ref "core:prelude/types.wado//Result<String,DeserializeError>" {
@@ -3174,27 +3348,27 @@ fn "wado-compiler/tests/fixtures/serde_json_rename.wado/ApiResponse^Deserialize:
                                 response_data = __local_12;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_11).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<ApiResponse,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_11).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b357;
+                        break b387;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<ApiResponse,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l358;
+                continue l388;
             };
         };
         if (seen & 3) != 3 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<ApiResponse,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse" { status_code: status_code, response_data: response_data }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<ApiResponse,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_json_rename.wado//ApiResponse" { status_code: status_code, response_data: response_data } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<ApiResponse,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 

--- a/wado-compiler/tests/fixtures.golden/serde_json_rename_all.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_rename_all.wir.wado
@@ -65,242 +65,319 @@ struct wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config {  // Typ
     mut is_verbose: bool,
 }
 
-variant core:prelude/types.wado//Option<i32> {  // TypeId(12)
+variant core:prelude/types.wado//Option<char> {  // TypeId(12)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(13)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<i32> {  // TypeId(14)
     Some(i32),
     None,
 }
 
-struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(13)
+struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(15)
     discriminant: i32,
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(14)
+variant core:prelude/types.wado//Option<f64> {  // TypeId(16)
+    Some(f64),
+    None,
+}
+
+struct core:prelude/types.wado//Option<f64>::Some {  // TypeId(17)
+    discriminant: i32,
+    payload_0: f64,
+}
+
+variant core:prelude/types.wado//Result<Config,DeserializeError> {  // TypeId(18)
+    Ok(ref "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Config,DeserializeError>::Ok {  // TypeId(19)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config",
+}
+
+struct core:prelude/types.wado//Result<Config,DeserializeError>::Err {  // TypeId(20)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(21)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(15)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(22)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(16)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(23)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<i64,DeserializeError> {  // TypeId(17)
+variant core:prelude/types.wado//Result<i64,DeserializeError> {  // TypeId(24)
     Ok(i64),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i64,DeserializeError>::Ok {  // TypeId(18)
+struct core:prelude/types.wado//Result<i64,DeserializeError>::Ok {  // TypeId(25)
     discriminant: i32,
     payload_0: i64,
 }
 
-struct core:prelude/types.wado//Result<i64,DeserializeError>::Err {  // TypeId(19)
+struct core:prelude/types.wado//Result<i64,DeserializeError>::Err {  // TypeId(26)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(20)
+variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(27)
     Ok(bool),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(21)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(28)
     discriminant: i32,
     payload_0: bool,
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(22)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(29)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(23)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(30)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(31)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(32)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(33)
+    Ok(ref "core:prelude/string.wado//String"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(34)
+    discriminant: i32,
+    payload_0: ref "core:prelude/string.wado//String",
+}
+
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(35)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(36)
     Ok(ref "core:prelude/types.wado//Option<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(24)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(37)
     discriminant: i32,
     payload_0: ref "core:prelude/types.wado//Option<i32>",
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(25)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(38)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(26)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(39)
 
-type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(27)
+type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(40)
 
-struct canonical//CanonicalClosure_0 {  // TypeId(28)
+struct canonical//CanonicalClosure_0 {  // TypeId(41)
     env: ref null struct,
     func: ref "functype/$canonical_closure_fn_0",
 }
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(29)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(42)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(30)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(43)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(31)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(44)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(32)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(45)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(33)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(46)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(34)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(47)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(35)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(48)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(36)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(49)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/__test_0_serialize_with_rename_all_snake_case" = fn();  // TypeId(37)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/__test_0_serialize_with_rename_all_snake_case" = fn();  // TypeId(50)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/__test_1_deserialize_with_rename_all_snake_case" = fn();  // TypeId(38)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/__test_1_deserialize_with_rename_all_snake_case" = fn();  // TypeId(51)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/_config_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(39)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/_config_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(52)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/__cm_export____test_0_serialize_with_rename_all_snake_case" = fn();  // TypeId(40)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/__cm_export____test_0_serialize_with_rename_all_snake_case" = fn();  // TypeId(53)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/__cm_export____test_1_deserialize_with_rename_all_snake_case" = fn();  // TypeId(41)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/__cm_export____test_1_deserialize_with_rename_all_snake_case" = fn();  // TypeId(54)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(42)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(55)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(43)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(56)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(44)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(57)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(45)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(58)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(46)
+type "functype//core:internal/unreachable" = fn();  // TypeId(59)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(47)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(60)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(48)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(61)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(49)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(62)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(50)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(63)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(51)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(64)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(52)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(65)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(53)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(66)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(54)
+type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> ref "core:prelude/types.wado//Option<f64>";  // TypeId(67)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(55)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(68)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(56)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(69)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(57)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(70)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(58)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(71)
 
-type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(59)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(72)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(60)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(73)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(61)
+type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(74)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(62)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(75)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(63)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(76)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(64)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(77)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(65)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(78)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(66)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(79)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(67)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(80)
 
-type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(68)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(81)
 
-type "functype//core:json/JsonDeserializer::parse_i64_from" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String", i64) -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(69)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(82)
 
-type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(70)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(83)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(71)
+type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(84)
 
-type "functype//core:json/JsonDeserializer::parse_i64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(72)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(85)
 
-type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(73)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(86)
 
-type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(74)
+type "functype//core:json/JsonDeserializer::parse_i64_from" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String", i64) -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(87)
 
-type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(75)
+type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(88)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_i64" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(76)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(89)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(77)
+type "functype//core:json/JsonDeserializer::parse_i64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(90)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(78)
+type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(91)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(79)
+type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(92)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(80)
+type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(93)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(81)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_i64" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(94)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(82)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(95)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(83)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(96)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(84)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(97)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(85)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(98)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(86)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(99)
 
-type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(87)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/Config^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Config,DeserializeError>";  // TypeId(100)
 
-type "functype//core:json/core/json/from_string<Config>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(88)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(101)
 
-type "functype//core:json/core/json/to_string<Config>" = fn(ref "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(89)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(102)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(90)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(103)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(91)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(104)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(92)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(105)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(93)
+type "functype//core:json/core/json/from_string<Config>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(106)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/Config^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(94)
+type "functype//core:json/core/json/to_string<Config>" = fn(ref "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(107)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(95)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(108)
 
-type "functype//core:prelude/primitive.wado/i64::fmt_decimal" = fn(i64, ref "core:prelude/format.wado//Formatter");  // TypeId(96)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(109)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(97)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(110)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(98)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(111)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i64" = fn(ref "core:prelude/string.wado//String", i64) -> ref null "core:serde//SerializeError";  // TypeId(99)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(112)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(100)
+type "functype//core:prelude/primitive.wado/i64::fmt_decimal" = fn(i64, ref "core:prelude/format.wado//Formatter");  // TypeId(113)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/Config^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(101)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(114)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<bool>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(102)
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(115)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<i64>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", i64) -> ref null "core:serde//SerializeError";  // TypeId(103)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(116)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<i32>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(104)
+type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(117)
 
-type "functype//core:json/JsonDeserializer::has_exp_or_dot" = fn(ref "core:prelude/string.wado//String") -> bool;  // TypeId(105)
+type "functype//core:json/JsonSerializer^Serializer::serialize_i64" = fn(ref "core:prelude/string.wado//String", i64) -> ref null "core:serde//SerializeError";  // TypeId(118)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(106)
+type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(119)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(107)
+type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/Config^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(120)
+
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<bool>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(121)
+
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<i64>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", i64) -> ref null "core:serde//SerializeError";  // TypeId(122)
+
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<i32>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(123)
+
+type "functype//core:json/JsonDeserializer::has_exp_or_dot" = fn(ref "core:prelude/string.wado//String") -> bool;  // TypeId(124)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(125)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_rename_all.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(126)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -1105,7 +1182,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     let _licm_repr_81: ref builtin::array<u8>;
     len = s.used;
     if len == 0 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     sign = 1;
     i = 0;
@@ -1117,7 +1194,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         i = 1;
     }
     if i >= len {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     remaining = len - i;
     c0 = builtin::array_get_u8(s.repr, i);
@@ -1152,7 +1229,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
             0;
         }) {
             if remaining == 3 {
-                return 0, f64.copysign(inf, sign);
+                return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(inf, sign) };
             }
             if remaining == 8 {
                 c3 = __inline_String__get_byte_5: block -> u8 {
@@ -1212,11 +1289,11 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
                 } else {
                     0;
                 }) {
-                    return 0, f64.copysign(inf, sign);
+                    return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(inf, sign) };
                 }
             }
         }
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     if (if (if c0 == 110 -> i32 {
         1;
@@ -1248,9 +1325,9 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         } else {
             0;
         }) {
-            return 0, 0 / 0;
+            return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: 0 / 0 };
         }
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     d = 0_i64;
     frac = 0;
@@ -1283,7 +1360,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         0;
     }) {
         if int_digits == 0 {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
         i = i + 1;
         frac_start = i;
@@ -1310,7 +1387,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
             };
         };
         if i == frac_start {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
     }
     total_digits = int_digits + frac;
@@ -1319,7 +1396,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     } else {
         total_digits > 19;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     p = 0;
     if (if i < len -> i32 {
@@ -1347,7 +1424,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         } else {
             (len - i) > 3;
         }) {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
         __for_2: block {
             _licm_repr_81 = s.repr;
@@ -1371,25 +1448,25 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
             };
         };
         if i == exp_start {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
         p = p * exp_sign;
     }
     if i != len {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     if d == 0_i64 {
-        return 0, f64.copysign(0, sign);
+        return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(0, sign) };
     }
     eff_p = p - frac;
     if eff_p > 350 {
-        return 0, f64.copysign(inf, sign);
+        return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(inf, sign) };
     }
     if eff_p < -351 {
-        return 0, f64.copysign(0, sign);
+        return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(0, sign) };
     }
     val = "core:prelude/fpfmt.wado/parse"(d, eff_p);
-    return 0, f64.copysign(val, sign);
+    return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(val, sign) };
 }
 
 fn "core:prelude/primitive.wado/count_digits_i64"(val) {
@@ -1439,36 +1516,77 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l183: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l183;
+                };
+            };
+        };
     }
-    return ((97 + v) - 10) & 255;
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
         return 1;
     }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l189: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l189;
+            };
+        };
+    };
+    return n;
 }
 
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b185: block {
-        l186: loop {
+    b191: block {
+        l192: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -1489,23 +1607,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b185;
+                break b191;
             }
-            continue l186;
+            continue l192;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -1513,62 +1633,135 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/from_string<Config>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_rename_all.wado/Config^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Config,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_rename_all.wado/Config^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Config,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Config,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Config,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Config,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Config,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Config,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Config>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_json_rename_all.wado/Config^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_rename_all.wado/Config^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1630,6 +1823,20 @@ fn "core:prelude/primitive.wado/i64::fmt_decimal"(self, f) {
     }
 }
 
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
+}
+
 fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     let s: ref "core:prelude/string.wado//String";
     let c: char;
@@ -1641,6 +1848,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
         "core:prelude/string.wado/String::push"(s, self);
         "core:prelude/format.wado/Formatter::pad"(f, s);
     }
+}
+
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
 }
 
 fn "core:prelude/string.wado/String::get_byte"(self, index) {
@@ -1710,7 +1931,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l211: loop {
+            l233: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -1718,7 +1939,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l211;
+                continue l233;
             };
         };
     };
@@ -1767,6 +1988,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -1864,10 +2134,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b225: block {
-        l226: loop {
+    b254: block {
+        l255: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b225;
+                break b254;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -1891,7 +2161,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l226;
+            continue l255;
         };
     };
     self.pos = _hfs_pos_8;
@@ -1970,11 +2240,11 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b234: block {
-        l235: loop {
+    b263: block {
+        l264: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= _licm_used_19 {
-                    break b234;
+                    break b263;
                 }
                 byte = builtin::array_get_u8(_licm_repr_20, __sroa___iter_3_index);
                 __sroa___iter_3_index = __sroa___iter_3_index + 1;
@@ -2009,7 +2279,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
                 _hfs_pos_27 = _hfs_pos_27 + 1;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l235;
+            continue l264;
         };
     };
     self.pos = _hfs_pos_27;
@@ -2028,130 +2298,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
+        }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b241: block {
-        l242: loop {
-            if scan_pos >= _licm_used_90 {
-                break b241;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b270: block {
+        l271: loop {
+            if scan_pos >= _licm_used_56 {
+                break b270;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b241;
+                break b270;
             }
             scan_pos = scan_pos + 1;
-            continue l242;
+            continue l271;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -2160,94 +2402,95 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l249: loop {
+                l278: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l249;
+                    continue l278;
                 };
             };
         };
         self.pos = scan_pos + 1;
-        return 0, result_5, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l252: loop {
+            l281: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l252;
+                continue l281;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b254: block {
-        l255: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b283: block {
+        l284: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b254;
+                break b283;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
-                return 0, result_8, ref.null none;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
+                return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
-                    });
+                    self.pos = _hfs_pos_64;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
+                    }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -2265,213 +2508,140 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return 1, ref.null none, e;
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
-                    });
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
+                    }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
-                    });
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
+                    }) };
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l255;
+            continue l284;
         };
     };
-    self.pos = _hfs_pos_98;
-    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
-    });
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
+    }) };
 }
 
 fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l280: loop {
+            l304: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l280;
+                continue l304;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -2485,7 +2655,7 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(raw) {
         _licm_used_7 = raw.used;
         _licm_repr_8 = raw.repr;
         block {
-            l290: loop {
+            l310: loop {
                 if i >= _licm_used_7 {
                     break __for_4;
                 }
@@ -2502,7 +2672,7 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(raw) {
                     return 1;
                 }
                 i = i + 1;
-                continue l290;
+                continue l310;
             };
         };
     };
@@ -2511,38 +2681,47 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(raw) {
 
 fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {
     let has_exp: bool;
-    let v: f64;
+    let __local_4: f64;
     let neg: bool;
     let idx: i32;
     let len: i32;
     let result: i64;
     let b: i32;
     let digit: i64;
+    let __local_11: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/string.wado//String";
     let __local_15: ref "core:prelude/string.wado//String";
-    let __local_17: ref "core:prelude/string.wado//String";
-    let __local_24: ref "core:prelude/string.wado//String";
-    let _licm_repr_26: ref builtin::array<u8>;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let _licm_repr_24: ref builtin::array<u8>;
     has_exp = "core:json/JsonDeserializer::has_exp_or_dot"(raw);
     if has_exp {
-        let __sroa_parsed_discriminant: i32;
-        let __sroa_parsed_payload_0: f64;
-        __local_13 = value_copy "core:prelude/string.wado//String"(raw);
-        multivalue_bind [__sroa_parsed_discriminant, __sroa_parsed_payload_0] = "core:prelude/fpfmt.wado/parse_text"(__local_13);
-        if __sroa_parsed_discriminant == 0 {
-            v = __sroa_parsed_payload_0;
-            if v != builtin::f64_floor(v) {
+        let __match_scrut_0: ref "core:prelude/types.wado//Option<f64>";
+        __match_scrut_0 = __inline_f64__parse_0: block -> ref "core:prelude/types.wado//Option<f64>" {
+            __local_11 = value_copy "core:prelude/string.wado//String"(raw);
+            break __inline_f64__parse_0: "core:prelude/fpfmt.wado/parse_text"(__local_11);
+        };
+        if ref.test "core:prelude/types.wado//Option<f64>::Some"(__match_scrut_0) {
+            let __cast_1: ref "core:prelude/types.wado//Option<f64>::Some";
+            __cast_1 = ref.cast "core:prelude/types.wado//Option<f64>::Some"(__match_scrut_0);
+            __local_4 = __cast_1.payload_0;
+            if __local_4 != builtin::f64_floor(__local_4) {
                 return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_2: block -> ref "core:serde//DeserializeError" {
-                    __local_15 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
-                    break __inline_DeserializeError__unexpected_type_2: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_15, offset: start };
+                    __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
+                    break __inline_DeserializeError__unexpected_type_2: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_13, offset: start };
                 }) };
             }
-            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v) };
+            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(__local_4) };
+            unreachable;
+        } else if __match_scrut_0.discriminant == 1 {
+            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_3: block -> ref "core:serde//DeserializeError" {
+                __local_15 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid number"), used: 14 };
+                break __inline_DeserializeError__invalid_value_3: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_15, offset: start };
+            }) };
+            unreachable;
+        } else {
+            unreachable;
         }
-        return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_3: block -> ref "core:serde//DeserializeError" {
-            __local_17 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid number"), used: 14 };
-            break __inline_DeserializeError__invalid_value_3: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_17, offset: start };
-        }) };
+        unreachable;
     }
     neg = 0;
     idx = 0;
@@ -2556,27 +2735,27 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {
         idx = 1;
     }
     result = 0_i64;
-    _licm_repr_26 = raw.repr;
-    b300: block {
-        l301: loop {
+    _licm_repr_24 = raw.repr;
+    b321: block {
+        l322: loop {
             if idx >= len {
-                break b300;
+                break b321;
             }
-            b = builtin::array_get_u8(_licm_repr_26, idx);
+            b = builtin::array_get_u8(_licm_repr_24, idx);
             if (if b < 48 -> i32 {
                 1;
             } else {
                 b > 57;
             }) {
                 return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_7: block -> ref "core:serde//DeserializeError" {
-                    __local_24 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid digit in number"), used: 23 };
-                    break __inline_DeserializeError__invalid_value_7: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_24, offset: start };
+                    __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid digit in number"), used: 23 };
+                    break __inline_DeserializeError__invalid_value_7: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_22, offset: start };
                 }) };
             }
             digit = builtin::i64_extend_i32_s(b - 48);
             result = (result * 10_i64) + digit;
             idx = idx + 1;
-            continue l301;
+            continue l322;
         };
     };
     if neg {
@@ -2636,25 +2815,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b308: block {
-        l309: loop {
+    b329: block {
+        l330: loop {
             if _hfs_pos_36 >= _licm_used_28 {
-                break b308;
+                break b329;
             }
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
                 break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr_29, __local_11);
             };
-            if (if b_1 >= 48 -> i32 {
+            if (if 48 <= b_1 -> i32 {
                 b_1 <= 57;
             } else {
                 0;
             }) {
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
-                break b308;
+                break b329;
             }
-            continue l309;
+            continue l330;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2675,25 +2854,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b315: block {
-            l316: loop {
+        b336: block {
+            l337: loop {
                 if _hfs_pos_37 >= _licm_used_31 {
-                    break b315;
+                    break b336;
                 }
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
                     break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_32, __local_17);
                 };
-                if (if b_2 >= 48 -> i32 {
+                if (if 48 <= b_2 -> i32 {
                     b_2 <= 57;
                 } else {
                     0;
                 }) {
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
-                    break b315;
+                    break b336;
                 }
-                continue l316;
+                continue l337;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2734,25 +2913,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b326: block {
-                l327: loop {
+            b347: block {
+                l348: loop {
                     if _hfs_pos_38 >= _licm_used_34 {
-                        break b326;
+                        break b347;
                     }
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
                         break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_35, __local_26);
                     };
-                    if (if b2 >= 48 -> i32 {
+                    if (if 48 <= b2 -> i32 {
                         b2 <= 57;
                     } else {
                         0;
                     }) {
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
-                        break b326;
+                        break b347;
                     }
-                    continue l327;
+                    continue l348;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -2846,16 +3025,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b336: block {
-        l337: loop {
+    b357: block {
+        l358: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b336;
+                break b357;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -2876,17 +3055,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b345: block {
-                        l346: loop {
+                    b366: block {
+                        l367: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b345;
+                                break b366;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -2896,9 +3075,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b345;
+                                break b366;
                             }
-                            continue l346;
+                            continue l367;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -2929,17 +3108,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b355: block {
-                            l356: loop {
+                        b376: block {
+                            l377: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b355;
+                                    break b376;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -2948,9 +3127,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b355;
+                                    break b376;
                                 }
-                                continue l356;
+                                continue l377;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -2988,9 +3167,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b336;
+                break b357;
             }
-            continue l337;
+            continue l358;
         };
     };
     self.pos = _hfs_pos_51;
@@ -3085,16 +3264,16 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b371: block {
-        l372: loop {
+    b392: block {
+        l393: loop {
             if _hfs_pos_49 >= _licm_used_45 {
-                break b371;
+                break b392;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_49;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_46, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -3115,17 +3294,17 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b380: block {
-                        l381: loop {
+                    b401: block {
+                        l402: loop {
                             if _hfs_pos_47 >= _licm_used_45 {
                                 self.pos = _hfs_pos_49;
-                                break b380;
+                                break b401;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_47;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_46, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -3135,9 +3314,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                                 _hfs_pos_47 = _hfs_pos_47 + 1;
                             } else {
                                 self.pos = _hfs_pos_49;
-                                break b380;
+                                break b401;
                             }
-                            continue l381;
+                            continue l402;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -3168,17 +3347,17 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                             }
                         }
                         _hfs_pos_48 = _hfs_pos_49;
-                        b390: block {
-                            l391: loop {
+                        b411: block {
+                            l412: loop {
                                 if _hfs_pos_48 >= _licm_used_45 {
                                     self.pos = _hfs_pos_49;
-                                    break b390;
+                                    break b411;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_48;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_46, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -3187,9 +3366,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                                     _hfs_pos_48 = _hfs_pos_48 + 1;
                                 } else {
                                     self.pos = _hfs_pos_49;
-                                    break b390;
+                                    break b411;
                                 }
-                                continue l391;
+                                continue l412;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -3215,9 +3394,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                 self.pos = _hfs_pos_49;
                 return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v_signed) };
             } else {
-                break b371;
+                break b392;
             }
-            continue l372;
+            continue l393;
         };
     };
     self.pos = _hfs_pos_49;
@@ -3243,10 +3422,10 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b399: block {
-        l400: loop {
+    b420: block {
+        l421: loop {
             if _hfs_pos_14 >= _licm_used_12 {
-                break b399;
+                break b420;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -3276,7 +3455,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
                 }
             }
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l400;
+            continue l421;
         };
     };
     self.pos = _hfs_pos_14;
@@ -3287,19 +3466,284 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
 }
 
 fn "core:json/JsonDeserializer::skip_value"(self) {
-    let b: i32;
-    let r: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let c_4: i32;
-    let kr: ref null "core:serde//DeserializeError";
-    let e_6: ref "core:serde//DeserializeError";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let vr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let c_11: i32;
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: char;
+    let __local_6: ref "core:serde//DeserializeError";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_10: ref "core:serde//DeserializeError";
+    let __local_11: char;
     let __local_12: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/format.wado//Formatter";
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i64;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i32;
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
+    let __local_20: i32;
+    let __local_21: ref "core:prelude/string.wado//String";
+    let __local_22: i64;
+    let __local_23: ref "core:prelude/string.wado//String";
+    let __local_24: i32;
+    let __local_25: ref "core:prelude/string.wado//String";
+    let __local_26: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let __local_30: ref "core:prelude/string.wado//String";
+    let __local_31: ref "core:prelude/string.wado//String";
+    let __local_32: i32;
+    let __local_33: ref "core:prelude/string.wado//String";
+    let __local_34: i64;
+    let __local_35: ref "core:prelude/string.wado//String";
+    let __local_36: i64;
+    let __local_37: ref "core:prelude/string.wado//String";
+    let __local_38: i32;
+    let __local_39: ref "core:prelude/string.wado//String";
+    let __local_40: i64;
+    let __local_43: ref "core:prelude/string.wado//String";
+    let __local_44: i64;
+    "core:json/JsonDeserializer::skip_whitespace"(self);
+    if self.pos >= __inline_String__len_0: block -> i32 {
+        __local_14 = self.input;
+        break __inline_String__len_0: __local_14.used;
+    } {
+        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_15 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_15 };
+        });
+    }
+    b = __inline_String__get_byte_2: block -> u8 {
+        __local_16 = self.input;
+        __local_17 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_16.repr, __local_17);
+    } & 255;
+    if b == 34 {
+        return "core:json/JsonDeserializer::skip_string"(self);
+        unreachable;
+    } else if b == 116 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        unreachable;
+    } else if b == 102 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        unreachable;
+    } else if b == 110 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
+        unreachable;
+    } else if b == 91 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_3: block -> i32 {
+            __local_18 = self.input;
+            break __inline_String__len_3: __local_18.used;
+        } -> i32 {
+            __inline_String__get_byte_4: block -> u8 {
+                __local_19 = self.input;
+                __local_20 = self.pos;
+                break __inline_String__get_byte_4: builtin::array_get_u8(__local_19.repr, __local_20);
+            } == 93;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l436: loop {
+                let __match_scrut_5: ref null "core:serde//DeserializeError";
+                __match_scrut_5 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_5) {
+                } else if ref.is_null(__match_scrut_5) == 0 {
+                    let __cast_4: ref null "core:serde//DeserializeError";
+                    __cast_4 = ref.as_non_null(__match_scrut_5);
+                    __local_3 = ref.as_non_null(__cast_4);
+                    return __local_3;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_5: block -> i32 {
+                    __local_21 = self.input;
+                    break __inline_String__len_5: __local_21.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
+                        __local_22 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_22 };
+                    });
+                }
+                __local_4 = __inline_String__get_byte_7: block -> u8 {
+                    __local_23 = self.input;
+                    __local_24 = self.pos;
+                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_23.repr, __local_24);
+                } & 255;
+                if __local_4 == 93 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_4 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
+                        __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
+                        __local_26 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_25, offset: __local_26 };
+                    });
+                    unreachable;
+                }
+                continue l436;
+            };
+        };
+    } else if b == 123 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_9: block -> i32 {
+            __local_27 = self.input;
+            break __inline_String__len_9: __local_27.used;
+        } -> i32 {
+            __inline_String__get_byte_10: block -> u8 {
+                __local_28 = self.input;
+                __local_29 = self.pos;
+                break __inline_String__get_byte_10: builtin::array_get_u8(__local_28.repr, __local_29);
+            } == 125;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l446: loop {
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if (if self.pos >= __inline_String__len_11: block -> i32 {
+                    __local_30 = self.input;
+                    break __inline_String__len_11: __local_30.used;
+                } -> i32 {
+                    1;
+                } else {
+                    __inline_String__get_byte_12: block -> u8 {
+                        __local_31 = self.input;
+                        __local_32 = self.pos;
+                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_31.repr, __local_32);
+                    } != 34;
+                }) {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
+                        __local_33 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+                        __local_34 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_33, offset: __local_34 };
+                    });
+                }
+                let __match_scrut_1: ref null "core:serde//DeserializeError";
+                __match_scrut_1 = "core:json/JsonDeserializer::skip_string"(self);
+                if ref.is_null(__match_scrut_1) {
+                } else if ref.is_null(__match_scrut_1) == 0 {
+                    let __cast_1: ref null "core:serde//DeserializeError";
+                    __cast_1 = ref.as_non_null(__match_scrut_1);
+                    __local_6 = ref.as_non_null(__cast_1);
+                    return __local_6;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_2: ref null "core:serde//DeserializeError";
+                __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+                if ref.is_null(__match_scrut_2) {
+                } else if ref.is_null(__match_scrut_2) == 0 {
+                    let __cast_2: ref null "core:serde//DeserializeError";
+                    __cast_2 = ref.as_non_null(__match_scrut_2);
+                    __local_8 = ref.as_non_null(__cast_2);
+                    return __local_8;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_3: ref null "core:serde//DeserializeError";
+                __match_scrut_3 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_3) {
+                } else if ref.is_null(__match_scrut_3) == 0 {
+                    let __cast_3: ref null "core:serde//DeserializeError";
+                    __cast_3 = ref.as_non_null(__match_scrut_3);
+                    __local_10 = ref.as_non_null(__cast_3);
+                    return __local_10;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_14: block -> i32 {
+                    __local_35 = self.input;
+                    break __inline_String__len_14: __local_35.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
+                        __local_36 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_36 };
+                    });
+                }
+                __local_11 = __inline_String__get_byte_16: block -> u8 {
+                    __local_37 = self.input;
+                    __local_38 = self.pos;
+                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_37.repr, __local_38);
+                } & 255;
+                if __local_11 == 125 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_11 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
+                        __local_39 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
+                        __local_40 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_39, offset: __local_40 };
+                    });
+                    unreachable;
+                }
+                continue l446;
+            };
+        };
+    } else {
+        if (if b == 45 -> i32 {
+            1;
+        } else if 48 <= b -> i32 {
+            b <= 57;
+        } else {
+            0;
+        }) {
+            "core:json/JsonDeserializer::skip_number"(self);
+            return ref.null none;
+        }
+        return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
+            __local_43 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
+                "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
+                __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
+                "core:prelude/primitive.wado/char^Display::fmt"(b, __local_13);
+                "core:prelude/string.wado/String::push"(__local_12, 39);
+                break __tmpl: __local_12;
+            };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
+        });
+        unreachable;
+    }
+}
+
+fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
+    let __local_2: ref "core:serde//DeserializeError";
+    let key_start: i32;
+    let has_escape: bool;
+    let b: i32;
+    let key_end: i32;
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: i32;
+    let idx_10: i32;
+    let __local_11: ref "core:prelude/string.wado//String";
+    let __local_12: ref "core:serde//DeserializeError";
+    let key: ref "core:prelude/string.wado//String";
+    let __local_15: ref "core:serde//DeserializeError";
+    let __local_16: i32;
+    let idx_17: i32;
     let __local_18: ref "core:prelude/string.wado//String";
     let __local_19: i64;
     let __local_20: ref "core:prelude/string.wado//String";
@@ -3310,505 +3754,285 @@ fn "core:json/JsonDeserializer::skip_value"(self) {
     let __local_25: ref "core:prelude/string.wado//String";
     let __local_26: i64;
     let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: i64;
-    let __local_31: ref "core:prelude/string.wado//String";
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i32;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
-    let __local_37: ref "core:prelude/string.wado//String";
-    let __local_38: i64;
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
-    let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_47: ref "core:prelude/string.wado//String";
-    let __local_48: i64;
-    let _hfs_pos_49: i32;
-    let _hfs_pos_50: i32;
-    "core:json/JsonDeserializer::skip_whitespace"(self);
-    if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_18 = self.input;
-        break __inline_String__len_0: __local_18.used;
-    } {
-        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_19 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
-        });
-    }
-    b = __inline_String__get_byte_2: block -> u8 {
-        __local_20 = self.input;
-        __local_21 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
-    };
-    if b == 34 {
-        return "core:json/JsonDeserializer::skip_string"(self);
-    }
-    if b == 116 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-    }
-    if b == 102 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-    }
-    if b == 110 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
-    }
-    if b == 91 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_3: block -> i32 {
-            __local_22 = self.input;
-            break __inline_String__len_3: __local_22.used;
-        } -> i32 {
-            __inline_String__get_byte_4: block -> u8 {
-                __local_23 = self.input;
-                __local_24 = self.pos;
-                break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
-            } == 93;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_49 = self.pos;
-        block {
-            l415: loop {
-                self.pos = _hfs_pos_49;
-                r = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_49 = self.pos;
-                if ref.is_null(r) == 0 {
-                    e_3 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-                    self.pos = _hfs_pos_49;
-                    return e_3;
-                }
-                self.pos = _hfs_pos_49;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_49 = self.pos;
-                if _hfs_pos_49 >= __inline_String__len_5: block -> i32 {
-                    __local_25 = self.input;
-                    self.pos = _hfs_pos_49;
-                    break __inline_String__len_5: __local_25.used;
-                } {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
-                        __local_26 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
-                    });
-                }
-                c_4 = __inline_String__get_byte_7: block -> u8 {
-                    __local_27 = self.input;
-                    __local_28 = _hfs_pos_49;
-                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_27.repr, __local_28);
-                };
-                if c_4 == 93 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                    self.pos = _hfs_pos_49;
-                    return ref.null none;
-                }
-                if c_4 == 44 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                } else {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
-                        __local_29 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
-                        __local_30 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_29, offset: __local_30 };
-                    });
-                }
-                continue l415;
-            };
-        };
-        self.pos = _hfs_pos_49;
-    }
-    if b == 123 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_9: block -> i32 {
-            __local_31 = self.input;
-            break __inline_String__len_9: __local_31.used;
-        } -> i32 {
-            __inline_String__get_byte_10: block -> u8 {
-                __local_32 = self.input;
-                __local_33 = self.pos;
-                break __inline_String__get_byte_10: builtin::array_get_u8(__local_32.repr, __local_33);
-            } == 125;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_50 = self.pos;
-        block {
-            l424: loop {
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if (if _hfs_pos_50 >= __inline_String__len_11: block -> i32 {
-                    __local_34 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_11: __local_34.used;
-                } -> i32 {
-                    1;
-                } else {
-                    __inline_String__get_byte_12: block -> u8 {
-                        __local_35 = self.input;
-                        __local_36 = _hfs_pos_50;
-                        self.pos = _hfs_pos_50;
-                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_35.repr, __local_36);
-                    } != 34;
-                }) {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
-                        __local_37 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-                        __local_38 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_37, offset: __local_38 };
-                    });
-                }
-                self.pos = _hfs_pos_50;
-                kr = "core:json/JsonDeserializer::skip_string"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(kr) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(kr));
-                    self.pos = _hfs_pos_50;
-                    return e_6;
-                }
-                self.pos = _hfs_pos_50;
-                cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(cr) == 0 {
-                    e_8 = value_copy "core:serde//DeserializeError"(ref.as_non_null(cr));
-                    self.pos = _hfs_pos_50;
-                    return e_8;
-                }
-                self.pos = _hfs_pos_50;
-                vr = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(vr) == 0 {
-                    e_10 = value_copy "core:serde//DeserializeError"(ref.as_non_null(vr));
-                    self.pos = _hfs_pos_50;
-                    return e_10;
-                }
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if _hfs_pos_50 >= __inline_String__len_14: block -> i32 {
-                    __local_39 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_14: __local_39.used;
-                } {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
-                        __local_40 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-                    });
-                }
-                c_11 = __inline_String__get_byte_16: block -> u8 {
-                    __local_41 = self.input;
-                    __local_42 = _hfs_pos_50;
-                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_41.repr, __local_42);
-                };
-                if c_11 == 125 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                    self.pos = _hfs_pos_50;
-                    return ref.null none;
-                }
-                if c_11 == 44 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                } else {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
-                        __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
-                        __local_44 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
-                    });
-                }
-                continue l424;
-            };
-        };
-        self.pos = _hfs_pos_50;
-    }
-    if (if b == 45 -> i32 {
-        1;
-    } else if b >= 48 -> i32 {
-        b <= 57;
-    } else {
-        0;
-    }) {
-        "core:json/JsonDeserializer::skip_number"(self);
-        return ref.null none;
-    }
-    return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
-        __local_47 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-            __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
-            "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
-            __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
-            "core:prelude/primitive.wado/char^Display::fmt"(b & 255, __local_13);
-            "core:prelude/string.wado/String::push"(__local_12, 39);
-            break __tmpl: __local_12;
-        };
-        __local_48 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_47, offset: __local_48 };
-    });
-}
-
-fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
-    let r_1: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let key_start: i32;
-    let has_escape: bool;
-    let b: i32;
-    let key_end: i32;
-    let r_7: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let idx_9: ref "core:prelude/types.wado//Option<i32>";
-    let i_10: i32;
-    let key: ref "core:prelude/string.wado//String";
-    let r_13: ref null "core:serde//DeserializeError";
-    let e_14: ref "core:serde//DeserializeError";
-    let idx_15: ref "core:prelude/types.wado//Option<i32>";
-    let i_16: i32;
-    let e_17: ref "core:serde//DeserializeError";
-    let __local_25: ref "core:prelude/string.wado//String";
-    let __local_26: i64;
-    let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: ref "core:prelude/string.wado//String";
-    let __local_31: i32;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i64;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_25 = self.de.input;
-        break __inline_String__len_0: __local_25.used;
+        __local_18 = self.de.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
+            __local_19 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_27 = self.de.input;
-        __local_28 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_27.repr, __local_28);
+        __local_20 = self.de.input;
+        __local_21 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } == 125 {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r_1 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r_1) == 0 {
-            e_2 = ref.as_non_null(r_1);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if (if self.de.pos >= __inline_String__len_3: block -> i32 {
-        __local_29 = self.de.input;
-        break __inline_String__len_3: __local_29.used;
+        __local_22 = self.de.input;
+        break __inline_String__len_3: __local_22.used;
     } -> i32 {
         1;
     } else {
         __inline_String__get_byte_4: block -> u8 {
-            __local_30 = self.de.input;
-            __local_31 = self.de.pos;
-            break __inline_String__get_byte_4: builtin::array_get_u8(__local_30.repr, __local_31);
+            __local_23 = self.de.input;
+            __local_24 = self.de.pos;
+            break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
         } != 34;
     }) {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_5: block -> ref "core:serde//DeserializeError" {
-            __local_32 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-            __local_33 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_32, offset: __local_33 };
+            __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_25, offset: __local_26 };
         }) };
     }
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b442: block {
-        l443: loop {
+    b468: block {
+        l469: loop {
             if self.de.pos >= __inline_String__len_6: block -> i32 {
-                __local_34 = self.de.input;
-                break __inline_String__len_6: __local_34.used;
+                __local_27 = self.de.input;
+                break __inline_String__len_6: __local_27.used;
             } {
-                break b442;
+                break b468;
             }
             b = __inline_String__get_byte_7: block -> u8 {
-                __local_35 = self.de.input;
-                __local_36 = self.de.pos;
-                break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
+                __local_28 = self.de.input;
+                __local_29 = self.de.pos;
+                break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
             };
             if b == 34 {
-                break b442;
+                break b468;
             }
             if b == 92 {
                 has_escape = 1;
-                break b442;
+                break b468;
             }
             self.de.pos = self.de.pos + 1;
-            continue l443;
+            continue l469;
         };
     };
     if has_escape == 0 {
         key_end = self.de.pos;
         self.de.pos = self.de.pos + 1;
-        r_7 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_7) == 0 {
-            e_8 = ref.as_non_null(r_7);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_8 };
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_1);
+            __local_8 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        idx_9 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_0: ref "canonical//CanonicalClosure_0";
-            __indirect_call_0 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_0.func, __indirect_call_0.env, self.de.input, key_start, key_end);
+        let __match_scrut_2: ref "core:prelude/types.wado//Option<i32>";
+        __match_scrut_2 = block -> ref "core:prelude/types.wado//Option<i32>" {
+            let __indirect_call_2: ref "canonical//CanonicalClosure_0";
+            __indirect_call_2 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_2.func, __indirect_call_2.env, self.de.input, key_start, key_end);
         };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_9) {
-            i_10 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_9).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_10 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+        idx_10 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2) -> i32 {
+            let __cast_4: ref "core:prelude/types.wado//Option<i32>::Some";
+            __cast_4 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2);
+            __local_9 = __cast_4.payload_0;
+            __local_9;
+        } else if __match_scrut_2.discriminant == 1 -> i32 {
+            -1;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_10 } };
     }
     self.de.pos = key_start - 1;
-    let __sroa_key_r_discriminant: i32;
-    let __sroa_key_r_case0_payload_0: ref null "core:prelude/string.wado//String";
-    let __sroa_key_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_key_r_discriminant, __sroa_key_r_case0_payload_0, __sroa_key_r_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self.de);
-    if __sroa_key_r_discriminant == 0 {
-        key = __sroa_key_r_case0_payload_0;
-        r_13 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_13) == 0 {
-            e_14 = ref.as_non_null(r_13);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_14 };
-        }
-        idx_15 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_1: ref "canonical//CanonicalClosure_0";
-            __indirect_call_1 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_1.func, __indirect_call_1.env, key, 0, key.used);
-        };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_15) {
-            i_16 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_15).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_16 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+    key = value_copy "core:prelude/string.wado//String"(let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self.de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_6: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_6 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+        __local_11 = __cast_6.payload_0;
+        __local_11;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+        __local_12 = __cast_5.payload_0;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_12 };
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    let __match_scrut_4: ref null "core:serde//DeserializeError";
+    __match_scrut_4 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+    if ref.is_null(__match_scrut_4) {
+    } else if ref.is_null(__match_scrut_4) == 0 {
+        let __cast_7: ref null "core:serde//DeserializeError";
+        __cast_7 = ref.as_non_null(__match_scrut_4);
+        __local_15 = ref.as_non_null(__cast_7);
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_15 };
+        unreachable;
+    } else {
+        unreachable;
     }
-    if __sroa_key_r_discriminant == 1 {
-        e_17 = __sroa_key_r_case1_payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    let __match_scrut_5: ref "core:prelude/types.wado//Option<i32>";
+    __match_scrut_5 = block -> ref "core:prelude/types.wado//Option<i32>" {
+        let __indirect_call_7: ref "canonical//CanonicalClosure_0";
+        __indirect_call_7 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+        call_ref "functype/$canonical_closure_fn_0"(__indirect_call_7.func, __indirect_call_7.env, key, 0, key.used);
+    };
+    idx_17 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5) -> i32 {
+        let __cast_9: ref "core:prelude/types.wado//Option<i32>::Some";
+        __cast_9 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5);
+        __local_16 = __cast_9.payload_0;
+        __local_16;
+    } else if __match_scrut_5.discriminant == 1 -> i32 {
+        -1;
+    } else {
+        unreachable;
+    });
+    return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_17 } };
 }
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_i64"(self) {
     let start: i64;
+    let __local_2: ref "core:prelude/string.wado//String";
+    let __local_3: ref "core:serde//DeserializeError";
     let s: ref "core:prelude/string.wado//String";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     start = builtin::i64_extend_i32_s(self.pos);
     if (if self.pos < __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_5 = self.input;
+        break __inline_String__len_0: __local_5.used;
     } -> i32 {
         __inline_String__get_byte_1: block -> u8 {
-            __local_8 = self.input;
-            __local_9 = self.pos;
-            break __inline_String__get_byte_1: builtin::array_get_u8(__local_8.repr, __local_9);
+            __local_6 = self.input;
+            __local_7 = self.pos;
+            break __inline_String__get_byte_1: builtin::array_get_u8(__local_6.repr, __local_7);
         } == 34;
     } else {
         0;
     }) {
-        let __sroa_sr_discriminant: i32;
-        let __sroa_sr_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_sr_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_sr_discriminant, __sroa_sr_case0_payload_0, __sroa_sr_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self);
-        if __sroa_sr_discriminant == 0 {
-            s = __sroa_sr_case0_payload_0;
-            return "core:json/JsonDeserializer::parse_i64_from"(self, s, start);
-        }
-        if __sroa_sr_discriminant == 1 {
-            e = __sroa_sr_case1_payload_0;
-            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: e };
-        }
-        "core:internal/unreachable"();
-        unreachable;
+        s = value_copy "core:prelude/string.wado//String"(let __match_scrut_0: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_0 = "core:json/JsonDeserializer::read_json_string"(self); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+            let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0);
+            __local_2 = __cast_2.payload_0;
+            __local_2;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+            let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0);
+            __local_3 = __cast_1.payload_0;
+            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
+        }));
+        return "core:json/JsonDeserializer::parse_i64_from"(self, s, start);
     }
     return "core:json/JsonDeserializer::parse_i64_direct"(self);
 }
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_bool"(self) {
-    let b: i32;
-    let r_2: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let r_4: ref null "core:serde//DeserializeError";
-    let e_5: ref "core:serde//DeserializeError";
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:serde//DeserializeError";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
     let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i64;
+    let __local_9: i32;
     let __local_10: ref "core:prelude/string.wado//String";
-    let __local_11: i32;
-    let __local_12: ref "core:prelude/string.wado//String";
-    let __local_13: i64;
+    let __local_11: i64;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_8 = self.input;
-        break __inline_String__len_0: __local_8.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_9 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_9 };
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
         }) };
     }
     b = __inline_String__get_byte_2: block -> u8 {
-        __local_10 = self.input;
-        __local_11 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_10.repr, __local_11);
-    };
+        __local_8 = self.input;
+        __local_9 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_8.repr, __local_9);
+    } & 255;
     if b == 116 {
-        r_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-        if ref.is_null(r_2) == 0 {
-            e_3 = ref.as_non_null(r_2);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_3 };
+        let __match_scrut_2: ref null "core:serde//DeserializeError";
+        __match_scrut_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        if ref.is_null(__match_scrut_2) {
+        } else if ref.is_null(__match_scrut_2) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_2);
+            __local_3 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 1 };
-    }
-    if b == 102 {
-        r_4 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-        if ref.is_null(r_4) == 0 {
-            e_5 = ref.as_non_null(r_4);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
+        unreachable;
+    } else if b == 102 {
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_1);
+            __local_5 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_5 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 0 };
+        unreachable;
+    } else {
+        return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
+            __local_11 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_10, offset: __local_11 };
+        }) };
+        unreachable;
     }
-    return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-        __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
-        __local_13 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_12, offset: __local_13 };
-    }) };
+    unreachable;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_struct"(self, lookup) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 123);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_5: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 123);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_5 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_5;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonStructAccess" { de: self, lookup: lookup, first: 1 }, ref.null none;
 }
@@ -3820,13 +4044,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l467: loop {
+            l500: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l467;
+                continue l500;
             };
         };
     };
@@ -3963,8 +4187,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b490: block {
-        l491: loop {
+    b523: block {
+        l524: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3989,9 +4213,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b490;
+                break b523;
             }
-            continue l491;
+            continue l524;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -4029,8 +4253,8 @@ fn "wado-compiler/tests/fixtures/serde_json_rename_all.wado/Config^Deserialize::
         max_retries = 0;
         timeout_ms = 0_i64;
         is_verbose = 0;
-        b499: block {
-            l500: loop {
+        b532: block {
+            l533: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -4048,7 +4272,7 @@ fn "wado-compiler/tests/fixtures/serde_json_rename_all.wado/Config^Deserialize::
                                 max_retries = __local_11;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_10).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_10).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_12 = __inline_i64_Deserialize__deserialize_JsonDeserializer__6: block -> ref "core:prelude/types.wado//Result<i64,DeserializeError>" {
@@ -4061,7 +4285,7 @@ fn "wado-compiler/tests/fixtures/serde_json_rename_all.wado/Config^Deserialize::
                                 timeout_ms = __local_13;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(__local_12).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(__local_12).payload_0 };
                             }
                         } else if __idx == 2 {
                             __local_14 = __inline_bool_Deserialize__deserialize_JsonDeserializer__8: block -> ref "core:prelude/types.wado//Result<bool,DeserializeError>" {
@@ -4074,27 +4298,27 @@ fn "wado-compiler/tests/fixtures/serde_json_rename_all.wado/Config^Deserialize::
                                 is_verbose = __local_15;
                                 seen = seen | 4;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__local_14).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__local_14).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b499;
+                        break b532;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l500;
+                continue l533;
             };
         };
         if (seen & 7) != 7 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config" { max_retries: max_retries, timeout_ms: timeout_ms, is_verbose: is_verbose }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_json_rename_all.wado//Config" { max_retries: max_retries, timeout_ms: timeout_ms, is_verbose: is_verbose } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 

--- a/wado-compiler/tests/fixtures.golden/serde_json_result.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_result.wir.wado
@@ -56,169 +56,221 @@ struct core:serde//SerializeError {  // TypeId(9)
     mut message: ref "core:prelude/string.wado//String",
 }
 
-variant core:prelude/types.wado//Result<i32,String> {  // TypeId(10)
+variant core:prelude/types.wado//Option<char> {  // TypeId(10)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(11)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Result<i32,String> {  // TypeId(12)
     Ok(i32),
     Err(ref "core:prelude/string.wado//String"),
 }
 
-struct core:prelude/types.wado//Result<i32,String>::Ok {  // TypeId(11)
+struct core:prelude/types.wado//Result<i32,String>::Ok {  // TypeId(13)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,String>::Err {  // TypeId(12)
+struct core:prelude/types.wado//Result<i32,String>::Err {  // TypeId(14)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(13)
-    Ok(ref "core:prelude/string.wado//String"),
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(15)
+    Ok(char),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(14)
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(16)
     discriminant: i32,
-    payload_0: ref "core:prelude/string.wado//String",
+    payload_0: char,
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(15)
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(17)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(16)
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(18)
+    Ok(ref "core:prelude/string.wado//String"),
+    Err(ref "core:serde//DeserializeError"),
+}
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(17)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(19)
+    discriminant: i32,
+    payload_0: ref "core:prelude/string.wado//String",
+}
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(18)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(20)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(19)
+variant core:prelude/types.wado//Result<Result<i32,String>,DeserializeError> {  // TypeId(21)
+    Ok(ref "core:prelude/types.wado//Result<i32,String>"),
+    Err(ref "core:serde//DeserializeError"),
+}
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(20)
+struct core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Ok {  // TypeId(22)
+    discriminant: i32,
+    payload_0: ref "core:prelude/types.wado//Result<i32,String>",
+}
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(21)
+struct core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err {  // TypeId(23)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(22)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(24)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(23)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(25)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(24)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(26)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__test_0_result_serialize_ok" = fn();  // TypeId(25)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(27)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__test_1_result_serialize_err" = fn();  // TypeId(26)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(28)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__test_2_result_roundtrip_ok" = fn();  // TypeId(27)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(29)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__test_3_result_roundtrip_err" = fn();  // TypeId(28)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(30)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__cm_export____test_0_result_serialize_ok" = fn();  // TypeId(29)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(31)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__cm_export____test_1_result_serialize_err" = fn();  // TypeId(30)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(32)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__cm_export____test_2_result_roundtrip_ok" = fn();  // TypeId(31)
+type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__test_0_result_serialize_ok" = fn();  // TypeId(33)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__cm_export____test_3_result_roundtrip_err" = fn();  // TypeId(32)
+type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__test_1_result_serialize_err" = fn();  // TypeId(34)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(33)
+type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__test_2_result_roundtrip_ok" = fn();  // TypeId(35)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(34)
+type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__test_3_result_roundtrip_err" = fn();  // TypeId(36)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(35)
+type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__cm_export____test_0_result_serialize_ok" = fn();  // TypeId(37)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(36)
+type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__cm_export____test_1_result_serialize_err" = fn();  // TypeId(38)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(37)
+type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__cm_export____test_2_result_roundtrip_ok" = fn();  // TypeId(39)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(38)
+type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/__cm_export____test_3_result_roundtrip_err" = fn();  // TypeId(40)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(39)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(41)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(40)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(42)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(41)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(43)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(42)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(44)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(43)
+type "functype//core:internal/unreachable" = fn();  // TypeId(45)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(44)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(46)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(45)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(47)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(46)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(48)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(47)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(49)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(48)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(50)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(49)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(51)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(50)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(52)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(51)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(53)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(52)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(54)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(53)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(55)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(54)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(56)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(55)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(57)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(56)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(58)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(57)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(59)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(58)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(60)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(59)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(61)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(60)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(62)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(61)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(63)
 
-type "functype//core:json/JsonVariantSerializer^SerializeVariant::payload<String>" = fn(ref "core:json//JsonVariantSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(62)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(64)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(63)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(65)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(64)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(66)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(65)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(67)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(66)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(68)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(67)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(69)
 
-type "functype//core:json/core/json/from_string<Result<i32,String>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/types.wado//Result<i32,String>", ref null "core:serde//DeserializeError"];  // TypeId(68)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(70)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(69)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(71)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(70)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(72)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(71)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(73)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(72)
+type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/Result<i32,String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>";  // TypeId(74)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(73)
+type "functype//core:json/JsonVariantSerializer^SerializeVariant::payload<String>" = fn(ref "core:json//JsonVariantSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(75)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_result.wado/Result<i32,String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude/types.wado//Result<i32,String>", ref null "core:serde//DeserializeError"];  // TypeId(74)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(76)
 
-type "functype//core:json/core/json/to_string<Result<i32,String>>" = fn(ref "core:prelude/types.wado//Result<i32,String>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(75)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(77)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(76)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(78)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(77)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(79)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(78)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(80)
 
-type "functype//core:prelude/types.wado/Result<i32,String>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude/types.wado//Result<i32,String>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(79)
+type "functype//core:json/core/json/from_string<Result<i32,String>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/types.wado//Result<i32,String>", ref null "core:serde//DeserializeError"];  // TypeId(81)
 
-type "functype//core:json/JsonVariantSerializer^SerializeVariant::payload<i32>" = fn(ref "core:json//JsonVariantSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(80)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(82)
 
-type "functype//core:json/JsonSerializer^Serializer::begin_variant" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref null "core:json//JsonVariantSerializer", ref null "core:serde//SerializeError"];  // TypeId(81)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(83)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_variant" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:json//JsonVariantAccess", ref null "core:serde//DeserializeError"];  // TypeId(82)
+type "functype//core:json/core/json/to_string<Result<i32,String>>" = fn(ref "core:prelude/types.wado//Result<i32,String>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(84)
+
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(85)
+
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(86)
+
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(87)
+
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(88)
+
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(89)
+
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(90)
+
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(91)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(92)
+
+type "functype//core:prelude/types.wado/Result<i32,String>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude/types.wado//Result<i32,String>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(93)
+
+type "functype//core:json/JsonVariantSerializer^SerializeVariant::payload<i32>" = fn(ref "core:json//JsonVariantSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(94)
+
+type "functype//core:json/JsonSerializer^Serializer::begin_variant" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref null "core:json//JsonVariantSerializer", ref null "core:serde//SerializeError"];  // TypeId(95)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_variant" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:json//JsonVariantAccess", ref null "core:serde//DeserializeError"];  // TypeId(96)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -958,36 +1010,77 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l91: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l91;
+                };
+            };
+        };
     }
-    return ((97 + v) - 10) & 255;
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
         return 1;
     }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l97: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l97;
+            };
+        };
+    };
+    return n;
 }
 
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b93: block {
-        l94: loop {
+    b99: block {
+        l100: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -1008,23 +1101,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b93;
+                break b99;
             }
-            continue l94;
+            continue l100;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -1032,62 +1127,135 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/from_string<Result<i32,String>>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "core:prelude/types.wado//Result<i32,String>";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "core:prelude/types.wado//Result<i32,String>";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "core:prelude/types.wado//Result<i32,String>";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_result.wado/Result<i32,String>^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:prelude/types.wado//Result<i32,String>"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_result.wado/Result<i32,String>^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<i32,String>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<i32,String>" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Result<i32,String>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:prelude/types.wado/Result<i32,String>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:prelude/types.wado/Result<i32,String>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1110,6 +1278,20 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     }, offset, abs_val, digit_count);
 }
 
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
+}
+
 fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     let s: ref "core:prelude/string.wado//String";
     let c: char;
@@ -1121,6 +1303,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
         "core:prelude/string.wado/String::push"(s, self);
         "core:prelude/format.wado/Formatter::pad"(f, s);
     }
+}
+
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
 }
 
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
@@ -1186,7 +1382,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l117: loop {
+            l139: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -1194,7 +1390,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l117;
+                continue l139;
             };
         };
     };
@@ -1243,6 +1439,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -1302,10 +1547,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b128: block {
-        l129: loop {
+    b157: block {
+        l158: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b128;
+                break b157;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -1329,7 +1574,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l129;
+            continue l158;
         };
     };
     self.pos = _hfs_pos_8;
@@ -1393,130 +1638,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
+        }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b139: block {
-        l140: loop {
-            if scan_pos >= _licm_used_90 {
-                break b139;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b168: block {
+        l169: loop {
+            if scan_pos >= _licm_used_56 {
+                break b168;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b139;
+                break b168;
             }
             scan_pos = scan_pos + 1;
-            continue l140;
+            continue l169;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -1525,94 +1742,95 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l147: loop {
+                l176: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l147;
+                    continue l176;
                 };
             };
         };
         self.pos = scan_pos + 1;
-        return 0, result_5, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l150: loop {
+            l179: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l150;
+                continue l179;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b152: block {
-        l153: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b181: block {
+        l182: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b152;
+                break b181;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
-                return 0, result_8, ref.null none;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
+                return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
-                    });
+                    self.pos = _hfs_pos_64;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
+                    }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -1630,213 +1848,140 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return 1, ref.null none, e;
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
-                    });
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
+                    }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
-                    });
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
+                    }) };
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l153;
+            continue l182;
         };
     };
-    self.pos = _hfs_pos_98;
-    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
-    });
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
+    }) };
 }
 
 fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l178: loop {
+            l202: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l178;
+                continue l202;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -1926,16 +2071,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b192: block {
-        l193: loop {
+    b212: block {
+        l213: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b192;
+                break b212;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -1956,17 +2101,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b201: block {
-                        l202: loop {
+                    b221: block {
+                        l222: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b201;
+                                break b221;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -1976,9 +2121,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b201;
+                                break b221;
                             }
-                            continue l202;
+                            continue l222;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -2009,17 +2154,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b211: block {
-                            l212: loop {
+                        b231: block {
+                            l232: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b211;
+                                    break b231;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -2028,9 +2173,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b211;
+                                    break b231;
                                 }
-                                continue l212;
+                                continue l232;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -2068,9 +2213,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return 0, builtin::i32_trunc_f64_s(v_signed), ref.null none;
             } else {
-                break b192;
+                break b212;
             }
-            continue l193;
+            continue l213;
         };
     };
     self.pos = _hfs_pos_51;
@@ -2081,73 +2226,95 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_variant"(self) {
-    let b: i32;
-    let name_5: ref "core:prelude/string.wado//String";
-    let e_6: ref "core:serde//DeserializeError";
-    let name_8: ref "core:prelude/string.wado//String";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let e_11: ref "core:serde//DeserializeError";
-    let __local_17: ref "core:prelude/string.wado//String";
-    let __local_18: i64;
-    let __local_19: ref "core:prelude/string.wado//String";
-    let __local_20: i32;
-    let __local_21: ref "core:prelude/string.wado//String";
-    let __local_22: i64;
+    let b: char;
+    let __local_4: ref "core:prelude/string.wado//String";
+    let __local_5: ref "core:serde//DeserializeError";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: ref "core:prelude/string.wado//String";
+    let __local_11: ref "core:serde//DeserializeError";
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i32;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i64;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_17 = self.input;
-        break __inline_String__len_0: __local_17.used;
+        __local_12 = self.input;
+        break __inline_String__len_0: __local_12.used;
     } {
         return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_18 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_18 };
+            __local_13 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_13 };
         });
     }
     b = __inline_String__get_byte_2: block -> u8 {
-        __local_19 = self.input;
-        __local_20 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_19.repr, __local_20);
-    };
+        __local_14 = self.input;
+        __local_15 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_14.repr, __local_15);
+    } & 255;
     if b == 34 {
-        let __sroa_r_4_discriminant: i32;
-        let __sroa_r_4_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_r_4_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_r_4_discriminant, __sroa_r_4_case0_payload_0, __sroa_r_4_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self);
-        if __sroa_r_4_discriminant == 0 {
-            name_5 = __sroa_r_4_case0_payload_0;
-            return 0, struct.new "core:json//JsonVariantAccess" { de: self, variant: name_5, is_object: 0 }, ref.null none;
-        }
-        if __sroa_r_4_discriminant == 1 {
-            e_6 = __sroa_r_4_case1_payload_0;
-            return 1, ref.null none, e_6;
-        }
-    }
-    if b == 123 {
+        let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+        __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self);
+        __local_6 = (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+            let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+            __local_4 = __cast_5.payload_0;
+            __local_4;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+            let __cast_4: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_4 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+            __local_5 = __cast_4.payload_0;
+            return 1, ref.null none, __local_5;
+            unreachable;
+        } else {
+            unreachable;
+        });
+        return 0, struct.new "core:json//JsonVariantAccess" { de: self, variant: __local_6, is_object: 0 }, ref.null none;
+        unreachable;
+    } else if b == 123 {
         self.pos = self.pos + 1;
-        let __sroa_r_7_discriminant: i32;
-        let __sroa_r_7_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_r_7_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_r_7_discriminant, __sroa_r_7_case0_payload_0, __sroa_r_7_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self);
-        if __sroa_r_7_discriminant == 0 {
-            name_8 = __sroa_r_7_case0_payload_0;
-            cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-            if ref.is_null(cr) == 0 {
-                e_10 = value_copy "core:serde//DeserializeError"(ref.as_non_null(cr));
-                return 1, ref.null none, e_10;
-            }
-            return 0, struct.new "core:json//JsonVariantAccess" { de: self, variant: name_8, is_object: 1 }, ref.null none;
+        let __match_scrut_1: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+        __match_scrut_1 = "core:json/JsonDeserializer::read_json_string"(self);
+        __local_9 = (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/string.wado//String" {
+            let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1);
+            __local_7 = __cast_2.payload_0;
+            __local_7;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/string.wado//String" {
+            let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1);
+            __local_8 = __cast_1.payload_0;
+            return 1, ref.null none, __local_8;
+            unreachable;
+        } else {
+            unreachable;
+        });
+        let __match_scrut_2: ref null "core:serde//DeserializeError";
+        __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+        if ref.is_null(__match_scrut_2) {
+        } else if ref.is_null(__match_scrut_2) == 0 {
+            let __cast_3: ref null "core:serde//DeserializeError";
+            __cast_3 = ref.as_non_null(__match_scrut_2);
+            __local_11 = ref.as_non_null(__cast_3);
+            return 1, ref.null none, __local_11;
+            unreachable;
+        } else {
+            unreachable;
         }
-        if __sroa_r_7_discriminant == 1 {
-            e_11 = __sroa_r_7_case1_payload_0;
-            return 1, ref.null none, e_11;
-        }
+        return 0, struct.new "core:json//JsonVariantAccess" { de: self, variant: __local_9, is_object: 1 }, ref.null none;
+        unreachable;
+    } else {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_16 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string or object for variant"), used: 37 };
+            __local_17 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_16, offset: __local_17 };
+        });
+        unreachable;
     }
-    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-        __local_21 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string or object for variant"), used: 37 };
-        __local_22 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_21, offset: __local_22 };
-    });
+    unreachable;
 }
 
 fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
@@ -2157,13 +2324,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l231: loop {
+            l252: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l231;
+                continue l252;
             };
         };
     };
@@ -2300,8 +2467,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b254: block {
-        l255: loop {
+    b275: block {
+        l276: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -2326,9 +2493,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b254;
+                break b275;
             }
-            continue l255;
+            continue l276;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -2342,6 +2509,7 @@ fn "wado-compiler/tests/fixtures/serde_json_result.wado/Result<i32,String>^Deser
     let end_r_7: ref null "core:serde//DeserializeError";
     let e_8: ref "core:serde//DeserializeError";
     let e_9: ref "core:serde//DeserializeError";
+    let val_r_10: ref "core:prelude/types.wado//Result<String,DeserializeError>";
     let val_11: ref "core:prelude/string.wado//String";
     let end_r_12: ref null "core:serde//DeserializeError";
     let e_13: ref "core:serde//DeserializeError";
@@ -2375,24 +2543,23 @@ fn "wado-compiler/tests/fixtures/serde_json_result.wado/Result<i32,String>^Deser
                         break __inline_JsonVariantAccess_DeserializeVariant__end_3: ref.null none;
                     };
                     if ref.is_null(end_r_7) == 0 {
-                        e_8 = value_copy "core:serde//DeserializeError"(ref.as_non_null(end_r_7));
-                        return 1, ref.null none, e_8;
+                        e_8 = ref.as_non_null(end_r_7);
+                        return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_8 };
                     }
-                    return 0, struct.new "core:prelude/types.wado//Result<i32,String>::Ok" { discriminant: 0, payload_0: val_6 }, ref.null none;
+                    return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Result<i32,String>::Ok" { discriminant: 0, payload_0: val_6 } };
                 }
                 if __sroa_val_r_5_discriminant == 1 {
                     e_9 = __sroa_val_r_5_case1_payload_0;
-                    return 1, ref.null none, e_9;
+                    return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_9 };
                 }
             }
             if "core:prelude/string.wado/String^Eq::eq"(name, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Err"), used: 3 }) {
-                let __sroa_val_r_10_discriminant: i32;
-                let __sroa_val_r_10_case0_payload_0: ref null "core:prelude/string.wado//String";
-                let __sroa_val_r_10_case1_payload_0: ref null "core:serde//DeserializeError";
-                __local_33 = va.de;
-                multivalue_bind [__sroa_val_r_10_discriminant, __sroa_val_r_10_case0_payload_0, __sroa_val_r_10_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(__local_33);
-                if __sroa_val_r_10_discriminant == 0 {
-                    val_11 = __sroa_val_r_10_case0_payload_0;
+                val_r_10 = __inline_String_Deserialize__deserialize_JsonDeserializer__5: block -> ref "core:prelude/types.wado//Result<String,DeserializeError>" {
+                    __local_33 = va.de;
+                    break __inline_String_Deserialize__deserialize_JsonDeserializer__5: "core:json/JsonDeserializer::read_json_string"(__local_33);
+                };
+                if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(val_r_10) {
+                    val_11 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(val_r_10).payload_0;
                     end_r_12 = __inline_JsonVariantAccess_DeserializeVariant__end_6: block -> ref null "core:serde//DeserializeError" {
                         if va.is_object {
                             break __inline_JsonVariantAccess_DeserializeVariant__end_6: "core:json/JsonDeserializer::expect_char"(va.de, 125);
@@ -2400,31 +2567,31 @@ fn "wado-compiler/tests/fixtures/serde_json_result.wado/Result<i32,String>^Deser
                         break __inline_JsonVariantAccess_DeserializeVariant__end_6: ref.null none;
                     };
                     if ref.is_null(end_r_12) == 0 {
-                        e_13 = value_copy "core:serde//DeserializeError"(ref.as_non_null(end_r_12));
-                        return 1, ref.null none, e_13;
+                        e_13 = ref.as_non_null(end_r_12);
+                        return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_13 };
                     }
-                    return 0, struct.new "core:prelude/types.wado//Result<i32,String>::Err" { discriminant: 1, payload_0: val_11 }, ref.null none;
+                    return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Result<i32,String>::Err" { discriminant: 1, payload_0: val_11 } };
                 }
-                if __sroa_val_r_10_discriminant == 1 {
-                    e_14 = __sroa_val_r_10_case1_payload_0;
-                    return 1, ref.null none, e_14;
+                if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(val_r_10) {
+                    e_14 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(val_r_10).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_14 };
                 }
             }
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 2, message: ref.as_non_null(__tmpl: block -> ref "core:prelude/string.wado//String" {
+            return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 2, message: ref.as_non_null(__tmpl: block -> ref "core:prelude/string.wado//String" {
                 __local_17 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(40), used: 0 };
                 "core:prelude/string.wado/String::push_str"(__local_17, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unknown Result variant: "), used: 24 });
                 "core:prelude/string.wado/String::push_str"(__local_17, name);
                 break __tmpl: __local_17;
-            }), offset: -1_i64 };
+            }), offset: -1_i64 } };
         }
         if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(name_r) {
-            e_15 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(name_r).payload_0);
-            return 1, ref.null none, e_15;
+            e_15 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(name_r).payload_0;
+            return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_15 };
         }
     }
     if __sroa_va_r_discriminant == 1 {
         e_16 = __sroa_va_r_case1_payload_0;
-        return 1, ref.null none, e_16;
+        return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_16 };
     }
     "core:internal/unreachable"();
     unreachable;

--- a/wado-compiler/tests/fixtures.golden/serde_json_roundtrip_complex.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_roundtrip_complex.wir.wado
@@ -267,821 +267,1018 @@ struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(55)
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Result<i32,String> {  // TypeId(56)
+variant core:prelude/types.wado//Option<char> {  // TypeId(56)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(57)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Result<FullStruct,DeserializeError> {  // TypeId(58)
+    Ok(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<FullStruct,DeserializeError>::Ok {  // TypeId(59)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct",
+}
+
+struct core:prelude/types.wado//Result<FullStruct,DeserializeError>::Err {  // TypeId(60)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<Outer,DeserializeError> {  // TypeId(61)
+    Ok(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Outer,DeserializeError>::Ok {  // TypeId(62)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer",
+}
+
+struct core:prelude/types.wado//Result<Outer,DeserializeError>::Err {  // TypeId(63)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<i32,String> {  // TypeId(64)
     Ok(i32),
     Err(ref "core:prelude/string.wado//String"),
 }
 
-struct core:prelude/types.wado//Result<i32,String>::Ok {  // TypeId(57)
+struct core:prelude/types.wado//Result<i32,String>::Ok {  // TypeId(65)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,String>::Err {  // TypeId(58)
+struct core:prelude/types.wado//Result<i32,String>::Err {  // TypeId(66)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-variant core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError> {  // TypeId(59)
+variant core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError> {  // TypeId(67)
+    Ok(ref "core:collections//TreeMap<String,String>"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>::Ok {  // TypeId(68)
+    discriminant: i32,
+    payload_0: ref "core:collections//TreeMap<String,String>",
+}
+
+struct core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>::Err {  // TypeId(69)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError> {  // TypeId(70)
     Ok(ref "core:collections//TreeMap<String,i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Ok {  // TypeId(60)
+struct core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Ok {  // TypeId(71)
     discriminant: i32,
     payload_0: ref "core:collections//TreeMap<String,i32>",
 }
 
-struct core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err {  // TypeId(61)
+struct core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err {  // TypeId(72)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Direction,DeserializeError> {  // TypeId(62)
+variant core:prelude/types.wado//Result<Direction,DeserializeError> {  // TypeId(73)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Direction,DeserializeError>::Ok {  // TypeId(63)
+struct core:prelude/types.wado//Result<Direction,DeserializeError>::Ok {  // TypeId(74)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<Direction,DeserializeError>::Err {  // TypeId(64)
+struct core:prelude/types.wado//Result<Direction,DeserializeError>::Err {  // TypeId(75)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Shape,DeserializeError> {  // TypeId(65)
+variant core:prelude/types.wado//Result<Shape,DeserializeError> {  // TypeId(76)
     Ok(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Shape"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Shape,DeserializeError>::Ok {  // TypeId(66)
+struct core:prelude/types.wado//Result<Shape,DeserializeError>::Ok {  // TypeId(77)
     discriminant: i32,
     payload_0: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Shape",
 }
 
-struct core:prelude/types.wado//Result<Shape,DeserializeError>::Err {  // TypeId(67)
+struct core:prelude/types.wado//Result<Shape,DeserializeError>::Err {  // TypeId(78)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(68)
+variant core:prelude/types.wado//Result<Config,DeserializeError> {  // TypeId(79)
+    Ok(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Config"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Config,DeserializeError>::Ok {  // TypeId(80)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Config",
+}
+
+struct core:prelude/types.wado//Result<Config,DeserializeError>::Err {  // TypeId(81)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(82)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(69)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(83)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(70)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(84)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(71)
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(85)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(72)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(86)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(73)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(87)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(74)
+variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(88)
     Ok(f64),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(75)
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(89)
     discriminant: i32,
     payload_0: f64,
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(76)
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(90)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(77)
+variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(91)
     Ok(bool),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(78)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(92)
     discriminant: i32,
     payload_0: bool,
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(79)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(93)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError> {  // TypeId(80)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(94)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(95)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(96)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError> {  // TypeId(97)
     Ok(ref "core:json//JsonSeqSerializer"),
     Err(ref "core:serde//SerializeError"),
 }
 
-struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Ok {  // TypeId(81)
+struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Ok {  // TypeId(98)
     discriminant: i32,
     payload_0: ref "core:json//JsonSeqSerializer",
 }
 
-struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Err {  // TypeId(82)
+struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Err {  // TypeId(99)
     discriminant: i32,
     payload_0: ref "core:serde//SerializeError",
 }
 
-variant core:prelude/types.wado//Result<JsonMapSerializer,SerializeError> {  // TypeId(83)
+variant core:prelude/types.wado//Result<JsonMapSerializer,SerializeError> {  // TypeId(100)
     Ok(ref "core:json//JsonMapSerializer"),
     Err(ref "core:serde//SerializeError"),
 }
 
-struct core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok {  // TypeId(84)
+struct core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok {  // TypeId(101)
     discriminant: i32,
     payload_0: ref "core:json//JsonMapSerializer",
 }
 
-struct core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Err {  // TypeId(85)
+struct core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Err {  // TypeId(102)
     discriminant: i32,
     payload_0: ref "core:serde//SerializeError",
 }
 
-variant core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError> {  // TypeId(86)
+variant core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError> {  // TypeId(103)
     Ok(ref "core:json//JsonVariantAccess"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok {  // TypeId(87)
+struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok {  // TypeId(104)
     discriminant: i32,
     payload_0: ref "core:json//JsonVariantAccess",
 }
 
-struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err {  // TypeId(88)
+struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err {  // TypeId(105)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Inner,DeserializeError> {  // TypeId(89)
+variant core:prelude/types.wado//Result<Inner,DeserializeError> {  // TypeId(106)
     Ok(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Inner,DeserializeError>::Ok {  // TypeId(90)
+struct core:prelude/types.wado//Result<Inner,DeserializeError>::Ok {  // TypeId(107)
     discriminant: i32,
     payload_0: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner",
 }
 
-struct core:prelude/types.wado//Result<Inner,DeserializeError>::Err {  // TypeId(91)
+struct core:prelude/types.wado//Result<Inner,DeserializeError>::Err {  // TypeId(108)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Option<TreeMapNode<String>> {  // TypeId(92)
+variant core:prelude/types.wado//Option<TreeMapNode<String>> {  // TypeId(109)
     Some(ref "core:collections//TreeMapNode<String>"),
     None,
 }
 
-variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(93)
+variant core:prelude/types.wado//Option<Inner> {  // TypeId(110)
+    Some(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner"),
+    None,
+}
+
+variant core:prelude/types.wado//Result<Result<i32,String>,DeserializeError> {  // TypeId(111)
+    Ok(ref "core:prelude/types.wado//Result<i32,String>"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Ok {  // TypeId(112)
+    discriminant: i32,
+    payload_0: ref "core:prelude/types.wado//Result<i32,String>",
+}
+
+struct core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err {  // TypeId(113)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(114)
     Ok(ref "core:prelude/types.wado//Option<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(94)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(115)
     discriminant: i32,
     payload_0: ref "core:prelude/types.wado//Option<i32>",
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(95)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(116)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<String>,DeserializeError> {  // TypeId(96)
+variant core:prelude/types.wado//Result<Option<String>,DeserializeError> {  // TypeId(117)
     Ok(ref null "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok {  // TypeId(97)
+struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok {  // TypeId(118)
     discriminant: i32,
     payload_0: ref null "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err {  // TypeId(98)
+struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err {  // TypeId(119)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-struct core:prelude//Array<String> {  // TypeId(99)
+variant core:prelude/types.wado//Option<Option<i32>> {  // TypeId(120)
+    Some(ref "core:prelude/types.wado//Option<i32>"),
+    None,
+}
+
+variant core:prelude/types.wado//Result<Option<Inner>,DeserializeError> {  // TypeId(121)
+    Ok(ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Ok {  // TypeId(122)
+    discriminant: i32,
+    payload_0: ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner",
+}
+
+struct core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Err {  // TypeId(123)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError> {  // TypeId(124)
+    Ok(ref null "core:prelude/types.wado//Option<i32>"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Ok {  // TypeId(125)
+    discriminant: i32,
+    payload_0: ref null "core:prelude/types.wado//Option<i32>",
+}
+
+struct core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Err {  // TypeId(126)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+struct core:prelude//Array<String> {  // TypeId(127)
     mut repr: ref builtin::array<String>,
     mut used: i32,
 }
 
-struct core:prelude//Array<u64> {  // TypeId(100)
+struct core:prelude//Array<u64> {  // TypeId(128)
     mut repr: ref builtin::array<u64>,
     mut used: i32,
 }
 
-struct core:prelude//Array<Inner> {  // TypeId(101)
+struct core:prelude//Array<Inner> {  // TypeId(129)
     mut repr: ref builtin::array<Inner>,
     mut used: i32,
 }
 
-struct core:prelude//Array<Direction> {  // TypeId(102)
+struct core:prelude//Array<Direction> {  // TypeId(130)
     mut repr: ref builtin::array<Direction>,
     mut used: i32,
 }
 
-struct core:prelude//Array<i32> {  // TypeId(103)
+struct core:prelude//Array<i32> {  // TypeId(131)
     mut repr: ref builtin::array<i32>,
     mut used: i32,
 }
 
-struct core:prelude//Array<Option<i32>> {  // TypeId(104)
+struct core:prelude//Array<Option<i32>> {  // TypeId(132)
     mut repr: ref builtin::array<Option<i32>>,
     mut used: i32,
 }
 
-struct core:prelude//Array<TreeMapEntry<String,String>> {  // TypeId(105)
+struct core:prelude//Array<TreeMapEntry<String,String>> {  // TypeId(133)
     mut repr: ref builtin::array<TreeMapEntry<String,String>>,
     mut used: i32,
 }
 
-struct core:prelude//Array<TreeMapEntry<String,i32>> {  // TypeId(106)
+struct core:prelude//Array<TreeMapEntry<String,i32>> {  // TypeId(134)
     mut repr: ref builtin::array<TreeMapEntry<String,i32>>,
     mut used: i32,
 }
 
-struct core:prelude//Array<Tuple<String,i32>> {  // TypeId(107)
+struct core:prelude//Array<Tuple<String,i32>> {  // TypeId(135)
     mut repr: ref builtin::array<Tuple<String,i32>>,
     mut used: i32,
 }
 
-struct core:prelude//Array<Tuple<String,String>> {  // TypeId(108)
+struct core:prelude//Array<Tuple<String,String>> {  // TypeId(136)
     mut repr: ref builtin::array<Tuple<String,String>>,
     mut used: i32,
 }
 
-variant core:prelude/types.wado//Option<Array<i32>> {  // TypeId(109)
-    Some(ref "core:prelude//Array<i32>"),
-    None,
-}
-
-variant core:prelude/types.wado//Result<Array<String>,DeserializeError> {  // TypeId(110)
-    Ok(ref "core:prelude//Array<String>"),
+variant core:prelude/types.wado//Result<Array<Inner>,DeserializeError> {  // TypeId(137)
+    Ok(ref "core:prelude//Array<Inner>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Array<String>,DeserializeError>::Ok {  // TypeId(111)
+struct core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Ok {  // TypeId(138)
     discriminant: i32,
-    payload_0: ref "core:prelude//Array<String>",
+    payload_0: ref "core:prelude//Array<Inner>",
 }
 
-struct core:prelude/types.wado//Result<Array<String>,DeserializeError>::Err {  // TypeId(112)
+struct core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Err {  // TypeId(139)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(113)
+variant core:prelude/types.wado//Option<Array<i32>> {  // TypeId(140)
+    Some(ref "core:prelude//Array<i32>"),
+    None,
+}
 
-enum wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//enum:Direction { North = 0, South = 1, East = 2, West = 3 };  // TypeId(114)
+variant core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError> {  // TypeId(141)
+    Ok(ref "core:prelude//Array<Option<i32>>"),
+    Err(ref "core:serde//DeserializeError"),
+}
 
-enum core:prelude/traits.wado//enum:Ordering { Less = 0, Equal = 1, Greater = 2 };  // TypeId(115)
+struct core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Ok {  // TypeId(142)
+    discriminant: i32,
+    payload_0: ref "core:prelude//Array<Option<i32>>",
+}
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(116)
+struct core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Err {  // TypeId(143)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
 
-type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(117)
+variant core:prelude/types.wado//Result<Array<String>,DeserializeError> {  // TypeId(144)
+    Ok(ref "core:prelude//Array<String>"),
+    Err(ref "core:serde//DeserializeError"),
+}
 
-struct canonical//CanonicalClosure_0 {  // TypeId(118)
+struct core:prelude/types.wado//Result<Array<String>,DeserializeError>::Ok {  // TypeId(145)
+    discriminant: i32,
+    payload_0: ref "core:prelude//Array<String>",
+}
+
+struct core:prelude/types.wado//Result<Array<String>,DeserializeError>::Err {  // TypeId(146)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError> {  // TypeId(147)
+    Ok(ref null "core:prelude//Array<i32>"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError>::Ok {  // TypeId(148)
+    discriminant: i32,
+    payload_0: ref null "core:prelude//Array<i32>",
+}
+
+struct core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError>::Err {  // TypeId(149)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(150)
+
+enum wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//enum:Direction { North = 0, South = 1, East = 2, West = 3 };  // TypeId(151)
+
+enum core:prelude/traits.wado//enum:Ordering { Less = 0, Equal = 1, Greater = 2 };  // TypeId(152)
+
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(153)
+
+type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(154)
+
+struct canonical//CanonicalClosure_0 {  // TypeId(155)
     env: ref null struct,
     func: ref "functype/$canonical_closure_fn_0",
 }
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(119)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(156)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(120)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(157)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(121)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(158)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(122)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(159)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(123)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(160)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(124)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(161)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(125)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(162)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(126)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(163)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_0_full_struct_roundtrip_with_all_fields" = fn();  // TypeId(127)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_0_full_struct_roundtrip_with_all_fields" = fn();  // TypeId(164)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_1_full_struct_roundtrip_with_none_fields" = fn();  // TypeId(128)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_1_full_struct_roundtrip_with_none_fields" = fn();  // TypeId(165)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_2_nested_struct_roundtrip" = fn();  // TypeId(129)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_2_nested_struct_roundtrip" = fn();  // TypeId(166)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_3_array_of_structs_roundtrip" = fn();  // TypeId(130)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_3_array_of_structs_roundtrip" = fn();  // TypeId(167)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_4_empty_array_roundtrip" = fn();  // TypeId(131)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_4_empty_array_roundtrip" = fn();  // TypeId(168)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_5_result_ok_roundtrip" = fn();  // TypeId(132)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_5_result_ok_roundtrip" = fn();  // TypeId(169)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_6_result_err_roundtrip" = fn();  // TypeId(133)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_6_result_err_roundtrip" = fn();  // TypeId(170)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_7_treemap_string_values_roundtrip" = fn();  // TypeId(134)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_7_treemap_string_values_roundtrip" = fn();  // TypeId(171)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_8_treemap_i32_values_roundtrip" = fn();  // TypeId(135)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_8_treemap_i32_values_roundtrip" = fn();  // TypeId(172)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_9_empty_treemap_roundtrip" = fn();  // TypeId(136)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_9_empty_treemap_roundtrip" = fn();  // TypeId(173)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_10_enum_roundtrip" = fn();  // TypeId(137)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_10_enum_roundtrip" = fn();  // TypeId(174)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_11_all_enum_variants_roundtrip" = fn();  // TypeId(138)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_11_all_enum_variants_roundtrip" = fn();  // TypeId(175)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_12_variant_unit_case_roundtrip" = fn();  // TypeId(139)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_12_variant_unit_case_roundtrip" = fn();  // TypeId(176)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_13_variant_payload_f64_roundtrip" = fn();  // TypeId(140)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_13_variant_payload_f64_roundtrip" = fn();  // TypeId(177)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_14_variant_payload_struct_roundtrip" = fn();  // TypeId(141)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_14_variant_payload_struct_roundtrip" = fn();  // TypeId(178)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_15_struct_with_treemap_field_roundtrip" = fn();  // TypeId(142)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_15_struct_with_treemap_field_roundtrip" = fn();  // TypeId(179)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_16_string_with_special_chars_roundtrip" = fn();  // TypeId(143)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_16_string_with_special_chars_roundtrip" = fn();  // TypeId(180)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_17_string_with_backslash_roundtrip" = fn();  // TypeId(144)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_17_string_with_backslash_roundtrip" = fn();  // TypeId(181)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_18_string_with_newlines_roundtrip" = fn();  // TypeId(145)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_18_string_with_newlines_roundtrip" = fn();  // TypeId(182)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_19_option_some_array_roundtrip" = fn();  // TypeId(146)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_19_option_some_array_roundtrip" = fn();  // TypeId(183)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_20_option_none_array_roundtrip" = fn();  // TypeId(147)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_20_option_none_array_roundtrip" = fn();  // TypeId(184)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_21_array_of_options_roundtrip" = fn();  // TypeId(148)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_21_array_of_options_roundtrip" = fn();  // TypeId(185)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/_fullstruct_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(149)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/_fullstruct_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(186)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/_inner_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(150)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/_inner_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(187)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/_outer_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(151)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/_outer_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(188)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/_config_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(152)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/_config_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(189)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_0_full_struct_roundtrip_with_all_fields" = fn();  // TypeId(153)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_0_full_struct_roundtrip_with_all_fields" = fn();  // TypeId(190)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_1_full_struct_roundtrip_with_none_fields" = fn();  // TypeId(154)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_1_full_struct_roundtrip_with_none_fields" = fn();  // TypeId(191)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_2_nested_struct_roundtrip" = fn();  // TypeId(155)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_2_nested_struct_roundtrip" = fn();  // TypeId(192)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_3_array_of_structs_roundtrip" = fn();  // TypeId(156)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_3_array_of_structs_roundtrip" = fn();  // TypeId(193)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_4_empty_array_roundtrip" = fn();  // TypeId(157)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_4_empty_array_roundtrip" = fn();  // TypeId(194)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_5_result_ok_roundtrip" = fn();  // TypeId(158)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_5_result_ok_roundtrip" = fn();  // TypeId(195)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_6_result_err_roundtrip" = fn();  // TypeId(159)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_6_result_err_roundtrip" = fn();  // TypeId(196)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_7_treemap_string_values_roundtrip" = fn();  // TypeId(160)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_7_treemap_string_values_roundtrip" = fn();  // TypeId(197)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_8_treemap_i32_values_roundtrip" = fn();  // TypeId(161)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_8_treemap_i32_values_roundtrip" = fn();  // TypeId(198)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_9_empty_treemap_roundtrip" = fn();  // TypeId(162)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_9_empty_treemap_roundtrip" = fn();  // TypeId(199)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_10_enum_roundtrip" = fn();  // TypeId(163)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_10_enum_roundtrip" = fn();  // TypeId(200)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_11_all_enum_variants_roundtrip" = fn();  // TypeId(164)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_11_all_enum_variants_roundtrip" = fn();  // TypeId(201)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_12_variant_unit_case_roundtrip" = fn();  // TypeId(165)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_12_variant_unit_case_roundtrip" = fn();  // TypeId(202)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_13_variant_payload_f64_roundtrip" = fn();  // TypeId(166)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_13_variant_payload_f64_roundtrip" = fn();  // TypeId(203)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_14_variant_payload_struct_roundtrip" = fn();  // TypeId(167)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_14_variant_payload_struct_roundtrip" = fn();  // TypeId(204)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_15_struct_with_treemap_field_roundtrip" = fn();  // TypeId(168)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_15_struct_with_treemap_field_roundtrip" = fn();  // TypeId(205)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_16_string_with_special_chars_roundtrip" = fn();  // TypeId(169)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_16_string_with_special_chars_roundtrip" = fn();  // TypeId(206)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_17_string_with_backslash_roundtrip" = fn();  // TypeId(170)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_17_string_with_backslash_roundtrip" = fn();  // TypeId(207)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_18_string_with_newlines_roundtrip" = fn();  // TypeId(171)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_18_string_with_newlines_roundtrip" = fn();  // TypeId(208)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_19_option_some_array_roundtrip" = fn();  // TypeId(172)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_19_option_some_array_roundtrip" = fn();  // TypeId(209)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_20_option_none_array_roundtrip" = fn();  // TypeId(173)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_20_option_none_array_roundtrip" = fn();  // TypeId(210)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_21_array_of_options_roundtrip" = fn();  // TypeId(174)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__cm_export____test_21_array_of_options_roundtrip" = fn();  // TypeId(211)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__initialize_module" = fn();  // TypeId(175)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__initialize_module" = fn();  // TypeId(212)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(176)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(213)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(177)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(214)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(178)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(215)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(179)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(216)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(180)
+type "functype//core:internal/unreachable" = fn();  // TypeId(217)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(181)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(218)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(182)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(219)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(183)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(220)
 
-type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(184)
+type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(221)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(185)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(222)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(186)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(223)
 
-type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(187)
+type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(224)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(188)
+type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(225)
 
-type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(189)
+type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(226)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(190)
+type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(227)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(191)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(228)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(192)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(229)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(193)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(230)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(194)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(231)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(195)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(232)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(196)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(233)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(197)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(234)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(198)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(235)
 
-type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(199)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(236)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(200)
+type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(237)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(201)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(238)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(202)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(239)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(203)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(240)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(204)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(241)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(205)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(242)
 
-type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(206)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(243)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(207)
+type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(244)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(208)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(245)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(209)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(246)
 
-type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(210)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(247)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(211)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(248)
 
-type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(212)
+type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(249)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(213)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(250)
 
-type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(214)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(251)
 
-type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(215)
+type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(252)
 
-type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(216)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(253)
 
-type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(217)
+type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(254)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(218)
+type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(255)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(219)
+type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(256)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(220)
+type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(257)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(221)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(258)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(222)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(259)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(223)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(260)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(224)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(261)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(225)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(262)
 
-type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,i32>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,i32>>") -> ref null "core:collections//TreeMapEntry<String,i32>";  // TypeId(226)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(263)
 
-type "functype//core:prelude/array.wado/Array<Option<i32>>::push" = fn(ref "core:prelude//Array<Option<i32>>", ref "core:prelude/types.wado//Option<i32>");  // TypeId(227)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(264)
 
-type "functype//core:prelude/array.wado/Array<Option<i32>>::grow" = fn(ref "core:prelude//Array<Option<i32>>");  // TypeId(228)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(265)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(229)
+type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,i32>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,i32>>") -> ref null "core:collections//TreeMapEntry<String,i32>";  // TypeId(266)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(230)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<Option<i32>>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>";  // TypeId(267)
 
-type "functype//core:prelude/array.wado/ArrayIter<Option<i32>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Option<i32>>") -> ref null "core:prelude/types.wado//Option<i32>";  // TypeId(231)
+type "functype//core:prelude/array.wado/Array<Option<i32>>::push" = fn(ref "core:prelude//Array<Option<i32>>", ref "core:prelude/types.wado//Option<i32>");  // TypeId(268)
 
-type "functype//core:prelude/array.wado/Array<i32>::push" = fn(ref "core:prelude//Array<i32>", i32);  // TypeId(232)
+type "functype//core:prelude/array.wado/Array<Option<i32>>::grow" = fn(ref "core:prelude//Array<Option<i32>>");  // TypeId(269)
 
-type "functype//core:prelude/array.wado/Array<i32>::grow" = fn(ref "core:prelude//Array<i32>");  // TypeId(233)
+type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<Option<i32>>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>";  // TypeId(270)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(234)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(271)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/TreeMap<String,i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>";  // TypeId(235)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(272)
 
-type "functype//core:collections/TreeMap<String,i32>::insert" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String", i32);  // TypeId(236)
+type "functype//core:prelude/array.wado/ArrayIter<Option<i32>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Option<i32>>") -> ref null "core:prelude/types.wado//Option<i32>";  // TypeId(273)
 
-type "functype//core:collections/TreeMap<String,i32>::insert_node" = fn(ref "core:collections//TreeMap<String,i32>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(237)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<Array<i32>>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError>";  // TypeId(274)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,i32>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,i32>>", ref "core:collections//TreeMapEntry<String,i32>");  // TypeId(238)
+type "functype//core:prelude/array.wado/Array<i32>::push" = fn(ref "core:prelude//Array<i32>", i32);  // TypeId(275)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,i32>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,i32>>");  // TypeId(239)
+type "functype//core:prelude/array.wado/Array<i32>::grow" = fn(ref "core:prelude//Array<i32>");  // TypeId(276)
 
-type "functype//core:collections/TreeMap<String,i32>::find_index" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(240)
+type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(277)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<TreeMap<String,i32>>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:collections//TreeMap<String,i32>") -> ref null "core:serde//SerializeError";  // TypeId(241)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(278)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(242)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Config^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Config,DeserializeError>";  // TypeId(279)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,i32>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,i32>>") -> ref null "tuple//[String, i32]";  // TypeId(243)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/TreeMap<String,i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>";  // TypeId(280)
 
-type "functype//core:collections/TreeMap<String,i32>::entries" = fn(ref "core:collections//TreeMap<String,i32>") -> ref "core:prelude//Array<Tuple<String,i32>>";  // TypeId(244)
+type "functype//core:collections/TreeMap<String,i32>::insert" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String", i32);  // TypeId(281)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,i32>>::push" = fn(ref "core:prelude//Array<Tuple<String,i32>>", ref "tuple//[String, i32]");  // TypeId(245)
+type "functype//core:collections/TreeMap<String,i32>::insert_node" = fn(ref "core:collections//TreeMap<String,i32>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(282)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,i32>>::grow" = fn(ref "core:prelude//Array<Tuple<String,i32>>");  // TypeId(246)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,i32>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,i32>>", ref "core:collections//TreeMapEntry<String,i32>");  // TypeId(283)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Shape^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Shape,DeserializeError>";  // TypeId(247)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,i32>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,i32>>");  // TypeId(284)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Inner,DeserializeError>";  // TypeId(248)
+type "functype//core:collections/TreeMap<String,i32>::find_index" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(285)
 
-type "functype//core:json/JsonVariantSerializer^SerializeVariant::payload<Inner>" = fn(ref "core:json//JsonVariantSerializer", ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner") -> ref null "core:serde//SerializeError";  // TypeId(249)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<TreeMap<String,i32>>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:collections//TreeMap<String,i32>") -> ref null "core:serde//SerializeError";  // TypeId(286)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<String>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(250)
+type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(287)
 
-type "functype//core:prelude/array.wado/Array<Direction>::push" = fn(ref "core:prelude//Array<Direction>", "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//enum:Direction");  // TypeId(251)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,i32>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,i32>>") -> ref null "tuple//[String, i32]";  // TypeId(288)
 
-type "functype//core:prelude/array.wado/Array<Direction>::grow" = fn(ref "core:prelude//Array<Direction>");  // TypeId(252)
+type "functype//core:collections/TreeMap<String,i32>::entries" = fn(ref "core:collections//TreeMap<String,i32>") -> ref "core:prelude//Array<Tuple<String,i32>>";  // TypeId(289)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Direction^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Direction,DeserializeError>";  // TypeId(253)
+type "functype//core:prelude/array.wado/Array<Tuple<String,i32>>::push" = fn(ref "core:prelude//Array<Tuple<String,i32>>", ref "tuple//[String, i32]");  // TypeId(290)
 
-type "functype//core:collections/TreeMap<String,i32>^IndexValue<K>::index_value" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(254)
+type "functype//core:prelude/array.wado/Array<Tuple<String,i32>>::grow" = fn(ref "core:prelude//Array<Tuple<String,i32>>");  // TypeId(291)
 
-type "functype//core:collections/TreeMap<String,String>^IndexValue<K>::index_value" = fn(ref "core:collections//TreeMap<String,String>", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(255)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Shape^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Shape,DeserializeError>";  // TypeId(292)
 
-type "functype//core:collections/TreeMap<String,String>::find_index" = fn(ref "core:collections//TreeMap<String,String>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(256)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Inner,DeserializeError>";  // TypeId(293)
 
-type "functype//core:collections/TreeMap<String,String>::insert" = fn(ref "core:collections//TreeMap<String,String>", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(257)
+type "functype//core:json/JsonVariantSerializer^SerializeVariant::payload<Inner>" = fn(ref "core:json//JsonVariantSerializer", ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner") -> ref null "core:serde//SerializeError";  // TypeId(294)
 
-type "functype//core:collections/TreeMap<String,String>::insert_node" = fn(ref "core:collections//TreeMap<String,String>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(258)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<String>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(295)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,String>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,String>>", ref "core:collections//TreeMapEntry<String,String>");  // TypeId(259)
+type "functype//core:prelude/array.wado/Array<Direction>::push" = fn(ref "core:prelude//Array<Direction>", "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//enum:Direction");  // TypeId(296)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,String>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,String>>");  // TypeId(260)
+type "functype//core:prelude/array.wado/Array<Direction>::grow" = fn(ref "core:prelude//Array<Direction>");  // TypeId(297)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::value<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(261)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Direction^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Direction,DeserializeError>";  // TypeId(298)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,String>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,String>>") -> ref null "tuple//[String, String]";  // TypeId(262)
+type "functype//core:collections/TreeMap<String,i32>^IndexValue<K>::index_value" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(299)
 
-type "functype//core:collections/TreeMap<String,String>::entries" = fn(ref "core:collections//TreeMap<String,String>") -> ref "core:prelude//Array<Tuple<String,String>>";  // TypeId(263)
+type "functype//core:collections/TreeMap<String,String>^IndexValue<K>::index_value" = fn(ref "core:collections//TreeMap<String,String>", ref "core:prelude/string.wado//String") -> ref "core:prelude/string.wado//String";  // TypeId(300)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,String>>::push" = fn(ref "core:prelude//Array<Tuple<String,String>>", ref "tuple//[String, String]");  // TypeId(264)
+type "functype//core:collections/TreeMap<String,String>::find_index" = fn(ref "core:collections//TreeMap<String,String>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(301)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,String>>::grow" = fn(ref "core:prelude//Array<Tuple<String,String>>");  // TypeId(265)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/TreeMap<String,String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>";  // TypeId(302)
 
-type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,String>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,String>>") -> ref null "core:collections//TreeMapEntry<String,String>";  // TypeId(266)
+type "functype//core:collections/TreeMap<String,String>::insert" = fn(ref "core:collections//TreeMap<String,String>", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(303)
 
-type "functype//core:json/JsonVariantSerializer^SerializeVariant::payload<String>" = fn(ref "core:json//JsonVariantSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(267)
+type "functype//core:collections/TreeMap<String,String>::insert_node" = fn(ref "core:collections//TreeMap<String,String>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(304)
 
-type "functype//core:prelude/array.wado/Array<Inner>::push" = fn(ref "core:prelude//Array<Inner>", ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner");  // TypeId(268)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,String>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,String>>", ref "core:collections//TreeMapEntry<String,String>");  // TypeId(305)
 
-type "functype//core:prelude/array.wado/Array<Inner>::grow" = fn(ref "core:prelude//Array<Inner>");  // TypeId(269)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,String>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,String>>");  // TypeId(306)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Inner>" = fn(ref "core:json//JsonSeqSerializer", ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner") -> ref null "core:serde//SerializeError";  // TypeId(270)
+type "functype//core:json/JsonMapSerializer^SerializeMap::value<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(307)
 
-type "functype//core:prelude/array.wado/ArrayIter<Inner>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Inner>") -> ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner";  // TypeId(271)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,String>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,String>>") -> ref null "tuple//[String, String]";  // TypeId(308)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<Inner>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner") -> ref null "core:serde//SerializeError";  // TypeId(272)
+type "functype//core:collections/TreeMap<String,String>::entries" = fn(ref "core:collections//TreeMap<String,String>") -> ref "core:prelude//Array<Tuple<String,String>>";  // TypeId(309)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";  // TypeId(273)
+type "functype//core:prelude/array.wado/Array<Tuple<String,String>>::push" = fn(ref "core:prelude//Array<Tuple<String,String>>", ref "tuple//[String, String]");  // TypeId(310)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Array<String>,DeserializeError>";  // TypeId(274)
+type "functype//core:prelude/array.wado/Array<Tuple<String,String>>::grow" = fn(ref "core:prelude//Array<Tuple<String,String>>");  // TypeId(311)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<Array<String>>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude//Array<String>") -> ref null "core:serde//SerializeError";  // TypeId(275)
+type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,String>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,String>>") -> ref null "core:collections//TreeMapEntry<String,String>";  // TypeId(312)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<String>" = fn(ref "core:json//JsonSeqSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(276)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Result<i32,String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>";  // TypeId(313)
 
-type "functype//core:prelude/array.wado/ArrayIter<String>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<String>") -> ref null "core:prelude/string.wado//String";  // TypeId(277)
+type "functype//core:json/JsonVariantSerializer^SerializeVariant::payload<String>" = fn(ref "core:json//JsonVariantSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(314)
 
-type "functype//core:prelude/array.wado/Array<String>::push" = fn(ref "core:prelude//Array<String>", ref "core:prelude/string.wado//String");  // TypeId(278)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<Inner>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>";  // TypeId(315)
 
-type "functype//core:prelude/array.wado/Array<String>::grow" = fn(ref "core:prelude//Array<String>");  // TypeId(279)
+type "functype//core:prelude/array.wado/Array<Inner>::push" = fn(ref "core:prelude//Array<Inner>", ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner");  // TypeId(316)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(280)
+type "functype//core:prelude/array.wado/Array<Inner>::grow" = fn(ref "core:prelude//Array<Inner>");  // TypeId(317)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(281)
+type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<Inner>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>";  // TypeId(318)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(282)
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Inner>" = fn(ref "core:json//JsonSeqSerializer", ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner") -> ref null "core:serde//SerializeError";  // TypeId(319)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(283)
+type "functype//core:prelude/array.wado/ArrayIter<Inner>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Inner>") -> ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner";  // TypeId(320)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(284)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Outer^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Outer,DeserializeError>";  // TypeId(321)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(285)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<Inner>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner") -> ref null "core:serde//SerializeError";  // TypeId(322)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(286)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<FullStruct,DeserializeError>";  // TypeId(323)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(287)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";  // TypeId(324)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(288)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Array<String>,DeserializeError>";  // TypeId(325)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(289)
+type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<String>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";  // TypeId(326)
 
-type "functype//core:json/core/json/from_string<Array<Option<i32>>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude//Array<Option<i32>>", ref null "core:serde//DeserializeError"];  // TypeId(290)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<Array<String>>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude//Array<String>") -> ref null "core:serde//SerializeError";  // TypeId(327)
 
-type "functype//core:json/core/json/to_string<Array<Option<i32>>>" = fn(ref "core:prelude//Array<Option<i32>>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(291)
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<String>" = fn(ref "core:json//JsonSeqSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(328)
 
-type "functype//core:json/core/json/from_string<Option<Array<i32>>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude//Array<i32>", ref null "core:serde//DeserializeError"];  // TypeId(292)
+type "functype//core:prelude/array.wado/ArrayIter<String>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<String>") -> ref null "core:prelude/string.wado//String";  // TypeId(329)
 
-type "functype//core:json/core/json/from_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(293)
+type "functype//core:prelude/array.wado/Array<String>::push" = fn(ref "core:prelude//Array<String>", ref "core:prelude/string.wado//String");  // TypeId(330)
 
-type "functype//core:json/core/json/to_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(294)
+type "functype//core:prelude/array.wado/Array<String>::grow" = fn(ref "core:prelude//Array<String>");  // TypeId(331)
 
-type "functype//core:json/core/json/from_string<Config>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(295)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(332)
 
-type "functype//core:json/core/json/from_string<Shape>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Shape", ref null "core:serde//DeserializeError"];  // TypeId(296)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(333)
 
-type "functype//core:json/core/json/from_string<Direction>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(297)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(334)
 
-type "functype//core:json/core/json/to_string<Direction>" = fn("wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//enum:Direction") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(298)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(335)
 
-type "functype//core:json/core/json/from_string<TreeMap<String,i32>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:collections//TreeMap<String,i32>", ref null "core:serde//DeserializeError"];  // TypeId(299)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(336)
 
-type "functype//core:json/core/json/to_string<TreeMap<String,i32>>" = fn(ref "core:collections//TreeMap<String,i32>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(300)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(337)
 
-type "functype//core:json/core/json/from_string<TreeMap<String,String>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:collections//TreeMap<String,String>", ref null "core:serde//DeserializeError"];  // TypeId(301)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(338)
 
-type "functype//core:json/core/json/to_string<TreeMap<String,String>>" = fn(ref "core:collections//TreeMap<String,String>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(302)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(339)
 
-type "functype//core:json/core/json/from_string<Result<i32,String>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/types.wado//Result<i32,String>", ref null "core:serde//DeserializeError"];  // TypeId(303)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(340)
 
-type "functype//core:json/core/json/from_string<Array<Inner>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude//Array<Inner>", ref null "core:serde//DeserializeError"];  // TypeId(304)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(341)
 
-type "functype//core:json/core/json/to_string<Array<Inner>>" = fn(ref "core:prelude//Array<Inner>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(305)
+type "functype//core:json/core/json/from_string<Array<Option<i32>>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude//Array<Option<i32>>", ref null "core:serde//DeserializeError"];  // TypeId(342)
 
-type "functype//core:json/core/json/from_string<Outer>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer", ref null "core:serde//DeserializeError"];  // TypeId(306)
+type "functype//core:json/core/json/to_string<Array<Option<i32>>>" = fn(ref "core:prelude//Array<Option<i32>>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(343)
 
-type "functype//core:json/core/json/to_string<Outer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(307)
+type "functype//core:json/core/json/from_string<Option<Array<i32>>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude//Array<i32>", ref null "core:serde//DeserializeError"];  // TypeId(344)
 
-type "functype//core:json/core/json/from_string<FullStruct>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct", ref null "core:serde//DeserializeError"];  // TypeId(308)
+type "functype//core:json/core/json/from_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(345)
 
-type "functype//core:json/core/json/to_string<FullStruct>" = fn(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(309)
+type "functype//core:json/core/json/to_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(346)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(310)
+type "functype//core:json/core/json/from_string<Config>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(347)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(311)
+type "functype//core:json/core/json/from_string<Shape>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Shape", ref null "core:serde//DeserializeError"];  // TypeId(348)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(312)
+type "functype//core:json/core/json/from_string<Direction>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(349)
 
-type "functype//core:json/JsonMapAccess^DeserializeMap::next_key_string" = fn(ref "core:json//JsonMapAccess") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(313)
+type "functype//core:json/core/json/to_string<Direction>" = fn("wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//enum:Direction") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(350)
 
-type "functype//core:json/JsonDeserializer^Deserializer::is_null" = fn(ref "core:json//JsonDeserializer") -> [i32, bool, ref null "core:serde//DeserializeError"];  // TypeId(314)
+type "functype//core:json/core/json/from_string<TreeMap<String,i32>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:collections//TreeMap<String,i32>", ref null "core:serde//DeserializeError"];  // TypeId(351)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_seq" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:json//JsonSeqAccess", ref null "core:serde//DeserializeError"];  // TypeId(315)
+type "functype//core:json/core/json/to_string<TreeMap<String,i32>>" = fn(ref "core:collections//TreeMap<String,i32>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(352)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_map" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:json//JsonMapAccess", ref null "core:serde//DeserializeError"];  // TypeId(316)
+type "functype//core:json/core/json/from_string<TreeMap<String,String>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:collections//TreeMap<String,String>", ref null "core:serde//DeserializeError"];  // TypeId(353)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<Option<i32>>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude//Array<Option<i32>>", ref null "core:serde//DeserializeError"];  // TypeId(317)
+type "functype//core:json/core/json/to_string<TreeMap<String,String>>" = fn(ref "core:collections//TreeMap<String,String>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(354)
 
-type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<Option<i32>>" = fn(ref "core:json//JsonSeqAccess") -> [i32, ref null "core:prelude/types.wado//Option<i32>", ref null "core:serde//DeserializeError"];  // TypeId(318)
+type "functype//core:json/core/json/from_string<Result<i32,String>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/types.wado//Result<i32,String>", ref null "core:serde//DeserializeError"];  // TypeId(355)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<Array<i32>>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude//Array<i32>", ref null "core:serde//DeserializeError"];  // TypeId(319)
+type "functype//core:json/core/json/from_string<Array<Inner>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude//Array<Inner>", ref null "core:serde//DeserializeError"];  // TypeId(356)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude//Array<i32>", ref null "core:serde//DeserializeError"];  // TypeId(320)
+type "functype//core:json/core/json/to_string<Array<Inner>>" = fn(ref "core:prelude//Array<Inner>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(357)
 
-type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>" = fn(ref "core:json//JsonSeqAccess") -> [i32, ref null "core:prelude/types.wado//Option<i32>", ref null "core:serde//DeserializeError"];  // TypeId(321)
+type "functype//core:json/core/json/from_string<Outer>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer", ref null "core:serde//DeserializeError"];  // TypeId(358)
 
-type "functype//core:prelude/array.wado/ArrayIter<i32>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<i32>") -> [i32, i32];  // TypeId(322)
+type "functype//core:json/core/json/to_string<Outer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(359)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Config^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(323)
+type "functype//core:json/core/json/from_string<FullStruct>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct", ref null "core:serde//DeserializeError"];  // TypeId(360)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/TreeMap<String,String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:collections//TreeMap<String,String>", ref null "core:serde//DeserializeError"];  // TypeId(324)
+type "functype//core:json/core/json/to_string<FullStruct>" = fn(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(361)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Result<i32,String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude/types.wado//Result<i32,String>", ref null "core:serde//DeserializeError"];  // TypeId(325)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(362)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<Inner>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude//Array<Inner>", ref null "core:serde//DeserializeError"];  // TypeId(326)
+type "functype//core:json/JsonMapAccess^DeserializeMap::next_key_string" = fn(ref "core:json//JsonMapAccess") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(363)
 
-type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<Inner>" = fn(ref "core:json//JsonSeqAccess") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner", ref null "core:serde//DeserializeError"];  // TypeId(327)
+type "functype//core:json/JsonDeserializer^Deserializer::is_null" = fn(ref "core:json//JsonDeserializer") -> [i32, bool, ref null "core:serde//DeserializeError"];  // TypeId(364)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Outer^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer", ref null "core:serde//DeserializeError"];  // TypeId(328)
+type "functype//core:json/JsonDeserializer^Deserializer::begin_seq" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:json//JsonSeqAccess", ref null "core:serde//DeserializeError"];  // TypeId(365)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct", ref null "core:serde//DeserializeError"];  // TypeId(329)
+type "functype//core:json/JsonDeserializer^Deserializer::begin_map" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:json//JsonMapAccess", ref null "core:serde//DeserializeError"];  // TypeId(366)
 
-type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<String>" = fn(ref "core:json//JsonSeqAccess") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(330)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude//Array<i32>", ref null "core:serde//DeserializeError"];  // TypeId(367)
 
-type "functype//core:json/core/json/to_string<Option<Array<i32>>>" = fn(ref null "core:prelude//Array<i32>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(331)
+type "functype//core:prelude/array.wado/ArrayIter<i32>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<i32>") -> [i32, i32];  // TypeId(368)
 
-type "functype//core:json/core/json/to_string<Config>" = fn(ref "core:collections//TreeMap<String,i32>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(332)
+type "functype//core:json/core/json/to_string<Option<Array<i32>>>" = fn(ref null "core:prelude//Array<i32>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(369)
 
-type "functype//core:json/core/json/to_string<Shape>" = fn(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Shape") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(333)
+type "functype//core:json/core/json/to_string<Config>" = fn(ref "core:collections//TreeMap<String,i32>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(370)
 
-type "functype//core:json/core/json/to_string<Result<i32,String>>" = fn(ref "core:prelude/types.wado//Result<i32,String>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(334)
+type "functype//core:json/core/json/to_string<Shape>" = fn(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Shape") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(371)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(335)
+type "functype//core:json/core/json/to_string<Result<i32,String>>" = fn(ref "core:prelude/types.wado//Result<i32,String>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(372)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(336)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(373)
 
-type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(337)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(374)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(338)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(375)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(339)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(376)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(340)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(377)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(341)
+type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(378)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(342)
+type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(379)
 
-type "functype//core:prelude/array.wado/Array<Option<i32>>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<Option<i32>>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(343)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(380)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Option<i32>>" = fn(ref "core:json//JsonSeqSerializer", ref "core:prelude/types.wado//Option<i32>") -> ref null "core:serde//SerializeError";  // TypeId(344)
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(381)
 
-type "functype//core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<i32>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(345)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(382)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<i32>" = fn(ref "core:json//JsonSeqSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(346)
+type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(383)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Config^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(347)
+type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(384)
 
-type "functype//core:collections/TreeMap<String,i32>^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(348)
+type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(385)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::value<i32>" = fn(ref "core:json//JsonMapSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(349)
+type "functype//core:prelude/array.wado/Array<Option<i32>>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<Option<i32>>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(386)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Shape^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Shape", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(350)
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<Option<i32>>" = fn(ref "core:json//JsonSeqSerializer", ref "core:prelude/types.wado//Option<i32>") -> ref null "core:serde//SerializeError";  // TypeId(387)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<f64>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(351)
+type "functype//core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<i32>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(388)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(352)
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<i32>" = fn(ref "core:json//JsonSeqSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(389)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<i32>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(353)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Config^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(390)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<bool>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(354)
+type "functype//core:collections/TreeMap<String,i32>^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(391)
 
-type "functype//core:json/JsonVariantSerializer^SerializeVariant::payload<f64>" = fn(ref "core:json//JsonVariantSerializer", f64) -> ref null "core:serde//SerializeError";  // TypeId(355)
+type "functype//core:json/JsonMapSerializer^SerializeMap::value<i32>" = fn(ref "core:json//JsonMapSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(392)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Direction^Serialize::serialize<JsonSerializer>" = fn("wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//enum:Direction", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(356)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Shape^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Shape", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(393)
 
-type "functype//core:collections/TreeMap<String,String>^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,String>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(357)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<f64>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(394)
 
-type "functype//core:prelude/types.wado/Result<i32,String>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude/types.wado//Result<i32,String>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(358)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(395)
 
-type "functype//core:prelude/array.wado/Array<String>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<String>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(359)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<i32>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(396)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<Option<String>>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref null "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(360)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<bool>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(397)
 
-type "functype//core:json/JsonVariantSerializer^SerializeVariant::payload<i32>" = fn(ref "core:json//JsonVariantSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(361)
+type "functype//core:json/JsonVariantSerializer^SerializeVariant::payload<f64>" = fn(ref "core:json//JsonVariantSerializer", f64) -> ref null "core:serde//SerializeError";  // TypeId(398)
 
-type "functype//core:prelude/array.wado/Array<Inner>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<Inner>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(362)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Direction^Serialize::serialize<JsonSerializer>" = fn("wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//enum:Direction", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(399)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Outer^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(363)
+type "functype//core:collections/TreeMap<String,String>^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,String>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(400)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(364)
+type "functype//core:prelude/types.wado/Result<i32,String>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude/types.wado//Result<i32,String>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(401)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<Option<i32>>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude/types.wado//Option<i32>") -> ref null "core:serde//SerializeError";  // TypeId(365)
+type "functype//core:prelude/array.wado/Array<String>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<String>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(402)
 
-type "functype//core:json/JsonSerializer^Serializer::begin_variant" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref null "core:json//JsonVariantSerializer", ref null "core:serde//SerializeError"];  // TypeId(366)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<Option<String>>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref null "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(403)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(367)
+type "functype//core:json/JsonVariantSerializer^SerializeVariant::payload<i32>" = fn(ref "core:json//JsonVariantSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(404)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_variant" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>";  // TypeId(368)
+type "functype//core:prelude/array.wado/Array<Inner>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<Inner>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(405)
 
-type "functype//core:collections/TreeMap<String,i32>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(369)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Outer^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(406)
 
-type "functype//core:collections/TreeMap<String,i32>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(370)
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(407)
 
-type "functype//core:collections/TreeMap<String,String>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(371)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<Option<i32>>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude/types.wado//Option<i32>") -> ref null "core:serde//SerializeError";  // TypeId(408)
 
-type "functype//core:collections/TreeMap<String,String>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(372)
+type "functype//core:json/JsonSerializer^Serializer::begin_variant" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref null "core:json//JsonVariantSerializer", ref null "core:serde//SerializeError"];  // TypeId(409)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(373)
+type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(410)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__Closure_3::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(374)
+type "functype//core:json/JsonDeserializer^Deserializer::begin_variant" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>";  // TypeId(411)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__Closure_4::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(375)
+type "functype//core:collections/TreeMap<String,i32>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(412)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__Closure_5::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(376)
+type "functype//core:collections/TreeMap<String,i32>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(413)
+
+type "functype//core:collections/TreeMap<String,String>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(414)
+
+type "functype//core:collections/TreeMap<String,String>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(415)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(416)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__Closure_3::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(417)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__Closure_4::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(418)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__Closure_5::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(419)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -5507,6 +5704,67 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l348: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l348;
+                };
+            };
+        };
+    }
+}
+
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
+        return 1;
+    }
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l354: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l354;
+            };
+        };
+    };
+    return n;
+}
+
 fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     let mark: i32;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -5535,36 +5793,16 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
-    }
-    return ((97 + v) - 10) & 255;
-}
-
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b354: block {
-        l355: loop {
+    b360: block {
+        l361: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -5585,23 +5823,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b354;
+                break b360;
             }
-            continue l355;
+            continue l361;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -5609,581 +5849,752 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/from_string<Array<Option<i32>>>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "core:prelude//Array<Option<i32>>";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "core:prelude//Array<Option<i32>>";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "core:prelude//Array<Option<i32>>";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<Option<i32>>^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:prelude//Array<Option<i32>>"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<Option<i32>>^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude//Array<Option<i32>>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude//Array<Option<i32>>" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Array<Option<i32>>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:prelude/array.wado/Array<Option<i32>>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:prelude/array.wado/Array<Option<i32>>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<Option<Array<i32>>>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref null "core:prelude//Array<i32>";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref null "core:prelude//Array<i32>";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "core:prelude//Array<i32>";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<Array<i32>>^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:prelude/types.wado//Option<Array<i32>>"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<Array<i32>>^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError>::Ok"(__match_scrut_0) -> ref null "core:prelude//Array<i32>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError>::Err"(__match_scrut_0) -> ref null "core:prelude//Array<i32>" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Option<Array<i32>>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
-    let __local_6: ref "core:json//JsonSerializer";
-    let __local_7: ref "core:prelude//Array<i32>";
-    let __local_8: ref null "core:prelude//Array<i32>";
+    let __local_3: ref "core:serde//SerializeError";
+    let __local_5: ref "core:json//JsonSerializer";
+    let __local_6: ref "core:prelude//Array<i32>";
+    let __local_7: ref null "core:prelude//Array<i32>";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = __inline_Option_Array_i32___Serialize__serialize_JsonSerializer__0: block -> ref null "core:serde//SerializeError" {
-        __local_6 = ser;
-        __local_8 = value_copy "core:prelude/types.wado//Option<Array<i32>>"(value);
-        if ref.is_null(__local_8) == 0 {
-            __local_7 = ref.as_non_null(__local_8);
-            break __inline_Option_Array_i32___Serialize__serialize_JsonSerializer__0: "core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>"(__local_7, __local_6.buf);
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = __inline_Option_Array_i32___Serialize__serialize_JsonSerializer__0: block -> ref null "core:serde//SerializeError" {
+        __local_5 = ser;
+        __local_7 = value_copy "core:prelude/types.wado//Option<Array<i32>>"(value);
+        if ref.is_null(__local_7) == 0 {
+            __local_6 = ref.as_non_null(__local_7);
+            break __inline_Option_Array_i32___Serialize__serialize_JsonSerializer__0: "core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>"(__local_6, __local_5.buf);
         }
-        __inline_JsonSerializer_Serializer__serialize_null_1: block -> ref null "core:serde//SerializeError" {
-            "core:prelude/string.wado/String::push"(__local_6.buf, 110);
-            "core:prelude/string.wado/String::push"(__local_6.buf, 117);
-            "core:prelude/string.wado/String::push"(__local_6.buf, 108);
-            "core:prelude/string.wado/String::push"(__local_6.buf, 108);
-            break __inline_JsonSerializer_Serializer__serialize_null_1: ref.null none;
+        __inline_JsonSerializer_Serializer__serialize_null_0: block -> ref null "core:serde//SerializeError" {
+            "core:prelude/string.wado/String::push"(__local_5.buf, 110);
+            "core:prelude/string.wado/String::push"(__local_5.buf, 117);
+            "core:prelude/string.wado/String::push"(__local_5.buf, 108);
+            "core:prelude/string.wado/String::push"(__local_5.buf, 108);
+            break __inline_JsonSerializer_Serializer__serialize_null_0: ref.null none;
         };
         break __inline_Option_Array_i32___Serialize__serialize_JsonSerializer__0;
     };
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<String>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+    let __local_2: ref "core:prelude/string.wado//String";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "core:prelude/string.wado//String";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/String^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r) {
-        v = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r).payload_0);
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:prelude/string.wado//String"(let __match_scrut_0: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/String^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+        let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+        let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r).payload_0);
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<String>"(value) {
-    let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
-    ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = __inline_JsonSerializer_Serializer__serialize_string_1: block -> ref null "core:serde//SerializeError" {
-        "core:json/write_escaped_string"(ser.buf, value);
-        break __inline_JsonSerializer_Serializer__serialize_string_1: ref.null none;
+    let __local_3: ref "core:serde//SerializeError";
+    let __sroa_ser_buf: ref "core:prelude/string.wado//String";
+    __sroa_ser_buf = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = __inline_JsonSerializer_Serializer__serialize_string_0: block -> ref null "core:serde//SerializeError" {
+        "core:json/write_escaped_string"(__sroa_ser_buf, value);
+        break __inline_JsonSerializer_Serializer__serialize_string_0: ref.null none;
     };
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
-    return 0, ser.buf, ref.null none;
+    return 0, __sroa_ser_buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<Config>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Config";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Config";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Config";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Config^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Config"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Config,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Config^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Config,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Config" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Config,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Config,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Config,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Config" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Config,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Config,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Config>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Config^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Config^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<Shape>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<Shape,DeserializeError>";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Shape";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Shape";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Shape^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<Shape,DeserializeError>::Ok"(r) {
-        v = value_copy "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Shape"(ref.cast "core:prelude/types.wado//Result<Shape,DeserializeError>::Ok"(r).payload_0);
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Shape"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Shape,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Shape^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Shape,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Shape" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Shape,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Shape,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Shape,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Shape" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Shape,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Shape,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<Shape,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<Shape,DeserializeError>::Err"(r).payload_0);
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Shape>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Shape^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Shape^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<Direction>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<Direction,DeserializeError>";
+    let __local_2: "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//enum:Direction";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//enum:Direction";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Direction^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<Direction,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<Direction,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<Direction,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Direction^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<Direction,DeserializeError>::Ok"(__match_scrut_0) -> "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//enum:Direction" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Direction,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Direction,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Direction,DeserializeError>::Err"(__match_scrut_0) -> "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//enum:Direction" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Direction,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Direction,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<Direction,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<Direction,DeserializeError>::Err"(r).payload_0);
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Direction>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Direction^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Direction^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<TreeMap<String,i32>>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>";
+    let __local_2: ref "core:collections//TreeMap<String,i32>";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "core:collections//TreeMap<String,i32>";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/TreeMap<String,i32>^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Ok"(r) {
-        v = value_copy "core:collections//TreeMap<String,i32>"(ref.cast "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Ok"(r).payload_0);
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:collections//TreeMap<String,i32>"(let __match_scrut_0: ref "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/TreeMap<String,i32>^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:collections//TreeMap<String,i32>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err"(__match_scrut_0) -> ref "core:collections//TreeMap<String,i32>" {
+        let __cast_1: ref "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err"(r).payload_0);
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<TreeMap<String,i32>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:collections/TreeMap<String,i32>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:collections/TreeMap<String,i32>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<TreeMap<String,String>>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "core:collections//TreeMap<String,String>";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "core:collections//TreeMap<String,String>";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "core:collections//TreeMap<String,String>";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/TreeMap<String,String>^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:collections//TreeMap<String,String>"(let __match_scrut_0: ref "core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/TreeMap<String,String>^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:collections//TreeMap<String,String>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>::Err"(__match_scrut_0) -> ref "core:collections//TreeMap<String,String>" {
+        let __cast_1: ref "core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<TreeMap<String,String>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:collections/TreeMap<String,String>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:collections/TreeMap<String,String>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<Result<i32,String>>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "core:prelude/types.wado//Result<i32,String>";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "core:prelude/types.wado//Result<i32,String>";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "core:prelude/types.wado//Result<i32,String>";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Result<i32,String>^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:prelude/types.wado//Result<i32,String>"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Result<i32,String>^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<i32,String>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<i32,String>" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Result<i32,String>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:prelude/types.wado/Result<i32,String>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:prelude/types.wado/Result<i32,String>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<Array<Inner>>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "core:prelude//Array<Inner>";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "core:prelude//Array<Inner>";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "core:prelude//Array<Inner>";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<Inner>^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:prelude//Array<Inner>"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<Inner>^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude//Array<Inner>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude//Array<Inner>" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Array<Inner>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:prelude/array.wado/Array<Inner>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:prelude/array.wado/Array<Inner>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<Outer>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Outer^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Outer,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Outer^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Outer,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Outer,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Outer,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Outer,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Outer,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Outer,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Outer>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Outer^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Outer^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<FullStruct>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct"(let __match_scrut_0: ref "core:prelude/types.wado//Result<FullStruct,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct" {
+        let __cast_2: ref "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct" {
+        let __cast_1: ref "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<FullStruct>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -6204,6 +6615,20 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
         __local_6 = f.buf;
         break __inline_String__internal_raw_bytes_0: __local_6.repr;
     }, offset, abs_val, digit_count);
+}
+
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
 }
 
 fn "core:prelude/primitive.wado/f64::fmt_into"(self, f) {
@@ -6464,6 +6889,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     }
 }
 
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
+}
+
 fn "core:prelude/string.wado/String::get_byte"(self, index) {
     return builtin::array_get_u8(self.repr, index);
 }
@@ -6544,7 +6983,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l452: loop {
+            l485: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -6552,7 +6991,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l452;
+                continue l485;
             };
         };
     };
@@ -6576,7 +7015,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
     __for_2: block {
         i = 0;
         block {
-            l456: loop {
+            l489: loop {
                 if i >= min_len {
                     break __for_2;
                 }
@@ -6589,7 +7028,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
                     return 2;
                 }
                 i = i + 1;
-                continue l456;
+                continue l489;
             };
         };
     };
@@ -6644,6 +7083,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -6741,10 +7229,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b473: block {
-        l474: loop {
+    b513: block {
+        l514: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b473;
+                break b513;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -6768,7 +7256,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l474;
+            continue l514;
         };
     };
     self.pos = _hfs_pos_8;
@@ -6847,11 +7335,11 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b482: block {
-        l483: loop {
+    b522: block {
+        l523: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= _licm_used_19 {
-                    break b482;
+                    break b522;
                 }
                 byte = builtin::array_get_u8(_licm_repr_20, __sroa___iter_3_index);
                 __sroa___iter_3_index = __sroa___iter_3_index + 1;
@@ -6886,7 +7374,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
                 _hfs_pos_27 = _hfs_pos_27 + 1;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l483;
+            continue l523;
         };
     };
     self.pos = _hfs_pos_27;
@@ -6905,130 +7393,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b489: block {
-        l490: loop {
-            if scan_pos >= _licm_used_90 {
-                break b489;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b529: block {
+        l530: loop {
+            if scan_pos >= _licm_used_56 {
+                break b529;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b489;
+                break b529;
             }
             scan_pos = scan_pos + 1;
-            continue l490;
+            continue l530;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -7037,22 +7497,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l497: loop {
+                l537: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l497;
+                    continue l537;
                 };
             };
         };
@@ -7060,71 +7520,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l500: loop {
+            l540: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l500;
+                continue l540;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b502: block {
-        l503: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b542: block {
+        l543: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b502;
+                break b542;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -7142,125 +7603,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l503;
+            continue l543;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -7268,87 +7672,71 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l528: loop {
+            l563: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l528;
+                continue l563;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -7403,25 +7791,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b539: block {
-        l540: loop {
+    b570: block {
+        l571: loop {
             if _hfs_pos_36 >= _licm_used_28 {
-                break b539;
+                break b570;
             }
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
                 break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr_29, __local_11);
             };
-            if (if b_1 >= 48 -> i32 {
+            if (if 48 <= b_1 -> i32 {
                 b_1 <= 57;
             } else {
                 0;
             }) {
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
-                break b539;
+                break b570;
             }
-            continue l540;
+            continue l571;
         };
     };
     self.pos = _hfs_pos_36;
@@ -7442,25 +7830,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b546: block {
-            l547: loop {
+        b577: block {
+            l578: loop {
                 if _hfs_pos_37 >= _licm_used_31 {
-                    break b546;
+                    break b577;
                 }
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
                     break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_32, __local_17);
                 };
-                if (if b_2 >= 48 -> i32 {
+                if (if 48 <= b_2 -> i32 {
                     b_2 <= 57;
                 } else {
                     0;
                 }) {
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
-                    break b546;
+                    break b577;
                 }
-                continue l547;
+                continue l578;
             };
         };
         self.pos = _hfs_pos_37;
@@ -7501,25 +7889,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b557: block {
-                l558: loop {
+            b588: block {
+                l589: loop {
                     if _hfs_pos_38 >= _licm_used_34 {
-                        break b557;
+                        break b588;
                     }
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
                         break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_35, __local_26);
                     };
-                    if (if b2 >= 48 -> i32 {
+                    if (if 48 <= b2 -> i32 {
                         b2 <= 57;
                     } else {
                         0;
                     }) {
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
-                        break b557;
+                        break b588;
                     }
-                    continue l558;
+                    continue l589;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -7613,16 +8001,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b567: block {
-        l568: loop {
+    b598: block {
+        l599: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b567;
+                break b598;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -7643,17 +8031,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b576: block {
-                        l577: loop {
+                    b607: block {
+                        l608: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b576;
+                                break b607;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -7663,9 +8051,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b576;
+                                break b607;
                             }
-                            continue l577;
+                            continue l608;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -7696,17 +8084,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b586: block {
-                            l587: loop {
+                        b617: block {
+                            l618: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b586;
+                                    break b617;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -7715,9 +8103,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b586;
+                                    break b617;
                                 }
-                                continue l587;
+                                continue l618;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -7755,9 +8143,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b567;
+                break b598;
             }
-            continue l568;
+            continue l599;
         };
     };
     self.pos = _hfs_pos_51;
@@ -7869,16 +8257,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b602: block {
-        l603: loop {
+    b633: block {
+        l634: loop {
             if _hfs_pos_57 >= _licm_used_49 {
-                break b602;
+                break b633;
             }
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_50, __local_32);
             };
-            if (if b_6 >= 48 -> i32 {
+            if (if 48 <= b_6 -> i32 {
                 b_6 <= 57;
             } else {
                 0;
@@ -7889,9 +8277,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                 total_digits = total_digits + 1;
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
-                break b602;
+                break b633;
             }
-            continue l603;
+            continue l634;
         };
     };
     self.pos = _hfs_pos_57;
@@ -7913,16 +8301,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b610: block {
-            l611: loop {
+        b641: block {
+            l642: loop {
                 if _hfs_pos_58 >= _licm_used_52 {
-                    break b610;
+                    break b641;
                 }
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
                     break __inline_String__get_byte_12: builtin::array_get_u8(_licm_repr_53, __local_38);
                 };
-                if (if b_8 >= 48 -> i32 {
+                if (if 48 <= b_8 -> i32 {
                     b_8 <= 57;
                 } else {
                     0;
@@ -7934,9 +8322,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                     total_digits = total_digits + 1;
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
-                    break b610;
+                    break b641;
                 }
-                continue l611;
+                continue l642;
             };
         };
         self.pos = _hfs_pos_58;
@@ -7978,16 +8366,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b622: block {
-                l623: loop {
+            b653: block {
+                l654: loop {
                     if _hfs_pos_59 >= _licm_used_55 {
-                        break b622;
+                        break b653;
                     }
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
                         break __inline_String__get_byte_18: builtin::array_get_u8(_licm_repr_56, __local_47);
                     };
-                    if (if b3 >= 48 -> i32 {
+                    if (if 48 <= b3 -> i32 {
                         b3 <= 57;
                     } else {
                         0;
@@ -7995,9 +8383,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                         exp = (exp * 10) + (b3 - 48);
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
-                        break b622;
+                        break b653;
                     }
-                    continue l623;
+                    continue l654;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -8047,10 +8435,10 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b633: block {
-        l634: loop {
+    b664: block {
+        l665: loop {
             if _hfs_pos_14 >= _licm_used_12 {
-                break b633;
+                break b664;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -8080,7 +8468,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
                 }
             }
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l634;
+            continue l665;
         };
     };
     self.pos = _hfs_pos_14;
@@ -8091,19 +8479,355 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
 }
 
 fn "core:json/JsonDeserializer::skip_value"(self) {
-    let b: i32;
-    let r: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let c_4: i32;
-    let kr: ref null "core:serde//DeserializeError";
-    let e_6: ref "core:serde//DeserializeError";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let vr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let c_11: i32;
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: char;
+    let __local_6: ref "core:serde//DeserializeError";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_10: ref "core:serde//DeserializeError";
+    let __local_11: char;
     let __local_12: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/format.wado//Formatter";
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i64;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i32;
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
+    let __local_20: i32;
+    let __local_21: ref "core:prelude/string.wado//String";
+    let __local_22: i64;
+    let __local_23: ref "core:prelude/string.wado//String";
+    let __local_24: i32;
+    let __local_25: ref "core:prelude/string.wado//String";
+    let __local_26: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let __local_30: ref "core:prelude/string.wado//String";
+    let __local_31: ref "core:prelude/string.wado//String";
+    let __local_32: i32;
+    let __local_33: ref "core:prelude/string.wado//String";
+    let __local_34: i64;
+    let __local_35: ref "core:prelude/string.wado//String";
+    let __local_36: i64;
+    let __local_37: ref "core:prelude/string.wado//String";
+    let __local_38: i32;
+    let __local_39: ref "core:prelude/string.wado//String";
+    let __local_40: i64;
+    let __local_43: ref "core:prelude/string.wado//String";
+    let __local_44: i64;
+    "core:json/JsonDeserializer::skip_whitespace"(self);
+    if self.pos >= __inline_String__len_0: block -> i32 {
+        __local_14 = self.input;
+        break __inline_String__len_0: __local_14.used;
+    } {
+        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_15 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_15 };
+        });
+    }
+    b = __inline_String__get_byte_2: block -> u8 {
+        __local_16 = self.input;
+        __local_17 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_16.repr, __local_17);
+    } & 255;
+    if b == 34 {
+        return "core:json/JsonDeserializer::skip_string"(self);
+        unreachable;
+    } else if b == 116 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        unreachable;
+    } else if b == 102 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        unreachable;
+    } else if b == 110 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
+        unreachable;
+    } else if b == 91 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_3: block -> i32 {
+            __local_18 = self.input;
+            break __inline_String__len_3: __local_18.used;
+        } -> i32 {
+            __inline_String__get_byte_4: block -> u8 {
+                __local_19 = self.input;
+                __local_20 = self.pos;
+                break __inline_String__get_byte_4: builtin::array_get_u8(__local_19.repr, __local_20);
+            } == 93;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l680: loop {
+                let __match_scrut_5: ref null "core:serde//DeserializeError";
+                __match_scrut_5 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_5) {
+                } else if ref.is_null(__match_scrut_5) == 0 {
+                    let __cast_4: ref null "core:serde//DeserializeError";
+                    __cast_4 = ref.as_non_null(__match_scrut_5);
+                    __local_3 = ref.as_non_null(__cast_4);
+                    return __local_3;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_5: block -> i32 {
+                    __local_21 = self.input;
+                    break __inline_String__len_5: __local_21.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
+                        __local_22 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_22 };
+                    });
+                }
+                __local_4 = __inline_String__get_byte_7: block -> u8 {
+                    __local_23 = self.input;
+                    __local_24 = self.pos;
+                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_23.repr, __local_24);
+                } & 255;
+                if __local_4 == 93 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_4 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
+                        __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
+                        __local_26 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_25, offset: __local_26 };
+                    });
+                    unreachable;
+                }
+                continue l680;
+            };
+        };
+    } else if b == 123 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_9: block -> i32 {
+            __local_27 = self.input;
+            break __inline_String__len_9: __local_27.used;
+        } -> i32 {
+            __inline_String__get_byte_10: block -> u8 {
+                __local_28 = self.input;
+                __local_29 = self.pos;
+                break __inline_String__get_byte_10: builtin::array_get_u8(__local_28.repr, __local_29);
+            } == 125;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l690: loop {
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if (if self.pos >= __inline_String__len_11: block -> i32 {
+                    __local_30 = self.input;
+                    break __inline_String__len_11: __local_30.used;
+                } -> i32 {
+                    1;
+                } else {
+                    __inline_String__get_byte_12: block -> u8 {
+                        __local_31 = self.input;
+                        __local_32 = self.pos;
+                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_31.repr, __local_32);
+                    } != 34;
+                }) {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
+                        __local_33 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+                        __local_34 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_33, offset: __local_34 };
+                    });
+                }
+                let __match_scrut_1: ref null "core:serde//DeserializeError";
+                __match_scrut_1 = "core:json/JsonDeserializer::skip_string"(self);
+                if ref.is_null(__match_scrut_1) {
+                } else if ref.is_null(__match_scrut_1) == 0 {
+                    let __cast_1: ref null "core:serde//DeserializeError";
+                    __cast_1 = ref.as_non_null(__match_scrut_1);
+                    __local_6 = ref.as_non_null(__cast_1);
+                    return __local_6;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_2: ref null "core:serde//DeserializeError";
+                __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+                if ref.is_null(__match_scrut_2) {
+                } else if ref.is_null(__match_scrut_2) == 0 {
+                    let __cast_2: ref null "core:serde//DeserializeError";
+                    __cast_2 = ref.as_non_null(__match_scrut_2);
+                    __local_8 = ref.as_non_null(__cast_2);
+                    return __local_8;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_3: ref null "core:serde//DeserializeError";
+                __match_scrut_3 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_3) {
+                } else if ref.is_null(__match_scrut_3) == 0 {
+                    let __cast_3: ref null "core:serde//DeserializeError";
+                    __cast_3 = ref.as_non_null(__match_scrut_3);
+                    __local_10 = ref.as_non_null(__cast_3);
+                    return __local_10;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_14: block -> i32 {
+                    __local_35 = self.input;
+                    break __inline_String__len_14: __local_35.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
+                        __local_36 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_36 };
+                    });
+                }
+                __local_11 = __inline_String__get_byte_16: block -> u8 {
+                    __local_37 = self.input;
+                    __local_38 = self.pos;
+                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_37.repr, __local_38);
+                } & 255;
+                if __local_11 == 125 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_11 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
+                        __local_39 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
+                        __local_40 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_39, offset: __local_40 };
+                    });
+                    unreachable;
+                }
+                continue l690;
+            };
+        };
+    } else {
+        if (if b == 45 -> i32 {
+            1;
+        } else if 48 <= b -> i32 {
+            b <= 57;
+        } else {
+            0;
+        }) {
+            "core:json/JsonDeserializer::skip_number"(self);
+            return ref.null none;
+        }
+        return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
+            __local_43 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
+                "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
+                __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
+                "core:prelude/primitive.wado/char^Display::fmt"(b, __local_13);
+                "core:prelude/string.wado/String::push"(__local_12, 39);
+                break __tmpl: __local_12;
+            };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
+        });
+        unreachable;
+    }
+}
+
+fn "core:json/JsonMapAccess^DeserializeMap::next_key_string"(self) {
+    let __local_2: ref "core:serde//DeserializeError";
+    let __local_3: ref "core:prelude/string.wado//String";
+    let __local_4: ref "core:serde//DeserializeError";
+    let key: ref "core:prelude/string.wado//String";
+    let __local_7: ref "core:serde//DeserializeError";
+    let __local_8: ref "core:prelude/string.wado//String";
+    let __local_9: i64;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i32;
+    "core:json/JsonDeserializer::skip_whitespace"(self.de);
+    if self.de.pos >= __inline_String__len_0: block -> i32 {
+        __local_8 = self.de.input;
+        break __inline_String__len_0: __local_8.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_9 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_9 };
+        });
+    }
+    if __inline_String__get_byte_2: block -> u8 {
+        __local_10 = self.de.input;
+        __local_11 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_10.repr, __local_11);
+    } == 125 {
+        return 0, ref.null none, ref.null none;
+    }
+    if self.first == 0 {
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return 1, ref.null none, __local_2;
+            unreachable;
+        } else {
+            unreachable;
+        }
+    }
+    self.first = 0;
+    key = value_copy "core:prelude/string.wado//String"(let __match_scrut_1: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_1 = "core:json/JsonDeserializer::read_json_string"(self.de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/string.wado//String" {
+        let __cast_3: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_3 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1);
+        __local_3 = __cast_3.payload_0;
+        __local_3;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/string.wado//String" {
+        let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1);
+        __local_4 = __cast_2.payload_0;
+        return 1, ref.null none, __local_4;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    let __match_scrut_2: ref null "core:serde//DeserializeError";
+    __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+    if ref.is_null(__match_scrut_2) {
+    } else if ref.is_null(__match_scrut_2) == 0 {
+        let __cast_4: ref null "core:serde//DeserializeError";
+        __cast_4 = ref.as_non_null(__match_scrut_2);
+        __local_7 = ref.as_non_null(__cast_4);
+        return 1, ref.null none, __local_7;
+        unreachable;
+    } else {
+        unreachable;
+    }
+    return 0, key, ref.null none;
+}
+
+fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
+    let __local_2: ref "core:serde//DeserializeError";
+    let key_start: i32;
+    let has_escape: bool;
+    let b: i32;
+    let key_end: i32;
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: i32;
+    let idx_10: i32;
+    let __local_11: ref "core:prelude/string.wado//String";
+    let __local_12: ref "core:serde//DeserializeError";
+    let key: ref "core:prelude/string.wado//String";
+    let __local_15: ref "core:serde//DeserializeError";
+    let __local_16: i32;
+    let idx_17: i32;
     let __local_18: ref "core:prelude/string.wado//String";
     let __local_19: i64;
     let __local_20: ref "core:prelude/string.wado//String";
@@ -8114,510 +8838,229 @@ fn "core:json/JsonDeserializer::skip_value"(self) {
     let __local_25: ref "core:prelude/string.wado//String";
     let __local_26: i64;
     let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: i64;
-    let __local_31: ref "core:prelude/string.wado//String";
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i32;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
-    let __local_37: ref "core:prelude/string.wado//String";
-    let __local_38: i64;
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
-    let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_47: ref "core:prelude/string.wado//String";
-    let __local_48: i64;
-    let _hfs_pos_49: i32;
-    let _hfs_pos_50: i32;
-    "core:json/JsonDeserializer::skip_whitespace"(self);
-    if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_18 = self.input;
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    "core:json/JsonDeserializer::skip_whitespace"(self.de);
+    if self.de.pos >= __inline_String__len_0: block -> i32 {
+        __local_18 = self.de.input;
         break __inline_String__len_0: __local_18.used;
     } {
-        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_19 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
-        });
-    }
-    b = __inline_String__get_byte_2: block -> u8 {
-        __local_20 = self.input;
-        __local_21 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
-    };
-    if b == 34 {
-        return "core:json/JsonDeserializer::skip_string"(self);
-    }
-    if b == 116 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-    }
-    if b == 102 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-    }
-    if b == 110 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
-    }
-    if b == 91 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_3: block -> i32 {
-            __local_22 = self.input;
-            break __inline_String__len_3: __local_22.used;
-        } -> i32 {
-            __inline_String__get_byte_4: block -> u8 {
-                __local_23 = self.input;
-                __local_24 = self.pos;
-                break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
-            } == 93;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_49 = self.pos;
-        block {
-            l649: loop {
-                self.pos = _hfs_pos_49;
-                r = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_49 = self.pos;
-                if ref.is_null(r) == 0 {
-                    e_3 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-                    self.pos = _hfs_pos_49;
-                    return e_3;
-                }
-                self.pos = _hfs_pos_49;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_49 = self.pos;
-                if _hfs_pos_49 >= __inline_String__len_5: block -> i32 {
-                    __local_25 = self.input;
-                    self.pos = _hfs_pos_49;
-                    break __inline_String__len_5: __local_25.used;
-                } {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
-                        __local_26 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
-                    });
-                }
-                c_4 = __inline_String__get_byte_7: block -> u8 {
-                    __local_27 = self.input;
-                    __local_28 = _hfs_pos_49;
-                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_27.repr, __local_28);
-                };
-                if c_4 == 93 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                    self.pos = _hfs_pos_49;
-                    return ref.null none;
-                }
-                if c_4 == 44 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                } else {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
-                        __local_29 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
-                        __local_30 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_29, offset: __local_30 };
-                    });
-                }
-                continue l649;
-            };
-        };
-        self.pos = _hfs_pos_49;
-    }
-    if b == 123 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_9: block -> i32 {
-            __local_31 = self.input;
-            break __inline_String__len_9: __local_31.used;
-        } -> i32 {
-            __inline_String__get_byte_10: block -> u8 {
-                __local_32 = self.input;
-                __local_33 = self.pos;
-                break __inline_String__get_byte_10: builtin::array_get_u8(__local_32.repr, __local_33);
-            } == 125;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_50 = self.pos;
-        block {
-            l658: loop {
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if (if _hfs_pos_50 >= __inline_String__len_11: block -> i32 {
-                    __local_34 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_11: __local_34.used;
-                } -> i32 {
-                    1;
-                } else {
-                    __inline_String__get_byte_12: block -> u8 {
-                        __local_35 = self.input;
-                        __local_36 = _hfs_pos_50;
-                        self.pos = _hfs_pos_50;
-                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_35.repr, __local_36);
-                    } != 34;
-                }) {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
-                        __local_37 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-                        __local_38 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_37, offset: __local_38 };
-                    });
-                }
-                self.pos = _hfs_pos_50;
-                kr = "core:json/JsonDeserializer::skip_string"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(kr) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(kr));
-                    self.pos = _hfs_pos_50;
-                    return e_6;
-                }
-                self.pos = _hfs_pos_50;
-                cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(cr) == 0 {
-                    e_8 = value_copy "core:serde//DeserializeError"(ref.as_non_null(cr));
-                    self.pos = _hfs_pos_50;
-                    return e_8;
-                }
-                self.pos = _hfs_pos_50;
-                vr = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(vr) == 0 {
-                    e_10 = value_copy "core:serde//DeserializeError"(ref.as_non_null(vr));
-                    self.pos = _hfs_pos_50;
-                    return e_10;
-                }
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if _hfs_pos_50 >= __inline_String__len_14: block -> i32 {
-                    __local_39 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_14: __local_39.used;
-                } {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
-                        __local_40 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-                    });
-                }
-                c_11 = __inline_String__get_byte_16: block -> u8 {
-                    __local_41 = self.input;
-                    __local_42 = _hfs_pos_50;
-                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_41.repr, __local_42);
-                };
-                if c_11 == 125 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                    self.pos = _hfs_pos_50;
-                    return ref.null none;
-                }
-                if c_11 == 44 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                } else {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
-                        __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
-                        __local_44 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
-                    });
-                }
-                continue l658;
-            };
-        };
-        self.pos = _hfs_pos_50;
-    }
-    if (if b == 45 -> i32 {
-        1;
-    } else if b >= 48 -> i32 {
-        b <= 57;
-    } else {
-        0;
-    }) {
-        "core:json/JsonDeserializer::skip_number"(self);
-        return ref.null none;
-    }
-    return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
-        __local_47 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-            __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
-            "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
-            __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
-            "core:prelude/primitive.wado/char^Display::fmt"(b & 255, __local_13);
-            "core:prelude/string.wado/String::push"(__local_12, 39);
-            break __tmpl: __local_12;
-        };
-        __local_48 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_47, offset: __local_48 };
-    });
-}
-
-fn "core:json/JsonMapAccess^DeserializeMap::next_key_string"(self) {
-    let r_1: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let key_r: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let key: ref "core:prelude/string.wado//String";
-    let r_5: ref null "core:serde//DeserializeError";
-    let e_6: ref "core:serde//DeserializeError";
-    let e_7: ref "core:serde//DeserializeError";
-    let __local_12: ref "core:prelude/string.wado//String";
-    let __local_13: i64;
-    let __local_14: ref "core:prelude/string.wado//String";
-    let __local_15: i32;
-    "core:json/JsonDeserializer::skip_whitespace"(self.de);
-    if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_12 = self.de.input;
-        break __inline_String__len_0: __local_12.used;
-    } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_13 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_13 };
-        });
-    }
-    if __inline_String__get_byte_2: block -> u8 {
-        __local_14 = self.de.input;
-        __local_15 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_14.repr, __local_15);
-    } == 125 {
-        return 0, ref.null none, ref.null none;
-    }
-    if self.first == 0 {
-        r_1 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r_1) == 0 {
-            e_2 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r_1));
-            return 1, ref.null none, e_2;
-        }
-    }
-    self.first = 0;
-    key_r = "core:json/JsonDeserializer::read_json_string"(self.de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r) {
-        key = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r).payload_0);
-        r_5 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_5) == 0 {
-            e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r_5));
-            return 1, ref.null none, e_6;
-        }
-        return 0, key, ref.null none;
-    }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r) {
-        e_7 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r).payload_0);
-        return 1, ref.null none, e_7;
-    }
-    "core:internal/unreachable"();
-    unreachable;
-}
-
-fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
-    let r_1: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let key_start: i32;
-    let has_escape: bool;
-    let b: i32;
-    let key_end: i32;
-    let r_7: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let idx_9: ref "core:prelude/types.wado//Option<i32>";
-    let i_10: i32;
-    let key_r: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let key: ref "core:prelude/string.wado//String";
-    let r_13: ref null "core:serde//DeserializeError";
-    let e_14: ref "core:serde//DeserializeError";
-    let idx_15: ref "core:prelude/types.wado//Option<i32>";
-    let i_16: i32;
-    let e_17: ref "core:serde//DeserializeError";
-    let __local_25: ref "core:prelude/string.wado//String";
-    let __local_26: i64;
-    let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: ref "core:prelude/string.wado//String";
-    let __local_31: i32;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i64;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
-    "core:json/JsonDeserializer::skip_whitespace"(self.de);
-    if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_25 = self.de.input;
-        break __inline_String__len_0: __local_25.used;
-    } {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
+            __local_19 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_27 = self.de.input;
-        __local_28 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_27.repr, __local_28);
+        __local_20 = self.de.input;
+        __local_21 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } == 125 {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r_1 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r_1) == 0 {
-            e_2 = ref.as_non_null(r_1);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if (if self.de.pos >= __inline_String__len_3: block -> i32 {
-        __local_29 = self.de.input;
-        break __inline_String__len_3: __local_29.used;
+        __local_22 = self.de.input;
+        break __inline_String__len_3: __local_22.used;
     } -> i32 {
         1;
     } else {
         __inline_String__get_byte_4: block -> u8 {
-            __local_30 = self.de.input;
-            __local_31 = self.de.pos;
-            break __inline_String__get_byte_4: builtin::array_get_u8(__local_30.repr, __local_31);
+            __local_23 = self.de.input;
+            __local_24 = self.de.pos;
+            break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
         } != 34;
     }) {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_5: block -> ref "core:serde//DeserializeError" {
-            __local_32 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-            __local_33 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_32, offset: __local_33 };
+            __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_25, offset: __local_26 };
         }) };
     }
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b683: block {
-        l684: loop {
+    b721: block {
+        l722: loop {
             if self.de.pos >= __inline_String__len_6: block -> i32 {
-                __local_34 = self.de.input;
-                break __inline_String__len_6: __local_34.used;
+                __local_27 = self.de.input;
+                break __inline_String__len_6: __local_27.used;
             } {
-                break b683;
+                break b721;
             }
             b = __inline_String__get_byte_7: block -> u8 {
-                __local_35 = self.de.input;
-                __local_36 = self.de.pos;
-                break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
+                __local_28 = self.de.input;
+                __local_29 = self.de.pos;
+                break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
             };
             if b == 34 {
-                break b683;
+                break b721;
             }
             if b == 92 {
                 has_escape = 1;
-                break b683;
+                break b721;
             }
             self.de.pos = self.de.pos + 1;
-            continue l684;
+            continue l722;
         };
     };
     if has_escape == 0 {
         key_end = self.de.pos;
         self.de.pos = self.de.pos + 1;
-        r_7 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_7) == 0 {
-            e_8 = ref.as_non_null(r_7);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_8 };
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_1);
+            __local_8 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        idx_9 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_0: ref "canonical//CanonicalClosure_0";
-            __indirect_call_0 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_0.func, __indirect_call_0.env, self.de.input, key_start, key_end);
+        let __match_scrut_2: ref "core:prelude/types.wado//Option<i32>";
+        __match_scrut_2 = block -> ref "core:prelude/types.wado//Option<i32>" {
+            let __indirect_call_2: ref "canonical//CanonicalClosure_0";
+            __indirect_call_2 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_2.func, __indirect_call_2.env, self.de.input, key_start, key_end);
         };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_9) {
-            i_10 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_9).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_10 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+        idx_10 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2) -> i32 {
+            let __cast_4: ref "core:prelude/types.wado//Option<i32>::Some";
+            __cast_4 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2);
+            __local_9 = __cast_4.payload_0;
+            __local_9;
+        } else if __match_scrut_2.discriminant == 1 -> i32 {
+            -1;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_10 } };
     }
     self.de.pos = key_start - 1;
-    key_r = "core:json/JsonDeserializer::read_json_string"(self.de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r) {
-        key = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r).payload_0);
-        r_13 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_13) == 0 {
-            e_14 = ref.as_non_null(r_13);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_14 };
-        }
-        idx_15 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_1: ref "canonical//CanonicalClosure_0";
-            __indirect_call_1 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_1.func, __indirect_call_1.env, key, 0, key.used);
-        };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_15) {
-            i_16 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_15).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_16 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+    key = value_copy "core:prelude/string.wado//String"(let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self.de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_6: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_6 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+        __local_11 = __cast_6.payload_0;
+        __local_11;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+        __local_12 = __cast_5.payload_0;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_12 };
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    let __match_scrut_4: ref null "core:serde//DeserializeError";
+    __match_scrut_4 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+    if ref.is_null(__match_scrut_4) {
+    } else if ref.is_null(__match_scrut_4) == 0 {
+        let __cast_7: ref null "core:serde//DeserializeError";
+        __cast_7 = ref.as_non_null(__match_scrut_4);
+        __local_15 = ref.as_non_null(__cast_7);
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_15 };
+        unreachable;
+    } else {
+        unreachable;
     }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r) {
-        e_17 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    let __match_scrut_5: ref "core:prelude/types.wado//Option<i32>";
+    __match_scrut_5 = block -> ref "core:prelude/types.wado//Option<i32>" {
+        let __indirect_call_7: ref "canonical//CanonicalClosure_0";
+        __indirect_call_7 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+        call_ref "functype/$canonical_closure_fn_0"(__indirect_call_7.func, __indirect_call_7.env, key, 0, key.used);
+    };
+    idx_17 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5) -> i32 {
+        let __cast_9: ref "core:prelude/types.wado//Option<i32>::Some";
+        __cast_9 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5);
+        __local_16 = __cast_9.payload_0;
+        __local_16;
+    } else if __match_scrut_5.discriminant == 1 -> i32 {
+        -1;
+    } else {
+        unreachable;
+    });
+    return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_17 } };
 }
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_bool"(self) {
-    let b: i32;
-    let r_2: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let r_4: ref null "core:serde//DeserializeError";
-    let e_5: ref "core:serde//DeserializeError";
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:serde//DeserializeError";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
     let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i64;
+    let __local_9: i32;
     let __local_10: ref "core:prelude/string.wado//String";
-    let __local_11: i32;
-    let __local_12: ref "core:prelude/string.wado//String";
-    let __local_13: i64;
+    let __local_11: i64;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_8 = self.input;
-        break __inline_String__len_0: __local_8.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_9 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_9 };
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
         }) };
     }
     b = __inline_String__get_byte_2: block -> u8 {
-        __local_10 = self.input;
-        __local_11 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_10.repr, __local_11);
-    };
+        __local_8 = self.input;
+        __local_9 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_8.repr, __local_9);
+    } & 255;
     if b == 116 {
-        r_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-        if ref.is_null(r_2) == 0 {
-            e_3 = ref.as_non_null(r_2);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_3 };
+        let __match_scrut_2: ref null "core:serde//DeserializeError";
+        __match_scrut_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        if ref.is_null(__match_scrut_2) {
+        } else if ref.is_null(__match_scrut_2) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_2);
+            __local_3 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 1 };
-    }
-    if b == 102 {
-        r_4 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-        if ref.is_null(r_4) == 0 {
-            e_5 = ref.as_non_null(r_4);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
+        unreachable;
+    } else if b == 102 {
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_1);
+            __local_5 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_5 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 0 };
+        unreachable;
+    } else {
+        return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
+            __local_11 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_10, offset: __local_11 };
+        }) };
+        unreachable;
     }
-    return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-        __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
-        __local_13 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_12, offset: __local_13 };
-    }) };
+    unreachable;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::is_null"(self) {
@@ -8672,102 +9115,146 @@ fn "core:json/JsonDeserializer^Deserializer::is_null"(self) {
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_seq"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 91);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 91);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_2 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_2;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonSeqAccess" { de: self, first: 1 }, ref.null none;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_map"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 123);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 123);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_2 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_2;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonMapAccess" { de: self, first: 1 }, ref.null none;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_struct"(self, lookup) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 123);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_5: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 123);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_5 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_5;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonStructAccess" { de: self, lookup: lookup, first: 1 }, ref.null none;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_variant"(self) {
-    let b: i32;
-    let r_4: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let name_5: ref "core:prelude/string.wado//String";
-    let e_6: ref "core:serde//DeserializeError";
-    let r_7: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let name_8: ref "core:prelude/string.wado//String";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let e_11: ref "core:serde//DeserializeError";
-    let __local_17: ref "core:prelude/string.wado//String";
-    let __local_18: i64;
-    let __local_19: ref "core:prelude/string.wado//String";
-    let __local_20: i32;
-    let __local_21: ref "core:prelude/string.wado//String";
-    let __local_22: i64;
+    let b: char;
+    let __local_4: ref "core:prelude/string.wado//String";
+    let __local_5: ref "core:serde//DeserializeError";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: ref "core:prelude/string.wado//String";
+    let __local_11: ref "core:serde//DeserializeError";
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i32;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i64;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_17 = self.input;
-        break __inline_String__len_0: __local_17.used;
+        __local_12 = self.input;
+        break __inline_String__len_0: __local_12.used;
     } {
         return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_18 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_18 };
+            __local_13 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_13 };
         }) };
     }
     b = __inline_String__get_byte_2: block -> u8 {
-        __local_19 = self.input;
-        __local_20 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_19.repr, __local_20);
-    };
+        __local_14 = self.input;
+        __local_15 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_14.repr, __local_15);
+    } & 255;
     if b == 34 {
-        r_4 = "core:json/JsonDeserializer::read_json_string"(self);
-        if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r_4) {
-            name_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r_4).payload_0;
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: name_5, is_object: 0 } };
-        }
-        if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r_4) {
-            e_6 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r_4).payload_0;
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e_6 };
-        }
-    }
-    if b == 123 {
+        let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+        __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self);
+        __local_6 = (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+            let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+            __local_4 = __cast_5.payload_0;
+            __local_4;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+            let __cast_4: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_4 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+            __local_5 = __cast_4.payload_0;
+            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_5 };
+            unreachable;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: __local_6, is_object: 0 } };
+        unreachable;
+    } else if b == 123 {
         self.pos = self.pos + 1;
-        r_7 = "core:json/JsonDeserializer::read_json_string"(self);
-        if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r_7) {
-            name_8 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r_7).payload_0;
-            cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-            if ref.is_null(cr) == 0 {
-                e_10 = ref.as_non_null(cr);
-                return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e_10 };
-            }
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: name_8, is_object: 1 } };
+        let __match_scrut_1: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+        __match_scrut_1 = "core:json/JsonDeserializer::read_json_string"(self);
+        __local_9 = (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/string.wado//String" {
+            let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1);
+            __local_7 = __cast_2.payload_0;
+            __local_7;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/string.wado//String" {
+            let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1);
+            __local_8 = __cast_1.payload_0;
+            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
+        });
+        let __match_scrut_2: ref null "core:serde//DeserializeError";
+        __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+        if ref.is_null(__match_scrut_2) {
+        } else if ref.is_null(__match_scrut_2) == 0 {
+            let __cast_3: ref null "core:serde//DeserializeError";
+            __cast_3 = ref.as_non_null(__match_scrut_2);
+            __local_11 = ref.as_non_null(__cast_3);
+            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_11 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r_7) {
-            e_11 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r_7).payload_0;
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e_11 };
-        }
+        return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: __local_9, is_object: 1 } };
+        unreachable;
+    } else {
+        return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_16 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string or object for variant"), used: 37 };
+            __local_17 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_16, offset: __local_17 };
+        }) };
+        unreachable;
     }
-    return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-        __local_21 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string or object for variant"), used: 37 };
-        __local_22 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_21, offset: __local_22 };
-    }) };
+    unreachable;
 }
 
 fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
@@ -8777,13 +9264,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l719: loop {
+            l767: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l719;
+                continue l767;
             };
         };
     };
@@ -8876,10 +9363,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b729: block {
-            l730: loop {
+        b777: block {
+            l778: loop {
                 if i_8 < 0 {
-                    break b729;
+                    break b777;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -8888,7 +9375,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l730;
+                continue l778;
             };
         };
         __for_1: block {
@@ -8896,14 +9383,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l733: loop {
+                l781: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l733;
+                    continue l781;
                 };
             };
         };
@@ -8913,10 +9400,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b735: block {
-            l736: loop {
+        b783: block {
+            l784: loop {
                 if i_10 < 0 {
-                    break b735;
+                    break b783;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -8925,7 +9412,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l736;
+                continue l784;
             };
         };
         __for_2: block {
@@ -8933,14 +9420,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l739: loop {
+                l787: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l739;
+                    continue l787;
                 };
             };
         };
@@ -9044,8 +9531,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b758: block {
-        l759: loop {
+    b806: block {
+        l807: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -9070,9 +9557,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b758;
+                break b806;
             }
-            continue l759;
+            continue l807;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -9107,13 +9594,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l768: loop {
+            l816: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l768;
+                continue l816;
             };
         };
     };
@@ -9132,12 +9619,14 @@ fn "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,i32>>^Iterator::next"(
 
 fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<Option<i32>>^Deserialize::deserialize<JsonDeserializer>"(d) {
     let seq: ref "core:json//JsonSeqAccess";
+    let first: ref "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>";
     let first_opt: ref null "core:prelude/types.wado//Option<i32>";
     let end_result_5: ref null "core:serde//DeserializeError";
     let e_6: ref "core:serde//DeserializeError";
     let __local_7: ref "core:prelude//Array<Option<i32>>";
     let first_elem: ref "core:prelude/types.wado//Option<i32>";
     let items: ref "core:prelude//Array<Option<i32>>";
+    let next: ref "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>";
     let next_opt: ref null "core:prelude/types.wado//Option<i32>";
     let end_result_12: ref null "core:serde//DeserializeError";
     let e_13: ref "core:serde//DeserializeError";
@@ -9151,65 +9640,59 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<Option<
     multivalue_bind [__sroa_seq_result_discriminant, __sroa_seq_result_case0_payload_0, __sroa_seq_result_case1_payload_0] = "core:json/JsonDeserializer^Deserializer::begin_seq"(d);
     if __sroa_seq_result_discriminant == 0 {
         seq = __sroa_seq_result_case0_payload_0;
-        let __sroa_first_discriminant: i32;
-        let __sroa_first_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
-        let __sroa_first_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_first_discriminant, __sroa_first_case0_payload_0, __sroa_first_case1_payload_0] = "core:json/JsonSeqAccess^DeserializeSeq::next_element<Option<i32>>"(seq);
-        if __sroa_first_discriminant == 0 {
-            first_opt = __sroa_first_case0_payload_0;
+        first = "core:json/JsonSeqAccess^DeserializeSeq::next_element<Option<i32>>"(seq);
+        if ref.test "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Ok"(first) {
+            first_opt = value_copy "core:prelude/types.wado//Option<Option<i32>>"(ref.cast "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Ok"(first).payload_0);
             if ref.is_null(first_opt) == 0 {
                 first_elem = value_copy "core:prelude/types.wado//Option<i32>"(ref.as_non_null(first_opt));
                 items = struct.new "core:prelude//Array<Option<i32>>" { repr: builtin::array_new<ref "core:prelude/types.wado//Option<i32>">(2), used: 0 };
                 "core:prelude/array.wado/Array<Option<i32>>::push"(items, first_elem);
                 block {
-                    l775: loop {
-                        let __sroa_next_discriminant: i32;
-                        let __sroa_next_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
-                        let __sroa_next_case1_payload_0: ref null "core:serde//DeserializeError";
-                        multivalue_bind [__sroa_next_discriminant, __sroa_next_case0_payload_0, __sroa_next_case1_payload_0] = "core:json/JsonSeqAccess^DeserializeSeq::next_element<Option<i32>>"(seq);
-                        if __sroa_next_discriminant == 0 {
-                            next_opt = __sroa_next_case0_payload_0;
+                    l823: loop {
+                        next = "core:json/JsonSeqAccess^DeserializeSeq::next_element<Option<i32>>"(seq);
+                        if ref.test "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Ok"(next) {
+                            next_opt = value_copy "core:prelude/types.wado//Option<Option<i32>>"(ref.cast "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Ok"(next).payload_0);
                             if ref.is_null(next_opt) == 0 {
                                 item = value_copy "core:prelude/types.wado//Option<i32>"(ref.as_non_null(next_opt));
                                 "core:prelude/array.wado/Array<Option<i32>>::push"(items, item);
                             } else {
                                 end_result_12 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
                                 if ref.is_null(end_result_12) == 0 {
-                                    e_13 = value_copy "core:serde//DeserializeError"(ref.as_non_null(end_result_12));
-                                    return 1, ref.null none, e_13;
+                                    e_13 = ref.as_non_null(end_result_12);
+                                    return struct.new "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Err" { discriminant: 1, payload_0: e_13 };
                                 }
-                                return 0, items, ref.null none;
+                                return struct.new "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Ok" { discriminant: 0, payload_0: items };
                             }
                         }
-                        if __sroa_next_discriminant == 1 {
-                            e_15 = __sroa_next_case1_payload_0;
-                            return 1, ref.null none, e_15;
+                        if ref.test "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Err"(next) {
+                            e_15 = ref.cast "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Err"(next).payload_0;
+                            return struct.new "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Err" { discriminant: 1, payload_0: e_15 };
                         }
-                        continue l775;
+                        continue l823;
                     };
                 };
             } else {
                 end_result_5 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
                 if ref.is_null(end_result_5) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(end_result_5));
-                    return 1, ref.null none, e_6;
+                    e_6 = ref.as_non_null(end_result_5);
+                    return struct.new "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Err" { discriminant: 1, payload_0: e_6 };
                 }
-                return 0, ref.as_non_null(__seq_lit: block -> ref "core:prelude//Array<Option<i32>>" {
+                return struct.new "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Ok" { discriminant: 0, payload_0: ref.as_non_null(__seq_lit: block -> ref "core:prelude//Array<Option<i32>>" {
                     __local_7 = struct.new "core:prelude//Array<Option<i32>>" { repr: builtin::array_new<ref "core:prelude/types.wado//Option<i32>">(0), used: 0 };
                     break __seq_lit: __local_7;
-                }), ref.null none;
+                }) };
             }
         }
-        if __sroa_first_discriminant == 1 {
-            e_16 = __sroa_first_case1_payload_0;
-            return 1, ref.null none, e_16;
+        if ref.test "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Err"(first) {
+            e_16 = ref.cast "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Err"(first).payload_0;
+            return struct.new "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Err" { discriminant: 1, payload_0: e_16 };
         }
         "core:internal/unreachable"();
         unreachable;
     }
     if __sroa_seq_result_discriminant == 1 {
         e_17 = __sroa_seq_result_case1_payload_0;
-        return 1, ref.null none, e_17;
+        return struct.new "core:prelude/types.wado//Result<Array<Option<i32>>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
     }
     "core:internal/unreachable"();
     unreachable;
@@ -9244,13 +9727,13 @@ fn "core:prelude/array.wado/Array<Option<i32>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l785: loop {
+            l833: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:prelude/types.wado//Option<i32>">(new_repr, i, builtin::array_get<ref "core:prelude/types.wado//Option<i32>">(old_repr, i));
                 i = i + 1;
-                continue l785;
+                continue l833;
             };
         };
     };
@@ -9258,51 +9741,58 @@ fn "core:prelude/array.wado/Array<Option<i32>>::grow"(self) {
 }
 
 fn "core:json/JsonSeqAccess^DeserializeSeq::next_element<Option<i32>>"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let elem: ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";
-    let v: ref "core:prelude/types.wado//Option<i32>";
-    let e_5: ref "core:serde//DeserializeError";
-    let __local_9: ref "core:prelude/string.wado//String";
-    let __local_10: i64;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i32;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __local_3: ref "core:prelude/types.wado//Option<i32>";
+    let __local_4: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_9 = self.de.input;
-        break __inline_String__len_0: __local_9.used;
+        __local_5 = self.de.input;
+        break __inline_String__len_0: __local_5.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_10 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_10 };
-        });
+        return struct.new "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_6 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_11 = self.de.input;
-        __local_12 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_11.repr, __local_12);
+        __local_7 = self.de.input;
+        __local_8 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_7.repr, __local_8);
     } == 93 {
-        return 0, ref.null none, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Ok" { discriminant: 0, payload_0: ref.null none };
     }
     if self.first == 0 {
-        r = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r) == 0 {
-            e_2 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-            return 1, ref.null none, e_2;
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
-    elem = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<i32>^Deserialize::deserialize<JsonDeserializer>"(self.de);
-    if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(elem) {
-        v = value_copy "core:prelude/types.wado//Option<i32>"(ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(elem).payload_0);
-        return 0, v, ref.null none;
-    }
-    if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(elem) {
-        e_5 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(elem).payload_0);
-        return 1, ref.null none, e_5;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return let __match_scrut_1: ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>", __match_scrut_1 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<i32>^Deserialize::deserialize<JsonDeserializer>"(self.de), (if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>" {
+        let __cast_3: ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok";
+        __cast_3 = ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__match_scrut_1);
+        __local_3 = __cast_3.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_3 };
+    } else if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__match_scrut_1);
+        __local_4 = __cast_2.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<Option<i32>>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_4 };
+    } else {
+        unreachable;
+    });
 }
 
 fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<i32>^Deserialize::deserialize<JsonDeserializer>"(d) {
@@ -9363,8 +9853,8 @@ fn "core:prelude/array.wado/Array<Option<i32>>^Serialize::serialize<JsonSerializ
             __local_16 = self;
             break __inline_Array_Option_i32___IntoIterator__into_iter_2: struct.new "core:prelude/array.wado//ArrayIter<Option<i32>>" { repr: __local_16.repr, used: __local_16.used, index: 0 };
         };
-        b799: block {
-            l800: loop {
+        b848: block {
+            l849: loop {
                 __pattern_temp_1 = "core:prelude/array.wado/ArrayIter<Option<i32>>^Iterator::next"(__iter_4);
                 if ref.is_null(__pattern_temp_1) == 0 {
                     r = "core:json/JsonSeqSerializer^SerializeSeq::element<Option<i32>>"(seq_3, ref.as_non_null(__pattern_temp_1));
@@ -9373,9 +9863,9 @@ fn "core:prelude/array.wado/Array<Option<i32>>^Serialize::serialize<JsonSerializ
                         return e_7;
                     }
                 } else {
-                    break b799;
+                    break b848;
                 }
-                continue l800;
+                continue l849;
             };
         };
         return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref null "core:serde//SerializeError" {
@@ -9443,7 +9933,7 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<Array<
     if __sroa_null_check_discriminant == 0 {
         is_null = __sroa_null_check_case0_payload_0;
         if is_null {
-            return 0, ref.null none, ref.null none;
+            return struct.new "core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError>::Ok" { discriminant: 0, payload_0: ref.null none };
         }
         let __sroa_inner_discriminant: i32;
         let __sroa_inner_case0_payload_0: ref null "core:prelude//Array<i32>";
@@ -9451,16 +9941,16 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<Array<
         multivalue_bind [__sroa_inner_discriminant, __sroa_inner_case0_payload_0, __sroa_inner_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<i32>^Deserialize::deserialize<JsonDeserializer>"(d);
         if __sroa_inner_discriminant == 0 {
             v = __sroa_inner_case0_payload_0;
-            return 0, v, ref.null none;
+            return struct.new "core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError>::Ok" { discriminant: 0, payload_0: v };
         }
         if __sroa_inner_discriminant == 1 {
             e_5 = __sroa_inner_case1_payload_0;
-            return 1, ref.null none, e_5;
+            return struct.new "core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
         }
     }
     if __sroa_null_check_discriminant == 1 {
         e_6 = __sroa_null_check_case1_payload_0;
-        return 1, ref.null none, e_6;
+        return struct.new "core:prelude/types.wado//Result<Option<Array<i32>>,DeserializeError>::Err" { discriminant: 1, payload_0: e_6 };
     }
     "core:internal/unreachable"();
     unreachable;
@@ -9468,12 +9958,14 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<Array<
 
 fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<i32>^Deserialize::deserialize<JsonDeserializer>"(d) {
     let seq: ref "core:json//JsonSeqAccess";
+    let first: ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";
     let first_opt: ref "core:prelude/types.wado//Option<i32>";
     let end_result_5: ref null "core:serde//DeserializeError";
     let e_6: ref "core:serde//DeserializeError";
     let __local_7: ref "core:prelude//Array<i32>";
     let first_elem: i32;
     let items: ref "core:prelude//Array<i32>";
+    let next: ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";
     let next_opt: ref "core:prelude/types.wado//Option<i32>";
     let end_result_12: ref null "core:serde//DeserializeError";
     let e_13: ref "core:serde//DeserializeError";
@@ -9487,24 +9979,18 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<i32>^De
     multivalue_bind [__sroa_seq_result_discriminant, __sroa_seq_result_case0_payload_0, __sroa_seq_result_case1_payload_0] = "core:json/JsonDeserializer^Deserializer::begin_seq"(d);
     if __sroa_seq_result_discriminant == 0 {
         seq = __sroa_seq_result_case0_payload_0;
-        let __sroa_first_discriminant: i32;
-        let __sroa_first_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
-        let __sroa_first_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_first_discriminant, __sroa_first_case0_payload_0, __sroa_first_case1_payload_0] = "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(seq);
-        if __sroa_first_discriminant == 0 {
-            first_opt = __sroa_first_case0_payload_0;
+        first = "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(seq);
+        if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(first) {
+            first_opt = ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(first).payload_0;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(first_opt) {
                 first_elem = ref.cast "core:prelude/types.wado//Option<i32>::Some"(first_opt).payload_0;
                 items = struct.new "core:prelude//Array<i32>" { repr: builtin::array_new<i32>(2), used: 0 };
                 "core:prelude/array.wado/Array<i32>::push"(items, first_elem);
                 block {
-                    l816: loop {
-                        let __sroa_next_discriminant: i32;
-                        let __sroa_next_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
-                        let __sroa_next_case1_payload_0: ref null "core:serde//DeserializeError";
-                        multivalue_bind [__sroa_next_discriminant, __sroa_next_case0_payload_0, __sroa_next_case1_payload_0] = "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(seq);
-                        if __sroa_next_discriminant == 0 {
-                            next_opt = __sroa_next_case0_payload_0;
+                    l865: loop {
+                        next = "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(seq);
+                        if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(next) {
+                            next_opt = ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(next).payload_0;
                             if ref.test "core:prelude/types.wado//Option<i32>::Some"(next_opt) {
                                 item = ref.cast "core:prelude/types.wado//Option<i32>::Some"(next_opt).payload_0;
                                 "core:prelude/array.wado/Array<i32>::push"(items, item);
@@ -9517,11 +10003,11 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<i32>^De
                                 return 0, items, ref.null none;
                             }
                         }
-                        if __sroa_next_discriminant == 1 {
-                            e_15 = __sroa_next_case1_payload_0;
+                        if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(next) {
+                            e_15 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(next).payload_0);
                             return 1, ref.null none, e_15;
                         }
-                        continue l816;
+                        continue l865;
                     };
                 };
             } else {
@@ -9536,8 +10022,8 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<i32>^De
                 }), ref.null none;
             }
         }
-        if __sroa_first_discriminant == 1 {
-            e_16 = __sroa_first_case1_payload_0;
+        if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(first) {
+            e_16 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(first).payload_0);
             return 1, ref.null none, e_16;
         }
         "core:internal/unreachable"();
@@ -9580,13 +10066,13 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l826: loop {
+            l875: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
                 i = i + 1;
-                continue l826;
+                continue l875;
             };
         };
     };
@@ -9594,51 +10080,58 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
 }
 
 fn "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let elem: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
-    let v: i32;
-    let e_5: ref "core:serde//DeserializeError";
-    let __local_9: ref "core:prelude/string.wado//String";
-    let __local_10: i64;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i32;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __local_3: i32;
+    let __local_4: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_9 = self.de.input;
-        break __inline_String__len_0: __local_9.used;
+        __local_5 = self.de.input;
+        break __inline_String__len_0: __local_5.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_10 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_10 };
-        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_6 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_11 = self.de.input;
-        __local_12 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_11.repr, __local_12);
+        __local_7 = self.de.input;
+        __local_8 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_7.repr, __local_8);
     } == 93 {
-        return 0, struct.new "core:prelude/types.wado//Option<i32>" { 1 }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r) == 0 {
-            e_2 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-            return 1, ref.null none, e_2;
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
-    elem = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/i32^Deserialize::deserialize<JsonDeserializer>"(self.de);
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(elem) {
-        v = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(elem).payload_0;
-        return 0, struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: v }, ref.null none;
-    }
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(elem) {
-        e_5 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(elem).payload_0);
-        return 1, ref.null none, e_5;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return let __match_scrut_1: ref "core:prelude/types.wado//Result<i32,DeserializeError>", __match_scrut_1 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/i32^Deserialize::deserialize<JsonDeserializer>"(self.de), (if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>" {
+        let __cast_3: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Ok";
+        __cast_3 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_1);
+        __local_3 = __cast_3.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: __local_3 } };
+    } else if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Err";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_1);
+        __local_4 = __cast_2.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_4 };
+    } else {
+        unreachable;
+    });
 }
 
 fn "core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>"(self, s) {
@@ -9661,8 +10154,8 @@ fn "core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>"(sel
             __local_16 = self;
             break __inline_Array_i32__IntoIterator__into_iter_2: struct.new "core:prelude/array.wado//ArrayIter<i32>" { repr: __local_16.repr, used: __local_16.used, index: 0 };
         };
-        b835: block {
-            l836: loop {
+        b885: block {
+            l886: loop {
                 let __sroa___pattern_temp_1_discriminant: i32;
                 let __sroa___pattern_temp_1_payload_0: i32;
                 multivalue_bind [__sroa___pattern_temp_1_discriminant, __sroa___pattern_temp_1_payload_0] = "core:prelude/array.wado/ArrayIter<i32>^Iterator::next"(__iter_4);
@@ -9673,9 +10166,9 @@ fn "core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>"(sel
                         return e_7;
                     }
                 } else {
-                    break b835;
+                    break b885;
                 }
-                continue l836;
+                continue l886;
             };
         };
         return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref null "core:serde//SerializeError" {
@@ -9740,8 +10233,8 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Config^Deseri
             __local_14 = struct.new "core:prelude//Array<TreeMapEntry<String,i32>>" { repr: builtin::array_new<ref "core:collections//TreeMapEntry<String,i32>">(0), used: 0 };
             break __seq_lit: __local_14;
         }), size: 0, deleted_count: 0 };
-        b843: block {
-            l844: loop {
+        b893: block {
+            l894: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -9756,27 +10249,27 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Config^Deseri
                                 settings = __local_9;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err"(__local_8).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err"(__local_8).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b843;
+                        break b893;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l844;
+                continue l894;
             };
         };
         if (seen & 1) != 1 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Config" { settings: settings }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Config" { settings: settings } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 
@@ -9805,7 +10298,7 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/TreeMap<Strin
             break __seq_lit: __local_22;
         }), size: 0, deleted_count: 0 };
         block {
-            l852: loop {
+            l902: loop {
                 let __sroa_key_r_discriminant: i32;
                 let __sroa_key_r_case0_payload_0: ref null "core:prelude/string.wado//String";
                 let __sroa_key_r_case1_payload_0: ref null "core:serde//DeserializeError";
@@ -9839,7 +10332,7 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/TreeMap<Strin
                     e_12 = __sroa_key_r_case1_payload_0;
                     return struct.new "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_12 };
                 }
-                continue l852;
+                continue l902;
             };
         };
     }
@@ -9977,13 +10470,13 @@ fn "core:prelude/array.wado/Array<TreeMapEntry<String,i32>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l874: loop {
+            l924: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:collections//TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<String,i32>">(old_repr, i));
                 i = i + 1;
-                continue l874;
+                continue l924;
             };
         };
     };
@@ -10003,8 +10496,8 @@ fn "core:collections/TreeMap<String,i32>::find_index"(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b876: block {
-        l877: loop {
+    b926: block {
+        l927: loop {
             __pattern_temp_0 = value_copy "core:prelude/types.wado//Option<TreeMapNode<String>>"(current);
             if ref.is_null(__pattern_temp_0) == 0 {
                 n = ref.as_non_null(__pattern_temp_0);
@@ -10028,9 +10521,9 @@ fn "core:collections/TreeMap<String,i32>::find_index"(self, key) {
                     current = n.right;
                 }
             } else {
-                break b876;
+                break b926;
             }
-            continue l877;
+            continue l927;
         };
     };
     return -1;
@@ -10085,8 +10578,8 @@ fn "core:collections/TreeMap<String,i32>^Serialize::serialize<JsonSerializer>"(s
     if ref.test "core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok"(map_r) {
         m = value_copy "core:json//JsonMapSerializer"(ref.cast "core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok"(map_r).payload_0);
         __iter_5 = struct.new "core:prelude/array.wado//ArrayIter<Tuple<String,i32>>" { repr: entries.repr, used: entries.used, index: 0 };
-        b885: block {
-            l886: loop {
+        b935: block {
+            l936: loop {
                 __pattern_temp_1 = "core:prelude/array.wado/ArrayIter<Tuple<String,i32>>^Iterator::next"(__iter_5);
                 if ref.is_null(__pattern_temp_1) == 0 {
                     entry = value_copy "tuple//[String, i32]"(ref.as_non_null(__pattern_temp_1));
@@ -10102,9 +10595,9 @@ fn "core:collections/TreeMap<String,i32>^Serialize::serialize<JsonSerializer>"(s
                         return e_12;
                     }
                 } else {
-                    break b885;
+                    break b935;
                 }
-                continue l886;
+                continue l936;
             };
         };
         return __inline_JsonMapSerializer_SerializeMap__end_3: block -> ref null "core:serde//SerializeError" {
@@ -10173,8 +10666,8 @@ fn "core:collections/TreeMap<String,i32>::entries"(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_i32___IntoIterator__into_iter_3: struct.new "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,i32>>" { repr: __local_9.repr, used: __local_9.used, index: 0 };
     };
-    b893: block {
-        l894: loop {
+    b943: block {
+        l944: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,i32>>^Iterator::next"(__iter_3);
             if ref.is_null(__pattern_temp_0) == 0 {
                 entry = value_copy "core:collections//TreeMapEntry<String,i32>"(ref.as_non_null(__pattern_temp_0));
@@ -10182,9 +10675,9 @@ fn "core:collections/TreeMap<String,i32>::entries"(self) {
                     "core:prelude/array.wado/Array<Tuple<String,i32>>::push"(result, struct.new "tuple//[String, i32]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b893;
+                break b943;
             }
-            continue l894;
+            continue l944;
         };
     };
     return result;
@@ -10219,13 +10712,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,i32>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l899: loop {
+            l949: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, i32]">(new_repr, i, builtin::array_get<ref "tuple//[String, i32]">(old_repr, i));
                 i = i + 1;
-                continue l899;
+                continue l949;
             };
         };
     };
@@ -10392,8 +10885,8 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner^Deseria
         seen = 0;
         value = 0;
         label = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
-        b921: block {
-            l922: loop {
+        b971: block {
+            l972: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -10430,12 +10923,12 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner^Deseria
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b921;
+                        break b971;
                     }
                 } else {
                     return struct.new "core:prelude/types.wado//Result<Inner,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l922;
+                continue l972;
             };
         };
         if (seen & 3) != 3 {
@@ -10597,13 +11090,13 @@ fn "core:prelude/array.wado/Array<Direction>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l939: loop {
+            l989: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
                 i = i + 1;
-                continue l939;
+                continue l989;
             };
         };
     };
@@ -10821,8 +11314,8 @@ fn "core:collections/TreeMap<String,String>::find_index"(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b968: block {
-        l969: loop {
+    b1018: block {
+        l1019: loop {
             __pattern_temp_0 = value_copy "core:prelude/types.wado//Option<TreeMapNode<String>>"(current);
             if ref.is_null(__pattern_temp_0) == 0 {
                 n = ref.as_non_null(__pattern_temp_0);
@@ -10846,9 +11339,9 @@ fn "core:collections/TreeMap<String,String>::find_index"(self, key) {
                     current = n.right;
                 }
             } else {
-                break b968;
+                break b1018;
             }
-            continue l969;
+            continue l1019;
         };
     };
     return -1;
@@ -10879,7 +11372,7 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/TreeMap<Strin
             break __seq_lit: __local_22;
         }), size: 0, deleted_count: 0 };
         block {
-            l977: loop {
+            l1027: loop {
                 let __sroa_key_r_discriminant: i32;
                 let __sroa_key_r_case0_payload_0: ref null "core:prelude/string.wado//String";
                 let __sroa_key_r_case1_payload_0: ref null "core:serde//DeserializeError";
@@ -10897,29 +11390,29 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/TreeMap<Strin
                             "core:collections/TreeMap<String,String>::insert"(result, key, val);
                         }
                         if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(val_r) {
-                            e_11 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(val_r).payload_0);
-                            return 1, ref.null none, e_11;
+                            e_11 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(val_r).payload_0;
+                            return struct.new "core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_11 };
                         }
                     } else {
                         end_r = "core:json/JsonDeserializer::expect_char"(ma.de, 125);
                         if ref.is_null(end_r) == 0 {
-                            e_7 = value_copy "core:serde//DeserializeError"(ref.as_non_null(end_r));
-                            return 1, ref.null none, e_7;
+                            e_7 = ref.as_non_null(end_r);
+                            return struct.new "core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_7 };
                         }
-                        return 0, result, ref.null none;
+                        return struct.new "core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>::Ok" { discriminant: 0, payload_0: result };
                     }
                 }
                 if __sroa_key_r_discriminant == 1 {
                     e_12 = __sroa_key_r_case1_payload_0;
-                    return 1, ref.null none, e_12;
+                    return struct.new "core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_12 };
                 }
-                continue l977;
+                continue l1027;
             };
         };
     }
     if __sroa_map_r_discriminant == 1 {
         e_13 = __sroa_map_r_case1_payload_0;
-        return 1, ref.null none, e_13;
+        return struct.new "core:prelude/types.wado//Result<TreeMap<String,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_13 };
     }
     "core:internal/unreachable"();
     unreachable;
@@ -11051,13 +11544,13 @@ fn "core:prelude/array.wado/Array<TreeMapEntry<String,String>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l999: loop {
+            l1049: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:collections//TreeMapEntry<String,String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<String,String>">(old_repr, i));
                 i = i + 1;
-                continue l999;
+                continue l1049;
             };
         };
     };
@@ -11088,8 +11581,8 @@ fn "core:collections/TreeMap<String,String>^Serialize::serialize<JsonSerializer>
     if ref.test "core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok"(map_r) {
         m = value_copy "core:json//JsonMapSerializer"(ref.cast "core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok"(map_r).payload_0);
         __iter_5 = struct.new "core:prelude/array.wado//ArrayIter<Tuple<String,String>>" { repr: entries.repr, used: entries.used, index: 0 };
-        b1002: block {
-            l1003: loop {
+        b1052: block {
+            l1053: loop {
                 __pattern_temp_1 = "core:prelude/array.wado/ArrayIter<Tuple<String,String>>^Iterator::next"(__iter_5);
                 if ref.is_null(__pattern_temp_1) == 0 {
                     entry = ref.as_non_null(__pattern_temp_1);
@@ -11106,9 +11599,9 @@ fn "core:collections/TreeMap<String,String>^Serialize::serialize<JsonSerializer>
                         return e_12;
                     }
                 } else {
-                    break b1002;
+                    break b1052;
                 }
-                continue l1003;
+                continue l1053;
             };
         };
         return __inline_JsonMapSerializer_SerializeMap__end_3: block -> ref null "core:serde//SerializeError" {
@@ -11163,8 +11656,8 @@ fn "core:collections/TreeMap<String,String>::entries"(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_String___IntoIterator__into_iter_3: struct.new "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,String>>" { repr: __local_9.repr, used: __local_9.used, index: 0 };
     };
-    b1009: block {
-        l1010: loop {
+    b1059: block {
+        l1060: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,String>>^Iterator::next"(__iter_3);
             if ref.is_null(__pattern_temp_0) == 0 {
                 entry = value_copy "core:collections//TreeMapEntry<String,String>"(ref.as_non_null(__pattern_temp_0));
@@ -11172,9 +11665,9 @@ fn "core:collections/TreeMap<String,String>::entries"(self) {
                     "core:prelude/array.wado/Array<Tuple<String,String>>::push"(result, struct.new "tuple//[String, String]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b1009;
+                break b1059;
             }
-            continue l1010;
+            continue l1060;
         };
     };
     return result;
@@ -11209,13 +11702,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,String>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l1015: loop {
+            l1065: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, String]">(new_repr, i, builtin::array_get<ref "tuple//[String, String]">(old_repr, i));
                 i = i + 1;
-                continue l1015;
+                continue l1065;
             };
         };
     };
@@ -11272,14 +11765,14 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Result<i32,St
                         break __inline_JsonVariantAccess_DeserializeVariant__end_3: ref.null none;
                     };
                     if ref.is_null(end_r_7) == 0 {
-                        e_8 = value_copy "core:serde//DeserializeError"(ref.as_non_null(end_r_7));
-                        return 1, ref.null none, e_8;
+                        e_8 = ref.as_non_null(end_r_7);
+                        return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_8 };
                     }
-                    return 0, struct.new "core:prelude/types.wado//Result<i32,String>::Ok" { discriminant: 0, payload_0: val_6 }, ref.null none;
+                    return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Result<i32,String>::Ok" { discriminant: 0, payload_0: val_6 } };
                 }
                 if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(val_r_5) {
-                    e_9 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(val_r_5).payload_0);
-                    return 1, ref.null none, e_9;
+                    e_9 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(val_r_5).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_9 };
                 }
             }
             if "core:prelude/string.wado/String^Eq::eq"(name, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Err"), used: 3 }) {
@@ -11296,31 +11789,31 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Result<i32,St
                         break __inline_JsonVariantAccess_DeserializeVariant__end_6: ref.null none;
                     };
                     if ref.is_null(end_r_12) == 0 {
-                        e_13 = value_copy "core:serde//DeserializeError"(ref.as_non_null(end_r_12));
-                        return 1, ref.null none, e_13;
+                        e_13 = ref.as_non_null(end_r_12);
+                        return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_13 };
                     }
-                    return 0, struct.new "core:prelude/types.wado//Result<i32,String>::Err" { discriminant: 1, payload_0: val_11 }, ref.null none;
+                    return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Result<i32,String>::Err" { discriminant: 1, payload_0: val_11 } };
                 }
                 if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(val_r_10) {
-                    e_14 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(val_r_10).payload_0);
-                    return 1, ref.null none, e_14;
+                    e_14 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(val_r_10).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_14 };
                 }
             }
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 2, message: ref.as_non_null(__tmpl: block -> ref "core:prelude/string.wado//String" {
+            return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 2, message: ref.as_non_null(__tmpl: block -> ref "core:prelude/string.wado//String" {
                 __local_17 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(40), used: 0 };
                 "core:prelude/string.wado/String::push_str"(__local_17, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unknown Result variant: "), used: 24 });
                 "core:prelude/string.wado/String::push_str"(__local_17, name);
                 break __tmpl: __local_17;
-            }), offset: -1_i64 };
+            }), offset: -1_i64 } };
         }
         if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(name_r) {
-            e_15 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(name_r).payload_0);
-            return 1, ref.null none, e_15;
+            e_15 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(name_r).payload_0;
+            return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_15 };
         }
     }
     if ref.test "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err"(va_r) {
-        e_16 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err"(va_r).payload_0);
-        return 1, ref.null none, e_16;
+        e_16 = ref.cast "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err"(va_r).payload_0;
+        return struct.new "core:prelude/types.wado//Result<Result<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_16 };
     }
     "core:internal/unreachable"();
     unreachable;
@@ -11412,12 +11905,14 @@ fn "core:json/JsonVariantSerializer^SerializeVariant::payload<i32>"(self, value)
 
 fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<Inner>^Deserialize::deserialize<JsonDeserializer>"(d) {
     let seq: ref "core:json//JsonSeqAccess";
+    let first: ref "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>";
     let first_opt: ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner";
     let end_result_5: ref null "core:serde//DeserializeError";
     let e_6: ref "core:serde//DeserializeError";
     let __local_7: ref "core:prelude//Array<Inner>";
     let first_elem: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner";
     let items: ref "core:prelude//Array<Inner>";
+    let next: ref "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>";
     let next_opt: ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner";
     let end_result_12: ref null "core:serde//DeserializeError";
     let e_13: ref "core:serde//DeserializeError";
@@ -11431,65 +11926,59 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<Inner>^
     multivalue_bind [__sroa_seq_result_discriminant, __sroa_seq_result_case0_payload_0, __sroa_seq_result_case1_payload_0] = "core:json/JsonDeserializer^Deserializer::begin_seq"(d);
     if __sroa_seq_result_discriminant == 0 {
         seq = __sroa_seq_result_case0_payload_0;
-        let __sroa_first_discriminant: i32;
-        let __sroa_first_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner";
-        let __sroa_first_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_first_discriminant, __sroa_first_case0_payload_0, __sroa_first_case1_payload_0] = "core:json/JsonSeqAccess^DeserializeSeq::next_element<Inner>"(seq);
-        if __sroa_first_discriminant == 0 {
-            first_opt = __sroa_first_case0_payload_0;
+        first = "core:json/JsonSeqAccess^DeserializeSeq::next_element<Inner>"(seq);
+        if ref.test "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Ok"(first) {
+            first_opt = value_copy "core:prelude/types.wado//Option<Inner>"(ref.cast "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Ok"(first).payload_0);
             if ref.is_null(first_opt) == 0 {
                 first_elem = value_copy "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner"(ref.as_non_null(first_opt));
                 items = struct.new "core:prelude//Array<Inner>" { repr: builtin::array_new<ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner">(2), used: 0 };
                 "core:prelude/array.wado/Array<Inner>::push"(items, first_elem);
                 block {
-                    l1044: loop {
-                        let __sroa_next_discriminant: i32;
-                        let __sroa_next_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner";
-                        let __sroa_next_case1_payload_0: ref null "core:serde//DeserializeError";
-                        multivalue_bind [__sroa_next_discriminant, __sroa_next_case0_payload_0, __sroa_next_case1_payload_0] = "core:json/JsonSeqAccess^DeserializeSeq::next_element<Inner>"(seq);
-                        if __sroa_next_discriminant == 0 {
-                            next_opt = __sroa_next_case0_payload_0;
+                    l1094: loop {
+                        next = "core:json/JsonSeqAccess^DeserializeSeq::next_element<Inner>"(seq);
+                        if ref.test "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Ok"(next) {
+                            next_opt = value_copy "core:prelude/types.wado//Option<Inner>"(ref.cast "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Ok"(next).payload_0);
                             if ref.is_null(next_opt) == 0 {
                                 item = value_copy "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner"(ref.as_non_null(next_opt));
                                 "core:prelude/array.wado/Array<Inner>::push"(items, item);
                             } else {
                                 end_result_12 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
                                 if ref.is_null(end_result_12) == 0 {
-                                    e_13 = value_copy "core:serde//DeserializeError"(ref.as_non_null(end_result_12));
-                                    return 1, ref.null none, e_13;
+                                    e_13 = ref.as_non_null(end_result_12);
+                                    return struct.new "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Err" { discriminant: 1, payload_0: e_13 };
                                 }
-                                return 0, items, ref.null none;
+                                return struct.new "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Ok" { discriminant: 0, payload_0: items };
                             }
                         }
-                        if __sroa_next_discriminant == 1 {
-                            e_15 = __sroa_next_case1_payload_0;
-                            return 1, ref.null none, e_15;
+                        if ref.test "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Err"(next) {
+                            e_15 = ref.cast "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Err"(next).payload_0;
+                            return struct.new "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Err" { discriminant: 1, payload_0: e_15 };
                         }
-                        continue l1044;
+                        continue l1094;
                     };
                 };
             } else {
                 end_result_5 = "core:json/JsonDeserializer::expect_char"(seq.de, 93);
                 if ref.is_null(end_result_5) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(end_result_5));
-                    return 1, ref.null none, e_6;
+                    e_6 = ref.as_non_null(end_result_5);
+                    return struct.new "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Err" { discriminant: 1, payload_0: e_6 };
                 }
-                return 0, ref.as_non_null(__seq_lit: block -> ref "core:prelude//Array<Inner>" {
+                return struct.new "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Ok" { discriminant: 0, payload_0: ref.as_non_null(__seq_lit: block -> ref "core:prelude//Array<Inner>" {
                     __local_7 = struct.new "core:prelude//Array<Inner>" { repr: builtin::array_new<ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner">(0), used: 0 };
                     break __seq_lit: __local_7;
-                }), ref.null none;
+                }) };
             }
         }
-        if __sroa_first_discriminant == 1 {
-            e_16 = __sroa_first_case1_payload_0;
-            return 1, ref.null none, e_16;
+        if ref.test "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Err"(first) {
+            e_16 = ref.cast "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Err"(first).payload_0;
+            return struct.new "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Err" { discriminant: 1, payload_0: e_16 };
         }
         "core:internal/unreachable"();
         unreachable;
     }
     if __sroa_seq_result_discriminant == 1 {
         e_17 = __sroa_seq_result_case1_payload_0;
-        return 1, ref.null none, e_17;
+        return struct.new "core:prelude/types.wado//Result<Array<Inner>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
     }
     "core:internal/unreachable"();
     unreachable;
@@ -11524,13 +12013,13 @@ fn "core:prelude/array.wado/Array<Inner>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l1054: loop {
+            l1104: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner">(new_repr, i, builtin::array_get<ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner">(old_repr, i));
                 i = i + 1;
-                continue l1054;
+                continue l1104;
             };
         };
     };
@@ -11538,51 +12027,58 @@ fn "core:prelude/array.wado/Array<Inner>::grow"(self) {
 }
 
 fn "core:json/JsonSeqAccess^DeserializeSeq::next_element<Inner>"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let elem: ref "core:prelude/types.wado//Result<Inner,DeserializeError>";
-    let v: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner";
-    let e_5: ref "core:serde//DeserializeError";
-    let __local_9: ref "core:prelude/string.wado//String";
-    let __local_10: i64;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i32;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __local_3: ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner";
+    let __local_4: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_9 = self.de.input;
-        break __inline_String__len_0: __local_9.used;
+        __local_5 = self.de.input;
+        break __inline_String__len_0: __local_5.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_10 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_10 };
-        });
+        return struct.new "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_6 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_11 = self.de.input;
-        __local_12 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_11.repr, __local_12);
+        __local_7 = self.de.input;
+        __local_8 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_7.repr, __local_8);
     } == 93 {
-        return 0, ref.null none, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Ok" { discriminant: 0, payload_0: ref.null none };
     }
     if self.first == 0 {
-        r = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r) == 0 {
-            e_2 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-            return 1, ref.null none, e_2;
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
-    elem = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner^Deserialize::deserialize<JsonDeserializer>"(self.de);
-    if ref.test "core:prelude/types.wado//Result<Inner,DeserializeError>::Ok"(elem) {
-        v = value_copy "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner"(ref.cast "core:prelude/types.wado//Result<Inner,DeserializeError>::Ok"(elem).payload_0);
-        return 0, v, ref.null none;
-    }
-    if ref.test "core:prelude/types.wado//Result<Inner,DeserializeError>::Err"(elem) {
-        e_5 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<Inner,DeserializeError>::Err"(elem).payload_0);
-        return 1, ref.null none, e_5;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return let __match_scrut_1: ref "core:prelude/types.wado//Result<Inner,DeserializeError>", __match_scrut_1 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner^Deserialize::deserialize<JsonDeserializer>"(self.de), (if ref.test "core:prelude/types.wado//Result<Inner,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>" {
+        let __cast_3: ref "core:prelude/types.wado//Result<Inner,DeserializeError>::Ok";
+        __cast_3 = ref.cast "core:prelude/types.wado//Result<Inner,DeserializeError>::Ok"(__match_scrut_1);
+        __local_3 = __cast_3.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_3 };
+    } else if ref.test "core:prelude/types.wado//Result<Inner,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Inner,DeserializeError>::Err";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Inner,DeserializeError>::Err"(__match_scrut_1);
+        __local_4 = __cast_2.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<Inner>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_4 };
+    } else {
+        unreachable;
+    });
 }
 
 fn "core:prelude/array.wado/Array<Inner>^Serialize::serialize<JsonSerializer>"(self, s) {
@@ -11607,8 +12103,8 @@ fn "core:prelude/array.wado/Array<Inner>^Serialize::serialize<JsonSerializer>"(s
             __local_16 = self;
             break __inline_Array_Inner__IntoIterator__into_iter_2: struct.new "core:prelude/array.wado//ArrayIter<Inner>" { repr: __local_16.repr, used: __local_16.used, index: 0 };
         };
-        b1063: block {
-            l1064: loop {
+        b1114: block {
+            l1115: loop {
                 __pattern_temp_1 = "core:prelude/array.wado/ArrayIter<Inner>^Iterator::next"(__iter_4);
                 if ref.is_null(__pattern_temp_1) == 0 {
                     item = value_copy "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner"(ref.as_non_null(__pattern_temp_1));
@@ -11618,9 +12114,9 @@ fn "core:prelude/array.wado/Array<Inner>^Serialize::serialize<JsonSerializer>"(s
                         return e_7;
                     }
                 } else {
-                    break b1063;
+                    break b1114;
                 }
-                continue l1064;
+                continue l1115;
             };
         };
         return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref null "core:serde//SerializeError" {
@@ -11683,8 +12179,8 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Outer^Deseria
         seen = 0;
         inner = ref.null none;
         count = 0;
-        b1071: block {
-            l1072: loop {
+        b1122: block {
+            l1123: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -11699,7 +12195,7 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Outer^Deseria
                                 inner = __local_10;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Inner,DeserializeError>::Err"(__local_9).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Outer,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Inner,DeserializeError>::Err"(__local_9).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_11 = __inline_i32_Deserialize__deserialize_JsonDeserializer__3: block -> ref "core:prelude/types.wado//Result<i32,DeserializeError>" {
@@ -11712,27 +12208,27 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Outer^Deseria
                                 count = __local_12;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_11).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Outer,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_11).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b1071;
+                        break b1122;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<Outer,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l1072;
+                continue l1123;
             };
         };
         if (seen & 3) != 3 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<Outer,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer" { inner: inner, count: count }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Outer,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Outer" { inner: inner, count: count } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<Outer,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 
@@ -11820,8 +12316,8 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^De
         };
         address = ref.null none;
         rating = struct.new "core:prelude/types.wado//Option<i32>" { 1 };
-        b1082: block {
-            l1083: loop {
+        b1133: block {
+            l1134: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -11839,7 +12335,7 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^De
                                 name = __local_15;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_14).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_14).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_16 = __inline_i32_Deserialize__deserialize_JsonDeserializer__13: block -> ref "core:prelude/types.wado//Result<i32,DeserializeError>" {
@@ -11852,7 +12348,7 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^De
                                 age = __local_17;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_16).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_16).payload_0 };
                             }
                         } else if __idx == 2 {
                             __local_18 = __inline_f64_Deserialize__deserialize_JsonDeserializer__15: block -> ref "core:prelude/types.wado//Result<f64,DeserializeError>" {
@@ -11865,7 +12361,7 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^De
                                 score = __local_19;
                                 seen = seen | 4;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__local_18).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__local_18).payload_0 };
                             }
                         } else if __idx == 3 {
                             __local_20 = __inline_bool_Deserialize__deserialize_JsonDeserializer__17: block -> ref "core:prelude/types.wado//Result<bool,DeserializeError>" {
@@ -11878,7 +12374,7 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^De
                                 active = __local_21;
                                 seen = seen | 8;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__local_20).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__local_20).payload_0 };
                             }
                         } else if __idx == 4 {
                             __local_22 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<String>^Deserialize::deserialize<JsonDeserializer>"(sd.de);
@@ -11888,7 +12384,7 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^De
                                 tags = __local_23;
                                 seen = seen | 16;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Array<String>,DeserializeError>::Err"(__local_22).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Array<String>,DeserializeError>::Err"(__local_22).payload_0 };
                             }
                         } else if __idx == 5 {
                             __local_24 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<String>^Deserialize::deserialize<JsonDeserializer>"(sd.de);
@@ -11898,7 +12394,7 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^De
                                 address = __local_25;
                                 seen = seen | 32;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(__local_24).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(__local_24).payload_0 };
                             }
                         } else if __idx == 6 {
                             __local_26 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<i32>^Deserialize::deserialize<JsonDeserializer>"(sd.de);
@@ -11908,27 +12404,27 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^De
                                 rating = __local_27;
                                 seen = seen | 64;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__local_26).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__local_26).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b1082;
+                        break b1133;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l1083;
+                continue l1134;
             };
         };
         if (seen & 127) != 127 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct" { name: name, age: age, score: score, active: active, tags: tags, address: address, rating: rating }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//FullStruct" { name: name, age: age, score: score, active: active, tags: tags, address: address, rating: rating } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<FullStruct,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 
@@ -11967,12 +12463,14 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Option<String
 
 fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<String>^Deserialize::deserialize<JsonDeserializer>"(d) {
     let seq: ref "core:json//JsonSeqAccess";
+    let first: ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";
     let first_opt: ref null "core:prelude/string.wado//String";
     let end_result_5: ref null "core:serde//DeserializeError";
     let e_6: ref "core:serde//DeserializeError";
     let __local_7: ref "core:prelude//Array<String>";
     let first_elem: ref "core:prelude/string.wado//String";
     let items: ref "core:prelude//Array<String>";
+    let next: ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";
     let next_opt: ref null "core:prelude/string.wado//String";
     let end_result_12: ref null "core:serde//DeserializeError";
     let e_13: ref "core:serde//DeserializeError";
@@ -11986,24 +12484,18 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<String>
     multivalue_bind [__sroa_seq_result_discriminant, __sroa_seq_result_case0_payload_0, __sroa_seq_result_case1_payload_0] = "core:json/JsonDeserializer^Deserializer::begin_seq"(d);
     if __sroa_seq_result_discriminant == 0 {
         seq = __sroa_seq_result_case0_payload_0;
-        let __sroa_first_discriminant: i32;
-        let __sroa_first_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_first_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_first_discriminant, __sroa_first_case0_payload_0, __sroa_first_case1_payload_0] = "core:json/JsonSeqAccess^DeserializeSeq::next_element<String>"(seq);
-        if __sroa_first_discriminant == 0 {
-            first_opt = __sroa_first_case0_payload_0;
+        first = "core:json/JsonSeqAccess^DeserializeSeq::next_element<String>"(seq);
+        if ref.test "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok"(first) {
+            first_opt = value_copy "core:prelude/types.wado//Option<String>"(ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok"(first).payload_0);
             if ref.is_null(first_opt) == 0 {
                 first_elem = value_copy "core:prelude/string.wado//String"(ref.as_non_null(first_opt));
                 items = struct.new "core:prelude//Array<String>" { repr: builtin::array_new<ref "core:prelude/string.wado//String">(2), used: 0 };
                 "core:prelude/array.wado/Array<String>::push"(items, first_elem);
                 block {
-                    l1110: loop {
-                        let __sroa_next_discriminant: i32;
-                        let __sroa_next_case0_payload_0: ref null "core:prelude/string.wado//String";
-                        let __sroa_next_case1_payload_0: ref null "core:serde//DeserializeError";
-                        multivalue_bind [__sroa_next_discriminant, __sroa_next_case0_payload_0, __sroa_next_case1_payload_0] = "core:json/JsonSeqAccess^DeserializeSeq::next_element<String>"(seq);
-                        if __sroa_next_discriminant == 0 {
-                            next_opt = __sroa_next_case0_payload_0;
+                    l1161: loop {
+                        next = "core:json/JsonSeqAccess^DeserializeSeq::next_element<String>"(seq);
+                        if ref.test "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok"(next) {
+                            next_opt = value_copy "core:prelude/types.wado//Option<String>"(ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok"(next).payload_0);
                             if ref.is_null(next_opt) == 0 {
                                 item = value_copy "core:prelude/string.wado//String"(ref.as_non_null(next_opt));
                                 "core:prelude/array.wado/Array<String>::push"(items, item);
@@ -12016,11 +12508,11 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<String>
                                 return struct.new "core:prelude/types.wado//Result<Array<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: items };
                             }
                         }
-                        if __sroa_next_discriminant == 1 {
-                            e_15 = __sroa_next_case1_payload_0;
+                        if ref.test "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(next) {
+                            e_15 = ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(next).payload_0;
                             return struct.new "core:prelude/types.wado//Result<Array<String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_15 };
                         }
-                        continue l1110;
+                        continue l1161;
                     };
                 };
             } else {
@@ -12035,8 +12527,8 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<String>
                 }) };
             }
         }
-        if __sroa_first_discriminant == 1 {
-            e_16 = __sroa_first_case1_payload_0;
+        if ref.test "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(first) {
+            e_16 = ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(first).payload_0;
             return struct.new "core:prelude/types.wado//Result<Array<String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_16 };
         }
         "core:internal/unreachable"();
@@ -12051,51 +12543,58 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Array<String>
 }
 
 fn "core:json/JsonSeqAccess^DeserializeSeq::next_element<String>"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let elem: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let v: ref "core:prelude/string.wado//String";
-    let e_5: ref "core:serde//DeserializeError";
-    let __local_9: ref "core:prelude/string.wado//String";
-    let __local_10: i64;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i32;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __local_3: ref "core:prelude/string.wado//String";
+    let __local_4: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_9 = self.de.input;
-        break __inline_String__len_0: __local_9.used;
+        __local_5 = self.de.input;
+        break __inline_String__len_0: __local_5.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_10 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_10 };
-        });
+        return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_6 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_11 = self.de.input;
-        __local_12 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_11.repr, __local_12);
+        __local_7 = self.de.input;
+        __local_8 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_7.repr, __local_8);
     } == 93 {
-        return 0, ref.null none, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: ref.null none };
     }
     if self.first == 0 {
-        r = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r) == 0 {
-            e_2 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-            return 1, ref.null none, e_2;
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
-    elem = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/String^Deserialize::deserialize<JsonDeserializer>"(self.de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(elem) {
-        v = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(elem).payload_0);
-        return 0, v, ref.null none;
-    }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(elem) {
-        e_5 = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(elem).payload_0);
-        return 1, ref.null none, e_5;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return let __match_scrut_1: ref "core:prelude/types.wado//Result<String,DeserializeError>", __match_scrut_1 = "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/String^Deserialize::deserialize<JsonDeserializer>"(self.de), (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>" {
+        let __cast_3: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_3 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1);
+        __local_3 = __cast_3.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_3 };
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1);
+        __local_4 = __cast_2.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_4 };
+    } else {
+        unreachable;
+    });
 }
 
 fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^Serialize::serialize<JsonSerializer>"(self, s) {
@@ -12220,8 +12719,8 @@ fn "core:prelude/array.wado/Array<String>^Serialize::serialize<JsonSerializer>"(
             __local_16 = self;
             break __inline_Array_String__IntoIterator__into_iter_2: struct.new "core:prelude/array.wado//ArrayIter<String>" { repr: __local_16.repr, used: __local_16.used, index: 0 };
         };
-        b1130: block {
-            l1131: loop {
+        b1182: block {
+            l1183: loop {
                 __pattern_temp_1 = "core:prelude/array.wado/ArrayIter<String>^Iterator::next"(__iter_4);
                 if ref.is_null(__pattern_temp_1) == 0 {
                     item = value_copy "core:prelude/string.wado//String"(ref.as_non_null(__pattern_temp_1));
@@ -12231,9 +12730,9 @@ fn "core:prelude/array.wado/Array<String>^Serialize::serialize<JsonSerializer>"(
                         return e_7;
                     }
                 } else {
-                    break b1130;
+                    break b1182;
                 }
-                continue l1131;
+                continue l1183;
             };
         };
         return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref null "core:serde//SerializeError" {
@@ -12333,13 +12832,13 @@ fn "core:prelude/array.wado/Array<String>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l1141: loop {
+            l1193: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
                 i = i + 1;
-                continue l1141;
+                continue l1193;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/serde_json_scientific_notation.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_scientific_notation.wir.wado
@@ -33,372 +33,426 @@ struct core:serde//DeserializeError {  // TypeId(4)
 
 array builtin::array<u64> (mut u64);  // TypeId(5)
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(6)
-    Ok(i32),
-    Err(ref "core:serde//DeserializeError"),
+variant core:prelude/types.wado//Option<char> {  // TypeId(6)
+    Some(char),
+    None,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(7)
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(7)
     discriminant: i32,
-    payload_0: i32,
+    payload_0: char,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(8)
-    discriminant: i32,
-    payload_0: ref "core:serde//DeserializeError",
+variant core:prelude/types.wado//Option<f64> {  // TypeId(8)
+    Some(f64),
+    None,
 }
 
-variant core:prelude/types.wado//Result<i64,DeserializeError> {  // TypeId(9)
-    Ok(i64),
-    Err(ref "core:serde//DeserializeError"),
-}
-
-struct core:prelude/types.wado//Result<i64,DeserializeError>::Ok {  // TypeId(10)
-    discriminant: i32,
-    payload_0: i64,
-}
-
-struct core:prelude/types.wado//Result<i64,DeserializeError>::Err {  // TypeId(11)
-    discriminant: i32,
-    payload_0: ref "core:serde//DeserializeError",
-}
-
-variant core:prelude/types.wado//Result<u32,DeserializeError> {  // TypeId(12)
-    Ok(u32),
-    Err(ref "core:serde//DeserializeError"),
-}
-
-struct core:prelude/types.wado//Result<u32,DeserializeError>::Ok {  // TypeId(13)
-    discriminant: i32,
-    payload_0: u32,
-}
-
-struct core:prelude/types.wado//Result<u32,DeserializeError>::Err {  // TypeId(14)
-    discriminant: i32,
-    payload_0: ref "core:serde//DeserializeError",
-}
-
-variant core:prelude/types.wado//Result<u64,DeserializeError> {  // TypeId(15)
-    Ok(u64),
-    Err(ref "core:serde//DeserializeError"),
-}
-
-struct core:prelude/types.wado//Result<u64,DeserializeError>::Ok {  // TypeId(16)
-    discriminant: i32,
-    payload_0: u64,
-}
-
-struct core:prelude/types.wado//Result<u64,DeserializeError>::Err {  // TypeId(17)
-    discriminant: i32,
-    payload_0: ref "core:serde//DeserializeError",
-}
-
-variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(18)
-    Ok(f64),
-    Err(ref "core:serde//DeserializeError"),
-}
-
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(19)
+struct core:prelude/types.wado//Option<f64>::Some {  // TypeId(9)
     discriminant: i32,
     payload_0: f64,
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(20)
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(10)
+    Ok(i32),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(11)
+    discriminant: i32,
+    payload_0: i32,
+}
+
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(12)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<f32,DeserializeError> {  // TypeId(21)
+variant core:prelude/types.wado//Result<i64,DeserializeError> {  // TypeId(13)
+    Ok(i64),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<i64,DeserializeError>::Ok {  // TypeId(14)
+    discriminant: i32,
+    payload_0: i64,
+}
+
+struct core:prelude/types.wado//Result<i64,DeserializeError>::Err {  // TypeId(15)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<u32,DeserializeError> {  // TypeId(16)
+    Ok(u32),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<u32,DeserializeError>::Ok {  // TypeId(17)
+    discriminant: i32,
+    payload_0: u32,
+}
+
+struct core:prelude/types.wado//Result<u32,DeserializeError>::Err {  // TypeId(18)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<u64,DeserializeError> {  // TypeId(19)
+    Ok(u64),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<u64,DeserializeError>::Ok {  // TypeId(20)
+    discriminant: i32,
+    payload_0: u64,
+}
+
+struct core:prelude/types.wado//Result<u64,DeserializeError>::Err {  // TypeId(21)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(22)
+    Ok(f64),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(23)
+    discriminant: i32,
+    payload_0: f64,
+}
+
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(24)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<f32,DeserializeError> {  // TypeId(25)
     Ok(f32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<f32,DeserializeError>::Ok {  // TypeId(22)
+struct core:prelude/types.wado//Result<f32,DeserializeError>::Ok {  // TypeId(26)
     discriminant: i32,
     payload_0: f32,
 }
 
-struct core:prelude/types.wado//Result<f32,DeserializeError>::Err {  // TypeId(23)
+struct core:prelude/types.wado//Result<f32,DeserializeError>::Err {  // TypeId(27)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-struct core:prelude//Array<u64> {  // TypeId(24)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(28)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(29)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(30)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(31)
+    Ok(ref "core:prelude/string.wado//String"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(32)
+    discriminant: i32,
+    payload_0: ref "core:prelude/string.wado//String",
+}
+
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(33)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+struct core:prelude//Array<u64> {  // TypeId(34)
     mut repr: ref builtin::array<u64>,
     mut used: i32,
 }
 
-enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(25)
+enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(35)
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(26)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(36)
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(27)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(37)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(28)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(38)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(29)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(39)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(30)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(40)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(31)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(41)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(32)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(42)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(33)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(43)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(34)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(44)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_0_i32_from_1e2" = fn();  // TypeId(35)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_0_i32_from_1e2" = fn();  // TypeId(45)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_1_i32_from_1e2" = fn();  // TypeId(36)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_1_i32_from_1e2" = fn();  // TypeId(46)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_2_i32_from_5e0" = fn();  // TypeId(37)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_2_i32_from_5e0" = fn();  // TypeId(47)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_3_i32_from_15e1" = fn();  // TypeId(38)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_3_i32_from_15e1" = fn();  // TypeId(48)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_4_i32_from_1_5e1" = fn();  // TypeId(39)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_4_i32_from_1_5e1" = fn();  // TypeId(49)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_5_i32_from_1_0e3" = fn();  // TypeId(40)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_5_i32_from_1_0e3" = fn();  // TypeId(50)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_6_i32_from_negative_scientific" = fn();  // TypeId(41)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_6_i32_from_negative_scientific" = fn();  // TypeId(51)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_7_i32_from_explicit_positive_exponent" = fn();  // TypeId(42)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_7_i32_from_explicit_positive_exponent" = fn();  // TypeId(52)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_10_i64_from_1e10" = fn();  // TypeId(43)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_10_i64_from_1e10" = fn();  // TypeId(53)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_11_i64_from_1e15" = fn();  // TypeId(44)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_11_i64_from_1e15" = fn();  // TypeId(54)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_12_i64_from_9_007199254740991e15" = fn();  // TypeId(45)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_12_i64_from_9_007199254740991e15" = fn();  // TypeId(55)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_13_i64_from__1e10" = fn();  // TypeId(46)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_13_i64_from__1e10" = fn();  // TypeId(56)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_14_u32_from_1e3" = fn();  // TypeId(47)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_14_u32_from_1e3" = fn();  // TypeId(57)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_15_u32_from_4_294967295e9" = fn();  // TypeId(48)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_15_u32_from_4_294967295e9" = fn();  // TypeId(58)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_16_u64_from_1e10" = fn();  // TypeId(49)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_16_u64_from_1e10" = fn();  // TypeId(59)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_18_f64_from_1e10" = fn();  // TypeId(50)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_18_f64_from_1e10" = fn();  // TypeId(60)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_19_f64_from_2_5e_3" = fn();  // TypeId(51)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_19_f64_from_2_5e_3" = fn();  // TypeId(61)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_20_f64_from__1_23e4" = fn();  // TypeId(52)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_20_f64_from__1_23e4" = fn();  // TypeId(62)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_21_f32_from_1e2" = fn();  // TypeId(53)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_21_f32_from_1e2" = fn();  // TypeId(63)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_22_i32_plain_integer_still_works" = fn();  // TypeId(54)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_22_i32_plain_integer_still_works" = fn();  // TypeId(64)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_23_i64_plain_integer_still_works" = fn();  // TypeId(55)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__test_23_i64_plain_integer_still_works" = fn();  // TypeId(65)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_0_i32_from_1e2" = fn();  // TypeId(56)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_0_i32_from_1e2" = fn();  // TypeId(66)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_1_i32_from_1e2" = fn();  // TypeId(57)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_1_i32_from_1e2" = fn();  // TypeId(67)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_2_i32_from_5e0" = fn();  // TypeId(58)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_2_i32_from_5e0" = fn();  // TypeId(68)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_3_i32_from_15e1" = fn();  // TypeId(59)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_3_i32_from_15e1" = fn();  // TypeId(69)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_4_i32_from_1_5e1" = fn();  // TypeId(60)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_4_i32_from_1_5e1" = fn();  // TypeId(70)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_5_i32_from_1_0e3" = fn();  // TypeId(61)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_5_i32_from_1_0e3" = fn();  // TypeId(71)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_6_i32_from_negative_scientific" = fn();  // TypeId(62)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_6_i32_from_negative_scientific" = fn();  // TypeId(72)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_7_i32_from_explicit_positive_exponent" = fn();  // TypeId(63)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_7_i32_from_explicit_positive_exponent" = fn();  // TypeId(73)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_8_i32_rejects_non_integer_scientific" = fn();  // TypeId(64)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_8_i32_rejects_non_integer_scientific" = fn();  // TypeId(74)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_9_i32_rejects_negative_exponent_non_integer" = fn();  // TypeId(65)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_9_i32_rejects_negative_exponent_non_integer" = fn();  // TypeId(75)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_10_i64_from_1e10" = fn();  // TypeId(66)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_10_i64_from_1e10" = fn();  // TypeId(76)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_11_i64_from_1e15" = fn();  // TypeId(67)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_11_i64_from_1e15" = fn();  // TypeId(77)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_12_i64_from_9_007199254740991e15" = fn();  // TypeId(68)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_12_i64_from_9_007199254740991e15" = fn();  // TypeId(78)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_13_i64_from__1e10" = fn();  // TypeId(69)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_13_i64_from__1e10" = fn();  // TypeId(79)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_14_u32_from_1e3" = fn();  // TypeId(70)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_14_u32_from_1e3" = fn();  // TypeId(80)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_15_u32_from_4_294967295e9" = fn();  // TypeId(71)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_15_u32_from_4_294967295e9" = fn();  // TypeId(81)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_16_u64_from_1e10" = fn();  // TypeId(72)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_16_u64_from_1e10" = fn();  // TypeId(82)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_17_u64_rejects_negative_scientific" = fn();  // TypeId(73)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_17_u64_rejects_negative_scientific" = fn();  // TypeId(83)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_18_f64_from_1e10" = fn();  // TypeId(74)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_18_f64_from_1e10" = fn();  // TypeId(84)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_19_f64_from_2_5e_3" = fn();  // TypeId(75)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_19_f64_from_2_5e_3" = fn();  // TypeId(85)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_20_f64_from__1_23e4" = fn();  // TypeId(76)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_20_f64_from__1_23e4" = fn();  // TypeId(86)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_21_f32_from_1e2" = fn();  // TypeId(77)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_21_f32_from_1e2" = fn();  // TypeId(87)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_22_i32_plain_integer_still_works" = fn();  // TypeId(78)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_22_i32_plain_integer_still_works" = fn();  // TypeId(88)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_23_i64_plain_integer_still_works" = fn();  // TypeId(79)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__cm_export____test_23_i64_plain_integer_still_works" = fn();  // TypeId(89)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__initialize_module" = fn();  // TypeId(80)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/__initialize_module" = fn();  // TypeId(90)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(81)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(91)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(82)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(92)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(83)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(93)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(84)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(94)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(85)
+type "functype//core:internal/unreachable" = fn();  // TypeId(95)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(86)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(96)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(87)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(97)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(88)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(98)
 
-type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(89)
+type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(99)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(90)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(100)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(91)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(101)
 
-type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(92)
+type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(102)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(93)
+type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(103)
 
-type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(94)
+type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(104)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(95)
+type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(105)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(96)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(106)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(97)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(107)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(98)
+type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> ref "core:prelude/types.wado//Option<f64>";  // TypeId(108)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(99)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(109)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(100)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(110)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(101)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(111)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(102)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(112)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(103)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(113)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(104)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(114)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(105)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(115)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(106)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(116)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(107)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(117)
 
-type "functype//core:json/JsonDeserializer::parse_i64_from" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String", i64) -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(108)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(118)
 
-type "functype//core:json/JsonDeserializer::parse_u64_from" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String", i64) -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(109)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(119)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(110)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(120)
 
-type "functype//core:json/JsonDeserializer::parse_i64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(111)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(121)
 
-type "functype//core:json/JsonDeserializer::parse_u64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(112)
+type "functype//core:json/JsonDeserializer::parse_i64_from" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String", i64) -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(122)
 
-type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(113)
+type "functype//core:json/JsonDeserializer::parse_u64_from" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String", i64) -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(123)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_i64" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(114)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(124)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_u32" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u32,DeserializeError>";  // TypeId(115)
+type "functype//core:json/JsonDeserializer::parse_i64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(125)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_u64" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(116)
+type "functype//core:json/JsonDeserializer::parse_u64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(126)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_f32" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f32,DeserializeError>";  // TypeId(117)
+type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(127)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(118)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_i64" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(128)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(119)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_u32" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u32,DeserializeError>";  // TypeId(129)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(120)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_u64" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(130)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(121)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(131)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(122)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(132)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(123)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(133)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/f32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f32,DeserializeError>";  // TypeId(124)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(134)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/f64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(125)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(135)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/u64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(126)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(136)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/u32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u32,DeserializeError>";  // TypeId(127)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/f32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f32,DeserializeError>";  // TypeId(137)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/i64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(128)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/f64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(138)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(129)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/u64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u64,DeserializeError>";  // TypeId(139)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(130)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/u32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u32,DeserializeError>";  // TypeId(140)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(131)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/i64^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i64,DeserializeError>";  // TypeId(141)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(132)
+type "functype//wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(142)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(133)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(143)
 
-type "functype//core:prelude/fpfmt.wado/unpack32" = fn(f32) -> [u64, i32];  // TypeId(134)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(144)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(135)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(145)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(136)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(146)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(137)
+type "functype//core:prelude/fpfmt.wado/unpack32" = fn(f32) -> [u64, i32];  // TypeId(147)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(138)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(148)
 
-type "functype//core:prelude/fpfmt.wado/short32" = fn(f32) -> [u64, i32];  // TypeId(139)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(149)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(140)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(150)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(141)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(151)
 
-type "functype//core:prelude/fpfmt.wado/parse_text" = fn(ref "core:prelude/string.wado//String") -> [i32, f64];  // TypeId(142)
+type "functype//core:prelude/fpfmt.wado/short32" = fn(f32) -> [u64, i32];  // TypeId(152)
 
-type "functype//core:json/core/json/from_string<f32>" = fn(ref "core:prelude/string.wado//String") -> [i32, f32, ref null "core:serde//DeserializeError"];  // TypeId(143)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(153)
 
-type "functype//core:json/core/json/from_string<f64>" = fn(ref "core:prelude/string.wado//String") -> [i32, f64, ref null "core:serde//DeserializeError"];  // TypeId(144)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(154)
 
-type "functype//core:json/core/json/from_string<u64>" = fn(ref "core:prelude/string.wado//String") -> [i32, u64, ref null "core:serde//DeserializeError"];  // TypeId(145)
+type "functype//core:json/core/json/from_string<f32>" = fn(ref "core:prelude/string.wado//String") -> [i32, f32, ref null "core:serde//DeserializeError"];  // TypeId(155)
 
-type "functype//core:json/core/json/from_string<u32>" = fn(ref "core:prelude/string.wado//String") -> [i32, u32, ref null "core:serde//DeserializeError"];  // TypeId(146)
+type "functype//core:json/core/json/from_string<f64>" = fn(ref "core:prelude/string.wado//String") -> [i32, f64, ref null "core:serde//DeserializeError"];  // TypeId(156)
 
-type "functype//core:json/core/json/from_string<i64>" = fn(ref "core:prelude/string.wado//String") -> [i32, i64, ref null "core:serde//DeserializeError"];  // TypeId(147)
+type "functype//core:json/core/json/from_string<u64>" = fn(ref "core:prelude/string.wado//String") -> [i32, u64, ref null "core:serde//DeserializeError"];  // TypeId(157)
 
-type "functype//core:json/core/json/from_string<i32>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(148)
+type "functype//core:json/core/json/from_string<u32>" = fn(ref "core:prelude/string.wado//String") -> [i32, u32, ref null "core:serde//DeserializeError"];  // TypeId(158)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(149)
+type "functype//core:json/core/json/from_string<i64>" = fn(ref "core:prelude/string.wado//String") -> [i32, i64, ref null "core:serde//DeserializeError"];  // TypeId(159)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(150)
+type "functype//core:json/core/json/from_string<i32>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(160)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(151)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(161)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(152)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(162)
 
-type "functype//core:prelude/primitive.wado/u32::fmt_decimal" = fn(u32, ref "core:prelude/format.wado//Formatter");  // TypeId(153)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(163)
 
-type "functype//core:prelude/primitive.wado/i64::fmt_decimal" = fn(i64, ref "core:prelude/format.wado//Formatter");  // TypeId(154)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(164)
 
-type "functype//core:prelude/primitive.wado/u64::fmt_decimal" = fn(u64, ref "core:prelude/format.wado//Formatter");  // TypeId(155)
+type "functype//core:prelude/primitive.wado/u32::fmt_decimal" = fn(u32, ref "core:prelude/format.wado//Formatter");  // TypeId(165)
 
-type "functype//core:prelude/primitive.wado/f32::inspect_into" = fn(f32, ref "core:prelude/format.wado//Formatter");  // TypeId(156)
+type "functype//core:prelude/primitive.wado/i64::fmt_decimal" = fn(i64, ref "core:prelude/format.wado//Formatter");  // TypeId(166)
 
-type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(157)
+type "functype//core:prelude/primitive.wado/u64::fmt_decimal" = fn(u64, ref "core:prelude/format.wado//Formatter");  // TypeId(167)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(158)
+type "functype//core:prelude/primitive.wado/f32::inspect_into" = fn(f32, ref "core:prelude/format.wado//Formatter");  // TypeId(168)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(159)
+type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(169)
 
-type "functype//core:json/JsonDeserializer::has_exp_or_dot" = fn(ref "core:prelude/string.wado//String") -> bool;  // TypeId(160)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(170)
+
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(171)
+
+type "functype//core:json/JsonDeserializer::has_exp_or_dot" = fn(ref "core:prelude/string.wado//String") -> bool;  // TypeId(172)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -2889,7 +2943,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     let _licm_repr_81: ref builtin::array<u8>;
     len = s.used;
     if len == 0 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     sign = 1;
     i = 0;
@@ -2901,7 +2955,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         i = 1;
     }
     if i >= len {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     remaining = len - i;
     c0 = builtin::array_get_u8(s.repr, i);
@@ -2936,7 +2990,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
             0;
         }) {
             if remaining == 3 {
-                return 0, f64.copysign(inf, sign);
+                return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(inf, sign) };
             }
             if remaining == 8 {
                 c3 = __inline_String__get_byte_5: block -> u8 {
@@ -2996,11 +3050,11 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
                 } else {
                     0;
                 }) {
-                    return 0, f64.copysign(inf, sign);
+                    return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(inf, sign) };
                 }
             }
         }
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     if (if (if c0 == 110 -> i32 {
         1;
@@ -3032,9 +3086,9 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         } else {
             0;
         }) {
-            return 0, 0 / 0;
+            return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: 0 / 0 };
         }
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     d = 0_i64;
     frac = 0;
@@ -3067,7 +3121,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         0;
     }) {
         if int_digits == 0 {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
         i = i + 1;
         frac_start = i;
@@ -3094,7 +3148,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
             };
         };
         if i == frac_start {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
     }
     total_digits = int_digits + frac;
@@ -3103,7 +3157,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
     } else {
         total_digits > 19;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     p = 0;
     if (if i < len -> i32 {
@@ -3131,7 +3185,7 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
         } else {
             (len - i) > 3;
         }) {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
         __for_2: block {
             _licm_repr_81 = s.repr;
@@ -3155,25 +3209,25 @@ fn "core:prelude/fpfmt.wado/parse_text"(s) {
             };
         };
         if i == exp_start {
-            return 1, 0;
+            return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
         }
         p = p * exp_sign;
     }
     if i != len {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<f64>" { 1 };
     }
     if d == 0_i64 {
-        return 0, f64.copysign(0, sign);
+        return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(0, sign) };
     }
     eff_p = p - frac;
     if eff_p > 350 {
-        return 0, f64.copysign(inf, sign);
+        return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(inf, sign) };
     }
     if eff_p < -351 {
-        return 0, f64.copysign(0, sign);
+        return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(0, sign) };
     }
     val = "core:prelude/fpfmt.wado/parse"(d, eff_p);
-    return 0, f64.copysign(val, sign);
+    return struct.new "core:prelude/types.wado//Option<f64>::Some" { discriminant: 0, payload_0: f64.copysign(val, sign) };
 }
 
 fn "core:prelude/primitive.wado/count_digits_i64"(val) {
@@ -3251,217 +3305,305 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/core/json/from_string<f32>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<f32,DeserializeError>";
+    let __local_2: f32;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: f32;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/f32^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<f32,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<f32,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0_f32, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<f32,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/f32^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<f32,DeserializeError>::Ok"(__match_scrut_0) -> f32 {
+        let __cast_2: ref "core:prelude/types.wado//Result<f32,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<f32,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<f32,DeserializeError>::Err"(__match_scrut_0) -> f32 {
+        let __cast_1: ref "core:prelude/types.wado//Result<f32,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<f32,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0_f32, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0_f32, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<f32,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<f32,DeserializeError>::Err"(r).payload_0);
-        return 1, 0_f32, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/from_string<f64>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<f64,DeserializeError>";
+    let __local_2: f64;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: f64;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/f64^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<f64,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/f64^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(__match_scrut_0) -> f64 {
+        let __cast_2: ref "core:prelude/types.wado//Result<f64,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__match_scrut_0) -> f64 {
+        let __cast_1: ref "core:prelude/types.wado//Result<f64,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(r).payload_0);
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/from_string<u64>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<u64,DeserializeError>";
+    let __local_2: u64;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: u64;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/u64^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<u64,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<u64,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<u64,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/u64^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<u64,DeserializeError>::Ok"(__match_scrut_0) -> u64 {
+        let __cast_2: ref "core:prelude/types.wado//Result<u64,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<u64,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<u64,DeserializeError>::Err"(__match_scrut_0) -> u64 {
+        let __cast_1: ref "core:prelude/types.wado//Result<u64,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<u64,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0_i64, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<u64,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<u64,DeserializeError>::Err"(r).payload_0);
-        return 1, 0_i64, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/from_string<u32>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<u32,DeserializeError>";
+    let __local_2: u32;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: u32;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/u32^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<u32,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<u32,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<u32,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/u32^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<u32,DeserializeError>::Ok"(__match_scrut_0) -> u32 {
+        let __cast_2: ref "core:prelude/types.wado//Result<u32,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<u32,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<u32,DeserializeError>::Err"(__match_scrut_0) -> u32 {
+        let __cast_1: ref "core:prelude/types.wado//Result<u32,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<u32,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<u32,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<u32,DeserializeError>::Err"(r).payload_0);
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/from_string<i64>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<i64,DeserializeError>";
+    let __local_2: i64;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: i64;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/i64^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<i64,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/i64^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(__match_scrut_0) -> i64 {
+        let __cast_2: ref "core:prelude/types.wado//Result<i64,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(__match_scrut_0) -> i64 {
+        let __cast_1: ref "core:prelude/types.wado//Result<i64,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0_i64, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0_i64, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(r).payload_0);
-        return 1, 0_i64, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/from_string<i32>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
+    let __local_2: i32;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: i32;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/i32^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/i32^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_0) -> i32 {
+        let __cast_2: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_0) -> i32 {
+        let __cast_1: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(r).payload_0);
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -3573,10 +3715,10 @@ fn "core:prelude/primitive.wado/u64::fmt_decimal"(self, f) {
     }
     digit_count = 0;
     temp = val_i64;
-    b292: block {
-        l293: loop {
+    b303: block {
+        l304: loop {
             if temp == 0_i64 {
-                break b292;
+                break b303;
             }
             digit_count = digit_count + 1;
             if temp >= 0_i64 {
@@ -3591,7 +3733,7 @@ fn "core:prelude/primitive.wado/u64::fmt_decimal"(self, f) {
                 }
                 temp = (signed_quot_9 + 1844674407370955161_i64) + carry_10;
             }
-            continue l293;
+            continue l304;
         };
     };
     offset_11 = "core:prelude/format.wado/Formatter::prepare_int_write"(f, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
@@ -3601,10 +3743,10 @@ fn "core:prelude/primitive.wado/u64::fmt_decimal"(self, f) {
     };
     pos = offset_11 + digit_count;
     temp = val_i64;
-    b297: block {
-        l298: loop {
+    b308: block {
+        l309: loop {
             if temp == 0_i64 {
-                break b297;
+                break b308;
             }
             pos = pos - 1;
             digit = 0;
@@ -3627,7 +3769,7 @@ fn "core:prelude/primitive.wado/u64::fmt_decimal"(self, f) {
                 temp = (signed_quot_17 + 1844674407370955161_i64) + carry_18;
             }
             builtin::array_set_u8(repr, pos, (48 + digit) & 255);
-            continue l298;
+            continue l309;
         };
     };
 }
@@ -3968,6 +4110,55 @@ fn "core:prelude/string.wado/String::push_str"(self, other) {
     self.used = new_used;
 }
 
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
+}
+
 fn "core:prelude/string.wado/String::push"(self, c) {
     let code: u32;
     code = c;
@@ -4006,10 +4197,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b344: block {
-        l345: loop {
+    b362: block {
+        l363: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b344;
+                break b362;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -4033,7 +4224,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l345;
+            continue l363;
         };
     };
     self.pos = _hfs_pos_8;
@@ -4051,130 +4242,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
+        }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b353: block {
-        l354: loop {
-            if scan_pos >= _licm_used_90 {
-                break b353;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b371: block {
+        l372: loop {
+            if scan_pos >= _licm_used_56 {
+                break b371;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b353;
+                break b371;
             }
             scan_pos = scan_pos + 1;
-            continue l354;
+            continue l372;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -4183,94 +4346,95 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l361: loop {
+                l379: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l361;
+                    continue l379;
                 };
             };
         };
         self.pos = scan_pos + 1;
-        return 0, result_5, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l364: loop {
+            l382: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l364;
+                continue l382;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b366: block {
-        l367: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b384: block {
+        l385: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b366;
+                break b384;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
-                return 0, result_8, ref.null none;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
+                return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
-                    });
+                    self.pos = _hfs_pos_64;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
+                    }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -4288,213 +4452,140 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return 1, ref.null none, e;
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
-                    });
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
+                    }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
-                    });
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
+                    }) };
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l367;
+            continue l385;
         };
     };
-    self.pos = _hfs_pos_98;
-    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
-    });
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
+    }) };
 }
 
 fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l392: loop {
+            l405: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l392;
+                continue l405;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -4508,7 +4599,7 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(raw) {
         _licm_used_7 = raw.used;
         _licm_repr_8 = raw.repr;
         block {
-            l402: loop {
+            l411: loop {
                 if i >= _licm_used_7 {
                     break __for_4;
                 }
@@ -4525,7 +4616,7 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(raw) {
                     return 1;
                 }
                 i = i + 1;
-                continue l402;
+                continue l411;
             };
         };
     };
@@ -4534,38 +4625,47 @@ fn "core:json/JsonDeserializer::has_exp_or_dot"(raw) {
 
 fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {
     let has_exp: bool;
-    let v: f64;
+    let __local_4: f64;
     let neg: bool;
     let idx: i32;
     let len: i32;
     let result: i64;
     let b: i32;
     let digit: i64;
+    let __local_11: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/string.wado//String";
     let __local_15: ref "core:prelude/string.wado//String";
-    let __local_17: ref "core:prelude/string.wado//String";
-    let __local_24: ref "core:prelude/string.wado//String";
-    let _licm_repr_26: ref builtin::array<u8>;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let _licm_repr_24: ref builtin::array<u8>;
     has_exp = "core:json/JsonDeserializer::has_exp_or_dot"(raw);
     if has_exp {
-        let __sroa_parsed_discriminant: i32;
-        let __sroa_parsed_payload_0: f64;
-        __local_13 = value_copy "core:prelude/string.wado//String"(raw);
-        multivalue_bind [__sroa_parsed_discriminant, __sroa_parsed_payload_0] = "core:prelude/fpfmt.wado/parse_text"(__local_13);
-        if __sroa_parsed_discriminant == 0 {
-            v = __sroa_parsed_payload_0;
-            if v != builtin::f64_floor(v) {
+        let __match_scrut_0: ref "core:prelude/types.wado//Option<f64>";
+        __match_scrut_0 = __inline_f64__parse_0: block -> ref "core:prelude/types.wado//Option<f64>" {
+            __local_11 = value_copy "core:prelude/string.wado//String"(raw);
+            break __inline_f64__parse_0: "core:prelude/fpfmt.wado/parse_text"(__local_11);
+        };
+        if ref.test "core:prelude/types.wado//Option<f64>::Some"(__match_scrut_0) {
+            let __cast_1: ref "core:prelude/types.wado//Option<f64>::Some";
+            __cast_1 = ref.cast "core:prelude/types.wado//Option<f64>::Some"(__match_scrut_0);
+            __local_4 = __cast_1.payload_0;
+            if __local_4 != builtin::f64_floor(__local_4) {
                 return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_2: block -> ref "core:serde//DeserializeError" {
-                    __local_15 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
-                    break __inline_DeserializeError__unexpected_type_2: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_15, offset: start };
+                    __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
+                    break __inline_DeserializeError__unexpected_type_2: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_13, offset: start };
                 }) };
             }
-            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v) };
+            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(__local_4) };
+            unreachable;
+        } else if __match_scrut_0.discriminant == 1 {
+            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_3: block -> ref "core:serde//DeserializeError" {
+                __local_15 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid number"), used: 14 };
+                break __inline_DeserializeError__invalid_value_3: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_15, offset: start };
+            }) };
+            unreachable;
+        } else {
+            unreachable;
         }
-        return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_3: block -> ref "core:serde//DeserializeError" {
-            __local_17 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid number"), used: 14 };
-            break __inline_DeserializeError__invalid_value_3: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_17, offset: start };
-        }) };
+        unreachable;
     }
     neg = 0;
     idx = 0;
@@ -4579,27 +4679,27 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {
         idx = 1;
     }
     result = 0_i64;
-    _licm_repr_26 = raw.repr;
-    b412: block {
-        l413: loop {
+    _licm_repr_24 = raw.repr;
+    b422: block {
+        l423: loop {
             if idx >= len {
-                break b412;
+                break b422;
             }
-            b = builtin::array_get_u8(_licm_repr_26, idx);
+            b = builtin::array_get_u8(_licm_repr_24, idx);
             if (if b < 48 -> i32 {
                 1;
             } else {
                 b > 57;
             }) {
                 return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_7: block -> ref "core:serde//DeserializeError" {
-                    __local_24 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid digit in number"), used: 23 };
-                    break __inline_DeserializeError__invalid_value_7: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_24, offset: start };
+                    __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid digit in number"), used: 23 };
+                    break __inline_DeserializeError__invalid_value_7: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_22, offset: start };
                 }) };
             }
             digit = builtin::i64_extend_i32_s(b - 48);
             result = (result * 10_i64) + digit;
             idx = idx + 1;
-            continue l413;
+            continue l423;
         };
     };
     if neg {
@@ -4610,80 +4710,89 @@ fn "core:json/JsonDeserializer::parse_i64_from"(self, raw, start) {
 
 fn "core:json/JsonDeserializer::parse_u64_from"(self, raw, start) {
     let has_exp: bool;
-    let v: f64;
+    let __local_4: f64;
     let idx: i32;
     let len: i32;
     let result: u64;
     let b: i32;
     let digit: u64;
+    let __local_13: ref "core:prelude/string.wado//String";
     let __local_15: ref "core:prelude/string.wado//String";
-    let __local_17: ref "core:prelude/string.wado//String";
-    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
     let __local_21: ref "core:prelude/string.wado//String";
-    let __local_23: ref "core:prelude/string.wado//String";
-    let __local_28: ref "core:prelude/string.wado//String";
-    let _licm_repr_30: ref builtin::array<u8>;
+    let __local_26: ref "core:prelude/string.wado//String";
+    let _licm_repr_28: ref builtin::array<u8>;
     if (if raw.used > 0 -> i32 {
         builtin::array_get_u8(raw.repr, 0) == 45;
     } else {
         0;
     }) {
         return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__overflow_2: block -> ref "core:serde//DeserializeError" {
-            __local_15 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative value for u64"), used: 22 };
-            break __inline_DeserializeError__overflow_2: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_15, offset: start };
+            __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative value for u64"), used: 22 };
+            break __inline_DeserializeError__overflow_2: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_13, offset: start };
         }) };
     }
     has_exp = "core:json/JsonDeserializer::has_exp_or_dot"(raw);
     if has_exp {
-        let __sroa_parsed_discriminant: i32;
-        let __sroa_parsed_payload_0: f64;
-        __local_17 = value_copy "core:prelude/string.wado//String"(raw);
-        multivalue_bind [__sroa_parsed_discriminant, __sroa_parsed_payload_0] = "core:prelude/fpfmt.wado/parse_text"(__local_17);
-        if __sroa_parsed_discriminant == 0 {
-            v = __sroa_parsed_payload_0;
-            if v < 0 {
+        let __match_scrut_0: ref "core:prelude/types.wado//Option<f64>";
+        __match_scrut_0 = __inline_f64__parse_3: block -> ref "core:prelude/types.wado//Option<f64>" {
+            __local_15 = value_copy "core:prelude/string.wado//String"(raw);
+            break __inline_f64__parse_3: "core:prelude/fpfmt.wado/parse_text"(__local_15);
+        };
+        if ref.test "core:prelude/types.wado//Option<f64>::Some"(__match_scrut_0) {
+            let __cast_1: ref "core:prelude/types.wado//Option<f64>::Some";
+            __cast_1 = ref.cast "core:prelude/types.wado//Option<f64>::Some"(__match_scrut_0);
+            __local_4 = __cast_1.payload_0;
+            if __local_4 < 0 {
                 return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__overflow_4: block -> ref "core:serde//DeserializeError" {
-                    __local_18 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative value for u64"), used: 22 };
-                    break __inline_DeserializeError__overflow_4: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_18, offset: start };
+                    __local_16 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative value for u64"), used: 22 };
+                    break __inline_DeserializeError__overflow_4: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_16, offset: start };
                 }) };
             }
-            if v != builtin::f64_floor(v) {
+            if __local_4 != builtin::f64_floor(__local_4) {
                 return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_6: block -> ref "core:serde//DeserializeError" {
-                    __local_21 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
-                    break __inline_DeserializeError__unexpected_type_6: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_21, offset: start };
+                    __local_19 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected integer, got float"), used: 27 };
+                    break __inline_DeserializeError__unexpected_type_6: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_19, offset: start };
                 }) };
             }
-            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_u(v) };
+            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_u(__local_4) };
+            unreachable;
+        } else if __match_scrut_0.discriminant == 1 {
+            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_7: block -> ref "core:serde//DeserializeError" {
+                __local_21 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid number"), used: 14 };
+                break __inline_DeserializeError__invalid_value_7: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_21, offset: start };
+            }) };
+            unreachable;
+        } else {
+            unreachable;
         }
-        return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_7: block -> ref "core:serde//DeserializeError" {
-            __local_23 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid number"), used: 14 };
-            break __inline_DeserializeError__invalid_value_7: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_23, offset: start };
-        }) };
+        unreachable;
     }
     idx = 0;
     len = raw.used;
     result = 0_i64;
-    _licm_repr_30 = raw.repr;
-    b424: block {
-        l425: loop {
+    _licm_repr_28 = raw.repr;
+    b435: block {
+        l436: loop {
             if idx >= len {
-                break b424;
+                break b435;
             }
-            b = builtin::array_get_u8(_licm_repr_30, idx);
+            b = builtin::array_get_u8(_licm_repr_28, idx);
             if (if b < 48 -> i32 {
                 1;
             } else {
                 b > 57;
             }) {
                 return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__invalid_value_10: block -> ref "core:serde//DeserializeError" {
-                    __local_28 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid digit"), used: 13 };
-                    break __inline_DeserializeError__invalid_value_10: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_28, offset: start };
+                    __local_26 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid digit"), used: 13 };
+                    break __inline_DeserializeError__invalid_value_10: struct.new "core:serde//DeserializeError" { kind: 4, message: __local_26, offset: start };
                 }) };
             }
             digit = builtin::i64_extend_i32_s(b - 48);
             result = (result * 10_i64) + digit;
             idx = idx + 1;
-            continue l425;
+            continue l436;
         };
     };
     return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Ok" { discriminant: 0, payload_0: result };
@@ -4775,16 +4884,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b434: block {
-        l435: loop {
+    b445: block {
+        l446: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b434;
+                break b445;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -4805,17 +4914,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b443: block {
-                        l444: loop {
+                    b454: block {
+                        l455: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b443;
+                                break b454;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -4825,9 +4934,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b443;
+                                break b454;
                             }
-                            continue l444;
+                            continue l455;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -4858,17 +4967,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b453: block {
-                            l454: loop {
+                        b464: block {
+                            l465: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b453;
+                                    break b464;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -4877,9 +4986,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b453;
+                                    break b464;
                                 }
-                                continue l454;
+                                continue l465;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -4917,9 +5026,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b434;
+                break b445;
             }
-            continue l435;
+            continue l446;
         };
     };
     self.pos = _hfs_pos_51;
@@ -5014,16 +5123,16 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b469: block {
-        l470: loop {
+    b480: block {
+        l481: loop {
             if _hfs_pos_49 >= _licm_used_45 {
-                break b469;
+                break b480;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_49;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_46, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -5044,17 +5153,17 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b478: block {
-                        l479: loop {
+                    b489: block {
+                        l490: loop {
                             if _hfs_pos_47 >= _licm_used_45 {
                                 self.pos = _hfs_pos_49;
-                                break b478;
+                                break b489;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_47;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_46, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -5064,9 +5173,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                                 _hfs_pos_47 = _hfs_pos_47 + 1;
                             } else {
                                 self.pos = _hfs_pos_49;
-                                break b478;
+                                break b489;
                             }
-                            continue l479;
+                            continue l490;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -5097,17 +5206,17 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                             }
                         }
                         _hfs_pos_48 = _hfs_pos_49;
-                        b488: block {
-                            l489: loop {
+                        b499: block {
+                            l500: loop {
                                 if _hfs_pos_48 >= _licm_used_45 {
                                     self.pos = _hfs_pos_49;
-                                    break b488;
+                                    break b499;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_48;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_46, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -5116,9 +5225,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                                     _hfs_pos_48 = _hfs_pos_48 + 1;
                                 } else {
                                     self.pos = _hfs_pos_49;
-                                    break b488;
+                                    break b499;
                                 }
-                                continue l489;
+                                continue l500;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -5144,9 +5253,9 @@ fn "core:json/JsonDeserializer::parse_i64_direct"(self) {
                 self.pos = _hfs_pos_49;
                 return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_s(v_signed) };
             } else {
-                break b469;
+                break b480;
             }
-            continue l470;
+            continue l481;
         };
     };
     self.pos = _hfs_pos_49;
@@ -5231,16 +5340,16 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
     _licm_used_45 = _licm_input_44.used;
     _licm_repr_46 = _licm_input_44.repr;
     _hfs_pos_49 = self.pos;
-    b501: block {
-        l502: loop {
+    b512: block {
+        l513: loop {
             if _hfs_pos_49 >= _licm_used_45 {
-                break b501;
+                break b512;
             }
             b = __inline_String__get_byte_7: block -> u8 {
                 __local_26 = _hfs_pos_49;
                 break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_46, __local_26);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -5261,17 +5370,17 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                 if b == 46 {
                     _hfs_pos_49 = _hfs_pos_49 + 1;
                     _hfs_pos_47 = _hfs_pos_49;
-                    b510: block {
-                        l511: loop {
+                    b521: block {
+                        l522: loop {
                             if _hfs_pos_47 >= _licm_used_45 {
                                 self.pos = _hfs_pos_49;
-                                break b510;
+                                break b521;
                             }
                             b2 = __inline_String__get_byte_9: block -> u8 {
                                 __local_29 = _hfs_pos_47;
                                 break __inline_String__get_byte_9: builtin::array_get_u8(_licm_repr_46, __local_29);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -5281,9 +5390,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                                 _hfs_pos_47 = _hfs_pos_47 + 1;
                             } else {
                                 self.pos = _hfs_pos_49;
-                                break b510;
+                                break b521;
                             }
-                            continue l511;
+                            continue l522;
                         };
                     };
                     _hfs_pos_49 = _hfs_pos_47;
@@ -5314,17 +5423,17 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                             }
                         }
                         _hfs_pos_48 = _hfs_pos_49;
-                        b520: block {
-                            l521: loop {
+                        b531: block {
+                            l532: loop {
                                 if _hfs_pos_48 >= _licm_used_45 {
                                     self.pos = _hfs_pos_49;
-                                    break b520;
+                                    break b531;
                                 }
                                 b3 = __inline_String__get_byte_15: block -> u8 {
                                     __local_38 = _hfs_pos_48;
                                     break __inline_String__get_byte_15: builtin::array_get_u8(_licm_repr_46, __local_38);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -5333,9 +5442,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                                     _hfs_pos_48 = _hfs_pos_48 + 1;
                                 } else {
                                     self.pos = _hfs_pos_49;
-                                    break b520;
+                                    break b531;
                                 }
-                                continue l521;
+                                continue l532;
                             };
                         };
                         _hfs_pos_49 = _hfs_pos_48;
@@ -5364,9 +5473,9 @@ fn "core:json/JsonDeserializer::parse_u64_direct"(self) {
                 self.pos = _hfs_pos_49;
                 return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i64_trunc_f64_u(v) };
             } else {
-                break b501;
+                break b512;
             }
-            continue l502;
+            continue l513;
         };
     };
     self.pos = _hfs_pos_49;
@@ -5475,16 +5584,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b533: block {
-        l534: loop {
+    b544: block {
+        l545: loop {
             if _hfs_pos_57 >= _licm_used_49 {
-                break b533;
+                break b544;
             }
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_50, __local_32);
             };
-            if (if b_6 >= 48 -> i32 {
+            if (if 48 <= b_6 -> i32 {
                 b_6 <= 57;
             } else {
                 0;
@@ -5495,9 +5604,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                 total_digits = total_digits + 1;
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
-                break b533;
+                break b544;
             }
-            continue l534;
+            continue l545;
         };
     };
     self.pos = _hfs_pos_57;
@@ -5519,16 +5628,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b541: block {
-            l542: loop {
+        b552: block {
+            l553: loop {
                 if _hfs_pos_58 >= _licm_used_52 {
-                    break b541;
+                    break b552;
                 }
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
                     break __inline_String__get_byte_12: builtin::array_get_u8(_licm_repr_53, __local_38);
                 };
-                if (if b_8 >= 48 -> i32 {
+                if (if 48 <= b_8 -> i32 {
                     b_8 <= 57;
                 } else {
                     0;
@@ -5540,9 +5649,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                     total_digits = total_digits + 1;
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
-                    break b541;
+                    break b552;
                 }
-                continue l542;
+                continue l553;
             };
         };
         self.pos = _hfs_pos_58;
@@ -5584,16 +5693,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b553: block {
-                l554: loop {
+            b564: block {
+                l565: loop {
                     if _hfs_pos_59 >= _licm_used_55 {
-                        break b553;
+                        break b564;
                     }
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
                         break __inline_String__get_byte_18: builtin::array_get_u8(_licm_repr_56, __local_47);
                     };
-                    if (if b3 >= 48 -> i32 {
+                    if (if 48 <= b3 -> i32 {
                         b3 <= 57;
                     } else {
                         0;
@@ -5601,9 +5710,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                         exp = (exp * 10) + (b3 - 48);
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
-                        break b553;
+                        break b564;
                     }
-                    continue l554;
+                    continue l565;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -5639,127 +5748,120 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_i64"(self) {
     let start: i64;
+    let __local_2: ref "core:prelude/string.wado//String";
+    let __local_3: ref "core:serde//DeserializeError";
     let s: ref "core:prelude/string.wado//String";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     start = builtin::i64_extend_i32_s(self.pos);
     if (if self.pos < __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_5 = self.input;
+        break __inline_String__len_0: __local_5.used;
     } -> i32 {
         __inline_String__get_byte_1: block -> u8 {
-            __local_8 = self.input;
-            __local_9 = self.pos;
-            break __inline_String__get_byte_1: builtin::array_get_u8(__local_8.repr, __local_9);
+            __local_6 = self.input;
+            __local_7 = self.pos;
+            break __inline_String__get_byte_1: builtin::array_get_u8(__local_6.repr, __local_7);
         } == 34;
     } else {
         0;
     }) {
-        let __sroa_sr_discriminant: i32;
-        let __sroa_sr_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_sr_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_sr_discriminant, __sroa_sr_case0_payload_0, __sroa_sr_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self);
-        if __sroa_sr_discriminant == 0 {
-            s = __sroa_sr_case0_payload_0;
-            return "core:json/JsonDeserializer::parse_i64_from"(self, s, start);
-        }
-        if __sroa_sr_discriminant == 1 {
-            e = __sroa_sr_case1_payload_0;
-            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: e };
-        }
-        "core:internal/unreachable"();
-        unreachable;
+        s = value_copy "core:prelude/string.wado//String"(let __match_scrut_0: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_0 = "core:json/JsonDeserializer::read_json_string"(self); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+            let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0);
+            __local_2 = __cast_2.payload_0;
+            __local_2;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+            let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0);
+            __local_3 = __cast_1.payload_0;
+            return struct.new "core:prelude/types.wado//Result<i64,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
+        }));
+        return "core:json/JsonDeserializer::parse_i64_from"(self, s, start);
     }
     return "core:json/JsonDeserializer::parse_i64_direct"(self);
 }
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_u32"(self) {
     let start: i64;
-    let ir: ref "core:prelude/types.wado//Result<i64,DeserializeError>";
+    let __local_2: i64;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: i64;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_5: ref "core:prelude/string.wado//String";
     start = builtin::i64_extend_i32_s(self.pos);
-    ir = "core:json/JsonDeserializer::parse_i64_direct"(self);
-    if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(ir) {
-        v = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(ir).payload_0;
-        if (if v < 0_i64 -> i32 {
-            1;
-        } else {
-            v > 4294967295_i64;
-        }) {
-            return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__overflow_0: block -> ref "core:serde//DeserializeError" {
-                __local_7 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("value out of range for u32"), used: 26 };
-                break __inline_DeserializeError__overflow_0: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_7, offset: start };
-            }) };
-        }
-        return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_wrap_i64(v) };
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<i64,DeserializeError>";
+    __match_scrut_0 = "core:json/JsonDeserializer::parse_i64_direct"(self);
+    v = (if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(__match_scrut_0) -> i64 {
+        let __cast_2: ref "core:prelude/types.wado//Result<i64,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(__match_scrut_0) -> i64 {
+        let __cast_1: ref "core:prelude/types.wado//Result<i64,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+        unreachable;
+    } else {
+        unreachable;
+    });
+    if (if v < 0_i64 -> i32 {
+        1;
+    } else {
+        v > 4294967295_i64;
+    }) {
+        return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__overflow_0: block -> ref "core:serde//DeserializeError" {
+            __local_5 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("value out of range for u32"), used: 26 };
+            break __inline_DeserializeError__overflow_0: struct.new "core:serde//DeserializeError" { kind: 5, message: __local_5, offset: start };
+        }) };
     }
-    if ref.test "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(ir) {
-        e = ref.cast "core:prelude/types.wado//Result<i64,DeserializeError>::Err"(ir).payload_0;
-        return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Err" { discriminant: 1, payload_0: e };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_wrap_i64(v) };
 }
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_u64"(self) {
     let start: i64;
+    let __local_2: ref "core:prelude/string.wado//String";
+    let __local_3: ref "core:serde//DeserializeError";
     let s: ref "core:prelude/string.wado//String";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     start = builtin::i64_extend_i32_s(self.pos);
     if (if self.pos < __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_5 = self.input;
+        break __inline_String__len_0: __local_5.used;
     } -> i32 {
         __inline_String__get_byte_1: block -> u8 {
-            __local_8 = self.input;
-            __local_9 = self.pos;
-            break __inline_String__get_byte_1: builtin::array_get_u8(__local_8.repr, __local_9);
+            __local_6 = self.input;
+            __local_7 = self.pos;
+            break __inline_String__get_byte_1: builtin::array_get_u8(__local_6.repr, __local_7);
         } == 34;
     } else {
         0;
     }) {
-        let __sroa_sr_discriminant: i32;
-        let __sroa_sr_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_sr_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_sr_discriminant, __sroa_sr_case0_payload_0, __sroa_sr_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self);
-        if __sroa_sr_discriminant == 0 {
-            s = __sroa_sr_case0_payload_0;
-            return "core:json/JsonDeserializer::parse_u64_from"(self, s, start);
-        }
-        if __sroa_sr_discriminant == 1 {
-            e = __sroa_sr_case1_payload_0;
-            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: e };
-        }
-        "core:internal/unreachable"();
-        unreachable;
+        s = value_copy "core:prelude/string.wado//String"(let __match_scrut_0: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_0 = "core:json/JsonDeserializer::read_json_string"(self); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+            let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0);
+            __local_2 = __cast_2.payload_0;
+            __local_2;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+            let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0);
+            __local_3 = __cast_1.payload_0;
+            return struct.new "core:prelude/types.wado//Result<u64,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
+        }));
+        return "core:json/JsonDeserializer::parse_u64_from"(self, s, start);
     }
     return "core:json/JsonDeserializer::parse_u64_direct"(self);
-}
-
-fn "core:json/JsonDeserializer^Deserializer::deserialize_f32"(self) {
-    let r: ref "core:prelude/types.wado//Result<f64,DeserializeError>";
-    let v: f64;
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::parse_f64_direct"(self);
-    if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(r).payload_0;
-        return struct.new "core:prelude/types.wado//Result<f32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::f32_demote_f64(v) };
-    }
-    if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(r) {
-        e = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(r).payload_0;
-        return struct.new "core:prelude/types.wado//Result<f32,DeserializeError>::Err" { discriminant: 1, payload_0: e };
-    }
-    "core:internal/unreachable"();
-    unreachable;
 }
 
 fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
@@ -5769,13 +5871,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l579: loop {
+            l588: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l579;
+                continue l588;
             };
         };
     };
@@ -5868,10 +5970,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b589: block {
-            l590: loop {
+        b598: block {
+            l599: loop {
                 if i_8 < 0 {
-                    break b589;
+                    break b598;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -5880,7 +5982,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l590;
+                continue l599;
             };
         };
         __for_1: block {
@@ -5888,14 +5990,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l593: loop {
+                l602: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l593;
+                    continue l602;
                 };
             };
         };
@@ -5905,10 +6007,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b595: block {
-            l596: loop {
+        b604: block {
+            l605: loop {
                 if i_10 < 0 {
-                    break b595;
+                    break b604;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -5917,7 +6019,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l596;
+                continue l605;
             };
         };
         __for_2: block {
@@ -5925,14 +6027,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l599: loop {
+                l608: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l599;
+                    continue l608;
                 };
             };
         };
@@ -6050,13 +6152,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l620: loop {
+            l629: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l620;
+                continue l629;
             };
         };
     };
@@ -6064,7 +6166,28 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
 }
 
 fn "wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/f32^Deserialize::deserialize<JsonDeserializer>"(d) {
-    return "core:json/JsonDeserializer^Deserializer::deserialize_f32"(d);
+    let __local_2: f64;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: f64;
+    return __inline_JsonDeserializer_Deserializer__deserialize_f32_0: block -> ref "core:prelude/types.wado//Result<f32,DeserializeError>" {
+        let __match_scrut_0: ref "core:prelude/types.wado//Result<f64,DeserializeError>";
+        __match_scrut_0 = "core:json/JsonDeserializer::parse_f64_direct"(d);
+        __local_4 = (if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(__match_scrut_0) -> f64 {
+            let __cast_2: ref "core:prelude/types.wado//Result<f64,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Ok"(__match_scrut_0);
+            __local_2 = __cast_2.payload_0;
+            __local_2;
+        } else if ref.test "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__match_scrut_0) -> f64 {
+            let __cast_1: ref "core:prelude/types.wado//Result<f64,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__match_scrut_0);
+            __local_3 = __cast_1.payload_0;
+            break __inline_JsonDeserializer_Deserializer__deserialize_f32_0: struct.new "core:prelude/types.wado//Result<f32,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
+        });
+        break __inline_JsonDeserializer_Deserializer__deserialize_f32_0: struct.new "core:prelude/types.wado//Result<f32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::f32_demote_f64(__local_4) };
+    };
 }
 
 fn "wado-compiler/tests/fixtures/serde_json_scientific_notation.wado/f64^Deserialize::deserialize<JsonDeserializer>"(d) {

--- a/wado-compiler/tests/fixtures.golden/serde_json_ser_error.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_ser_error.wir.wado
@@ -1716,26 +1716,38 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
 
 fn "core:json/core/json/to_string<f32>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_f32"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_f32"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<f64>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/JsonSerializer^Serializer::serialize_f64"(ser.buf, value);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/JsonSerializer^Serializer::serialize_f64"(ser.buf, value);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
@@ -2000,7 +2012,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l182: loop {
+            l184: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -2008,7 +2020,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l182;
+                continue l184;
             };
         };
     };
@@ -2137,13 +2149,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l198: loop {
+            l200: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l198;
+                continue l200;
             };
         };
     };
@@ -2236,10 +2248,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b208: block {
-            l209: loop {
+        b210: block {
+            l211: loop {
                 if i_8 < 0 {
-                    break b208;
+                    break b210;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -2248,7 +2260,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l209;
+                continue l211;
             };
         };
         __for_1: block {
@@ -2256,14 +2268,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l212: loop {
+                l214: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l212;
+                    continue l214;
                 };
             };
         };
@@ -2273,10 +2285,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b214: block {
-            l215: loop {
+        b216: block {
+            l217: loop {
                 if i_10 < 0 {
-                    break b214;
+                    break b216;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -2285,7 +2297,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l215;
+                continue l217;
             };
         };
         __for_2: block {
@@ -2293,14 +2305,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l218: loop {
+                l220: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l218;
+                    continue l220;
                 };
             };
         };
@@ -2404,8 +2416,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b237: block {
-        l238: loop {
+    b239: block {
+        l240: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -2430,9 +2442,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b237;
+                break b239;
             }
-            continue l238;
+            continue l240;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -2467,13 +2479,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l247: loop {
+            l249: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l247;
+                continue l249;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/serde_json_string_escape.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_string_escape.wir.wado
@@ -31,157 +31,188 @@ struct core:json//JsonDeserializer {  // TypeId(4)
     mut pos: i32,
 }
 
-struct core:json//JsonSerializer {  // TypeId(5)
-    mut buf: ref "core:prelude/string.wado//String",
-}
-
-struct core:serde//DeserializeError {  // TypeId(6)
+struct core:serde//DeserializeError {  // TypeId(5)
     mut kind: i32,
     mut message: ref "core:prelude/string.wado//String",
     mut offset: i64,
 }
 
-struct core:serde//SerializeError {  // TypeId(7)
+struct core:serde//SerializeError {  // TypeId(6)
     mut kind: i32,
     mut message: ref "core:prelude/string.wado//String",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(8)
+variant core:prelude/types.wado//Option<char> {  // TypeId(7)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(8)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(9)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(9)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(10)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(10)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(11)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(11)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(12)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(12)
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(13)
+    discriminant: i32,
+    payload_0: char,
+}
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(13)
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(14)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(14)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(15)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(15)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(16)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(16)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(17)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(17)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(18)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(18)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(19)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(19)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(20)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_0_serialize_string_with_quotes" = fn();  // TypeId(20)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(21)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_1_serialize_string_with_backslash" = fn();  // TypeId(21)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(22)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_2_serialize_string_with_newline" = fn();  // TypeId(22)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(23)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_3_serialize_string_with_tab" = fn();  // TypeId(23)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_0_serialize_string_with_quotes" = fn();  // TypeId(24)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_4_deserialize_string_with_unicode_escape" = fn();  // TypeId(24)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_1_serialize_string_with_backslash" = fn();  // TypeId(25)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_5_roundtrip_string_with_special_chars" = fn();  // TypeId(25)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_2_serialize_string_with_newline" = fn();  // TypeId(26)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_6_roundtrip_multibyte_utf8_string" = fn();  // TypeId(26)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_3_serialize_string_with_tab" = fn();  // TypeId(27)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_7_roundtrip_empty_string" = fn();  // TypeId(27)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_4_deserialize_string_with_unicode_escape" = fn();  // TypeId(28)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_0_serialize_string_with_quotes" = fn();  // TypeId(28)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_5_roundtrip_string_with_special_chars" = fn();  // TypeId(29)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_1_serialize_string_with_backslash" = fn();  // TypeId(29)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_6_roundtrip_multibyte_utf8_string" = fn();  // TypeId(30)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_2_serialize_string_with_newline" = fn();  // TypeId(30)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__test_7_roundtrip_empty_string" = fn();  // TypeId(31)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_3_serialize_string_with_tab" = fn();  // TypeId(31)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_0_serialize_string_with_quotes" = fn();  // TypeId(32)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_4_deserialize_string_with_unicode_escape" = fn();  // TypeId(32)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_1_serialize_string_with_backslash" = fn();  // TypeId(33)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_5_roundtrip_string_with_special_chars" = fn();  // TypeId(33)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_2_serialize_string_with_newline" = fn();  // TypeId(34)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_6_roundtrip_multibyte_utf8_string" = fn();  // TypeId(34)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_3_serialize_string_with_tab" = fn();  // TypeId(35)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_7_roundtrip_empty_string" = fn();  // TypeId(35)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_4_deserialize_string_with_unicode_escape" = fn();  // TypeId(36)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(36)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_5_roundtrip_string_with_special_chars" = fn();  // TypeId(37)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(37)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_6_roundtrip_multibyte_utf8_string" = fn();  // TypeId(38)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(38)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/__cm_export____test_7_roundtrip_empty_string" = fn();  // TypeId(39)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(39)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(40)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(40)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(41)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(41)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(42)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(42)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(43)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(43)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(44)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(44)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(45)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(45)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(46)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(46)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(47)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(47)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(48)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(48)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(49)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(49)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(50)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(50)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(51)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(51)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(52)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(52)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(53)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(53)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(54)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(54)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(55)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(55)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(56)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(56)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(57)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(57)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(58)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(58)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(59)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(59)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(60)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(60)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(61)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(61)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(62)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(62)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(63)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(63)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(64)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(64)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(65)
 
-type "functype//core:json/core/json/from_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(65)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(66)
 
-type "functype//core:json/core/json/to_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(66)
+type "functype//wado-compiler/tests/fixtures/serde_json_string_escape.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(67)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(67)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(68)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(68)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(69)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(69)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(70)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(70)
+type "functype//core:json/core/json/from_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(71)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(71)
+type "functype//core:json/core/json/to_string<String>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(72)
+
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(73)
+
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(74)
+
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(75)
+
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(76)
+
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(77)
+
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(78)
+
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(79)
+
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(80)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -809,10 +840,6 @@ fn "core:internal/panic"(message) {
     unreachable;
 }
 
-fn "core:internal/unreachable"() {
-    unreachable;
-}
-
 fn "core:internal/cm_lower_list_u8"(data, len) {
     let ptr: i32;
     ptr = "mem/realloc"(0, 0, 1, len);
@@ -896,36 +923,77 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l35: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l35;
+                };
+            };
+        };
     }
-    return ((97 + v) - 10) & 255;
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
         return 1;
     }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l41: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l41;
+            };
+        };
+    };
+    return n;
 }
 
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b37: block {
-        l38: loop {
+    b43: block {
+        l44: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -946,23 +1014,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b37;
+                break b43;
             }
-            continue l38;
+            continue l44;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -970,63 +1040,138 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/from_string<String>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+    let __local_2: ref "core:prelude/string.wado//String";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "core:prelude/string.wado//String";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_string_escape.wado/String^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r) {
-        v = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(r).payload_0);
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:prelude/string.wado//String"(let __match_scrut_0: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_string_escape.wado/String^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+        let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0) -> ref "core:prelude/string.wado//String" {
+        let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(r).payload_0);
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<String>"(value) {
-    let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
-    ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = __inline_JsonSerializer_Serializer__serialize_string_1: block -> ref null "core:serde//SerializeError" {
-        "core:json/write_escaped_string"(ser.buf, value);
-        break __inline_JsonSerializer_Serializer__serialize_string_1: ref.null none;
+    let __local_3: ref "core:serde//SerializeError";
+    let __sroa_ser_buf: ref "core:prelude/string.wado//String";
+    __sroa_ser_buf = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = __inline_JsonSerializer_Serializer__serialize_string_0: block -> ref null "core:serde//SerializeError" {
+        "core:json/write_escaped_string"(__sroa_ser_buf, value);
+        break __inline_JsonSerializer_Serializer__serialize_string_0: ref.null none;
     };
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
-    return 0, ser.buf, ref.null none;
+    return 0, __sroa_ser_buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1049,6 +1194,20 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     }, offset, abs_val, digit_count);
 }
 
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
+}
+
 fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     let s: ref "core:prelude/string.wado//String";
     let c: char;
@@ -1060,6 +1219,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
         "core:prelude/string.wado/String::push"(s, self);
         "core:prelude/format.wado/Formatter::pad"(f, s);
     }
+}
+
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
 }
 
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
@@ -1125,7 +1298,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l61: loop {
+            l83: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -1133,7 +1306,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l61;
+                continue l83;
             };
         };
     };
@@ -1184,6 +1357,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     return 0, code_10;
 }
 
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
+}
+
 fn "core:prelude/string.wado/String::push"(self, c) {
     let code: u32;
     code = c;
@@ -1222,10 +1444,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b72: block {
-        l73: loop {
+    b101: block {
+        l102: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b72;
+                break b101;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -1249,7 +1471,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l73;
+            continue l102;
         };
     };
     self.pos = _hfs_pos_8;
@@ -1267,130 +1489,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b81: block {
-        l82: loop {
-            if scan_pos >= _licm_used_90 {
-                break b81;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b110: block {
+        l111: loop {
+            if scan_pos >= _licm_used_56 {
+                break b110;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b81;
+                break b110;
             }
             scan_pos = scan_pos + 1;
-            continue l82;
+            continue l111;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -1399,22 +1593,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l89: loop {
+                l118: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l89;
+                    continue l118;
                 };
             };
         };
@@ -1422,71 +1616,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l92: loop {
+            l121: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l92;
+                continue l121;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b94: block {
-        l95: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b123: block {
+        l124: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b94;
+                break b123;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -1504,125 +1699,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l95;
+            continue l124;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -1630,87 +1768,71 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l120: loop {
+            l144: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l120;
+                continue l144;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -1721,13 +1843,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l130: loop {
+            l150: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l130;
+                continue l150;
             };
         };
     };
@@ -1864,8 +1986,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b153: block {
-        l154: loop {
+    b173: block {
+        l174: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -1890,9 +2012,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b153;
+                break b173;
             }
-            continue l154;
+            continue l174;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_synth_enum.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_synth_enum.wir.wado
@@ -52,177 +52,212 @@ struct core:serde//SerializeError {  // TypeId(8)
     mut message: ref "core:prelude/string.wado//String",
 }
 
-variant core:prelude/types.wado//Result<Color,DeserializeError> {  // TypeId(9)
+variant core:prelude/types.wado//Option<char> {  // TypeId(9)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(10)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Result<Color,DeserializeError> {  // TypeId(11)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Color,DeserializeError>::Ok {  // TypeId(10)
+struct core:prelude/types.wado//Result<Color,DeserializeError>::Ok {  // TypeId(12)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<Color,DeserializeError>::Err {  // TypeId(11)
+struct core:prelude/types.wado//Result<Color,DeserializeError>::Err {  // TypeId(13)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(12)
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(14)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(13)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(15)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(14)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(16)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(15)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(17)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(18)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(19)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(20)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(16)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(21)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(17)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(22)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError> {  // TypeId(18)
+variant core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError> {  // TypeId(23)
     Ok(ref "core:json//JsonVariantAccess"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok {  // TypeId(19)
+struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok {  // TypeId(24)
     discriminant: i32,
     payload_0: ref "core:json//JsonVariantAccess",
 }
 
-struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err {  // TypeId(20)
+struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err {  // TypeId(25)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum wado-compiler/tests/fixtures/serde_json_synth_enum.wado//enum:Color { Red = 0, Green = 1, Blue = 2 };  // TypeId(21)
+enum wado-compiler/tests/fixtures/serde_json_synth_enum.wado//enum:Color { Red = 0, Green = 1, Blue = 2 };  // TypeId(26)
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(22)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(27)
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(23)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(28)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(24)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(29)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(25)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(30)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(26)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(31)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(27)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(32)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(28)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(33)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(29)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(34)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(30)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(35)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/__test_0_enum_serialize_red" = fn();  // TypeId(31)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/__test_0_enum_serialize_red" = fn();  // TypeId(36)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/__test_1_enum_roundtrip_green" = fn();  // TypeId(32)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/__test_1_enum_roundtrip_green" = fn();  // TypeId(37)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/__test_2_enum_deserialize_unknown_variant" = fn();  // TypeId(33)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/__test_2_enum_deserialize_unknown_variant" = fn();  // TypeId(38)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/__cm_export____test_0_enum_serialize_red" = fn();  // TypeId(34)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/__cm_export____test_0_enum_serialize_red" = fn();  // TypeId(39)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/__cm_export____test_1_enum_roundtrip_green" = fn();  // TypeId(35)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/__cm_export____test_1_enum_roundtrip_green" = fn();  // TypeId(40)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/__cm_export____test_2_enum_deserialize_unknown_variant" = fn();  // TypeId(36)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/__cm_export____test_2_enum_deserialize_unknown_variant" = fn();  // TypeId(41)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(37)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(42)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(38)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(43)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(39)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(44)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(40)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(45)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(41)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(46)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(42)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(47)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(43)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(48)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(44)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(49)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(45)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(50)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(46)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(51)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(47)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(52)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(48)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(53)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(49)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(54)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(50)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(55)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(51)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(56)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(52)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(57)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(53)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(58)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(54)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(59)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(55)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(60)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/Color^Inspect::inspect" = fn("wado-compiler/tests/fixtures/serde_json_synth_enum.wado//enum:Color", ref "core:prelude/format.wado//Formatter");  // TypeId(56)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(61)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(57)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/Color^Inspect::inspect" = fn("wado-compiler/tests/fixtures/serde_json_synth_enum.wado//enum:Color", ref "core:prelude/format.wado//Formatter");  // TypeId(62)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(58)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(63)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(59)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(64)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(60)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(65)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(61)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(66)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(62)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(67)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/Color^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Color,DeserializeError>";  // TypeId(63)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(68)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(64)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(69)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(65)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(70)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(66)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/Color^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Color,DeserializeError>";  // TypeId(71)
 
-type "functype//core:json/core/json/from_string<Color>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(67)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(72)
 
-type "functype//core:json/core/json/to_string<Color>" = fn("wado-compiler/tests/fixtures/serde_json_synth_enum.wado//enum:Color") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(68)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(73)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(69)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(74)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(70)
+type "functype//core:json/core/json/from_string<Color>" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(75)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(71)
+type "functype//core:json/core/json/to_string<Color>" = fn("wado-compiler/tests/fixtures/serde_json_synth_enum.wado//enum:Color") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(76)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(72)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(77)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(73)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(78)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(74)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(79)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/Color^Serialize::serialize<JsonSerializer>" = fn("wado-compiler/tests/fixtures/serde_json_synth_enum.wado//enum:Color", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(75)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(80)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_variant" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>";  // TypeId(76)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(81)
+
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(82)
+
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(83)
+
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(84)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_enum.wado/Color^Serialize::serialize<JsonSerializer>" = fn("wado-compiler/tests/fixtures/serde_json_synth_enum.wado//enum:Color", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(85)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_variant" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>";  // TypeId(86)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -545,10 +580,6 @@ fn "core:internal/panic"(message) {
     unreachable;
 }
 
-fn "core:internal/unreachable"() {
-    unreachable;
-}
-
 fn "core:internal/cm_lower_list_u8"(data, len) {
     let ptr: i32;
     ptr = "mem/realloc"(0, 0, 1, len);
@@ -632,36 +663,77 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l26: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l26;
+                };
+            };
+        };
     }
-    return ((97 + v) - 10) & 255;
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
         return 1;
     }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l32: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l32;
+            };
+        };
+    };
+    return n;
 }
 
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b28: block {
-        l29: loop {
+    b34: block {
+        l35: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -682,23 +754,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b28;
+                break b34;
             }
-            continue l29;
+            continue l35;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -706,60 +780,137 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/from_string<Color>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<Color,DeserializeError>";
+    let __local_2: "wado-compiler/tests/fixtures/serde_json_synth_enum.wado//enum:Color";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: "wado-compiler/tests/fixtures/serde_json_synth_enum.wado//enum:Color";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_synth_enum.wado/Color^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<Color,DeserializeError>::Ok"(r) {
-        v = ref.cast "core:prelude/types.wado//Result<Color,DeserializeError>::Ok"(r).payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<Color,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_synth_enum.wado/Color^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<Color,DeserializeError>::Ok"(__match_scrut_0) -> "wado-compiler/tests/fixtures/serde_json_synth_enum.wado//enum:Color" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Color,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Color,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Color,DeserializeError>::Err"(__match_scrut_0) -> "wado-compiler/tests/fixtures/serde_json_synth_enum.wado//enum:Color" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Color,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Color,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<Color,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<Color,DeserializeError>::Err"(r).payload_0);
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Color>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_json_synth_enum.wado/Color^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_synth_enum.wado/Color^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -782,6 +933,20 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     }, offset, abs_val, digit_count);
 }
 
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
+}
+
 fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     let s: ref "core:prelude/string.wado//String";
     let c: char;
@@ -793,6 +958,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
         "core:prelude/string.wado/String::push"(s, self);
         "core:prelude/format.wado/Formatter::pad"(f, s);
     }
+}
+
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
 }
 
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
@@ -858,7 +1037,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l52: loop {
+            l74: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -866,7 +1045,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l52;
+                continue l74;
             };
         };
     };
@@ -915,6 +1094,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -971,10 +1199,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b66: block {
-        l67: loop {
+    b95: block {
+        l96: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b66;
+                break b95;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -998,7 +1226,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l67;
+            continue l96;
         };
     };
     self.pos = _hfs_pos_8;
@@ -1062,130 +1290,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
+        }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b77: block {
-        l78: loop {
-            if scan_pos >= _licm_used_90 {
-                break b77;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b106: block {
+        l107: loop {
+            if scan_pos >= _licm_used_56 {
+                break b106;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b77;
+                break b106;
             }
             scan_pos = scan_pos + 1;
-            continue l78;
+            continue l107;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -1194,94 +1394,95 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l85: loop {
+                l114: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l85;
+                    continue l114;
                 };
             };
         };
         self.pos = scan_pos + 1;
-        return 0, result_5, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l88: loop {
+            l117: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l88;
+                continue l117;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b90: block {
-        l91: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b119: block {
+        l120: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b90;
+                break b119;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
-                return 0, result_8, ref.null none;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
+                return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
-                    });
+                    self.pos = _hfs_pos_64;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
+                    }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -1299,284 +1500,233 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return 1, ref.null none, e;
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
-                    });
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
+                    }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
-                    });
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
+                    }) };
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l91;
+            continue l120;
         };
     };
-    self.pos = _hfs_pos_98;
-    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
-    });
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
+    }) };
 }
 
 fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l116: loop {
+            l140: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l116;
+                continue l140;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_variant"(self) {
-    let b: i32;
-    let name_5: ref "core:prelude/string.wado//String";
-    let e_6: ref "core:serde//DeserializeError";
-    let name_8: ref "core:prelude/string.wado//String";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let e_11: ref "core:serde//DeserializeError";
-    let __local_17: ref "core:prelude/string.wado//String";
-    let __local_18: i64;
-    let __local_19: ref "core:prelude/string.wado//String";
-    let __local_20: i32;
-    let __local_21: ref "core:prelude/string.wado//String";
-    let __local_22: i64;
+    let b: char;
+    let __local_4: ref "core:prelude/string.wado//String";
+    let __local_5: ref "core:serde//DeserializeError";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: ref "core:prelude/string.wado//String";
+    let __local_11: ref "core:serde//DeserializeError";
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i32;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i64;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_17 = self.input;
-        break __inline_String__len_0: __local_17.used;
+        __local_12 = self.input;
+        break __inline_String__len_0: __local_12.used;
     } {
         return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_18 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_18 };
+            __local_13 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_13 };
         }) };
     }
     b = __inline_String__get_byte_2: block -> u8 {
-        __local_19 = self.input;
-        __local_20 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_19.repr, __local_20);
-    };
+        __local_14 = self.input;
+        __local_15 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_14.repr, __local_15);
+    } & 255;
     if b == 34 {
-        let __sroa_r_4_discriminant: i32;
-        let __sroa_r_4_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_r_4_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_r_4_discriminant, __sroa_r_4_case0_payload_0, __sroa_r_4_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self);
-        if __sroa_r_4_discriminant == 0 {
-            name_5 = __sroa_r_4_case0_payload_0;
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: name_5, is_object: 0 } };
-        }
-        if __sroa_r_4_discriminant == 1 {
-            e_6 = __sroa_r_4_case1_payload_0;
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e_6 };
-        }
-    }
-    if b == 123 {
+        let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+        __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self);
+        __local_6 = (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+            let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+            __local_4 = __cast_5.payload_0;
+            __local_4;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+            let __cast_4: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_4 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+            __local_5 = __cast_4.payload_0;
+            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_5 };
+            unreachable;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: __local_6, is_object: 0 } };
+        unreachable;
+    } else if b == 123 {
         self.pos = self.pos + 1;
-        let __sroa_r_7_discriminant: i32;
-        let __sroa_r_7_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_r_7_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_r_7_discriminant, __sroa_r_7_case0_payload_0, __sroa_r_7_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self);
-        if __sroa_r_7_discriminant == 0 {
-            name_8 = __sroa_r_7_case0_payload_0;
-            cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-            if ref.is_null(cr) == 0 {
-                e_10 = ref.as_non_null(cr);
-                return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e_10 };
-            }
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: name_8, is_object: 1 } };
+        let __match_scrut_1: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+        __match_scrut_1 = "core:json/JsonDeserializer::read_json_string"(self);
+        __local_9 = (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/string.wado//String" {
+            let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1);
+            __local_7 = __cast_2.payload_0;
+            __local_7;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/string.wado//String" {
+            let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1);
+            __local_8 = __cast_1.payload_0;
+            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
+        });
+        let __match_scrut_2: ref null "core:serde//DeserializeError";
+        __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+        if ref.is_null(__match_scrut_2) {
+        } else if ref.is_null(__match_scrut_2) == 0 {
+            let __cast_3: ref null "core:serde//DeserializeError";
+            __cast_3 = ref.as_non_null(__match_scrut_2);
+            __local_11 = ref.as_non_null(__cast_3);
+            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_11 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        if __sroa_r_7_discriminant == 1 {
-            e_11 = __sroa_r_7_case1_payload_0;
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e_11 };
-        }
+        return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: __local_9, is_object: 1 } };
+        unreachable;
+    } else {
+        return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_16 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string or object for variant"), used: 37 };
+            __local_17 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_16, offset: __local_17 };
+        }) };
+        unreachable;
     }
-    return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-        __local_21 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string or object for variant"), used: 37 };
-        __local_22 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_21, offset: __local_22 };
-    }) };
+    unreachable;
 }
 
 fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
@@ -1586,13 +1736,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l134: loop {
+            l155: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l134;
+                continue l155;
             };
         };
     };
@@ -1729,8 +1879,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b157: block {
-        l158: loop {
+    b178: block {
+        l179: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -1755,9 +1905,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b157;
+                break b178;
             }
-            continue l158;
+            continue l179;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/serde_json_synth_flags.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_synth_flags.wir.wado
@@ -60,189 +60,239 @@ struct core:serde//SerializeError {  // TypeId(10)
     mut message: ref "core:prelude/string.wado//String",
 }
 
-variant core:prelude/types.wado//Option<String> {  // TypeId(11)
+variant core:prelude/types.wado//Option<char> {  // TypeId(11)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(12)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<String> {  // TypeId(13)
     Some(ref "core:prelude/string.wado//String"),
     None,
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(12)
+variant core:prelude/types.wado//Result<u32,DeserializeError> {  // TypeId(14)
+    Ok(u32),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<u32,DeserializeError>::Ok {  // TypeId(15)
+    discriminant: i32,
+    payload_0: u32,
+}
+
+struct core:prelude/types.wado//Result<u32,DeserializeError>::Err {  // TypeId(16)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(17)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(18)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(19)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(20)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(13)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(21)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(14)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(22)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError> {  // TypeId(15)
+variant core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError> {  // TypeId(23)
     Ok(ref "core:json//JsonSeqAccess"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Ok {  // TypeId(16)
+struct core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Ok {  // TypeId(24)
     discriminant: i32,
     payload_0: ref "core:json//JsonSeqAccess",
 }
 
-struct core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err {  // TypeId(17)
+struct core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err {  // TypeId(25)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<String>,DeserializeError> {  // TypeId(18)
+variant core:prelude/types.wado//Result<Option<String>,DeserializeError> {  // TypeId(26)
     Ok(ref null "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok {  // TypeId(19)
+struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok {  // TypeId(27)
     discriminant: i32,
     payload_0: ref null "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err {  // TypeId(20)
+struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err {  // TypeId(28)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(21)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(29)
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(22)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(30)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(23)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(31)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(24)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(32)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(25)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(33)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(26)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(34)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(27)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(35)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(28)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(36)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(29)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(37)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_0_flags_serialize_single" = fn();  // TypeId(30)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_0_flags_serialize_single" = fn();  // TypeId(38)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_1_flags_serialize_multiple" = fn();  // TypeId(31)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_1_flags_serialize_multiple" = fn();  // TypeId(39)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_2_flags_serialize_none" = fn();  // TypeId(32)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_2_flags_serialize_none" = fn();  // TypeId(40)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_3_flags_serialize_all" = fn();  // TypeId(33)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_3_flags_serialize_all" = fn();  // TypeId(41)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_4_flags_roundtrip_single" = fn();  // TypeId(34)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_4_flags_roundtrip_single" = fn();  // TypeId(42)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_5_flags_roundtrip_multiple" = fn();  // TypeId(35)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_5_flags_roundtrip_multiple" = fn();  // TypeId(43)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_6_flags_roundtrip_none" = fn();  // TypeId(36)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_6_flags_roundtrip_none" = fn();  // TypeId(44)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_7_flags_deserialize_unknown_flag" = fn();  // TypeId(37)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__test_7_flags_deserialize_unknown_flag" = fn();  // TypeId(45)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_0_flags_serialize_single" = fn();  // TypeId(38)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_0_flags_serialize_single" = fn();  // TypeId(46)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_1_flags_serialize_multiple" = fn();  // TypeId(39)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_1_flags_serialize_multiple" = fn();  // TypeId(47)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_2_flags_serialize_none" = fn();  // TypeId(40)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_2_flags_serialize_none" = fn();  // TypeId(48)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_3_flags_serialize_all" = fn();  // TypeId(41)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_3_flags_serialize_all" = fn();  // TypeId(49)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_4_flags_roundtrip_single" = fn();  // TypeId(42)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_4_flags_roundtrip_single" = fn();  // TypeId(50)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_5_flags_roundtrip_multiple" = fn();  // TypeId(43)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_5_flags_roundtrip_multiple" = fn();  // TypeId(51)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_6_flags_roundtrip_none" = fn();  // TypeId(44)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_6_flags_roundtrip_none" = fn();  // TypeId(52)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_7_flags_deserialize_unknown_flag" = fn();  // TypeId(45)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/__cm_export____test_7_flags_deserialize_unknown_flag" = fn();  // TypeId(53)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(46)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(54)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(47)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(55)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(48)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(56)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(49)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(57)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(50)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(58)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(51)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(59)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(52)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(60)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(53)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(61)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(54)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(62)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(55)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(63)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(56)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(64)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(57)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(65)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(58)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(66)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(59)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(67)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(60)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(68)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(61)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(69)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(62)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(70)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(63)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(71)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(64)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(72)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(65)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(73)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(66)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(74)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(67)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(75)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_seq" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>";  // TypeId(68)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(76)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(69)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(77)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(70)
+type "functype//core:json/JsonDeserializer^Deserializer::begin_seq" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>";  // TypeId(78)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(71)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(79)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(72)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(80)
 
-type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<String>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";  // TypeId(73)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(81)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(74)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(82)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<String>" = fn(ref "core:json//JsonSeqSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(75)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/Perms^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<u32,DeserializeError>";  // TypeId(83)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(76)
+type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<String>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";  // TypeId(84)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(77)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(85)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(78)
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<String>" = fn(ref "core:json//JsonSeqSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(86)
 
-type "functype//core:json/core/json/from_string<Perms>" = fn(ref "core:prelude/string.wado//String") -> [i32, u32, ref null "core:serde//DeserializeError"];  // TypeId(79)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(87)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(80)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(88)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(81)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(89)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(82)
+type "functype//core:json/core/json/from_string<Perms>" = fn(ref "core:prelude/string.wado//String") -> [i32, u32, ref null "core:serde//DeserializeError"];  // TypeId(90)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_flags.wado/Perms^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, u32, ref null "core:serde//DeserializeError"];  // TypeId(83)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(91)
 
-type "functype//core:json/core/json/to_string<Perms>" = fn(u32) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(84)
+type "functype//core:json/core/json/to_string<Perms>" = fn(u32) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(92)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(85)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(93)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(86)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(94)
 
-type "functype//core:json/Perms^Serialize::serialize<JsonSerializer>" = fn(u32, ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(87)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(95)
+
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(96)
+
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(97)
+
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(98)
+
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(99)
+
+type "functype//core:json/Perms^Serialize::serialize<JsonSerializer>" = fn(u32, ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(100)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -752,10 +802,6 @@ fn "core:internal/panic"(message) {
     unreachable;
 }
 
-fn "core:internal/unreachable"() {
-    unreachable;
-}
-
 fn "core:internal/cm_lower_list_u8"(data, len) {
     let ptr: i32;
     ptr = "mem/realloc"(0, 0, 1, len);
@@ -839,36 +885,77 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l34: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l34;
+                };
+            };
+        };
     }
-    return ((97 + v) - 10) & 255;
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
         return 1;
     }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l40: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l40;
+            };
+        };
+    };
+    return n;
 }
 
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b36: block {
-        l37: loop {
+    b42: block {
+        l43: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -889,23 +976,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b36;
+                break b42;
             }
-            continue l37;
+            continue l43;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -913,62 +1002,137 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/from_string<Perms>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: u32;
+    let __local_3: ref "core:serde//DeserializeError";
     let v: u32;
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: u32;
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_synth_flags.wado/Perms^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    let __match_scrut_0: ref "core:prelude/types.wado//Result<u32,DeserializeError>";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_synth_flags.wado/Perms^Deserialize::deserialize<JsonDeserializer>"(de);
+    v = (if ref.test "core:prelude/types.wado//Result<u32,DeserializeError>::Ok"(__match_scrut_0) -> u32 {
+        let __cast_2: ref "core:prelude/types.wado//Result<u32,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<u32,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<u32,DeserializeError>::Err"(__match_scrut_0) -> u32 {
+        let __cast_1: ref "core:prelude/types.wado//Result<u32,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<u32,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, 0, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    });
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, 0, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, 0, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Perms>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:json/Perms^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:json/Perms^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -991,6 +1155,20 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     }, offset, abs_val, digit_count);
 }
 
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
+}
+
 fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     let s: ref "core:prelude/string.wado//String";
     let c: char;
@@ -1002,6 +1180,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
         "core:prelude/string.wado/String::push"(s, self);
         "core:prelude/format.wado/Formatter::pad"(f, s);
     }
+}
+
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
 }
 
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
@@ -1067,7 +1259,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l60: loop {
+            l82: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -1075,7 +1267,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l60;
+                continue l82;
             };
         };
     };
@@ -1126,6 +1318,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     return 0, code_10;
 }
 
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
+}
+
 fn "core:prelude/string.wado/String::push"(self, c) {
     let code: u32;
     code = c;
@@ -1164,10 +1405,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b71: block {
-        l72: loop {
+    b100: block {
+        l101: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b71;
+                break b100;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -1191,7 +1432,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l72;
+            continue l101;
         };
     };
     self.pos = _hfs_pos_8;
@@ -1255,130 +1496,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b82: block {
-        l83: loop {
-            if scan_pos >= _licm_used_90 {
-                break b82;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b111: block {
+        l112: loop {
+            if scan_pos >= _licm_used_56 {
+                break b111;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b82;
+                break b111;
             }
             scan_pos = scan_pos + 1;
-            continue l83;
+            continue l112;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -1387,22 +1600,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l90: loop {
+                l119: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l90;
+                    continue l119;
                 };
             };
         };
@@ -1410,71 +1623,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l93: loop {
+            l122: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l93;
+                continue l122;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b95: block {
-        l96: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b124: block {
+        l125: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b95;
+                break b124;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -1492,125 +1706,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l96;
+            continue l125;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -1618,97 +1775,87 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l121: loop {
+            l145: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l121;
+                continue l145;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_seq"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 91);
-    if ref.is_null(r) == 0 {
-        e = ref.as_non_null(r);
-        return struct.new "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+    let __local_2: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 91);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_2 = ref.as_non_null(__cast_1);
+        return struct.new "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+        unreachable;
+    } else {
+        unreachable;
     }
     return struct.new "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonSeqAccess" { de: self, first: 1 } };
 }
@@ -1720,13 +1867,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l132: loop {
+            l153: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l132;
+                continue l153;
             };
         };
     };
@@ -1863,8 +2010,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b155: block {
-        l156: loop {
+    b176: block {
+        l177: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -1889,9 +2036,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b155;
+                break b176;
             }
-            continue l156;
+            continue l177;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -1912,8 +2059,8 @@ fn "wado-compiler/tests/fixtures/serde_json_synth_flags.wado/Perms^Deserialize::
     if ref.test "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Ok"(__pattern_temp_0) {
         seq = value_copy "core:json//JsonSeqAccess"(ref.cast "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Ok"(__pattern_temp_0).payload_0);
         bits = 0;
-        b164: block {
-            l165: loop {
+        b185: block {
+            l186: loop {
                 __elem_r = "core:json/JsonSeqAccess^DeserializeSeq::next_element<String>"(seq);
                 __pattern_temp_1 = __elem_r;
                 if ref.test "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -1922,84 +2069,91 @@ fn "wado-compiler/tests/fixtures/serde_json_synth_flags.wado/Perms^Deserialize::
                         __name = value_copy "core:prelude/string.wado//String"(ref.as_non_null(__elem));
                         if "core:prelude/string.wado/String^Eq::eq"(__name, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Read"), used: 4 }) {
                             bits = bits | 1;
-                            continue l165;
+                            continue l186;
                         }
                         if "core:prelude/string.wado/String^Eq::eq"(__name, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Write"), used: 5 }) {
                             bits = bits | 2;
-                            continue l165;
+                            continue l186;
                         }
                         if "core:prelude/string.wado/String^Eq::eq"(__name, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Execute"), used: 7 }) {
                             bits = bits | 4;
-                            continue l165;
+                            continue l186;
                         }
-                        return 1, 0, struct.new "core:serde//DeserializeError" { kind: 4, message: ref.as_non_null(__tmpl: block -> ref "core:prelude/string.wado//String" {
+                        return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 4, message: ref.as_non_null(__tmpl: block -> ref "core:prelude/string.wado//String" {
                             __local_7 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(30), used: 0 };
                             "core:prelude/string.wado/String::push_str"(__local_7, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unknown flag: "), used: 14 });
                             "core:prelude/string.wado/String::push_str"(__local_7, __name);
                             break __tmpl: __local_7;
-                        }), offset: -1_i64 };
+                        }), offset: -1_i64 } };
                     } else {
-                        break b164;
+                        break b185;
                     }
                 } else {
-                    return 1, 0, ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(__elem_r).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err"(__elem_r).payload_0 };
                 }
-                continue l165;
+                continue l186;
             };
         };
         drop("core:json/JsonDeserializer::expect_char"(seq.de, 93));
-        return 0, bits, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Ok" { discriminant: 0, payload_0: bits };
     } else {
-        return 1, 0, ref.cast "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err"(__seq_r).payload_0;
+        return struct.new "core:prelude/types.wado//Result<u32,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err"(__seq_r).payload_0 };
     }
 }
 
 fn "core:json/JsonSeqAccess^DeserializeSeq::next_element<String>"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let elem: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let v: ref "core:prelude/string.wado//String";
-    let e_5: ref "core:serde//DeserializeError";
-    let __local_9: ref "core:prelude/string.wado//String";
-    let __local_10: i64;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i32;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __local_3: ref "core:prelude/string.wado//String";
+    let __local_4: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_9 = self.de.input;
-        break __inline_String__len_0: __local_9.used;
+        __local_5 = self.de.input;
+        break __inline_String__len_0: __local_5.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_10 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_10 };
+            __local_6 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_6 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_11 = self.de.input;
-        __local_12 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_11.repr, __local_12);
+        __local_7 = self.de.input;
+        __local_8 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_7.repr, __local_8);
     } == 93 {
         return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: ref.null none };
     }
     if self.first == 0 {
-        r = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r) == 0 {
-            e_2 = ref.as_non_null(r);
-            return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
-    elem = "wado-compiler/tests/fixtures/serde_json_synth_flags.wado/String^Deserialize::deserialize<JsonDeserializer>"(self.de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(elem) {
-        v = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(elem).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: v };
-    }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(elem) {
-        e_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(elem).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return let __match_scrut_1: ref "core:prelude/types.wado//Result<String,DeserializeError>", __match_scrut_1 = "wado-compiler/tests/fixtures/serde_json_synth_flags.wado/String^Deserialize::deserialize<JsonDeserializer>"(self.de), (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>" {
+        let __cast_3: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_3 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1);
+        __local_3 = __cast_3.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_3 };
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1);
+        __local_4 = __cast_2.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_4 };
+    } else {
+        unreachable;
+    });
 }
 
 fn "wado-compiler/tests/fixtures/serde_json_synth_flags.wado/String^Deserialize::deserialize<JsonDeserializer>"(d) {

--- a/wado-compiler/tests/fixtures.golden/serde_json_synth_variant.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_synth_variant.wir.wado
@@ -72,257 +72,294 @@ struct wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape::Circle
 
 array builtin::array<u64> (mut u64);  // TypeId(13)
 
-variant core:prelude/types.wado//Result<Shape,DeserializeError> {  // TypeId(14)
+variant core:prelude/types.wado//Option<char> {  // TypeId(14)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(15)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Result<Shape,DeserializeError> {  // TypeId(16)
     Ok(ref "wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Shape,DeserializeError>::Ok {  // TypeId(15)
+struct core:prelude/types.wado//Result<Shape,DeserializeError>::Ok {  // TypeId(17)
     discriminant: i32,
     payload_0: ref "wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape",
 }
 
-struct core:prelude/types.wado//Result<Shape,DeserializeError>::Err {  // TypeId(16)
+struct core:prelude/types.wado//Result<Shape,DeserializeError>::Err {  // TypeId(18)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(17)
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(19)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(18)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(20)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(19)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(21)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(20)
+variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(22)
     Ok(f64),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(21)
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(23)
     discriminant: i32,
     payload_0: f64,
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(22)
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(24)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(23)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(25)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(26)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(27)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(28)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(24)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(29)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(25)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(30)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError> {  // TypeId(26)
+variant core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError> {  // TypeId(31)
     Ok(ref "core:json//JsonVariantAccess"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok {  // TypeId(27)
+struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok {  // TypeId(32)
     discriminant: i32,
     payload_0: ref "core:json//JsonVariantAccess",
 }
 
-struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err {  // TypeId(28)
+struct core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err {  // TypeId(33)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-struct core:prelude//Array<u64> {  // TypeId(29)
+struct core:prelude//Array<u64> {  // TypeId(34)
     mut repr: ref builtin::array<u64>,
     mut used: i32,
 }
 
-enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(30)
+enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(35)
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(31)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(36)
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(32)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(37)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(33)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(38)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(34)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(39)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(35)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(40)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(36)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(41)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(37)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(42)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(38)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(43)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(39)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(44)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__test_0_variant_serialize_unit_case" = fn();  // TypeId(40)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__test_0_variant_serialize_unit_case" = fn();  // TypeId(45)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__test_1_variant_serialize_payload_case" = fn();  // TypeId(41)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__test_1_variant_serialize_payload_case" = fn();  // TypeId(46)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__test_2_variant_roundtrip_unit_case" = fn();  // TypeId(42)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__test_2_variant_roundtrip_unit_case" = fn();  // TypeId(47)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__test_3_variant_roundtrip_payload_case" = fn();  // TypeId(43)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__test_3_variant_roundtrip_payload_case" = fn();  // TypeId(48)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__cm_export____test_0_variant_serialize_unit_case" = fn();  // TypeId(44)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__cm_export____test_0_variant_serialize_unit_case" = fn();  // TypeId(49)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__cm_export____test_1_variant_serialize_payload_case" = fn();  // TypeId(45)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__cm_export____test_1_variant_serialize_payload_case" = fn();  // TypeId(50)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__cm_export____test_2_variant_roundtrip_unit_case" = fn();  // TypeId(46)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__cm_export____test_2_variant_roundtrip_unit_case" = fn();  // TypeId(51)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__cm_export____test_3_variant_roundtrip_payload_case" = fn();  // TypeId(47)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__cm_export____test_3_variant_roundtrip_payload_case" = fn();  // TypeId(52)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__initialize_module" = fn();  // TypeId(48)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/__initialize_module" = fn();  // TypeId(53)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(49)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(54)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(50)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(55)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(51)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(56)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(52)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(57)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(53)
+type "functype//core:internal/unreachable" = fn();  // TypeId(58)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(54)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(59)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(55)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(60)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(56)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(61)
 
-type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(57)
+type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(62)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(58)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(63)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(59)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(64)
 
-type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(60)
+type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(65)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(61)
+type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(66)
 
-type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(62)
+type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(67)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(63)
+type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(68)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(64)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(69)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(65)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(70)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(66)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(71)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(67)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(72)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(68)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(73)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(69)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(74)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(70)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(75)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(71)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(76)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(72)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(77)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(73)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(78)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(74)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(79)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(75)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(80)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(76)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(81)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(77)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(82)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(78)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(83)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(79)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(84)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(80)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(85)
 
-type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(81)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(86)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(82)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(87)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(83)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(88)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(84)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(89)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(85)
+type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(90)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(86)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(91)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(87)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(92)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(88)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(93)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/Shape^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Shape,DeserializeError>";  // TypeId(89)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(94)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(90)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(95)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(91)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(96)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(92)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(97)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(93)
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/Shape^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Shape,DeserializeError>";  // TypeId(98)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(94)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(99)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(95)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(100)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(96)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(101)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(97)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(102)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(98)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(103)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(99)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(104)
 
-type "functype//core:json/core/json/from_string<Shape>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape", ref null "core:serde//DeserializeError"];  // TypeId(100)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(105)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(101)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(106)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(102)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(107)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(103)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(108)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(104)
+type "functype//core:json/core/json/from_string<Shape>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape", ref null "core:serde//DeserializeError"];  // TypeId(109)
 
-type "functype//core:json/core/json/to_string<Shape>" = fn(ref "wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(105)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(110)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(106)
+type "functype//core:json/core/json/to_string<Shape>" = fn(ref "wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(111)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(107)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(112)
 
-type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(108)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(113)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(109)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(114)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(110)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(115)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(111)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(116)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/Shape^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(112)
+type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(117)
 
-type "functype//core:json/JsonVariantSerializer^SerializeVariant::payload<f64>" = fn(ref "core:json//JsonVariantSerializer", f64) -> ref null "core:serde//SerializeError";  // TypeId(113)
+type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(118)
 
-type "functype//core:json/JsonSerializer^Serializer::begin_variant" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref null "core:json//JsonVariantSerializer", ref null "core:serde//SerializeError"];  // TypeId(114)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(119)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_variant" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>";  // TypeId(115)
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(120)
+
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(121)
+
+type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(122)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_synth_variant.wado/Shape^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(123)
+
+type "functype//core:json/JsonVariantSerializer^SerializeVariant::payload<f64>" = fn(ref "core:json//JsonVariantSerializer", f64) -> ref null "core:serde//SerializeError";  // TypeId(124)
+
+type "functype//core:json/JsonSerializer^Serializer::begin_variant" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> [i32, ref null "core:json//JsonVariantSerializer", ref null "core:serde//SerializeError"];  // TypeId(125)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_variant" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>";  // TypeId(126)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -1622,6 +1659,67 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l137: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l137;
+                };
+            };
+        };
+    }
+}
+
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
+        return 1;
+    }
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l143: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l143;
+            };
+        };
+    };
+    return n;
+}
+
 fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     let mark: i32;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -1650,36 +1748,16 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
-    }
-    return ((97 + v) - 10) & 255;
-}
-
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b143: block {
-        l144: loop {
+    b149: block {
+        l150: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -1700,23 +1778,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b143;
+                break b149;
             }
-            continue l144;
+            continue l150;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -1724,60 +1804,135 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/from_string<Shape>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<Shape,DeserializeError>";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/serde_json_synth_variant.wado/Shape^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<Shape,DeserializeError>::Ok"(r) {
-        v = value_copy "wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape"(ref.cast "core:prelude/types.wado//Result<Shape,DeserializeError>::Ok"(r).payload_0);
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Shape,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_synth_variant.wado/Shape^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Shape,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Shape,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Shape,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Shape,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_synth_variant.wado//Shape" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Shape,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Shape,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<Shape,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<Shape,DeserializeError>::Err"(r).payload_0);
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Shape>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_json_synth_variant.wado/Shape^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_synth_variant.wado/Shape^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1798,6 +1953,20 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
         __local_6 = f.buf;
         break __inline_String__internal_raw_bytes_0: __local_6.repr;
     }, offset, abs_val, digit_count);
+}
+
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
 }
 
 fn "core:prelude/primitive.wado/f64::fmt_into"(self, f) {
@@ -2058,6 +2227,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     }
 }
 
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
+}
+
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     let capacity: i32;
     let new_capacity: i32;
@@ -2134,7 +2317,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l196: loop {
+            l218: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -2142,7 +2325,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l196;
+                continue l218;
             };
         };
     };
@@ -2191,6 +2374,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -2260,10 +2492,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b209: block {
-        l210: loop {
+    b238: block {
+        l239: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b209;
+                break b238;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -2287,7 +2519,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l210;
+            continue l239;
         };
     };
     self.pos = _hfs_pos_8;
@@ -2351,130 +2583,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
+        }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b220: block {
-        l221: loop {
-            if scan_pos >= _licm_used_90 {
-                break b220;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b249: block {
+        l250: loop {
+            if scan_pos >= _licm_used_56 {
+                break b249;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b220;
+                break b249;
             }
             scan_pos = scan_pos + 1;
-            continue l221;
+            continue l250;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -2483,94 +2687,95 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l228: loop {
+                l257: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l228;
+                    continue l257;
                 };
             };
         };
         self.pos = scan_pos + 1;
-        return 0, result_5, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l231: loop {
+            l260: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l231;
+                continue l260;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b233: block {
-        l234: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b262: block {
+        l263: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b233;
+                break b262;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
-                return 0, result_8, ref.null none;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
+                return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
-                    });
+                    self.pos = _hfs_pos_64;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
+                    }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -2588,213 +2793,140 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return 1, ref.null none, e;
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
-                    });
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
+                    }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
-                    });
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
+                    }) };
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l234;
+            continue l263;
         };
     };
-    self.pos = _hfs_pos_98;
-    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
-    });
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
+    }) };
 }
 
 fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l259: loop {
+            l283: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l259;
+                continue l283;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -2900,16 +3032,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b273: block {
-        l274: loop {
+    b293: block {
+        l294: loop {
             if _hfs_pos_57 >= _licm_used_49 {
-                break b273;
+                break b293;
             }
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_50, __local_32);
             };
-            if (if b_6 >= 48 -> i32 {
+            if (if 48 <= b_6 -> i32 {
                 b_6 <= 57;
             } else {
                 0;
@@ -2920,9 +3052,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                 total_digits = total_digits + 1;
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
-                break b273;
+                break b293;
             }
-            continue l274;
+            continue l294;
         };
     };
     self.pos = _hfs_pos_57;
@@ -2944,16 +3076,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b281: block {
-            l282: loop {
+        b301: block {
+            l302: loop {
                 if _hfs_pos_58 >= _licm_used_52 {
-                    break b281;
+                    break b301;
                 }
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
                     break __inline_String__get_byte_12: builtin::array_get_u8(_licm_repr_53, __local_38);
                 };
-                if (if b_8 >= 48 -> i32 {
+                if (if 48 <= b_8 -> i32 {
                     b_8 <= 57;
                 } else {
                     0;
@@ -2965,9 +3097,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                     total_digits = total_digits + 1;
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
-                    break b281;
+                    break b301;
                 }
-                continue l282;
+                continue l302;
             };
         };
         self.pos = _hfs_pos_58;
@@ -3009,16 +3141,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b293: block {
-                l294: loop {
+            b313: block {
+                l314: loop {
                     if _hfs_pos_59 >= _licm_used_55 {
-                        break b293;
+                        break b313;
                     }
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
                         break __inline_String__get_byte_18: builtin::array_get_u8(_licm_repr_56, __local_47);
                     };
-                    if (if b3 >= 48 -> i32 {
+                    if (if 48 <= b3 -> i32 {
                         b3 <= 57;
                     } else {
                         0;
@@ -3026,9 +3158,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                         exp = (exp * 10) + (b3 - 48);
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
-                        break b293;
+                        break b313;
                     }
-                    continue l294;
+                    continue l314;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -3063,73 +3195,95 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_variant"(self) {
-    let b: i32;
-    let name_5: ref "core:prelude/string.wado//String";
-    let e_6: ref "core:serde//DeserializeError";
-    let name_8: ref "core:prelude/string.wado//String";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let e_11: ref "core:serde//DeserializeError";
-    let __local_17: ref "core:prelude/string.wado//String";
-    let __local_18: i64;
-    let __local_19: ref "core:prelude/string.wado//String";
-    let __local_20: i32;
-    let __local_21: ref "core:prelude/string.wado//String";
-    let __local_22: i64;
+    let b: char;
+    let __local_4: ref "core:prelude/string.wado//String";
+    let __local_5: ref "core:serde//DeserializeError";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: ref "core:prelude/string.wado//String";
+    let __local_11: ref "core:serde//DeserializeError";
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i32;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i64;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_17 = self.input;
-        break __inline_String__len_0: __local_17.used;
+        __local_12 = self.input;
+        break __inline_String__len_0: __local_12.used;
     } {
         return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_18 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_18 };
+            __local_13 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_13 };
         }) };
     }
     b = __inline_String__get_byte_2: block -> u8 {
-        __local_19 = self.input;
-        __local_20 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_19.repr, __local_20);
-    };
+        __local_14 = self.input;
+        __local_15 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_14.repr, __local_15);
+    } & 255;
     if b == 34 {
-        let __sroa_r_4_discriminant: i32;
-        let __sroa_r_4_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_r_4_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_r_4_discriminant, __sroa_r_4_case0_payload_0, __sroa_r_4_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self);
-        if __sroa_r_4_discriminant == 0 {
-            name_5 = __sroa_r_4_case0_payload_0;
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: name_5, is_object: 0 } };
-        }
-        if __sroa_r_4_discriminant == 1 {
-            e_6 = __sroa_r_4_case1_payload_0;
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e_6 };
-        }
-    }
-    if b == 123 {
+        let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+        __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self);
+        __local_6 = (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+            let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+            __local_4 = __cast_5.payload_0;
+            __local_4;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+            let __cast_4: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_4 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+            __local_5 = __cast_4.payload_0;
+            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_5 };
+            unreachable;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: __local_6, is_object: 0 } };
+        unreachable;
+    } else if b == 123 {
         self.pos = self.pos + 1;
-        let __sroa_r_7_discriminant: i32;
-        let __sroa_r_7_case0_payload_0: ref null "core:prelude/string.wado//String";
-        let __sroa_r_7_case1_payload_0: ref null "core:serde//DeserializeError";
-        multivalue_bind [__sroa_r_7_discriminant, __sroa_r_7_case0_payload_0, __sroa_r_7_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self);
-        if __sroa_r_7_discriminant == 0 {
-            name_8 = __sroa_r_7_case0_payload_0;
-            cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-            if ref.is_null(cr) == 0 {
-                e_10 = ref.as_non_null(cr);
-                return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e_10 };
-            }
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: name_8, is_object: 1 } };
+        let __match_scrut_1: ref "core:prelude/types.wado//Result<String,DeserializeError>";
+        __match_scrut_1 = "core:json/JsonDeserializer::read_json_string"(self);
+        __local_9 = (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/string.wado//String" {
+            let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+            __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1);
+            __local_7 = __cast_2.payload_0;
+            __local_7;
+        } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/string.wado//String" {
+            let __cast_1: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+            __cast_1 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1);
+            __local_8 = __cast_1.payload_0;
+            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
+        });
+        let __match_scrut_2: ref null "core:serde//DeserializeError";
+        __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+        if ref.is_null(__match_scrut_2) {
+        } else if ref.is_null(__match_scrut_2) == 0 {
+            let __cast_3: ref null "core:serde//DeserializeError";
+            __cast_3 = ref.as_non_null(__match_scrut_2);
+            __local_11 = ref.as_non_null(__cast_3);
+            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_11 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        if __sroa_r_7_discriminant == 1 {
-            e_11 = __sroa_r_7_case1_payload_0;
-            return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e_11 };
-        }
+        return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonVariantAccess" { de: self, variant: __local_9, is_object: 1 } };
+        unreachable;
+    } else {
+        return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_16 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string or object for variant"), used: 37 };
+            __local_17 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_16, offset: __local_17 };
+        }) };
+        unreachable;
     }
-    return struct.new "core:prelude/types.wado//Result<JsonVariantAccess,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-        __local_21 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string or object for variant"), used: 37 };
-        __local_22 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_21, offset: __local_22 };
-    }) };
+    unreachable;
 }
 
 fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
@@ -3139,13 +3293,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l313: loop {
+            l334: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l313;
+                continue l334;
             };
         };
     };
@@ -3238,10 +3392,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b323: block {
-            l324: loop {
+        b344: block {
+            l345: loop {
                 if i_8 < 0 {
-                    break b323;
+                    break b344;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -3250,7 +3404,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l324;
+                continue l345;
             };
         };
         __for_1: block {
@@ -3258,14 +3412,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l327: loop {
+                l348: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l327;
+                    continue l348;
                 };
             };
         };
@@ -3275,10 +3429,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b329: block {
-            l330: loop {
+        b350: block {
+            l351: loop {
                 if i_10 < 0 {
-                    break b329;
+                    break b350;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -3287,7 +3441,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l330;
+                continue l351;
             };
         };
         __for_2: block {
@@ -3295,14 +3449,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l333: loop {
+                l354: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l333;
+                    continue l354;
                 };
             };
         };
@@ -3406,8 +3560,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b352: block {
-        l353: loop {
+    b373: block {
+        l374: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3432,9 +3586,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b352;
+                break b373;
             }
-            continue l353;
+            continue l374;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -3469,13 +3623,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l362: loop {
+            l383: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l362;
+                continue l383;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/serde_json_treemap.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_treemap.wir.wado
@@ -258,427 +258,494 @@ struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(50)
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError> {  // TypeId(51)
+variant core:prelude/types.wado//Option<char> {  // TypeId(51)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(52)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError> {  // TypeId(53)
+    Ok(ref "core:collections//TreeMap<String,i32>"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Ok {  // TypeId(54)
+    discriminant: i32,
+    payload_0: ref "core:collections//TreeMap<String,i32>",
+}
+
+struct core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err {  // TypeId(55)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(56)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(57)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(58)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(59)
+    Ok(ref "core:prelude/string.wado//String"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(60)
+    discriminant: i32,
+    payload_0: ref "core:prelude/string.wado//String",
+}
+
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(61)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError> {  // TypeId(62)
     Ok(ref "core:json//JsonSeqSerializer"),
     Err(ref "core:serde//SerializeError"),
 }
 
-struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Ok {  // TypeId(52)
+struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Ok {  // TypeId(63)
     discriminant: i32,
     payload_0: ref "core:json//JsonSeqSerializer",
 }
 
-struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Err {  // TypeId(53)
+struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Err {  // TypeId(64)
     discriminant: i32,
     payload_0: ref "core:serde//SerializeError",
 }
 
-variant core:prelude/types.wado//Result<JsonMapSerializer,SerializeError> {  // TypeId(54)
+variant core:prelude/types.wado//Result<JsonMapSerializer,SerializeError> {  // TypeId(65)
     Ok(ref "core:json//JsonMapSerializer"),
     Err(ref "core:serde//SerializeError"),
 }
 
-struct core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok {  // TypeId(55)
+struct core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok {  // TypeId(66)
     discriminant: i32,
     payload_0: ref "core:json//JsonMapSerializer",
 }
 
-struct core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Err {  // TypeId(56)
+struct core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Err {  // TypeId(67)
     discriminant: i32,
     payload_0: ref "core:serde//SerializeError",
 }
 
-variant core:prelude/types.wado//Option<TreeMapNode<String>> {  // TypeId(57)
+variant core:prelude/types.wado//Option<TreeMapNode<String>> {  // TypeId(68)
     Some(ref "core:collections//TreeMapNode<String>"),
     None,
 }
 
-struct core:prelude//Array<i32> {  // TypeId(58)
+struct core:prelude//Array<i32> {  // TypeId(69)
     mut repr: ref builtin::array<i32>,
     mut used: i32,
 }
 
-struct core:prelude//Array<TreeMapEntry<String,Option<i32>>> {  // TypeId(59)
+struct core:prelude//Array<TreeMapEntry<String,Option<i32>>> {  // TypeId(70)
     mut repr: ref builtin::array<TreeMapEntry<String,Option<i32>>>,
     mut used: i32,
 }
 
-struct core:prelude//Array<TreeMapEntry<String,Array<i32>>> {  // TypeId(60)
+struct core:prelude//Array<TreeMapEntry<String,Array<i32>>> {  // TypeId(71)
     mut repr: ref builtin::array<TreeMapEntry<String,Array<i32>>>,
     mut used: i32,
 }
 
-struct core:prelude//Array<TreeMapEntry<String,bool>> {  // TypeId(61)
+struct core:prelude//Array<TreeMapEntry<String,bool>> {  // TypeId(72)
     mut repr: ref builtin::array<TreeMapEntry<String,bool>>,
     mut used: i32,
 }
 
-struct core:prelude//Array<TreeMapEntry<String,String>> {  // TypeId(62)
+struct core:prelude//Array<TreeMapEntry<String,String>> {  // TypeId(73)
     mut repr: ref builtin::array<TreeMapEntry<String,String>>,
     mut used: i32,
 }
 
-struct core:prelude//Array<TreeMapEntry<String,i32>> {  // TypeId(63)
+struct core:prelude//Array<TreeMapEntry<String,i32>> {  // TypeId(74)
     mut repr: ref builtin::array<TreeMapEntry<String,i32>>,
     mut used: i32,
 }
 
-struct core:prelude//Array<Tuple<String,Option<i32>>> {  // TypeId(64)
+struct core:prelude//Array<Tuple<String,Option<i32>>> {  // TypeId(75)
     mut repr: ref builtin::array<Tuple<String,Option<i32>>>,
     mut used: i32,
 }
 
-struct core:prelude//Array<Tuple<String,Array<i32>>> {  // TypeId(65)
+struct core:prelude//Array<Tuple<String,Array<i32>>> {  // TypeId(76)
     mut repr: ref builtin::array<Tuple<String,Array<i32>>>,
     mut used: i32,
 }
 
-struct core:prelude//Array<Tuple<String,bool>> {  // TypeId(66)
+struct core:prelude//Array<Tuple<String,bool>> {  // TypeId(77)
     mut repr: ref builtin::array<Tuple<String,bool>>,
     mut used: i32,
 }
 
-struct core:prelude//Array<Tuple<String,String>> {  // TypeId(67)
+struct core:prelude//Array<Tuple<String,String>> {  // TypeId(78)
     mut repr: ref builtin::array<Tuple<String,String>>,
     mut used: i32,
 }
 
-struct core:prelude//Array<Tuple<String,i32>> {  // TypeId(68)
+struct core:prelude//Array<Tuple<String,i32>> {  // TypeId(79)
     mut repr: ref builtin::array<Tuple<String,i32>>,
     mut used: i32,
 }
 
-enum core:prelude/traits.wado//enum:Ordering { Less = 0, Equal = 1, Greater = 2 };  // TypeId(69)
+enum core:prelude/traits.wado//enum:Ordering { Less = 0, Equal = 1, Greater = 2 };  // TypeId(80)
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(70)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(81)
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(71)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(82)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(72)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(83)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(73)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(84)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(74)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(85)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(75)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(86)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(76)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(87)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(77)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(88)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(78)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(89)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_0_treemap_serialize_string_keys" = fn();  // TypeId(79)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_0_treemap_serialize_string_keys" = fn();  // TypeId(90)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_1_treemap_roundtrip" = fn();  // TypeId(80)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_1_treemap_roundtrip" = fn();  // TypeId(91)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_2_treemap_empty" = fn();  // TypeId(81)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_2_treemap_empty" = fn();  // TypeId(92)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_3_treemap_empty_roundtrip" = fn();  // TypeId(82)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_3_treemap_empty_roundtrip" = fn();  // TypeId(93)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_4_treemap_single_entry" = fn();  // TypeId(83)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_4_treemap_single_entry" = fn();  // TypeId(94)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_5_treemap_with_string_values" = fn();  // TypeId(84)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_5_treemap_with_string_values" = fn();  // TypeId(95)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_6_treemap_with_bool_values" = fn();  // TypeId(85)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_6_treemap_with_bool_values" = fn();  // TypeId(96)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_7_treemap_with_nested_array_values" = fn();  // TypeId(86)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_7_treemap_with_nested_array_values" = fn();  // TypeId(97)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_8_treemap_with_option_values" = fn();  // TypeId(87)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_8_treemap_with_option_values" = fn();  // TypeId(98)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_9_treemap_keys_with_special_chars" = fn();  // TypeId(88)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_9_treemap_keys_with_special_chars" = fn();  // TypeId(99)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_10_treemap_preserves_insertion_order" = fn();  // TypeId(89)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_10_treemap_preserves_insertion_order" = fn();  // TypeId(100)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_11_treemap_many_entries_roundtrip" = fn();  // TypeId(90)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_11_treemap_many_entries_roundtrip" = fn();  // TypeId(101)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_12_treemap_deserialize_from_any_key_order" = fn();  // TypeId(91)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_12_treemap_deserialize_from_any_key_order" = fn();  // TypeId(102)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_0_treemap_serialize_string_keys" = fn();  // TypeId(92)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_0_treemap_serialize_string_keys" = fn();  // TypeId(103)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_1_treemap_roundtrip" = fn();  // TypeId(93)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_1_treemap_roundtrip" = fn();  // TypeId(104)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_2_treemap_empty" = fn();  // TypeId(94)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_2_treemap_empty" = fn();  // TypeId(105)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_3_treemap_empty_roundtrip" = fn();  // TypeId(95)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_3_treemap_empty_roundtrip" = fn();  // TypeId(106)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_4_treemap_single_entry" = fn();  // TypeId(96)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_4_treemap_single_entry" = fn();  // TypeId(107)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_5_treemap_with_string_values" = fn();  // TypeId(97)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_5_treemap_with_string_values" = fn();  // TypeId(108)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_6_treemap_with_bool_values" = fn();  // TypeId(98)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_6_treemap_with_bool_values" = fn();  // TypeId(109)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_7_treemap_with_nested_array_values" = fn();  // TypeId(99)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_7_treemap_with_nested_array_values" = fn();  // TypeId(110)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_8_treemap_with_option_values" = fn();  // TypeId(100)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_8_treemap_with_option_values" = fn();  // TypeId(111)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_9_treemap_keys_with_special_chars" = fn();  // TypeId(101)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_9_treemap_keys_with_special_chars" = fn();  // TypeId(112)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_10_treemap_preserves_insertion_order" = fn();  // TypeId(102)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_10_treemap_preserves_insertion_order" = fn();  // TypeId(113)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_11_treemap_many_entries_roundtrip" = fn();  // TypeId(103)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_11_treemap_many_entries_roundtrip" = fn();  // TypeId(114)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_12_treemap_deserialize_from_any_key_order" = fn();  // TypeId(104)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/__cm_export____test_12_treemap_deserialize_from_any_key_order" = fn();  // TypeId(115)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(105)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(116)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(106)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(117)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(107)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(118)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(108)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(119)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(109)
+type "functype//core:internal/unreachable" = fn();  // TypeId(120)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(110)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(121)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(111)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(122)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(112)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(123)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(113)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(124)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(114)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(125)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(115)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(126)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(116)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(127)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(117)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(128)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(118)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(129)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(119)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(130)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(120)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(131)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(121)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(132)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(122)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(133)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(123)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(134)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(124)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(135)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(125)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(136)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(126)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(137)
 
-type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(127)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(138)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(128)
+type "functype//core:prelude/string.wado/String^Ord::cmp" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> "core:prelude/traits.wado//enum:Ordering";  // TypeId(139)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(129)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(140)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(130)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(141)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(131)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(142)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(132)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(143)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(133)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(144)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(134)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(145)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(135)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(146)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Option<i32>>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Option<i32>>>") -> ref null "tuple//[String, Option<i32>]";  // TypeId(136)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(147)
 
-type "functype//core:collections/TreeMap<String,Option<i32>>::entries" = fn(ref "core:collections//TreeMap<String,Option<i32>>") -> ref "core:prelude//Array<Tuple<String,Option<i32>>>";  // TypeId(137)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(148)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Option<i32>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Option<i32>>>", ref "tuple//[String, Option<i32>]");  // TypeId(138)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(149)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Option<i32>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Option<i32>>>");  // TypeId(139)
+type "functype//core:json/JsonMapSerializer^SerializeMap::key<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(150)
 
-type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Option<i32>>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Option<i32>>>") -> ref null "core:collections//TreeMapEntry<String,Option<i32>>";  // TypeId(140)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Option<i32>>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Option<i32>>>") -> ref null "tuple//[String, Option<i32>]";  // TypeId(151)
 
-type "functype//core:collections/TreeMap<String,Option<i32>>::insert" = fn(ref "core:collections//TreeMap<String,Option<i32>>", ref "core:prelude/string.wado//String", ref "core:prelude/types.wado//Option<i32>");  // TypeId(141)
+type "functype//core:collections/TreeMap<String,Option<i32>>::entries" = fn(ref "core:collections//TreeMap<String,Option<i32>>") -> ref "core:prelude//Array<Tuple<String,Option<i32>>>";  // TypeId(152)
 
-type "functype//core:collections/TreeMap<String,Option<i32>>::insert_node" = fn(ref "core:collections//TreeMap<String,Option<i32>>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(142)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Option<i32>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Option<i32>>>", ref "tuple//[String, Option<i32>]");  // TypeId(153)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Option<i32>>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Option<i32>>>", ref "core:collections//TreeMapEntry<String,Option<i32>>");  // TypeId(143)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Option<i32>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Option<i32>>>");  // TypeId(154)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Option<i32>>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Option<i32>>>");  // TypeId(144)
+type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Option<i32>>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Option<i32>>>") -> ref null "core:collections//TreeMapEntry<String,Option<i32>>";  // TypeId(155)
 
-type "functype//core:collections/TreeMap<String,Option<i32>>::find_index" = fn(ref "core:collections//TreeMap<String,Option<i32>>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(145)
+type "functype//core:collections/TreeMap<String,Option<i32>>::insert" = fn(ref "core:collections//TreeMap<String,Option<i32>>", ref "core:prelude/string.wado//String", ref "core:prelude/types.wado//Option<i32>");  // TypeId(156)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::value<Array<i32>>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude//Array<i32>") -> ref null "core:serde//SerializeError";  // TypeId(146)
+type "functype//core:collections/TreeMap<String,Option<i32>>::insert_node" = fn(ref "core:collections//TreeMap<String,Option<i32>>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(157)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Array<i32>>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Array<i32>>>") -> ref null "tuple//[String, Array<i32>]";  // TypeId(147)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Option<i32>>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Option<i32>>>", ref "core:collections//TreeMapEntry<String,Option<i32>>");  // TypeId(158)
 
-type "functype//core:collections/TreeMap<String,Array<i32>>::entries" = fn(ref "core:collections//TreeMap<String,Array<i32>>") -> ref "core:prelude//Array<Tuple<String,Array<i32>>>";  // TypeId(148)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Option<i32>>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Option<i32>>>");  // TypeId(159)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Array<i32>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<i32>>>", ref "tuple//[String, Array<i32>]");  // TypeId(149)
+type "functype//core:collections/TreeMap<String,Option<i32>>::find_index" = fn(ref "core:collections//TreeMap<String,Option<i32>>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(160)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,Array<i32>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<i32>>>");  // TypeId(150)
+type "functype//core:json/JsonMapSerializer^SerializeMap::value<Array<i32>>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude//Array<i32>") -> ref null "core:serde//SerializeError";  // TypeId(161)
 
-type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Array<i32>>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Array<i32>>>") -> ref null "core:collections//TreeMapEntry<String,Array<i32>>";  // TypeId(151)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,Array<i32>>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,Array<i32>>>") -> ref null "tuple//[String, Array<i32>]";  // TypeId(162)
 
-type "functype//core:prelude/array.wado/Array<i32>::push" = fn(ref "core:prelude//Array<i32>", i32);  // TypeId(152)
+type "functype//core:collections/TreeMap<String,Array<i32>>::entries" = fn(ref "core:collections//TreeMap<String,Array<i32>>") -> ref "core:prelude//Array<Tuple<String,Array<i32>>>";  // TypeId(163)
 
-type "functype//core:prelude/array.wado/Array<i32>::grow" = fn(ref "core:prelude//Array<i32>");  // TypeId(153)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Array<i32>>>::push" = fn(ref "core:prelude//Array<Tuple<String,Array<i32>>>", ref "tuple//[String, Array<i32>]");  // TypeId(164)
 
-type "functype//core:collections/TreeMap<String,Array<i32>>::insert" = fn(ref "core:collections//TreeMap<String,Array<i32>>", ref "core:prelude/string.wado//String", ref "core:prelude//Array<i32>");  // TypeId(154)
+type "functype//core:prelude/array.wado/Array<Tuple<String,Array<i32>>>::grow" = fn(ref "core:prelude//Array<Tuple<String,Array<i32>>>");  // TypeId(165)
 
-type "functype//core:collections/TreeMap<String,Array<i32>>::insert_node" = fn(ref "core:collections//TreeMap<String,Array<i32>>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(155)
+type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Array<i32>>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Array<i32>>>") -> ref null "core:collections//TreeMapEntry<String,Array<i32>>";  // TypeId(166)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Array<i32>>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Array<i32>>>", ref "core:collections//TreeMapEntry<String,Array<i32>>");  // TypeId(156)
+type "functype//core:prelude/array.wado/Array<i32>::push" = fn(ref "core:prelude//Array<i32>", i32);  // TypeId(167)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Array<i32>>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Array<i32>>>");  // TypeId(157)
+type "functype//core:prelude/array.wado/Array<i32>::grow" = fn(ref "core:prelude//Array<i32>");  // TypeId(168)
 
-type "functype//core:collections/TreeMap<String,Array<i32>>::find_index" = fn(ref "core:collections//TreeMap<String,Array<i32>>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(158)
+type "functype//core:collections/TreeMap<String,Array<i32>>::insert" = fn(ref "core:collections//TreeMap<String,Array<i32>>", ref "core:prelude/string.wado//String", ref "core:prelude//Array<i32>");  // TypeId(169)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,bool>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,bool>>") -> ref null "tuple//[String, bool]";  // TypeId(159)
+type "functype//core:collections/TreeMap<String,Array<i32>>::insert_node" = fn(ref "core:collections//TreeMap<String,Array<i32>>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(170)
 
-type "functype//core:collections/TreeMap<String,bool>::entries" = fn(ref "core:collections//TreeMap<String,bool>") -> ref "core:prelude//Array<Tuple<String,bool>>";  // TypeId(160)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Array<i32>>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,Array<i32>>>", ref "core:collections//TreeMapEntry<String,Array<i32>>");  // TypeId(171)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,bool>>::push" = fn(ref "core:prelude//Array<Tuple<String,bool>>", ref "tuple//[String, bool]");  // TypeId(161)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,Array<i32>>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,Array<i32>>>");  // TypeId(172)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,bool>>::grow" = fn(ref "core:prelude//Array<Tuple<String,bool>>");  // TypeId(162)
+type "functype//core:collections/TreeMap<String,Array<i32>>::find_index" = fn(ref "core:collections//TreeMap<String,Array<i32>>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(173)
 
-type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,bool>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,bool>>") -> ref null "core:collections//TreeMapEntry<String,bool>";  // TypeId(163)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,bool>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,bool>>") -> ref null "tuple//[String, bool]";  // TypeId(174)
 
-type "functype//core:collections/TreeMap<String,bool>::insert" = fn(ref "core:collections//TreeMap<String,bool>", ref "core:prelude/string.wado//String", bool);  // TypeId(164)
+type "functype//core:collections/TreeMap<String,bool>::entries" = fn(ref "core:collections//TreeMap<String,bool>") -> ref "core:prelude//Array<Tuple<String,bool>>";  // TypeId(175)
 
-type "functype//core:collections/TreeMap<String,bool>::insert_node" = fn(ref "core:collections//TreeMap<String,bool>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(165)
+type "functype//core:prelude/array.wado/Array<Tuple<String,bool>>::push" = fn(ref "core:prelude//Array<Tuple<String,bool>>", ref "tuple//[String, bool]");  // TypeId(176)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,bool>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,bool>>", ref "core:collections//TreeMapEntry<String,bool>");  // TypeId(166)
+type "functype//core:prelude/array.wado/Array<Tuple<String,bool>>::grow" = fn(ref "core:prelude//Array<Tuple<String,bool>>");  // TypeId(177)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,bool>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,bool>>");  // TypeId(167)
+type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,bool>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,bool>>") -> ref null "core:collections//TreeMapEntry<String,bool>";  // TypeId(178)
 
-type "functype//core:collections/TreeMap<String,bool>::find_index" = fn(ref "core:collections//TreeMap<String,bool>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(168)
+type "functype//core:collections/TreeMap<String,bool>::insert" = fn(ref "core:collections//TreeMap<String,bool>", ref "core:prelude/string.wado//String", bool);  // TypeId(179)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::value<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(169)
+type "functype//core:collections/TreeMap<String,bool>::insert_node" = fn(ref "core:collections//TreeMap<String,bool>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(180)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,String>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,String>>") -> ref null "tuple//[String, String]";  // TypeId(170)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,bool>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,bool>>", ref "core:collections//TreeMapEntry<String,bool>");  // TypeId(181)
 
-type "functype//core:collections/TreeMap<String,String>::entries" = fn(ref "core:collections//TreeMap<String,String>") -> ref "core:prelude//Array<Tuple<String,String>>";  // TypeId(171)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,bool>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,bool>>");  // TypeId(182)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,String>>::push" = fn(ref "core:prelude//Array<Tuple<String,String>>", ref "tuple//[String, String]");  // TypeId(172)
+type "functype//core:collections/TreeMap<String,bool>::find_index" = fn(ref "core:collections//TreeMap<String,bool>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(183)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,String>>::grow" = fn(ref "core:prelude//Array<Tuple<String,String>>");  // TypeId(173)
+type "functype//core:json/JsonMapSerializer^SerializeMap::value<String>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(184)
 
-type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,String>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,String>>") -> ref null "core:collections//TreeMapEntry<String,String>";  // TypeId(174)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,String>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,String>>") -> ref null "tuple//[String, String]";  // TypeId(185)
 
-type "functype//core:collections/TreeMap<String,String>::insert" = fn(ref "core:collections//TreeMap<String,String>", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(175)
+type "functype//core:collections/TreeMap<String,String>::entries" = fn(ref "core:collections//TreeMap<String,String>") -> ref "core:prelude//Array<Tuple<String,String>>";  // TypeId(186)
 
-type "functype//core:collections/TreeMap<String,String>::insert_node" = fn(ref "core:collections//TreeMap<String,String>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(176)
+type "functype//core:prelude/array.wado/Array<Tuple<String,String>>::push" = fn(ref "core:prelude//Array<Tuple<String,String>>", ref "tuple//[String, String]");  // TypeId(187)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,String>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,String>>", ref "core:collections//TreeMapEntry<String,String>");  // TypeId(177)
+type "functype//core:prelude/array.wado/Array<Tuple<String,String>>::grow" = fn(ref "core:prelude//Array<Tuple<String,String>>");  // TypeId(188)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,String>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,String>>");  // TypeId(178)
+type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,String>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,String>>") -> ref null "core:collections//TreeMapEntry<String,String>";  // TypeId(189)
 
-type "functype//core:collections/TreeMap<String,String>::find_index" = fn(ref "core:collections//TreeMap<String,String>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(179)
+type "functype//core:collections/TreeMap<String,String>::insert" = fn(ref "core:collections//TreeMap<String,String>", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(190)
 
-type "functype//core:collections/TreeMap<String,i32>^IndexValue<K>::index_value" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(180)
+type "functype//core:collections/TreeMap<String,String>::insert_node" = fn(ref "core:collections//TreeMap<String,String>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(191)
 
-type "functype//core:collections/TreeMap<String,i32>::find_index" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(181)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,String>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,String>>", ref "core:collections//TreeMapEntry<String,String>");  // TypeId(192)
 
-type "functype//core:collections/TreeMap<String,i32>::insert" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String", i32);  // TypeId(182)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,String>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,String>>");  // TypeId(193)
 
-type "functype//core:collections/TreeMap<String,i32>::insert_node" = fn(ref "core:collections//TreeMap<String,i32>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(183)
+type "functype//core:collections/TreeMap<String,String>::find_index" = fn(ref "core:collections//TreeMap<String,String>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(194)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,i32>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,i32>>", ref "core:collections//TreeMapEntry<String,i32>");  // TypeId(184)
+type "functype//core:collections/TreeMap<String,i32>^IndexValue<K>::index_value" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(195)
 
-type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,i32>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,i32>>");  // TypeId(185)
+type "functype//core:collections/TreeMap<String,i32>::find_index" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String") -> i32;  // TypeId(196)
 
-type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,i32>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,i32>>") -> ref null "tuple//[String, i32]";  // TypeId(186)
+type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/TreeMap<String,i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>";  // TypeId(197)
 
-type "functype//core:collections/TreeMap<String,i32>::entries" = fn(ref "core:collections//TreeMap<String,i32>") -> ref "core:prelude//Array<Tuple<String,i32>>";  // TypeId(187)
+type "functype//core:collections/TreeMap<String,i32>::insert" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String", i32);  // TypeId(198)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,i32>>::push" = fn(ref "core:prelude//Array<Tuple<String,i32>>", ref "tuple//[String, i32]");  // TypeId(188)
+type "functype//core:collections/TreeMap<String,i32>::insert_node" = fn(ref "core:collections//TreeMap<String,i32>", ref null "core:collections//TreeMapNode<String>", ref "core:prelude/string.wado//String", i32) -> ref null "core:collections//TreeMapNode<String>";  // TypeId(199)
 
-type "functype//core:prelude/array.wado/Array<Tuple<String,i32>>::grow" = fn(ref "core:prelude//Array<Tuple<String,i32>>");  // TypeId(189)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,i32>>::push" = fn(ref "core:prelude//Array<TreeMapEntry<String,i32>>", ref "core:collections//TreeMapEntry<String,i32>");  // TypeId(200)
 
-type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,i32>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,i32>>") -> ref null "core:collections//TreeMapEntry<String,i32>";  // TypeId(190)
+type "functype//core:prelude/array.wado/Array<TreeMapEntry<String,i32>>::grow" = fn(ref "core:prelude//Array<TreeMapEntry<String,i32>>");  // TypeId(201)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(191)
+type "functype//core:prelude/array.wado/ArrayIter<Tuple<String,i32>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<Tuple<String,i32>>") -> ref null "tuple//[String, i32]";  // TypeId(202)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(192)
+type "functype//core:collections/TreeMap<String,i32>::entries" = fn(ref "core:collections//TreeMap<String,i32>") -> ref "core:prelude//Array<Tuple<String,i32>>";  // TypeId(203)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(193)
+type "functype//core:prelude/array.wado/Array<Tuple<String,i32>>::push" = fn(ref "core:prelude//Array<Tuple<String,i32>>", ref "tuple//[String, i32]");  // TypeId(204)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(194)
+type "functype//core:prelude/array.wado/Array<Tuple<String,i32>>::grow" = fn(ref "core:prelude//Array<Tuple<String,i32>>");  // TypeId(205)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(195)
+type "functype//core:prelude/array.wado/ArrayIter<TreeMapEntry<String,i32>>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,i32>>") -> ref null "core:collections//TreeMapEntry<String,i32>";  // TypeId(206)
 
-type "functype//core:json/core/json/to_string<TreeMap<String,Option<i32>>>" = fn(ref "core:collections//TreeMap<String,Option<i32>>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(196)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(207)
 
-type "functype//core:json/core/json/to_string<TreeMap<String,Array<i32>>>" = fn(ref "core:collections//TreeMap<String,Array<i32>>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(197)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(208)
 
-type "functype//core:json/core/json/to_string<TreeMap<String,bool>>" = fn(ref "core:collections//TreeMap<String,bool>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(198)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(209)
 
-type "functype//core:json/core/json/to_string<TreeMap<String,String>>" = fn(ref "core:collections//TreeMap<String,String>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(199)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(210)
 
-type "functype//core:json/core/json/from_string<TreeMap<String,i32>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:collections//TreeMap<String,i32>", ref null "core:serde//DeserializeError"];  // TypeId(200)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(211)
 
-type "functype//core:json/core/json/to_string<TreeMap<String,i32>>" = fn(ref "core:collections//TreeMap<String,i32>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(201)
+type "functype//core:json/core/json/to_string<TreeMap<String,Option<i32>>>" = fn(ref "core:collections//TreeMap<String,Option<i32>>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(212)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(202)
+type "functype//core:json/core/json/to_string<TreeMap<String,Array<i32>>>" = fn(ref "core:collections//TreeMap<String,Array<i32>>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(213)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(203)
+type "functype//core:json/core/json/to_string<TreeMap<String,bool>>" = fn(ref "core:collections//TreeMap<String,bool>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(214)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(204)
+type "functype//core:json/core/json/to_string<TreeMap<String,String>>" = fn(ref "core:collections//TreeMap<String,String>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(215)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(205)
+type "functype//core:json/core/json/from_string<TreeMap<String,i32>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "core:collections//TreeMap<String,i32>", ref null "core:serde//DeserializeError"];  // TypeId(216)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(206)
+type "functype//core:json/core/json/to_string<TreeMap<String,i32>>" = fn(ref "core:collections//TreeMap<String,i32>") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(217)
 
-type "functype//core:json/JsonMapAccess^DeserializeMap::next_key_string" = fn(ref "core:json//JsonMapAccess") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(207)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(218)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_map" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:json//JsonMapAccess", ref null "core:serde//DeserializeError"];  // TypeId(208)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> [i32, i32, ref null "core:serde//DeserializeError"];  // TypeId(219)
 
-type "functype//core:prelude/array.wado/ArrayIter<i32>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<i32>") -> [i32, i32];  // TypeId(209)
+type "functype//core:json/JsonMapAccess^DeserializeMap::next_key_string" = fn(ref "core:json//JsonMapAccess") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(220)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_treemap.wado/TreeMap<String,i32>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:collections//TreeMap<String,i32>", ref null "core:serde//DeserializeError"];  // TypeId(210)
+type "functype//core:json/JsonDeserializer^Deserializer::begin_map" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:json//JsonMapAccess", ref null "core:serde//DeserializeError"];  // TypeId(221)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(211)
+type "functype//core:prelude/array.wado/ArrayIter<i32>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<i32>") -> [i32, i32];  // TypeId(222)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(212)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(223)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(213)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(224)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(214)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(225)
 
-type "functype//core:collections/TreeMap<String,Option<i32>>^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,Option<i32>>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(215)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(226)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::value<Option<i32>>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/types.wado//Option<i32>") -> ref null "core:serde//SerializeError";  // TypeId(216)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(227)
 
-type "functype//core:collections/TreeMap<String,Array<i32>>^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,Array<i32>>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(217)
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(228)
 
-type "functype//core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<i32>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(218)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(229)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<i32>" = fn(ref "core:json//JsonSeqSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(219)
+type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(230)
 
-type "functype//core:collections/TreeMap<String,bool>^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,bool>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(220)
+type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(231)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::value<bool>" = fn(ref "core:json//JsonMapSerializer", bool) -> ref null "core:serde//SerializeError";  // TypeId(221)
+type "functype//core:collections/TreeMap<String,Option<i32>>^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,Option<i32>>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(232)
 
-type "functype//core:collections/TreeMap<String,String>^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,String>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(222)
+type "functype//core:json/JsonMapSerializer^SerializeMap::value<Option<i32>>" = fn(ref "core:json//JsonMapSerializer", ref "core:prelude/types.wado//Option<i32>") -> ref null "core:serde//SerializeError";  // TypeId(233)
 
-type "functype//core:collections/TreeMap<String,i32>^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(223)
+type "functype//core:collections/TreeMap<String,Array<i32>>^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,Array<i32>>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(234)
 
-type "functype//core:json/JsonMapSerializer^SerializeMap::value<i32>" = fn(ref "core:json//JsonMapSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(224)
+type "functype//core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>" = fn(ref "core:prelude//Array<i32>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(235)
 
-type "functype//core:collections/TreeMap<String,Option<i32>>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(225)
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<i32>" = fn(ref "core:json//JsonSeqSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(236)
 
-type "functype//core:collections/TreeMap<String,Option<i32>>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(226)
+type "functype//core:collections/TreeMap<String,bool>^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,bool>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(237)
 
-type "functype//core:collections/TreeMap<String,Array<i32>>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(227)
+type "functype//core:json/JsonMapSerializer^SerializeMap::value<bool>" = fn(ref "core:json//JsonMapSerializer", bool) -> ref null "core:serde//SerializeError";  // TypeId(238)
 
-type "functype//core:collections/TreeMap<String,Array<i32>>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(228)
+type "functype//core:collections/TreeMap<String,String>^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,String>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(239)
 
-type "functype//core:collections/TreeMap<String,bool>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(229)
+type "functype//core:collections/TreeMap<String,i32>^Serialize::serialize<JsonSerializer>" = fn(ref "core:collections//TreeMap<String,i32>", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(240)
 
-type "functype//core:collections/TreeMap<String,bool>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(230)
+type "functype//core:json/JsonMapSerializer^SerializeMap::value<i32>" = fn(ref "core:json//JsonMapSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(241)
 
-type "functype//core:collections/TreeMap<String,String>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(231)
+type "functype//core:collections/TreeMap<String,Option<i32>>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(242)
 
-type "functype//core:collections/TreeMap<String,String>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(232)
+type "functype//core:collections/TreeMap<String,Option<i32>>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(243)
 
-type "functype//core:collections/TreeMap<String,i32>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(233)
+type "functype//core:collections/TreeMap<String,Array<i32>>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(244)
 
-type "functype//core:collections/TreeMap<String,i32>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(234)
+type "functype//core:collections/TreeMap<String,Array<i32>>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(245)
+
+type "functype//core:collections/TreeMap<String,bool>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(246)
+
+type "functype//core:collections/TreeMap<String,bool>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(247)
+
+type "functype//core:collections/TreeMap<String,String>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(248)
+
+type "functype//core:collections/TreeMap<String,String>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(249)
+
+type "functype//core:collections/TreeMap<String,i32>::split" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(250)
+
+type "functype//core:collections/TreeMap<String,i32>::skew" = fn(ref null "core:collections//TreeMapNode<String>") -> ref null "core:collections//TreeMapNode<String>";  // TypeId(251)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -2352,36 +2419,77 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l120: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l120;
+                };
+            };
+        };
     }
-    return ((97 + v) - 10) & 255;
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
         return 1;
     }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l126: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l126;
+            };
+        };
+    };
+    return n;
 }
 
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b122: block {
-        l123: loop {
+    b128: block {
+        l129: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -2402,23 +2510,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b122;
+                break b128;
             }
-            continue l123;
+            continue l129;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -2426,114 +2536,211 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/to_string<TreeMap<String,Option<i32>>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:collections/TreeMap<String,Option<i32>>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:collections/TreeMap<String,Option<i32>>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<TreeMap<String,Array<i32>>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:collections/TreeMap<String,Array<i32>>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:collections/TreeMap<String,Array<i32>>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<TreeMap<String,bool>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:collections/TreeMap<String,bool>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:collections/TreeMap<String,bool>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<TreeMap<String,String>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:collections/TreeMap<String,String>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:collections/TreeMap<String,String>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<TreeMap<String,i32>>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "core:collections//TreeMap<String,i32>";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "core:collections//TreeMap<String,i32>";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "core:collections//TreeMap<String,i32>";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_treemap.wado/TreeMap<String,i32>^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "core:collections//TreeMap<String,i32>"(let __match_scrut_0: ref "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_treemap.wado/TreeMap<String,i32>^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Ok"(__match_scrut_0) -> ref "core:collections//TreeMap<String,i32>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err"(__match_scrut_0) -> ref "core:collections//TreeMap<String,i32>" {
+        let __cast_1: ref "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<TreeMap<String,i32>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:collections/TreeMap<String,i32>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:collections/TreeMap<String,i32>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -2556,6 +2763,20 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     }, offset, abs_val, digit_count);
 }
 
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
+}
+
 fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     let s: ref "core:prelude/string.wado//String";
     let c: char;
@@ -2567,6 +2788,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
         "core:prelude/string.wado/String::push"(s, self);
         "core:prelude/format.wado/Formatter::pad"(f, s);
     }
+}
+
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
 }
 
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
@@ -2632,7 +2867,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l150: loop {
+            l176: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -2640,7 +2875,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l150;
+                continue l176;
             };
         };
     };
@@ -2664,7 +2899,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
     __for_2: block {
         i = 0;
         block {
-            l154: loop {
+            l180: loop {
                 if i >= min_len {
                     break __for_2;
                 }
@@ -2677,7 +2912,7 @@ fn "core:prelude/string.wado/String^Ord::cmp"(self, other) {
                     return 2;
                 }
                 i = i + 1;
-                continue l154;
+                continue l180;
             };
         };
     };
@@ -2732,6 +2967,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -2800,10 +3084,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b169: block {
-        l170: loop {
+    b202: block {
+        l203: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b169;
+                break b202;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -2827,7 +3111,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l170;
+            continue l203;
         };
     };
     self.pos = _hfs_pos_8;
@@ -2891,130 +3175,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
+        }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b180: block {
-        l181: loop {
-            if scan_pos >= _licm_used_90 {
-                break b180;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b213: block {
+        l214: loop {
+            if scan_pos >= _licm_used_56 {
+                break b213;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b180;
+                break b213;
             }
             scan_pos = scan_pos + 1;
-            continue l181;
+            continue l214;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -3023,94 +3279,95 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l188: loop {
+                l221: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l188;
+                    continue l221;
                 };
             };
         };
         self.pos = scan_pos + 1;
-        return 0, result_5, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l191: loop {
+            l224: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l191;
+                continue l224;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b193: block {
-        l194: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b226: block {
+        l227: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b193;
+                break b226;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
-                return 0, result_8, ref.null none;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
+                return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
-                    });
+                    self.pos = _hfs_pos_64;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
+                    }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -3128,213 +3385,140 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return 1, ref.null none, e;
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
-                    });
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
+                    }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
-                    });
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
+                    }) };
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l194;
+            continue l227;
         };
     };
-    self.pos = _hfs_pos_98;
-    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
-    });
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
+    }) };
 }
 
 fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l219: loop {
+            l247: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l219;
+                continue l247;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -3424,16 +3608,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b233: block {
-        l234: loop {
+    b257: block {
+        l258: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b233;
+                break b257;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -3454,17 +3638,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b242: block {
-                        l243: loop {
+                    b266: block {
+                        l267: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b242;
+                                break b266;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -3474,9 +3658,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b242;
+                                break b266;
                             }
-                            continue l243;
+                            continue l267;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -3507,17 +3691,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b252: block {
-                            l253: loop {
+                        b276: block {
+                            l277: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b252;
+                                    break b276;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -3526,9 +3710,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b252;
+                                    break b276;
                                 }
-                                continue l253;
+                                continue l277;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -3566,9 +3750,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return 0, builtin::i32_trunc_f64_s(v_signed), ref.null none;
             } else {
-                break b233;
+                break b257;
             }
-            continue l234;
+            continue l258;
         };
     };
     self.pos = _hfs_pos_51;
@@ -3579,69 +3763,89 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
 }
 
 fn "core:json/JsonMapAccess^DeserializeMap::next_key_string"(self) {
-    let r_1: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
+    let __local_2: ref "core:serde//DeserializeError";
+    let __local_3: ref "core:prelude/string.wado//String";
+    let __local_4: ref "core:serde//DeserializeError";
     let key: ref "core:prelude/string.wado//String";
-    let r_5: ref null "core:serde//DeserializeError";
-    let e_6: ref "core:serde//DeserializeError";
-    let e_7: ref "core:serde//DeserializeError";
-    let __local_12: ref "core:prelude/string.wado//String";
-    let __local_13: i64;
-    let __local_14: ref "core:prelude/string.wado//String";
-    let __local_15: i32;
+    let __local_7: ref "core:serde//DeserializeError";
+    let __local_8: ref "core:prelude/string.wado//String";
+    let __local_9: i64;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_12 = self.de.input;
-        break __inline_String__len_0: __local_12.used;
+        __local_8 = self.de.input;
+        break __inline_String__len_0: __local_8.used;
     } {
         return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_13 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_13 };
+            __local_9 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_9 };
         });
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_14 = self.de.input;
-        __local_15 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_14.repr, __local_15);
+        __local_10 = self.de.input;
+        __local_11 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_10.repr, __local_11);
     } == 125 {
         return 0, ref.null none, ref.null none;
     }
     if self.first == 0 {
-        r_1 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r_1) == 0 {
-            e_2 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r_1));
-            return 1, ref.null none, e_2;
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return 1, ref.null none, __local_2;
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
-    let __sroa_key_r_discriminant: i32;
-    let __sroa_key_r_case0_payload_0: ref null "core:prelude/string.wado//String";
-    let __sroa_key_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_key_r_discriminant, __sroa_key_r_case0_payload_0, __sroa_key_r_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self.de);
-    if __sroa_key_r_discriminant == 0 {
-        key = __sroa_key_r_case0_payload_0;
-        r_5 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_5) == 0 {
-            e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r_5));
-            return 1, ref.null none, e_6;
-        }
-        return 0, key, ref.null none;
+    key = value_copy "core:prelude/string.wado//String"(let __match_scrut_1: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_1 = "core:json/JsonDeserializer::read_json_string"(self.de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/string.wado//String" {
+        let __cast_3: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_3 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1);
+        __local_3 = __cast_3.payload_0;
+        __local_3;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/string.wado//String" {
+        let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1);
+        __local_4 = __cast_2.payload_0;
+        return 1, ref.null none, __local_4;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    let __match_scrut_2: ref null "core:serde//DeserializeError";
+    __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+    if ref.is_null(__match_scrut_2) {
+    } else if ref.is_null(__match_scrut_2) == 0 {
+        let __cast_4: ref null "core:serde//DeserializeError";
+        __cast_4 = ref.as_non_null(__match_scrut_2);
+        __local_7 = ref.as_non_null(__cast_4);
+        return 1, ref.null none, __local_7;
+        unreachable;
+    } else {
+        unreachable;
     }
-    if __sroa_key_r_discriminant == 1 {
-        e_7 = __sroa_key_r_case1_payload_0;
-        return 1, ref.null none, e_7;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, key, ref.null none;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_map"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 123);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 123);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_2 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_2;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonMapAccess" { de: self, first: 1 }, ref.null none;
 }
@@ -3653,13 +3857,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l272: loop {
+            l299: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l272;
+                continue l299;
             };
         };
     };
@@ -3796,8 +4000,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b295: block {
-        l296: loop {
+    b322: block {
+        l323: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3822,9 +4026,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b295;
+                break b322;
             }
-            continue l296;
+            continue l323;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -3853,8 +4057,8 @@ fn "core:collections/TreeMap<String,Option<i32>>^Serialize::serialize<JsonSerial
     if ref.test "core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok"(map_r) {
         m = value_copy "core:json//JsonMapSerializer"(ref.cast "core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok"(map_r).payload_0);
         __iter_5 = struct.new "core:prelude/array.wado//ArrayIter<Tuple<String,Option<i32>>>" { repr: entries.repr, used: entries.used, index: 0 };
-        b304: block {
-            l305: loop {
+        b331: block {
+            l332: loop {
                 __pattern_temp_1 = "core:prelude/array.wado/ArrayIter<Tuple<String,Option<i32>>>^Iterator::next"(__iter_5);
                 if ref.is_null(__pattern_temp_1) == 0 {
                     entry = value_copy "tuple//[String, Option<i32>]"(ref.as_non_null(__pattern_temp_1));
@@ -3870,9 +4074,9 @@ fn "core:collections/TreeMap<String,Option<i32>>^Serialize::serialize<JsonSerial
                         return e_12;
                     }
                 } else {
-                    break b304;
+                    break b331;
                 }
-                continue l305;
+                continue l332;
             };
         };
         return __inline_JsonMapSerializer_SerializeMap__end_3: block -> ref null "core:serde//SerializeError" {
@@ -3959,8 +4163,8 @@ fn "core:collections/TreeMap<String,Option<i32>>::entries"(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_Option_i32____IntoIterator__into_iter_3: struct.new "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Option<i32>>>" { repr: __local_9.repr, used: __local_9.used, index: 0 };
     };
-    b313: block {
-        l314: loop {
+    b340: block {
+        l341: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Option<i32>>>^Iterator::next"(__iter_3);
             if ref.is_null(__pattern_temp_0) == 0 {
                 entry = value_copy "core:collections//TreeMapEntry<String,Option<i32>>"(ref.as_non_null(__pattern_temp_0));
@@ -3968,9 +4172,9 @@ fn "core:collections/TreeMap<String,Option<i32>>::entries"(self) {
                     "core:prelude/array.wado/Array<Tuple<String,Option<i32>>>::push"(result, struct.new "tuple//[String, Option<i32>]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b313;
+                break b340;
             }
-            continue l314;
+            continue l341;
         };
     };
     return result;
@@ -4005,13 +4209,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Option<i32>>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l319: loop {
+            l346: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Option<i32>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Option<i32>]">(old_repr, i));
                 i = i + 1;
-                continue l319;
+                continue l346;
             };
         };
     };
@@ -4154,13 +4358,13 @@ fn "core:prelude/array.wado/Array<TreeMapEntry<String,Option<i32>>>::grow"(self)
     __for_0: block {
         i = 0;
         block {
-            l336: loop {
+            l363: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:collections//TreeMapEntry<String,Option<i32>>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<String,Option<i32>>">(old_repr, i));
                 i = i + 1;
-                continue l336;
+                continue l363;
             };
         };
     };
@@ -4180,8 +4384,8 @@ fn "core:collections/TreeMap<String,Option<i32>>::find_index"(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b338: block {
-        l339: loop {
+    b365: block {
+        l366: loop {
             __pattern_temp_0 = value_copy "core:prelude/types.wado//Option<TreeMapNode<String>>"(current);
             if ref.is_null(__pattern_temp_0) == 0 {
                 n = ref.as_non_null(__pattern_temp_0);
@@ -4205,9 +4409,9 @@ fn "core:collections/TreeMap<String,Option<i32>>::find_index"(self, key) {
                     current = n.right;
                 }
             } else {
-                break b338;
+                break b365;
             }
-            continue l339;
+            continue l366;
         };
     };
     return -1;
@@ -4237,8 +4441,8 @@ fn "core:collections/TreeMap<String,Array<i32>>^Serialize::serialize<JsonSeriali
     if ref.test "core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok"(map_r) {
         m = value_copy "core:json//JsonMapSerializer"(ref.cast "core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok"(map_r).payload_0);
         __iter_5 = struct.new "core:prelude/array.wado//ArrayIter<Tuple<String,Array<i32>>>" { repr: entries.repr, used: entries.used, index: 0 };
-        b346: block {
-            l347: loop {
+        b373: block {
+            l374: loop {
                 __pattern_temp_1 = "core:prelude/array.wado/ArrayIter<Tuple<String,Array<i32>>>^Iterator::next"(__iter_5);
                 if ref.is_null(__pattern_temp_1) == 0 {
                     entry = ref.as_non_null(__pattern_temp_1);
@@ -4255,9 +4459,9 @@ fn "core:collections/TreeMap<String,Array<i32>>^Serialize::serialize<JsonSeriali
                         return e_12;
                     }
                 } else {
-                    break b346;
+                    break b373;
                 }
-                continue l347;
+                continue l374;
             };
         };
         return __inline_JsonMapSerializer_SerializeMap__end_3: block -> ref null "core:serde//SerializeError" {
@@ -4304,8 +4508,8 @@ fn "core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>"(sel
             __local_16 = self;
             break __inline_Array_i32__IntoIterator__into_iter_2: struct.new "core:prelude/array.wado//ArrayIter<i32>" { repr: __local_16.repr, used: __local_16.used, index: 0 };
         };
-        b353: block {
-            l354: loop {
+        b380: block {
+            l381: loop {
                 let __sroa___pattern_temp_1_discriminant: i32;
                 let __sroa___pattern_temp_1_payload_0: i32;
                 multivalue_bind [__sroa___pattern_temp_1_discriminant, __sroa___pattern_temp_1_payload_0] = "core:prelude/array.wado/ArrayIter<i32>^Iterator::next"(__iter_4);
@@ -4316,9 +4520,9 @@ fn "core:prelude/array.wado/Array<i32>^Serialize::serialize<JsonSerializer>"(sel
                         return e_7;
                     }
                 } else {
-                    break b353;
+                    break b380;
                 }
-                continue l354;
+                continue l381;
             };
         };
         return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref null "core:serde//SerializeError" {
@@ -4381,8 +4585,8 @@ fn "core:collections/TreeMap<String,Array<i32>>::entries"(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_Array_i32____IntoIterator__into_iter_3: struct.new "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,Array<i32>>>" { repr: __local_9.repr, used: __local_9.used, index: 0 };
     };
-    b361: block {
-        l362: loop {
+    b388: block {
+        l389: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,Array<i32>>>^Iterator::next"(__iter_3);
             if ref.is_null(__pattern_temp_0) == 0 {
                 entry = value_copy "core:collections//TreeMapEntry<String,Array<i32>>"(ref.as_non_null(__pattern_temp_0));
@@ -4390,9 +4594,9 @@ fn "core:collections/TreeMap<String,Array<i32>>::entries"(self) {
                     "core:prelude/array.wado/Array<Tuple<String,Array<i32>>>::push"(result, struct.new "tuple//[String, Array<i32>]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b361;
+                break b388;
             }
-            continue l362;
+            continue l389;
         };
     };
     return result;
@@ -4427,13 +4631,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,Array<i32>>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l367: loop {
+            l394: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, Array<i32>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<i32>]">(old_repr, i));
                 i = i + 1;
-                continue l367;
+                continue l394;
             };
         };
     };
@@ -4479,13 +4683,13 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l372: loop {
+            l399: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
                 i = i + 1;
-                continue l372;
+                continue l399;
             };
         };
     };
@@ -4618,13 +4822,13 @@ fn "core:prelude/array.wado/Array<TreeMapEntry<String,Array<i32>>>::grow"(self) 
     __for_0: block {
         i = 0;
         block {
-            l388: loop {
+            l415: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:collections//TreeMapEntry<String,Array<i32>>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<String,Array<i32>>">(old_repr, i));
                 i = i + 1;
-                continue l388;
+                continue l415;
             };
         };
     };
@@ -4644,8 +4848,8 @@ fn "core:collections/TreeMap<String,Array<i32>>::find_index"(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b390: block {
-        l391: loop {
+    b417: block {
+        l418: loop {
             __pattern_temp_0 = value_copy "core:prelude/types.wado//Option<TreeMapNode<String>>"(current);
             if ref.is_null(__pattern_temp_0) == 0 {
                 n = ref.as_non_null(__pattern_temp_0);
@@ -4669,9 +4873,9 @@ fn "core:collections/TreeMap<String,Array<i32>>::find_index"(self, key) {
                     current = n.right;
                 }
             } else {
-                break b390;
+                break b417;
             }
-            continue l391;
+            continue l418;
         };
     };
     return -1;
@@ -4700,8 +4904,8 @@ fn "core:collections/TreeMap<String,bool>^Serialize::serialize<JsonSerializer>"(
     if ref.test "core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok"(map_r) {
         m = value_copy "core:json//JsonMapSerializer"(ref.cast "core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok"(map_r).payload_0);
         __iter_5 = struct.new "core:prelude/array.wado//ArrayIter<Tuple<String,bool>>" { repr: entries.repr, used: entries.used, index: 0 };
-        b398: block {
-            l399: loop {
+        b425: block {
+            l426: loop {
                 __pattern_temp_1 = "core:prelude/array.wado/ArrayIter<Tuple<String,bool>>^Iterator::next"(__iter_5);
                 if ref.is_null(__pattern_temp_1) == 0 {
                     entry = value_copy "tuple//[String, bool]"(ref.as_non_null(__pattern_temp_1));
@@ -4717,9 +4921,9 @@ fn "core:collections/TreeMap<String,bool>^Serialize::serialize<JsonSerializer>"(
                         return e_12;
                     }
                 } else {
-                    break b398;
+                    break b425;
                 }
-                continue l399;
+                continue l426;
             };
         };
         return __inline_JsonMapSerializer_SerializeMap__end_3: block -> ref null "core:serde//SerializeError" {
@@ -4771,8 +4975,8 @@ fn "core:collections/TreeMap<String,bool>::entries"(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_bool___IntoIterator__into_iter_3: struct.new "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,bool>>" { repr: __local_9.repr, used: __local_9.used, index: 0 };
     };
-    b405: block {
-        l406: loop {
+    b432: block {
+        l433: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,bool>>^Iterator::next"(__iter_3);
             if ref.is_null(__pattern_temp_0) == 0 {
                 entry = value_copy "core:collections//TreeMapEntry<String,bool>"(ref.as_non_null(__pattern_temp_0));
@@ -4780,9 +4984,9 @@ fn "core:collections/TreeMap<String,bool>::entries"(self) {
                     "core:prelude/array.wado/Array<Tuple<String,bool>>::push"(result, struct.new "tuple//[String, bool]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b405;
+                break b432;
             }
-            continue l406;
+            continue l433;
         };
     };
     return result;
@@ -4817,13 +5021,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,bool>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l411: loop {
+            l438: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, bool]">(new_repr, i, builtin::array_get<ref "tuple//[String, bool]">(old_repr, i));
                 i = i + 1;
-                continue l411;
+                continue l438;
             };
         };
     };
@@ -4966,13 +5170,13 @@ fn "core:prelude/array.wado/Array<TreeMapEntry<String,bool>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l428: loop {
+            l455: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:collections//TreeMapEntry<String,bool>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<String,bool>">(old_repr, i));
                 i = i + 1;
-                continue l428;
+                continue l455;
             };
         };
     };
@@ -4992,8 +5196,8 @@ fn "core:collections/TreeMap<String,bool>::find_index"(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b430: block {
-        l431: loop {
+    b457: block {
+        l458: loop {
             __pattern_temp_0 = value_copy "core:prelude/types.wado//Option<TreeMapNode<String>>"(current);
             if ref.is_null(__pattern_temp_0) == 0 {
                 n = ref.as_non_null(__pattern_temp_0);
@@ -5017,9 +5221,9 @@ fn "core:collections/TreeMap<String,bool>::find_index"(self, key) {
                     current = n.right;
                 }
             } else {
-                break b430;
+                break b457;
             }
-            continue l431;
+            continue l458;
         };
     };
     return -1;
@@ -5049,8 +5253,8 @@ fn "core:collections/TreeMap<String,String>^Serialize::serialize<JsonSerializer>
     if ref.test "core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok"(map_r) {
         m = value_copy "core:json//JsonMapSerializer"(ref.cast "core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok"(map_r).payload_0);
         __iter_5 = struct.new "core:prelude/array.wado//ArrayIter<Tuple<String,String>>" { repr: entries.repr, used: entries.used, index: 0 };
-        b438: block {
-            l439: loop {
+        b465: block {
+            l466: loop {
                 __pattern_temp_1 = "core:prelude/array.wado/ArrayIter<Tuple<String,String>>^Iterator::next"(__iter_5);
                 if ref.is_null(__pattern_temp_1) == 0 {
                     entry = ref.as_non_null(__pattern_temp_1);
@@ -5067,9 +5271,9 @@ fn "core:collections/TreeMap<String,String>^Serialize::serialize<JsonSerializer>
                         return e_12;
                     }
                 } else {
-                    break b438;
+                    break b465;
                 }
-                continue l439;
+                continue l466;
             };
         };
         return __inline_JsonMapSerializer_SerializeMap__end_3: block -> ref null "core:serde//SerializeError" {
@@ -5124,8 +5328,8 @@ fn "core:collections/TreeMap<String,String>::entries"(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_String___IntoIterator__into_iter_3: struct.new "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,String>>" { repr: __local_9.repr, used: __local_9.used, index: 0 };
     };
-    b445: block {
-        l446: loop {
+    b472: block {
+        l473: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,String>>^Iterator::next"(__iter_3);
             if ref.is_null(__pattern_temp_0) == 0 {
                 entry = value_copy "core:collections//TreeMapEntry<String,String>"(ref.as_non_null(__pattern_temp_0));
@@ -5133,9 +5337,9 @@ fn "core:collections/TreeMap<String,String>::entries"(self) {
                     "core:prelude/array.wado/Array<Tuple<String,String>>::push"(result, struct.new "tuple//[String, String]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b445;
+                break b472;
             }
-            continue l446;
+            continue l473;
         };
     };
     return result;
@@ -5170,13 +5374,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,String>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l451: loop {
+            l478: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, String]">(new_repr, i, builtin::array_get<ref "tuple//[String, String]">(old_repr, i));
                 i = i + 1;
-                continue l451;
+                continue l478;
             };
         };
     };
@@ -5319,13 +5523,13 @@ fn "core:prelude/array.wado/Array<TreeMapEntry<String,String>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l468: loop {
+            l495: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:collections//TreeMapEntry<String,String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<String,String>">(old_repr, i));
                 i = i + 1;
-                continue l468;
+                continue l495;
             };
         };
     };
@@ -5345,8 +5549,8 @@ fn "core:collections/TreeMap<String,String>::find_index"(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b470: block {
-        l471: loop {
+    b497: block {
+        l498: loop {
             __pattern_temp_0 = value_copy "core:prelude/types.wado//Option<TreeMapNode<String>>"(current);
             if ref.is_null(__pattern_temp_0) == 0 {
                 n = ref.as_non_null(__pattern_temp_0);
@@ -5370,9 +5574,9 @@ fn "core:collections/TreeMap<String,String>::find_index"(self, key) {
                     current = n.right;
                 }
             } else {
-                break b470;
+                break b497;
             }
-            continue l471;
+            continue l498;
         };
     };
     return -1;
@@ -5417,8 +5621,8 @@ fn "core:collections/TreeMap<String,i32>::find_index"(self, key) {
     _licm_entries_8 = self.entries;
     _licm_used_9 = _licm_entries_8.used;
     _licm_repr_10 = _licm_entries_8.repr;
-    b479: block {
-        l480: loop {
+    b506: block {
+        l507: loop {
             __pattern_temp_0 = value_copy "core:prelude/types.wado//Option<TreeMapNode<String>>"(current);
             if ref.is_null(__pattern_temp_0) == 0 {
                 n = ref.as_non_null(__pattern_temp_0);
@@ -5442,9 +5646,9 @@ fn "core:collections/TreeMap<String,i32>::find_index"(self, key) {
                     current = n.right;
                 }
             } else {
-                break b479;
+                break b506;
             }
-            continue l480;
+            continue l507;
         };
     };
     return -1;
@@ -5474,7 +5678,7 @@ fn "wado-compiler/tests/fixtures/serde_json_treemap.wado/TreeMap<String,i32>^Des
             break __seq_lit: __local_22;
         }), size: 0, deleted_count: 0 };
         block {
-            l488: loop {
+            l515: loop {
                 let __sroa_key_r_discriminant: i32;
                 let __sroa_key_r_case0_payload_0: ref null "core:prelude/string.wado//String";
                 let __sroa_key_r_case1_payload_0: ref null "core:serde//DeserializeError";
@@ -5494,28 +5698,28 @@ fn "wado-compiler/tests/fixtures/serde_json_treemap.wado/TreeMap<String,i32>^Des
                         }
                         if __sroa_val_r_discriminant == 1 {
                             e_11 = __sroa_val_r_case1_payload_0;
-                            return 1, ref.null none, e_11;
+                            return struct.new "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_11 };
                         }
                     } else {
                         end_r = "core:json/JsonDeserializer::expect_char"(ma.de, 125);
                         if ref.is_null(end_r) == 0 {
-                            e_7 = value_copy "core:serde//DeserializeError"(ref.as_non_null(end_r));
-                            return 1, ref.null none, e_7;
+                            e_7 = ref.as_non_null(end_r);
+                            return struct.new "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_7 };
                         }
-                        return 0, result, ref.null none;
+                        return struct.new "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: result };
                     }
                 }
                 if __sroa_key_r_discriminant == 1 {
                     e_12 = __sroa_key_r_case1_payload_0;
-                    return 1, ref.null none, e_12;
+                    return struct.new "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_12 };
                 }
-                continue l488;
+                continue l515;
             };
         };
     }
     if __sroa_map_r_discriminant == 1 {
         e_13 = __sroa_map_r_case1_payload_0;
-        return 1, ref.null none, e_13;
+        return struct.new "core:prelude/types.wado//Result<TreeMap<String,i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_13 };
     }
     "core:internal/unreachable"();
     unreachable;
@@ -5647,13 +5851,13 @@ fn "core:prelude/array.wado/Array<TreeMapEntry<String,i32>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l510: loop {
+            l537: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "core:collections//TreeMapEntry<String,i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<String,i32>">(old_repr, i));
                 i = i + 1;
-                continue l510;
+                continue l537;
             };
         };
     };
@@ -5683,8 +5887,8 @@ fn "core:collections/TreeMap<String,i32>^Serialize::serialize<JsonSerializer>"(s
     if ref.test "core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok"(map_r) {
         m = value_copy "core:json//JsonMapSerializer"(ref.cast "core:prelude/types.wado//Result<JsonMapSerializer,SerializeError>::Ok"(map_r).payload_0);
         __iter_5 = struct.new "core:prelude/array.wado//ArrayIter<Tuple<String,i32>>" { repr: entries.repr, used: entries.used, index: 0 };
-        b513: block {
-            l514: loop {
+        b540: block {
+            l541: loop {
                 __pattern_temp_1 = "core:prelude/array.wado/ArrayIter<Tuple<String,i32>>^Iterator::next"(__iter_5);
                 if ref.is_null(__pattern_temp_1) == 0 {
                     entry = value_copy "tuple//[String, i32]"(ref.as_non_null(__pattern_temp_1));
@@ -5700,9 +5904,9 @@ fn "core:collections/TreeMap<String,i32>^Serialize::serialize<JsonSerializer>"(s
                         return e_12;
                     }
                 } else {
-                    break b513;
+                    break b540;
                 }
-                continue l514;
+                continue l541;
             };
         };
         return __inline_JsonMapSerializer_SerializeMap__end_3: block -> ref null "core:serde//SerializeError" {
@@ -5754,8 +5958,8 @@ fn "core:collections/TreeMap<String,i32>::entries"(self) {
         __local_9 = self.entries;
         break __inline_Array_TreeMapEntry_String_i32___IntoIterator__into_iter_3: struct.new "core:prelude/array.wado//ArrayIter<TreeMapEntry<String,i32>>" { repr: __local_9.repr, used: __local_9.used, index: 0 };
     };
-    b520: block {
-        l521: loop {
+    b547: block {
+        l548: loop {
             __pattern_temp_0 = "core:prelude/array.wado/ArrayIter<TreeMapEntry<String,i32>>^Iterator::next"(__iter_3);
             if ref.is_null(__pattern_temp_0) == 0 {
                 entry = value_copy "core:collections//TreeMapEntry<String,i32>"(ref.as_non_null(__pattern_temp_0));
@@ -5763,9 +5967,9 @@ fn "core:collections/TreeMap<String,i32>::entries"(self) {
                     "core:prelude/array.wado/Array<Tuple<String,i32>>::push"(result, struct.new "tuple//[String, i32]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b520;
+                break b547;
             }
-            continue l521;
+            continue l548;
         };
     };
     return result;
@@ -5800,13 +6004,13 @@ fn "core:prelude/array.wado/Array<Tuple<String,i32>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l526: loop {
+            l553: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[String, i32]">(new_repr, i, builtin::array_get<ref "tuple//[String, i32]">(old_repr, i));
                 i = i + 1;
-                continue l526;
+                continue l553;
             };
         };
     };

--- a/wado-compiler/tests/fixtures.golden/serde_json_tuple.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_tuple.wir.wado
@@ -78,307 +78,359 @@ struct tuple//[f64, f64] {  // TypeId(13)
 
 array builtin::array<u64> (mut u64);  // TypeId(14)
 
-variant core:prelude/types.wado//Option<i32> {  // TypeId(15)
+variant core:prelude/types.wado//Option<char> {  // TypeId(15)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(16)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<i32> {  // TypeId(17)
     Some(i32),
     None,
 }
 
-struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(16)
+struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(18)
     discriminant: i32,
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Option<String> {  // TypeId(17)
+variant core:prelude/types.wado//Option<String> {  // TypeId(19)
     Some(ref "core:prelude/string.wado//String"),
     None,
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(18)
+variant core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError> {  // TypeId(20)
+    Ok(ref "tuple//[i32, String]"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Ok {  // TypeId(21)
+    discriminant: i32,
+    payload_0: ref "tuple//[i32, String]",
+}
+
+struct core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err {  // TypeId(22)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(23)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(19)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(24)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(20)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(25)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(21)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(26)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(27)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(28)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(29)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(22)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(30)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(23)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(31)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError> {  // TypeId(24)
+variant core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError> {  // TypeId(32)
     Ok(ref "core:json//JsonSeqSerializer"),
     Err(ref "core:serde//SerializeError"),
 }
 
-struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Ok {  // TypeId(25)
+struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Ok {  // TypeId(33)
     discriminant: i32,
     payload_0: ref "core:json//JsonSeqSerializer",
 }
 
-struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Err {  // TypeId(26)
+struct core:prelude/types.wado//Result<JsonSeqSerializer,SerializeError>::Err {  // TypeId(34)
     discriminant: i32,
     payload_0: ref "core:serde//SerializeError",
 }
 
-variant core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError> {  // TypeId(27)
+variant core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError> {  // TypeId(35)
     Ok(ref "core:json//JsonSeqAccess"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Ok {  // TypeId(28)
+struct core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Ok {  // TypeId(36)
     discriminant: i32,
     payload_0: ref "core:json//JsonSeqAccess",
 }
 
-struct core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err {  // TypeId(29)
+struct core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err {  // TypeId(37)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(30)
+variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(38)
     Ok(ref "core:prelude/types.wado//Option<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(31)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(39)
     discriminant: i32,
     payload_0: ref "core:prelude/types.wado//Option<i32>",
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(32)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(40)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<String>,DeserializeError> {  // TypeId(33)
+variant core:prelude/types.wado//Result<Option<String>,DeserializeError> {  // TypeId(41)
     Ok(ref null "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok {  // TypeId(34)
+struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok {  // TypeId(42)
     discriminant: i32,
     payload_0: ref null "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err {  // TypeId(35)
+struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err {  // TypeId(43)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-struct core:prelude//Array<u64> {  // TypeId(36)
+struct core:prelude//Array<u64> {  // TypeId(44)
     mut repr: ref builtin::array<u64>,
     mut used: i32,
 }
 
-enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(37)
+enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(45)
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(38)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(46)
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(39)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(47)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(40)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(48)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(41)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(49)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(42)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(50)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(43)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(51)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(44)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(52)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(45)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(53)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(46)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(54)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/__test_0_tuple_serialize__i32__string__bool_" = fn();  // TypeId(47)
+type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/__test_0_tuple_serialize__i32__string__bool_" = fn();  // TypeId(55)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/__test_1_tuple_roundtrip__i32__string_" = fn();  // TypeId(48)
+type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/__test_1_tuple_roundtrip__i32__string_" = fn();  // TypeId(56)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/__test_2_pair_tuple_serialize" = fn();  // TypeId(49)
+type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/__test_2_pair_tuple_serialize" = fn();  // TypeId(57)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/__cm_export____test_0_tuple_serialize__i32__string__bool_" = fn();  // TypeId(50)
+type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/__cm_export____test_0_tuple_serialize__i32__string__bool_" = fn();  // TypeId(58)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/__cm_export____test_1_tuple_roundtrip__i32__string_" = fn();  // TypeId(51)
+type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/__cm_export____test_1_tuple_roundtrip__i32__string_" = fn();  // TypeId(59)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/__cm_export____test_2_pair_tuple_serialize" = fn();  // TypeId(52)
+type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/__cm_export____test_2_pair_tuple_serialize" = fn();  // TypeId(60)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/__initialize_module" = fn();  // TypeId(53)
+type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/__initialize_module" = fn();  // TypeId(61)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(54)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(62)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(55)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(63)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(56)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(64)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(57)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(65)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(58)
+type "functype//core:internal/unreachable" = fn();  // TypeId(66)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(59)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(67)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(60)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(68)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(61)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(69)
 
-type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(62)
+type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(70)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(63)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(71)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(64)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(72)
 
-type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(65)
+type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(73)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(66)
+type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(74)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(67)
+type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(75)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(68)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(76)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(69)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(77)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(70)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(78)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(71)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(79)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(72)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(80)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(73)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(81)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(74)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(82)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(75)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(83)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(76)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(84)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(77)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(85)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(78)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(86)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(79)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(87)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(80)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(88)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(81)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(89)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(82)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(90)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(83)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(91)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(84)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(92)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(85)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(93)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(86)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(94)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_seq" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>";  // TypeId(87)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(95)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(88)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(96)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(89)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(97)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(90)
+type "functype//core:json/JsonDeserializer^Deserializer::begin_seq" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>";  // TypeId(98)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(91)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(99)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(92)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(100)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(93)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(101)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(94)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(102)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/String^Deserialize::deserialize_next_element_from_seq<JsonSeqAccess>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(95)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(103)
 
-type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<String>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";  // TypeId(96)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(104)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(97)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(105)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/i32^Deserialize::deserialize_next_element_from_seq<JsonSeqAccess>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(98)
+type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/Tuple<i32,String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>";  // TypeId(106)
 
-type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(99)
+type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/String^Deserialize::deserialize_next_element_from_seq<JsonSeqAccess>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(107)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(100)
+type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<String>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";  // TypeId(108)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<String>" = fn(ref "core:json//JsonSeqSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(101)
+type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(109)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(102)
+type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/i32^Deserialize::deserialize_next_element_from_seq<JsonSeqAccess>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(110)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(103)
+type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(111)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(104)
+type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(112)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(105)
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<String>" = fn(ref "core:json//JsonSeqSerializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(113)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(106)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(114)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(107)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(115)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(108)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(116)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(109)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(117)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(110)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(118)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(111)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(119)
 
-type "functype//core:json/core/json/to_string<Tuple<f64,f64>>" = fn(ref "tuple//[f64, f64]") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(112)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(120)
 
-type "functype//core:json/core/json/from_string<Tuple<i32,String>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "tuple//[i32, String]", ref null "core:serde//DeserializeError"];  // TypeId(113)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(121)
 
-type "functype//core:json/core/json/to_string<Tuple<i32,String>>" = fn(ref "tuple//[i32, String]") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(114)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(122)
 
-type "functype//core:json/core/json/to_string<Tuple<i32,String,bool>>" = fn(ref "tuple//[i32, String, bool]") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(115)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(123)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(116)
+type "functype//core:json/core/json/to_string<Tuple<f64,f64>>" = fn(ref "tuple//[f64, f64]") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(124)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(117)
+type "functype//core:json/core/json/from_string<Tuple<i32,String>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "tuple//[i32, String]", ref null "core:serde//DeserializeError"];  // TypeId(125)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(118)
+type "functype//core:json/core/json/to_string<Tuple<i32,String>>" = fn(ref "tuple//[i32, String]") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(126)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_tuple.wado/Tuple<i32,String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "tuple//[i32, String]", ref null "core:serde//DeserializeError"];  // TypeId(119)
+type "functype//core:json/core/json/to_string<Tuple<i32,String,bool>>" = fn(ref "tuple//[i32, String, bool]") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(127)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(120)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(128)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(121)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(129)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(122)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(130)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(123)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(131)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(124)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(132)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(125)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(133)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(126)
+type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(134)
 
-type "functype//core:prelude/types.wado/Tuple<f64,f64>^Serialize::serialize<JsonSerializer>" = fn(ref "tuple//[f64, f64]", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(127)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(135)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<f64>" = fn(ref "core:json//JsonSeqSerializer", f64) -> ref null "core:serde//SerializeError";  // TypeId(128)
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(136)
 
-type "functype//core:prelude/types.wado/Tuple<i32,String>^Serialize::serialize<JsonSerializer>" = fn(ref "tuple//[i32, String]", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(129)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(137)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<i32>" = fn(ref "core:json//JsonSeqSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(130)
+type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(138)
 
-type "functype//core:prelude/types.wado/Tuple<i32,String,bool>^Serialize::serialize<JsonSerializer>" = fn(ref "tuple//[i32, String, bool]", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(131)
+type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(139)
 
-type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<bool>" = fn(ref "core:json//JsonSeqSerializer", bool) -> ref null "core:serde//SerializeError";  // TypeId(132)
+type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(140)
+
+type "functype//core:prelude/types.wado/Tuple<f64,f64>^Serialize::serialize<JsonSerializer>" = fn(ref "tuple//[f64, f64]", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(141)
+
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<f64>" = fn(ref "core:json//JsonSeqSerializer", f64) -> ref null "core:serde//SerializeError";  // TypeId(142)
+
+type "functype//core:prelude/types.wado/Tuple<i32,String>^Serialize::serialize<JsonSerializer>" = fn(ref "tuple//[i32, String]", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(143)
+
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<i32>" = fn(ref "core:json//JsonSeqSerializer", i32) -> ref null "core:serde//SerializeError";  // TypeId(144)
+
+type "functype//core:prelude/types.wado/Tuple<i32,String,bool>^Serialize::serialize<JsonSerializer>" = fn(ref "tuple//[i32, String, bool]", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(145)
+
+type "functype//core:json/JsonSeqSerializer^SerializeSeq::element<bool>" = fn(ref "core:json//JsonSeqSerializer", bool) -> ref null "core:serde//SerializeError";  // TypeId(146)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -1579,6 +1631,67 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l127: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l127;
+                };
+            };
+        };
+    }
+}
+
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
+        return 1;
+    }
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l133: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l133;
+            };
+        };
+    };
+    return n;
+}
+
 fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     let mark: i32;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -1607,36 +1720,16 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
-    }
-    return ((97 + v) - 10) & 255;
-}
-
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b133: block {
-        l134: loop {
+    b139: block {
+        l140: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -1657,23 +1750,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b133;
+                break b139;
             }
-            continue l134;
+            continue l140;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -1681,88 +1776,173 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/to_string<Tuple<f64,f64>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:prelude/types.wado/Tuple<f64,f64>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:prelude/types.wado/Tuple<f64,f64>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<Tuple<i32,String>>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "tuple//[i32, String]";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "tuple//[i32, String]";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "tuple//[i32, String]";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_tuple.wado/Tuple<i32,String>^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "tuple//[i32, String]"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_tuple.wado/Tuple<i32,String>^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Ok"(__match_scrut_0) -> ref "tuple//[i32, String]" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err"(__match_scrut_0) -> ref "tuple//[i32, String]" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Tuple<i32,String>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:prelude/types.wado/Tuple<i32,String>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:prelude/types.wado/Tuple<i32,String>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Tuple<i32,String,bool>>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "core:prelude/types.wado/Tuple<i32,String,bool>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "core:prelude/types.wado/Tuple<i32,String,bool>^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -1783,6 +1963,20 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
         __local_6 = f.buf;
         break __inline_String__internal_raw_bytes_0: __local_6.repr;
     }, offset, abs_val, digit_count);
+}
+
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
 }
 
 fn "core:prelude/primitive.wado/f64::fmt_into"(self, f) {
@@ -1962,6 +2156,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     }
 }
 
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
+}
+
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     let capacity: i32;
     let new_capacity: i32;
@@ -2038,7 +2246,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l179: loop {
+            l203: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -2046,7 +2254,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l179;
+                continue l203;
             };
         };
     };
@@ -2095,6 +2303,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -2185,10 +2442,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b193: block {
-        l194: loop {
+    b224: block {
+        l225: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b193;
+                break b224;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -2212,7 +2469,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l194;
+            continue l225;
         };
     };
     self.pos = _hfs_pos_8;
@@ -2276,130 +2533,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b204: block {
-        l205: loop {
-            if scan_pos >= _licm_used_90 {
-                break b204;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b235: block {
+        l236: loop {
+            if scan_pos >= _licm_used_56 {
+                break b235;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b204;
+                break b235;
             }
             scan_pos = scan_pos + 1;
-            continue l205;
+            continue l236;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -2408,22 +2637,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l212: loop {
+                l243: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l212;
+                    continue l243;
                 };
             };
         };
@@ -2431,71 +2660,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l215: loop {
+            l246: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l215;
+                continue l246;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b217: block {
-        l218: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b248: block {
+        l249: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b217;
+                break b248;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -2513,125 +2743,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l218;
+            continue l249;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -2639,87 +2812,71 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l243: loop {
+            l269: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l243;
+                continue l269;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -2809,16 +2966,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b257: block {
-        l258: loop {
+    b279: block {
+        l280: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b257;
+                break b279;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -2839,17 +2996,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b266: block {
-                        l267: loop {
+                    b288: block {
+                        l289: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b266;
+                                break b288;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -2859,9 +3016,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b266;
+                                break b288;
                             }
-                            continue l267;
+                            continue l289;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -2892,17 +3049,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b276: block {
-                            l277: loop {
+                        b298: block {
+                            l299: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b276;
+                                    break b298;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -2911,9 +3068,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b276;
+                                    break b298;
                                 }
-                                continue l277;
+                                continue l299;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -2951,9 +3108,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b257;
+                break b279;
             }
-            continue l258;
+            continue l280;
         };
     };
     self.pos = _hfs_pos_51;
@@ -2964,12 +3121,18 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_seq"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 91);
-    if ref.is_null(r) == 0 {
-        e = ref.as_non_null(r);
-        return struct.new "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+    let __local_2: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 91);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_2 = ref.as_non_null(__cast_1);
+        return struct.new "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+        unreachable;
+    } else {
+        unreachable;
     }
     return struct.new "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonSeqAccess" { de: self, first: 1 } };
 }
@@ -2981,13 +3144,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l289: loop {
+            l312: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l289;
+                continue l312;
             };
         };
     };
@@ -3080,10 +3243,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b299: block {
-            l300: loop {
+        b322: block {
+            l323: loop {
                 if i_8 < 0 {
-                    break b299;
+                    break b322;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -3092,7 +3255,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l300;
+                continue l323;
             };
         };
         __for_1: block {
@@ -3100,14 +3263,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l303: loop {
+                l326: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l303;
+                    continue l326;
                 };
             };
         };
@@ -3117,10 +3280,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b305: block {
-            l306: loop {
+        b328: block {
+            l329: loop {
                 if i_10 < 0 {
-                    break b305;
+                    break b328;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -3129,7 +3292,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l306;
+                continue l329;
             };
         };
         __for_2: block {
@@ -3137,14 +3300,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l309: loop {
+                l332: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l309;
+                    continue l332;
                 };
             };
         };
@@ -3248,8 +3411,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b328: block {
-        l329: loop {
+    b351: block {
+        l352: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -3274,9 +3437,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b328;
+                break b351;
             }
-            continue l329;
+            continue l352;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -3311,13 +3474,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l338: loop {
+            l361: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l338;
+                continue l361;
             };
         };
     };
@@ -3391,7 +3554,7 @@ fn "wado-compiler/tests/fixtures/serde_json_tuple.wado/Tuple<i32,String>^Deseria
         let __cast_1: ref "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err";
         __cast_1 = ref.cast "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err"(__match_scrut_0);
         __local_2 = __cast_1.payload_0;
-        return 1, ref.null none, __local_2;
+        return struct.new "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
         unreachable;
     } else {
         unreachable;
@@ -3405,7 +3568,7 @@ fn "wado-compiler/tests/fixtures/serde_json_tuple.wado/Tuple<i32,String>^Deseria
         let __cast_3: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Err";
         __cast_3 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_1);
         __local_5 = __cast_3.payload_0;
-        return 1, ref.null none, __local_5;
+        return struct.new "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_5 };
         unreachable;
     } else {
         unreachable;
@@ -3418,7 +3581,7 @@ fn "wado-compiler/tests/fixtures/serde_json_tuple.wado/Tuple<i32,String>^Deseria
         let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
         __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_2);
         __local_10 = __cast_5.payload_0;
-        return 1, ref.null none, __local_10;
+        return struct.new "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_10 };
         unreachable;
     } else {
         unreachable;
@@ -3430,12 +3593,12 @@ fn "wado-compiler/tests/fixtures/serde_json_tuple.wado/Tuple<i32,String>^Deseria
         let __cast_7: ref null "core:serde//DeserializeError";
         __cast_7 = ref.as_non_null(__match_scrut_3);
         __local_8 = ref.as_non_null(__cast_7);
-        return 1, ref.null none, __local_8;
+        return struct.new "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
         unreachable;
     } else {
         unreachable;
     }
-    return 0, tuple, ref.null none;
+    return struct.new "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Ok" { discriminant: 0, payload_0: tuple };
 }
 
 fn "wado-compiler/tests/fixtures/serde_json_tuple.wado/String^Deserialize::deserialize_next_element_from_seq<JsonSeqAccess>"(seq) {
@@ -3465,51 +3628,58 @@ fn "wado-compiler/tests/fixtures/serde_json_tuple.wado/String^Deserialize::deser
 }
 
 fn "core:json/JsonSeqAccess^DeserializeSeq::next_element<String>"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let elem: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let v: ref "core:prelude/string.wado//String";
-    let e_5: ref "core:serde//DeserializeError";
-    let __local_9: ref "core:prelude/string.wado//String";
-    let __local_10: i64;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i32;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __local_3: ref "core:prelude/string.wado//String";
+    let __local_4: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_9 = self.de.input;
-        break __inline_String__len_0: __local_9.used;
+        __local_5 = self.de.input;
+        break __inline_String__len_0: __local_5.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_10 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_10 };
+            __local_6 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_6 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_11 = self.de.input;
-        __local_12 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_11.repr, __local_12);
+        __local_7 = self.de.input;
+        __local_8 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_7.repr, __local_8);
     } == 93 {
         return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: ref.null none };
     }
     if self.first == 0 {
-        r = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r) == 0 {
-            e_2 = ref.as_non_null(r);
-            return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
-    elem = "wado-compiler/tests/fixtures/serde_json_tuple.wado/String^Deserialize::deserialize<JsonDeserializer>"(self.de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(elem) {
-        v = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(elem).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: v };
-    }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(elem) {
-        e_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(elem).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return let __match_scrut_1: ref "core:prelude/types.wado//Result<String,DeserializeError>", __match_scrut_1 = "wado-compiler/tests/fixtures/serde_json_tuple.wado/String^Deserialize::deserialize<JsonDeserializer>"(self.de), (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>" {
+        let __cast_3: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_3 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1);
+        __local_3 = __cast_3.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_3 };
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1);
+        __local_4 = __cast_2.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_4 };
+    } else {
+        unreachable;
+    });
 }
 
 fn "wado-compiler/tests/fixtures/serde_json_tuple.wado/String^Deserialize::deserialize<JsonDeserializer>"(d) {
@@ -3545,51 +3715,58 @@ fn "wado-compiler/tests/fixtures/serde_json_tuple.wado/i32^Deserialize::deserial
 }
 
 fn "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let elem: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
-    let v: i32;
-    let e_5: ref "core:serde//DeserializeError";
-    let __local_9: ref "core:prelude/string.wado//String";
-    let __local_10: i64;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i32;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __local_3: i32;
+    let __local_4: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_9 = self.de.input;
-        break __inline_String__len_0: __local_9.used;
+        __local_5 = self.de.input;
+        break __inline_String__len_0: __local_5.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_10 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_10 };
+            __local_6 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_6 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_11 = self.de.input;
-        __local_12 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_11.repr, __local_12);
+        __local_7 = self.de.input;
+        __local_8 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_7.repr, __local_8);
     } == 93 {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r) == 0 {
-            e_2 = ref.as_non_null(r);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
-    elem = "wado-compiler/tests/fixtures/serde_json_tuple.wado/i32^Deserialize::deserialize<JsonDeserializer>"(self.de);
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(elem) {
-        v = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(elem).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: v } };
-    }
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(elem) {
-        e_5 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(elem).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return let __match_scrut_1: ref "core:prelude/types.wado//Result<i32,DeserializeError>", __match_scrut_1 = "wado-compiler/tests/fixtures/serde_json_tuple.wado/i32^Deserialize::deserialize<JsonDeserializer>"(self.de), (if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>" {
+        let __cast_3: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Ok";
+        __cast_3 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_1);
+        __local_3 = __cast_3.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: __local_3 } };
+    } else if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Err";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_1);
+        __local_4 = __cast_2.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_4 };
+    } else {
+        unreachable;
+    });
 }
 
 fn "wado-compiler/tests/fixtures/serde_json_tuple.wado/i32^Deserialize::deserialize<JsonDeserializer>"(d) {

--- a/wado-compiler/tests/fixtures.golden/serde_json_unknown_fields.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_unknown_fields.wir.wado
@@ -46,217 +46,278 @@ struct wado-compiler/tests/fixtures/serde_json_unknown_fields.wado//Point {  // 
 
 array builtin::array<u64> (mut u64);  // TypeId(8)
 
-variant core:prelude/types.wado//Option<i32> {  // TypeId(9)
+variant core:prelude/types.wado//Option<char> {  // TypeId(9)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(10)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<i32> {  // TypeId(11)
     Some(i32),
     None,
 }
 
-struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(10)
+struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(12)
     discriminant: i32,
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(11)
+variant core:prelude/types.wado//Result<Point,DeserializeError> {  // TypeId(13)
+    Ok(ref "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado//Point"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Point,DeserializeError>::Ok {  // TypeId(14)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado//Point",
+}
+
+struct core:prelude/types.wado//Result<Point,DeserializeError>::Err {  // TypeId(15)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(16)
     Ok(f64),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(12)
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(17)
     discriminant: i32,
     payload_0: f64,
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(13)
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(18)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(14)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(19)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(20)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(21)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(22)
+    Ok(ref "core:prelude/string.wado//String"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(23)
+    discriminant: i32,
+    payload_0: ref "core:prelude/string.wado//String",
+}
+
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(24)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(25)
     Ok(ref "core:prelude/types.wado//Option<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(15)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(26)
     discriminant: i32,
     payload_0: ref "core:prelude/types.wado//Option<i32>",
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(16)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(27)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-struct core:prelude//Array<u64> {  // TypeId(17)
+struct core:prelude//Array<u64> {  // TypeId(28)
     mut repr: ref builtin::array<u64>,
     mut used: i32,
 }
 
-enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(18)
+enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(29)
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(19)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(30)
 
-type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(20)
+type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(31)
 
-struct canonical//CanonicalClosure_0 {  // TypeId(21)
+struct canonical//CanonicalClosure_0 {  // TypeId(32)
     env: ref null struct,
     func: ref "functype/$canonical_closure_fn_0",
 }
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(22)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(33)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(23)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(34)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(24)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(35)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(25)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(36)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(26)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(37)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(27)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(38)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(28)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(39)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(29)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(40)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__test_0_unknown_fields_ignored" = fn();  // TypeId(30)
+type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__test_0_unknown_fields_ignored" = fn();  // TypeId(41)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__test_1_unknown_field_with_object_value" = fn();  // TypeId(31)
+type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__test_1_unknown_field_with_object_value" = fn();  // TypeId(42)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__test_2_unknown_field_with_array_value" = fn();  // TypeId(32)
+type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__test_2_unknown_field_with_array_value" = fn();  // TypeId(43)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/_point_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(33)
+type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/_point_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(44)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__cm_export____test_0_unknown_fields_ignored" = fn();  // TypeId(34)
+type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__cm_export____test_0_unknown_fields_ignored" = fn();  // TypeId(45)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__cm_export____test_1_unknown_field_with_object_value" = fn();  // TypeId(35)
+type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__cm_export____test_1_unknown_field_with_object_value" = fn();  // TypeId(46)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__cm_export____test_2_unknown_field_with_array_value" = fn();  // TypeId(36)
+type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__cm_export____test_2_unknown_field_with_array_value" = fn();  // TypeId(47)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__initialize_module" = fn();  // TypeId(37)
+type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__initialize_module" = fn();  // TypeId(48)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(38)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(49)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(39)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(50)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(40)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(51)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(41)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(52)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(42)
+type "functype//core:internal/unreachable" = fn();  // TypeId(53)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(43)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(54)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(44)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(55)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(45)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(56)
 
-type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(46)
+type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(57)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(47)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(58)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(48)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(59)
 
-type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(49)
+type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(60)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(50)
+type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(61)
 
-type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(51)
+type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(62)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(52)
+type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(63)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(53)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(64)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(54)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(65)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(55)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(66)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(56)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(67)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(57)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(68)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(58)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(69)
 
-type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(59)
+type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(70)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(60)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(71)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(61)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(72)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(62)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(73)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(63)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(74)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(64)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(75)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(65)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(76)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(66)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(77)
 
-type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(67)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(78)
 
-type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(68)
+type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(79)
 
-type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(69)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(80)
 
-type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(70)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(81)
 
-type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(71)
+type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(82)
 
-type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(72)
+type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(83)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(73)
+type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(84)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(74)
+type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(85)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(75)
+type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(86)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(76)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(87)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(77)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(88)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(78)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(89)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(79)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(90)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(80)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(91)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(81)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(92)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(82)
+type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/Point^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Point,DeserializeError>";  // TypeId(93)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(83)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(94)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(84)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(95)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(85)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(96)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(86)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(97)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(87)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(98)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(88)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(99)
 
-type "functype//core:json/core/json/from_string<Point>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado//Point", ref null "core:serde//DeserializeError"];  // TypeId(89)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(100)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(90)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(101)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(91)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(102)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(92)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(103)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/Point^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado//Point", ref null "core:serde//DeserializeError"];  // TypeId(93)
+type "functype//core:json/core/json/from_string<Point>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado//Point", ref null "core:serde//DeserializeError"];  // TypeId(104)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(94)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(105)
 
-type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(95)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(106)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(96)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(107)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(97)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(108)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(98)
+type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(109)
 
-type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(99)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(110)
+
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(111)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(112)
+
+type "functype//wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(113)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -1664,64 +1725,118 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/core/json/from_string<Point>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado//Point";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado//Point";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado//Point";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/Point^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado//Point"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Point,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/Point^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Point,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado//Point" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Point,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Point,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Point,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado//Point" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Point,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Point,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -2001,6 +2116,55 @@ fn "core:prelude/string.wado/String::push_str"(self, other) {
     self.used = new_used;
 }
 
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
+}
+
 fn "core:prelude/string.wado/String::push"(self, c) {
     let code: u32;
     code = c;
@@ -2039,10 +2203,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b182: block {
-        l183: loop {
+    b200: block {
+        l201: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b182;
+                break b200;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -2066,7 +2230,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l183;
+            continue l201;
         };
     };
     self.pos = _hfs_pos_8;
@@ -2145,11 +2309,11 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b191: block {
-        l192: loop {
+    b209: block {
+        l210: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= _licm_used_19 {
-                    break b191;
+                    break b209;
                 }
                 byte = builtin::array_get_u8(_licm_repr_20, __sroa___iter_3_index);
                 __sroa___iter_3_index = __sroa___iter_3_index + 1;
@@ -2184,7 +2348,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
                 _hfs_pos_27 = _hfs_pos_27 + 1;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l192;
+            continue l210;
         };
     };
     self.pos = _hfs_pos_27;
@@ -2203,130 +2367,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
+        }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
-        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
-        });
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
+        }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b198: block {
-        l199: loop {
-            if scan_pos >= _licm_used_90 {
-                break b198;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b216: block {
+        l217: loop {
+            if scan_pos >= _licm_used_56 {
+                break b216;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b198;
+                break b216;
             }
             scan_pos = scan_pos + 1;
-            continue l199;
+            continue l217;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -2335,94 +2471,95 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l206: loop {
+                l224: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l206;
+                    continue l224;
                 };
             };
         };
         self.pos = scan_pos + 1;
-        return 0, result_5, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l209: loop {
+            l227: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l209;
+                continue l227;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b211: block {
-        l212: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b229: block {
+        l230: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b211;
+                break b229;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
-                return 0, result_8, ref.null none;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
+                return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
-                    });
+                    self.pos = _hfs_pos_64;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
+                    }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -2440,213 +2577,140 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return 1, ref.null none, e;
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
-                    });
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
+                    }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
-                    });
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
+                    }) };
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l212;
+            continue l230;
         };
     };
-    self.pos = _hfs_pos_98;
-    return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
-    });
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
+    }) };
 }
 
 fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l237: loop {
+            l250: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l237;
+                continue l250;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -2701,25 +2765,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b248: block {
-        l249: loop {
+    b257: block {
+        l258: loop {
             if _hfs_pos_36 >= _licm_used_28 {
-                break b248;
+                break b257;
             }
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
                 break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr_29, __local_11);
             };
-            if (if b_1 >= 48 -> i32 {
+            if (if 48 <= b_1 -> i32 {
                 b_1 <= 57;
             } else {
                 0;
             }) {
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
-                break b248;
+                break b257;
             }
-            continue l249;
+            continue l258;
         };
     };
     self.pos = _hfs_pos_36;
@@ -2740,25 +2804,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b255: block {
-            l256: loop {
+        b264: block {
+            l265: loop {
                 if _hfs_pos_37 >= _licm_used_31 {
-                    break b255;
+                    break b264;
                 }
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
                     break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_32, __local_17);
                 };
-                if (if b_2 >= 48 -> i32 {
+                if (if 48 <= b_2 -> i32 {
                     b_2 <= 57;
                 } else {
                     0;
                 }) {
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
-                    break b255;
+                    break b264;
                 }
-                continue l256;
+                continue l265;
             };
         };
         self.pos = _hfs_pos_37;
@@ -2799,25 +2863,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b266: block {
-                l267: loop {
+            b275: block {
+                l276: loop {
                     if _hfs_pos_38 >= _licm_used_34 {
-                        break b266;
+                        break b275;
                     }
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
                         break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_35, __local_26);
                     };
-                    if (if b2 >= 48 -> i32 {
+                    if (if 48 <= b2 -> i32 {
                         b2 <= 57;
                     } else {
                         0;
                     }) {
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
-                        break b266;
+                        break b275;
                     }
-                    continue l267;
+                    continue l276;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -2927,16 +2991,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b276: block {
-        l277: loop {
+    b285: block {
+        l286: loop {
             if _hfs_pos_57 >= _licm_used_49 {
-                break b276;
+                break b285;
             }
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_50, __local_32);
             };
-            if (if b_6 >= 48 -> i32 {
+            if (if 48 <= b_6 -> i32 {
                 b_6 <= 57;
             } else {
                 0;
@@ -2947,9 +3011,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                 total_digits = total_digits + 1;
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
-                break b276;
+                break b285;
             }
-            continue l277;
+            continue l286;
         };
     };
     self.pos = _hfs_pos_57;
@@ -2971,16 +3035,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b284: block {
-            l285: loop {
+        b293: block {
+            l294: loop {
                 if _hfs_pos_58 >= _licm_used_52 {
-                    break b284;
+                    break b293;
                 }
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
                     break __inline_String__get_byte_12: builtin::array_get_u8(_licm_repr_53, __local_38);
                 };
-                if (if b_8 >= 48 -> i32 {
+                if (if 48 <= b_8 -> i32 {
                     b_8 <= 57;
                 } else {
                     0;
@@ -2992,9 +3056,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                     total_digits = total_digits + 1;
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
-                    break b284;
+                    break b293;
                 }
-                continue l285;
+                continue l294;
             };
         };
         self.pos = _hfs_pos_58;
@@ -3036,16 +3100,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b296: block {
-                l297: loop {
+            b305: block {
+                l306: loop {
                     if _hfs_pos_59 >= _licm_used_55 {
-                        break b296;
+                        break b305;
                     }
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
                         break __inline_String__get_byte_18: builtin::array_get_u8(_licm_repr_56, __local_47);
                     };
-                    if (if b3 >= 48 -> i32 {
+                    if (if 48 <= b3 -> i32 {
                         b3 <= 57;
                     } else {
                         0;
@@ -3053,9 +3117,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                         exp = (exp * 10) + (b3 - 48);
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
-                        break b296;
+                        break b305;
                     }
-                    continue l297;
+                    continue l306;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -3105,10 +3169,10 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b307: block {
-        l308: loop {
+    b316: block {
+        l317: loop {
             if _hfs_pos_14 >= _licm_used_12 {
-                break b307;
+                break b316;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -3138,7 +3202,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
                 }
             }
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l308;
+            continue l317;
         };
     };
     self.pos = _hfs_pos_14;
@@ -3149,19 +3213,284 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
 }
 
 fn "core:json/JsonDeserializer::skip_value"(self) {
-    let b: i32;
-    let r: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let c_4: i32;
-    let kr: ref null "core:serde//DeserializeError";
-    let e_6: ref "core:serde//DeserializeError";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let vr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let c_11: i32;
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: char;
+    let __local_6: ref "core:serde//DeserializeError";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_10: ref "core:serde//DeserializeError";
+    let __local_11: char;
     let __local_12: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/format.wado//Formatter";
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i64;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i32;
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
+    let __local_20: i32;
+    let __local_21: ref "core:prelude/string.wado//String";
+    let __local_22: i64;
+    let __local_23: ref "core:prelude/string.wado//String";
+    let __local_24: i32;
+    let __local_25: ref "core:prelude/string.wado//String";
+    let __local_26: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let __local_30: ref "core:prelude/string.wado//String";
+    let __local_31: ref "core:prelude/string.wado//String";
+    let __local_32: i32;
+    let __local_33: ref "core:prelude/string.wado//String";
+    let __local_34: i64;
+    let __local_35: ref "core:prelude/string.wado//String";
+    let __local_36: i64;
+    let __local_37: ref "core:prelude/string.wado//String";
+    let __local_38: i32;
+    let __local_39: ref "core:prelude/string.wado//String";
+    let __local_40: i64;
+    let __local_43: ref "core:prelude/string.wado//String";
+    let __local_44: i64;
+    "core:json/JsonDeserializer::skip_whitespace"(self);
+    if self.pos >= __inline_String__len_0: block -> i32 {
+        __local_14 = self.input;
+        break __inline_String__len_0: __local_14.used;
+    } {
+        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_15 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_15 };
+        });
+    }
+    b = __inline_String__get_byte_2: block -> u8 {
+        __local_16 = self.input;
+        __local_17 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_16.repr, __local_17);
+    } & 255;
+    if b == 34 {
+        return "core:json/JsonDeserializer::skip_string"(self);
+        unreachable;
+    } else if b == 116 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        unreachable;
+    } else if b == 102 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        unreachable;
+    } else if b == 110 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
+        unreachable;
+    } else if b == 91 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_3: block -> i32 {
+            __local_18 = self.input;
+            break __inline_String__len_3: __local_18.used;
+        } -> i32 {
+            __inline_String__get_byte_4: block -> u8 {
+                __local_19 = self.input;
+                __local_20 = self.pos;
+                break __inline_String__get_byte_4: builtin::array_get_u8(__local_19.repr, __local_20);
+            } == 93;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l332: loop {
+                let __match_scrut_5: ref null "core:serde//DeserializeError";
+                __match_scrut_5 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_5) {
+                } else if ref.is_null(__match_scrut_5) == 0 {
+                    let __cast_4: ref null "core:serde//DeserializeError";
+                    __cast_4 = ref.as_non_null(__match_scrut_5);
+                    __local_3 = ref.as_non_null(__cast_4);
+                    return __local_3;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_5: block -> i32 {
+                    __local_21 = self.input;
+                    break __inline_String__len_5: __local_21.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
+                        __local_22 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_22 };
+                    });
+                }
+                __local_4 = __inline_String__get_byte_7: block -> u8 {
+                    __local_23 = self.input;
+                    __local_24 = self.pos;
+                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_23.repr, __local_24);
+                } & 255;
+                if __local_4 == 93 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_4 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
+                        __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
+                        __local_26 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_25, offset: __local_26 };
+                    });
+                    unreachable;
+                }
+                continue l332;
+            };
+        };
+    } else if b == 123 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_9: block -> i32 {
+            __local_27 = self.input;
+            break __inline_String__len_9: __local_27.used;
+        } -> i32 {
+            __inline_String__get_byte_10: block -> u8 {
+                __local_28 = self.input;
+                __local_29 = self.pos;
+                break __inline_String__get_byte_10: builtin::array_get_u8(__local_28.repr, __local_29);
+            } == 125;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l342: loop {
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if (if self.pos >= __inline_String__len_11: block -> i32 {
+                    __local_30 = self.input;
+                    break __inline_String__len_11: __local_30.used;
+                } -> i32 {
+                    1;
+                } else {
+                    __inline_String__get_byte_12: block -> u8 {
+                        __local_31 = self.input;
+                        __local_32 = self.pos;
+                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_31.repr, __local_32);
+                    } != 34;
+                }) {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
+                        __local_33 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+                        __local_34 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_33, offset: __local_34 };
+                    });
+                }
+                let __match_scrut_1: ref null "core:serde//DeserializeError";
+                __match_scrut_1 = "core:json/JsonDeserializer::skip_string"(self);
+                if ref.is_null(__match_scrut_1) {
+                } else if ref.is_null(__match_scrut_1) == 0 {
+                    let __cast_1: ref null "core:serde//DeserializeError";
+                    __cast_1 = ref.as_non_null(__match_scrut_1);
+                    __local_6 = ref.as_non_null(__cast_1);
+                    return __local_6;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_2: ref null "core:serde//DeserializeError";
+                __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+                if ref.is_null(__match_scrut_2) {
+                } else if ref.is_null(__match_scrut_2) == 0 {
+                    let __cast_2: ref null "core:serde//DeserializeError";
+                    __cast_2 = ref.as_non_null(__match_scrut_2);
+                    __local_8 = ref.as_non_null(__cast_2);
+                    return __local_8;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_3: ref null "core:serde//DeserializeError";
+                __match_scrut_3 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_3) {
+                } else if ref.is_null(__match_scrut_3) == 0 {
+                    let __cast_3: ref null "core:serde//DeserializeError";
+                    __cast_3 = ref.as_non_null(__match_scrut_3);
+                    __local_10 = ref.as_non_null(__cast_3);
+                    return __local_10;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_14: block -> i32 {
+                    __local_35 = self.input;
+                    break __inline_String__len_14: __local_35.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
+                        __local_36 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_36 };
+                    });
+                }
+                __local_11 = __inline_String__get_byte_16: block -> u8 {
+                    __local_37 = self.input;
+                    __local_38 = self.pos;
+                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_37.repr, __local_38);
+                } & 255;
+                if __local_11 == 125 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_11 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
+                        __local_39 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
+                        __local_40 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_39, offset: __local_40 };
+                    });
+                    unreachable;
+                }
+                continue l342;
+            };
+        };
+    } else {
+        if (if b == 45 -> i32 {
+            1;
+        } else if 48 <= b -> i32 {
+            b <= 57;
+        } else {
+            0;
+        }) {
+            "core:json/JsonDeserializer::skip_number"(self);
+            return ref.null none;
+        }
+        return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
+            __local_43 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
+                "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
+                __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
+                "core:prelude/primitive.wado/char^Display::fmt"(b, __local_13);
+                "core:prelude/string.wado/String::push"(__local_12, 39);
+                break __tmpl: __local_12;
+            };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
+        });
+        unreachable;
+    }
+}
+
+fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
+    let __local_2: ref "core:serde//DeserializeError";
+    let key_start: i32;
+    let has_escape: bool;
+    let b: i32;
+    let key_end: i32;
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: i32;
+    let idx_10: i32;
+    let __local_11: ref "core:prelude/string.wado//String";
+    let __local_12: ref "core:serde//DeserializeError";
+    let key: ref "core:prelude/string.wado//String";
+    let __local_15: ref "core:serde//DeserializeError";
+    let __local_16: i32;
+    let idx_17: i32;
     let __local_18: ref "core:prelude/string.wado//String";
     let __local_19: i64;
     let __local_20: ref "core:prelude/string.wado//String";
@@ -3172,416 +3501,178 @@ fn "core:json/JsonDeserializer::skip_value"(self) {
     let __local_25: ref "core:prelude/string.wado//String";
     let __local_26: i64;
     let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: i64;
-    let __local_31: ref "core:prelude/string.wado//String";
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i32;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
-    let __local_37: ref "core:prelude/string.wado//String";
-    let __local_38: i64;
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
-    let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_47: ref "core:prelude/string.wado//String";
-    let __local_48: i64;
-    let _hfs_pos_49: i32;
-    let _hfs_pos_50: i32;
-    "core:json/JsonDeserializer::skip_whitespace"(self);
-    if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_18 = self.input;
-        break __inline_String__len_0: __local_18.used;
-    } {
-        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_19 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
-        });
-    }
-    b = __inline_String__get_byte_2: block -> u8 {
-        __local_20 = self.input;
-        __local_21 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
-    };
-    if b == 34 {
-        return "core:json/JsonDeserializer::skip_string"(self);
-    }
-    if b == 116 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-    }
-    if b == 102 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-    }
-    if b == 110 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
-    }
-    if b == 91 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_3: block -> i32 {
-            __local_22 = self.input;
-            break __inline_String__len_3: __local_22.used;
-        } -> i32 {
-            __inline_String__get_byte_4: block -> u8 {
-                __local_23 = self.input;
-                __local_24 = self.pos;
-                break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
-            } == 93;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_49 = self.pos;
-        block {
-            l323: loop {
-                self.pos = _hfs_pos_49;
-                r = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_49 = self.pos;
-                if ref.is_null(r) == 0 {
-                    e_3 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-                    self.pos = _hfs_pos_49;
-                    return e_3;
-                }
-                self.pos = _hfs_pos_49;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_49 = self.pos;
-                if _hfs_pos_49 >= __inline_String__len_5: block -> i32 {
-                    __local_25 = self.input;
-                    self.pos = _hfs_pos_49;
-                    break __inline_String__len_5: __local_25.used;
-                } {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
-                        __local_26 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
-                    });
-                }
-                c_4 = __inline_String__get_byte_7: block -> u8 {
-                    __local_27 = self.input;
-                    __local_28 = _hfs_pos_49;
-                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_27.repr, __local_28);
-                };
-                if c_4 == 93 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                    self.pos = _hfs_pos_49;
-                    return ref.null none;
-                }
-                if c_4 == 44 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                } else {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
-                        __local_29 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
-                        __local_30 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_29, offset: __local_30 };
-                    });
-                }
-                continue l323;
-            };
-        };
-        self.pos = _hfs_pos_49;
-    }
-    if b == 123 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_9: block -> i32 {
-            __local_31 = self.input;
-            break __inline_String__len_9: __local_31.used;
-        } -> i32 {
-            __inline_String__get_byte_10: block -> u8 {
-                __local_32 = self.input;
-                __local_33 = self.pos;
-                break __inline_String__get_byte_10: builtin::array_get_u8(__local_32.repr, __local_33);
-            } == 125;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_50 = self.pos;
-        block {
-            l332: loop {
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if (if _hfs_pos_50 >= __inline_String__len_11: block -> i32 {
-                    __local_34 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_11: __local_34.used;
-                } -> i32 {
-                    1;
-                } else {
-                    __inline_String__get_byte_12: block -> u8 {
-                        __local_35 = self.input;
-                        __local_36 = _hfs_pos_50;
-                        self.pos = _hfs_pos_50;
-                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_35.repr, __local_36);
-                    } != 34;
-                }) {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
-                        __local_37 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-                        __local_38 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_37, offset: __local_38 };
-                    });
-                }
-                self.pos = _hfs_pos_50;
-                kr = "core:json/JsonDeserializer::skip_string"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(kr) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(kr));
-                    self.pos = _hfs_pos_50;
-                    return e_6;
-                }
-                self.pos = _hfs_pos_50;
-                cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(cr) == 0 {
-                    e_8 = value_copy "core:serde//DeserializeError"(ref.as_non_null(cr));
-                    self.pos = _hfs_pos_50;
-                    return e_8;
-                }
-                self.pos = _hfs_pos_50;
-                vr = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(vr) == 0 {
-                    e_10 = value_copy "core:serde//DeserializeError"(ref.as_non_null(vr));
-                    self.pos = _hfs_pos_50;
-                    return e_10;
-                }
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if _hfs_pos_50 >= __inline_String__len_14: block -> i32 {
-                    __local_39 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_14: __local_39.used;
-                } {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
-                        __local_40 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-                    });
-                }
-                c_11 = __inline_String__get_byte_16: block -> u8 {
-                    __local_41 = self.input;
-                    __local_42 = _hfs_pos_50;
-                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_41.repr, __local_42);
-                };
-                if c_11 == 125 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                    self.pos = _hfs_pos_50;
-                    return ref.null none;
-                }
-                if c_11 == 44 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                } else {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
-                        __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
-                        __local_44 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
-                    });
-                }
-                continue l332;
-            };
-        };
-        self.pos = _hfs_pos_50;
-    }
-    if (if b == 45 -> i32 {
-        1;
-    } else if b >= 48 -> i32 {
-        b <= 57;
-    } else {
-        0;
-    }) {
-        "core:json/JsonDeserializer::skip_number"(self);
-        return ref.null none;
-    }
-    return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
-        __local_47 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-            __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
-            "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
-            __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
-            "core:prelude/primitive.wado/char^Display::fmt"(b & 255, __local_13);
-            "core:prelude/string.wado/String::push"(__local_12, 39);
-            break __tmpl: __local_12;
-        };
-        __local_48 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_47, offset: __local_48 };
-    });
-}
-
-fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
-    let r_1: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let key_start: i32;
-    let has_escape: bool;
-    let b: i32;
-    let key_end: i32;
-    let r_7: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let idx_9: ref "core:prelude/types.wado//Option<i32>";
-    let i_10: i32;
-    let key: ref "core:prelude/string.wado//String";
-    let r_13: ref null "core:serde//DeserializeError";
-    let e_14: ref "core:serde//DeserializeError";
-    let idx_15: ref "core:prelude/types.wado//Option<i32>";
-    let i_16: i32;
-    let e_17: ref "core:serde//DeserializeError";
-    let __local_25: ref "core:prelude/string.wado//String";
-    let __local_26: i64;
-    let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: ref "core:prelude/string.wado//String";
-    let __local_31: i32;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i64;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_25 = self.de.input;
-        break __inline_String__len_0: __local_25.used;
+        __local_18 = self.de.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
+            __local_19 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_27 = self.de.input;
-        __local_28 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_27.repr, __local_28);
+        __local_20 = self.de.input;
+        __local_21 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } == 125 {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r_1 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r_1) == 0 {
-            e_2 = ref.as_non_null(r_1);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if (if self.de.pos >= __inline_String__len_3: block -> i32 {
-        __local_29 = self.de.input;
-        break __inline_String__len_3: __local_29.used;
+        __local_22 = self.de.input;
+        break __inline_String__len_3: __local_22.used;
     } -> i32 {
         1;
     } else {
         __inline_String__get_byte_4: block -> u8 {
-            __local_30 = self.de.input;
-            __local_31 = self.de.pos;
-            break __inline_String__get_byte_4: builtin::array_get_u8(__local_30.repr, __local_31);
+            __local_23 = self.de.input;
+            __local_24 = self.de.pos;
+            break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
         } != 34;
     }) {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_5: block -> ref "core:serde//DeserializeError" {
-            __local_32 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-            __local_33 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_32, offset: __local_33 };
+            __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_25, offset: __local_26 };
         }) };
     }
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b350: block {
-        l351: loop {
+    b364: block {
+        l365: loop {
             if self.de.pos >= __inline_String__len_6: block -> i32 {
-                __local_34 = self.de.input;
-                break __inline_String__len_6: __local_34.used;
+                __local_27 = self.de.input;
+                break __inline_String__len_6: __local_27.used;
             } {
-                break b350;
+                break b364;
             }
             b = __inline_String__get_byte_7: block -> u8 {
-                __local_35 = self.de.input;
-                __local_36 = self.de.pos;
-                break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
+                __local_28 = self.de.input;
+                __local_29 = self.de.pos;
+                break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
             };
             if b == 34 {
-                break b350;
+                break b364;
             }
             if b == 92 {
                 has_escape = 1;
-                break b350;
+                break b364;
             }
             self.de.pos = self.de.pos + 1;
-            continue l351;
+            continue l365;
         };
     };
     if has_escape == 0 {
         key_end = self.de.pos;
         self.de.pos = self.de.pos + 1;
-        r_7 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_7) == 0 {
-            e_8 = ref.as_non_null(r_7);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_8 };
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_1);
+            __local_8 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        idx_9 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_0: ref "canonical//CanonicalClosure_0";
-            __indirect_call_0 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_0.func, __indirect_call_0.env, self.de.input, key_start, key_end);
+        let __match_scrut_2: ref "core:prelude/types.wado//Option<i32>";
+        __match_scrut_2 = block -> ref "core:prelude/types.wado//Option<i32>" {
+            let __indirect_call_2: ref "canonical//CanonicalClosure_0";
+            __indirect_call_2 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_2.func, __indirect_call_2.env, self.de.input, key_start, key_end);
         };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_9) {
-            i_10 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_9).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_10 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+        idx_10 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2) -> i32 {
+            let __cast_4: ref "core:prelude/types.wado//Option<i32>::Some";
+            __cast_4 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2);
+            __local_9 = __cast_4.payload_0;
+            __local_9;
+        } else if __match_scrut_2.discriminant == 1 -> i32 {
+            -1;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_10 } };
     }
     self.de.pos = key_start - 1;
-    let __sroa_key_r_discriminant: i32;
-    let __sroa_key_r_case0_payload_0: ref null "core:prelude/string.wado//String";
-    let __sroa_key_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_key_r_discriminant, __sroa_key_r_case0_payload_0, __sroa_key_r_case1_payload_0] = "core:json/JsonDeserializer::read_json_string"(self.de);
-    if __sroa_key_r_discriminant == 0 {
-        key = __sroa_key_r_case0_payload_0;
-        r_13 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_13) == 0 {
-            e_14 = ref.as_non_null(r_13);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_14 };
-        }
-        idx_15 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_1: ref "canonical//CanonicalClosure_0";
-            __indirect_call_1 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_1.func, __indirect_call_1.env, key, 0, key.used);
-        };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_15) {
-            i_16 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_15).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_16 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+    key = value_copy "core:prelude/string.wado//String"(let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self.de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_6: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_6 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+        __local_11 = __cast_6.payload_0;
+        __local_11;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+        __local_12 = __cast_5.payload_0;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_12 };
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    let __match_scrut_4: ref null "core:serde//DeserializeError";
+    __match_scrut_4 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+    if ref.is_null(__match_scrut_4) {
+    } else if ref.is_null(__match_scrut_4) == 0 {
+        let __cast_7: ref null "core:serde//DeserializeError";
+        __cast_7 = ref.as_non_null(__match_scrut_4);
+        __local_15 = ref.as_non_null(__cast_7);
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_15 };
+        unreachable;
+    } else {
+        unreachable;
     }
-    if __sroa_key_r_discriminant == 1 {
-        e_17 = __sroa_key_r_case1_payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    let __match_scrut_5: ref "core:prelude/types.wado//Option<i32>";
+    __match_scrut_5 = block -> ref "core:prelude/types.wado//Option<i32>" {
+        let __indirect_call_7: ref "canonical//CanonicalClosure_0";
+        __indirect_call_7 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+        call_ref "functype/$canonical_closure_fn_0"(__indirect_call_7.func, __indirect_call_7.env, key, 0, key.used);
+    };
+    idx_17 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5) -> i32 {
+        let __cast_9: ref "core:prelude/types.wado//Option<i32>::Some";
+        __cast_9 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5);
+        __local_16 = __cast_9.payload_0;
+        __local_16;
+    } else if __match_scrut_5.discriminant == 1 -> i32 {
+        -1;
+    } else {
+        unreachable;
+    });
+    return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_17 } };
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_struct"(self, lookup) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 123);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_5: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 123);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_5 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_5;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonStructAccess" { de: self, lookup: lookup, first: 1 }, ref.null none;
 }
@@ -3593,13 +3684,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l366: loop {
+            l385: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l366;
+                continue l385;
             };
         };
     };
@@ -3692,10 +3783,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b376: block {
-            l377: loop {
+        b395: block {
+            l396: loop {
                 if i_8 < 0 {
-                    break b376;
+                    break b395;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -3704,7 +3795,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l377;
+                continue l396;
             };
         };
         __for_1: block {
@@ -3712,14 +3803,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l380: loop {
+                l399: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l380;
+                    continue l399;
                 };
             };
         };
@@ -3729,10 +3820,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b382: block {
-            l383: loop {
+        b401: block {
+            l402: loop {
                 if i_10 < 0 {
-                    break b382;
+                    break b401;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -3741,7 +3832,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l383;
+                continue l402;
             };
         };
         __for_2: block {
@@ -3749,14 +3840,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l386: loop {
+                l405: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l386;
+                    continue l405;
                 };
             };
         };
@@ -3874,13 +3965,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l407: loop {
+            l426: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l407;
+                continue l426;
             };
         };
     };
@@ -3913,8 +4004,8 @@ fn "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/Point^Deserializ
         seen = 0;
         x = 0;
         y = 0;
-        b410: block {
-            l411: loop {
+        b429: block {
+            l430: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -3932,7 +4023,7 @@ fn "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/Point^Deserializ
                                 x = __local_10;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__local_9).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__local_9).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_11 = __inline_f64_Deserialize__deserialize_JsonDeserializer__5: block -> ref "core:prelude/types.wado//Result<f64,DeserializeError>" {
@@ -3945,27 +4036,27 @@ fn "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado/Point^Deserializ
                                 y = __local_12;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__local_11).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__local_11).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b410;
+                        break b429;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l411;
+                continue l430;
             };
         };
         if (seen & 3) != 3 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado//Point" { x: x, y: y }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_json_unknown_fields.wado//Point" { x: x, y: y } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 

--- a/wado-compiler/tests/fixtures.golden/serde_synth.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_synth.wir.wado
@@ -86,334 +86,416 @@ struct wado-compiler/tests/fixtures/serde_synth.wado//Point {  // TypeId(16)
 
 array builtin::array<u64> (mut u64);  // TypeId(17)
 
-variant core:prelude/types.wado//Option<i32> {  // TypeId(18)
+variant core:prelude/types.wado//Option<char> {  // TypeId(18)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(19)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<i32> {  // TypeId(20)
     Some(i32),
     None,
 }
 
-struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(19)
+struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(21)
     discriminant: i32,
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(20)
+variant core:prelude/types.wado//Result<Point,DeserializeError> {  // TypeId(22)
+    Ok(ref "wado-compiler/tests/fixtures/serde_synth.wado//Point"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Point,DeserializeError>::Ok {  // TypeId(23)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_synth.wado//Point",
+}
+
+struct core:prelude/types.wado//Result<Point,DeserializeError>::Err {  // TypeId(24)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<User,DeserializeError> {  // TypeId(25)
+    Ok(ref "wado-compiler/tests/fixtures/serde_synth.wado//User"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<User,DeserializeError>::Ok {  // TypeId(26)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_synth.wado//User",
+}
+
+struct core:prelude/types.wado//Result<User,DeserializeError>::Err {  // TypeId(27)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<Config,DeserializeError> {  // TypeId(28)
+    Ok(ref "wado-compiler/tests/fixtures/serde_synth.wado//Config"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Config,DeserializeError>::Ok {  // TypeId(29)
+    discriminant: i32,
+    payload_0: ref "wado-compiler/tests/fixtures/serde_synth.wado//Config",
+}
+
+struct core:prelude/types.wado//Result<Config,DeserializeError>::Err {  // TypeId(30)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(31)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(21)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(32)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(22)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(33)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(23)
+variant core:prelude/types.wado//Result<f64,DeserializeError> {  // TypeId(34)
     Ok(f64),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(24)
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Ok {  // TypeId(35)
     discriminant: i32,
     payload_0: f64,
 }
 
-struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(25)
+struct core:prelude/types.wado//Result<f64,DeserializeError>::Err {  // TypeId(36)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(26)
+variant core:prelude/types.wado//Result<bool,DeserializeError> {  // TypeId(37)
     Ok(bool),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(27)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Ok {  // TypeId(38)
     discriminant: i32,
     payload_0: bool,
 }
 
-struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(28)
+struct core:prelude/types.wado//Result<bool,DeserializeError>::Err {  // TypeId(39)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(29)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(40)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(41)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(42)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(43)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(30)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(44)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(31)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(45)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(32)
+variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(46)
     Ok(ref "core:prelude/types.wado//Option<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(33)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(47)
     discriminant: i32,
     payload_0: ref "core:prelude/types.wado//Option<i32>",
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(34)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(48)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-struct core:prelude//Array<u64> {  // TypeId(35)
+struct core:prelude//Array<u64> {  // TypeId(49)
     mut repr: ref builtin::array<u64>,
     mut used: i32,
 }
 
-enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(36)
+enum core:prelude/fpfmt.wado//enum:SpecialKind { NotSpecial = 0, Zero = 1, Inf = 2, NaN = 3 };  // TypeId(50)
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(37)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(51)
 
-type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(38)
+type "functype/$canonical_closure_fn_0" = fn(ref null struct, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(52)
 
-struct canonical//CanonicalClosure_0 {  // TypeId(39)
+struct canonical//CanonicalClosure_0 {  // TypeId(53)
     env: ref null struct,
     func: ref "functype/$canonical_closure_fn_0",
 }
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(40)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(54)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(41)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(55)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(42)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(56)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(43)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(57)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(44)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(58)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(45)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(59)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(46)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(60)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(47)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(61)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__test_0_synthesized_deserialize_point" = fn();  // TypeId(48)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__test_0_synthesized_deserialize_point" = fn();  // TypeId(62)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__test_1_synthesized_deserialize_point_out_of_order_fields" = fn();  // TypeId(49)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__test_1_synthesized_deserialize_point_out_of_order_fields" = fn();  // TypeId(63)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__test_2_synthesized_deserialize_user_with_camelcase_keys" = fn();  // TypeId(50)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__test_2_synthesized_deserialize_user_with_camelcase_keys" = fn();  // TypeId(64)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__test_3_roundtrip_config" = fn();  // TypeId(51)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__test_3_roundtrip_config" = fn();  // TypeId(65)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__test_4_synthesized_serialize_point" = fn();  // TypeId(52)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__test_4_synthesized_serialize_point" = fn();  // TypeId(66)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__test_5_synthesized_serialize_user_with_snake_case____camelcase" = fn();  // TypeId(53)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__test_5_synthesized_serialize_user_with_snake_case____camelcase" = fn();  // TypeId(67)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/_point_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(54)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/_point_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(68)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/_user_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(55)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/_user_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(69)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/_config_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(56)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/_config_field_lookup" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(70)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__cm_export____test_0_synthesized_deserialize_point" = fn();  // TypeId(57)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__cm_export____test_0_synthesized_deserialize_point" = fn();  // TypeId(71)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__cm_export____test_1_synthesized_deserialize_point_out_of_order_fields" = fn();  // TypeId(58)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__cm_export____test_1_synthesized_deserialize_point_out_of_order_fields" = fn();  // TypeId(72)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__cm_export____test_2_synthesized_deserialize_user_with_camelcase_keys" = fn();  // TypeId(59)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__cm_export____test_2_synthesized_deserialize_user_with_camelcase_keys" = fn();  // TypeId(73)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__cm_export____test_3_roundtrip_config" = fn();  // TypeId(60)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__cm_export____test_3_roundtrip_config" = fn();  // TypeId(74)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__cm_export____test_4_synthesized_serialize_point" = fn();  // TypeId(61)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__cm_export____test_4_synthesized_serialize_point" = fn();  // TypeId(75)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__cm_export____test_5_synthesized_serialize_user_with_snake_case____camelcase" = fn();  // TypeId(62)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__cm_export____test_5_synthesized_serialize_user_with_snake_case____camelcase" = fn();  // TypeId(76)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__initialize_module" = fn();  // TypeId(63)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__initialize_module" = fn();  // TypeId(77)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(64)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(78)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(65)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(79)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(66)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(80)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(67)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(81)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(68)
+type "functype//core:internal/unreachable" = fn();  // TypeId(82)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(69)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(83)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(70)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(84)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(71)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(85)
 
-type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(72)
+type "functype//core:prelude/fpfmt.wado/unrounded_div" = fn(u64, u64) -> u64;  // TypeId(86)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(73)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(87)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(74)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(88)
 
-type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(75)
+type "functype//core:prelude/fpfmt.wado/write_digits_at" = fn(ref "core:prelude/string.wado//String", i32, u64, i32);  // TypeId(89)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(76)
+type "functype//core:prelude/fpfmt.wado/write_decimal" = fn(ref "core:prelude/string.wado//String", u64, i32, i32);  // TypeId(90)
 
-type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(77)
+type "functype//core:prelude/fpfmt.wado/write_exp" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, bool);  // TypeId(91)
 
-type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(78)
+type "functype//core:prelude/fpfmt.wado/write_decimal_prec" = fn(ref "core:prelude/string.wado//String", u64, i32, i32, i32);  // TypeId(92)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(79)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(93)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(80)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(94)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(81)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(95)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(82)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(96)
 
-type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(83)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(97)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(84)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(98)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(85)
+type "functype//core:prelude/primitive.wado/fmt_float_special" = fn(ref "core:prelude/format.wado//Formatter", bool, "core:prelude/fpfmt.wado//enum:SpecialKind", ref "core:prelude/string.wado//String");  // TypeId(99)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(86)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(100)
 
-type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(87)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(101)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(88)
+type "functype//core:prelude/string.wado/String::get_byte" = fn(ref "core:prelude/string.wado//String", i32) -> u8;  // TypeId(102)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(89)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(103)
 
-type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(90)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(104)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(91)
+type "functype//core:prelude/string.wado/String::append_byte_filled" = fn(ref "core:prelude/string.wado//String", u8, i32);  // TypeId(105)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(92)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(106)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(93)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(107)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(94)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(108)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(95)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(109)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(96)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(110)
 
-type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(97)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(111)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(98)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(112)
 
-type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(99)
+type "functype//core:json/JsonDeserializer::expect_literal" = fn(ref "core:json//JsonDeserializer", ref "core:prelude/string.wado//String") -> ref null "core:serde//DeserializeError";  // TypeId(113)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(100)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(114)
 
-type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(101)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(115)
 
-type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(102)
+type "functype//core:json/JsonDeserializer::skip_number" = fn(ref "core:json//JsonDeserializer");  // TypeId(116)
 
-type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(103)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(117)
 
-type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(104)
+type "functype//core:json/JsonDeserializer::parse_f64_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<f64,DeserializeError>";  // TypeId(118)
 
-type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(105)
+type "functype//core:json/JsonDeserializer::skip_string" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(119)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(106)
+type "functype//core:json/JsonDeserializer::skip_value" = fn(ref "core:json//JsonDeserializer") -> ref null "core:serde//DeserializeError";  // TypeId(120)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(107)
+type "functype//core:json/JsonStructAccess^DeserializeStruct::next_field" = fn(ref "core:json//JsonStructAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(121)
 
-type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(108)
+type "functype//core:json/JsonDeserializer^Deserializer::deserialize_bool" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<bool,DeserializeError>";  // TypeId(122)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(109)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(123)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(110)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(124)
 
-type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(111)
+type "functype//core:prelude/format.wado/Formatter::apply_padding" = fn(ref "core:prelude/format.wado//Formatter", i32);  // TypeId(125)
 
-type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(112)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(126)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<String>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(113)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(127)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(114)
+type "functype//core:prelude/array.wado/Array<u64>::push" = fn(ref "core:prelude//Array<u64>", u64);  // TypeId(128)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(115)
+type "functype//core:prelude/array.wado/Array<u64>::grow" = fn(ref "core:prelude//Array<u64>");  // TypeId(129)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(116)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<String>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(130)
 
-type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(117)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/Config^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Config,DeserializeError>";  // TypeId(131)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(118)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/User^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<User,DeserializeError>";  // TypeId(132)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(119)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/Point^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Point,DeserializeError>";  // TypeId(133)
 
-type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(120)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(134)
 
-type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(121)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(135)
 
-type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(122)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(136)
 
-type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(123)
+type "functype//core:prelude/fpfmt.wado/unpack64" = fn(f64) -> [u64, i32];  // TypeId(137)
 
-type "functype//core:json/core/json/to_string<User>" = fn(ref "wado-compiler/tests/fixtures/serde_synth.wado//User") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(124)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(138)
 
-type "functype//core:json/core/json/to_string<Point>" = fn(ref "wado-compiler/tests/fixtures/serde_synth.wado//Point") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(125)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(139)
 
-type "functype//core:json/core/json/from_string<Config>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_synth.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(126)
+type "functype//core:prelude/fpfmt.wado/fixed_width_for_prec" = fn(f64, i32) -> [u64, i32];  // TypeId(140)
 
-type "functype//core:json/core/json/to_string<Config>" = fn(ref "wado-compiler/tests/fixtures/serde_synth.wado//Config") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(127)
+type "functype//core:prelude/fpfmt.wado/short" = fn(f64) -> [u64, i32];  // TypeId(141)
 
-type "functype//core:json/core/json/from_string<User>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_synth.wado//User", ref null "core:serde//DeserializeError"];  // TypeId(128)
+type "functype//core:prelude/fpfmt.wado/trim_zeros" = fn(u64, i32) -> [u64, i32];  // TypeId(142)
 
-type "functype//core:json/core/json/from_string<Point>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_synth.wado//Point", ref null "core:serde//DeserializeError"];  // TypeId(129)
+type "functype//core:prelude/fpfmt.wado/check_special" = fn(f64) -> [bool, bool, i32];  // TypeId(143)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(130)
+type "functype//core:json/core/json/to_string<User>" = fn(ref "wado-compiler/tests/fixtures/serde_synth.wado//User") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(144)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(131)
+type "functype//core:json/core/json/to_string<Point>" = fn(ref "wado-compiler/tests/fixtures/serde_synth.wado//Point") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(145)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(132)
+type "functype//core:json/core/json/from_string<Config>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_synth.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(146)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/Config^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_synth.wado//Config", ref null "core:serde//DeserializeError"];  // TypeId(133)
+type "functype//core:json/core/json/to_string<Config>" = fn(ref "wado-compiler/tests/fixtures/serde_synth.wado//Config") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(147)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/User^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_synth.wado//User", ref null "core:serde//DeserializeError"];  // TypeId(134)
+type "functype//core:json/core/json/from_string<User>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_synth.wado//User", ref null "core:serde//DeserializeError"];  // TypeId(148)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/Point^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "wado-compiler/tests/fixtures/serde_synth.wado//Point", ref null "core:serde//DeserializeError"];  // TypeId(135)
+type "functype//core:json/core/json/from_string<Point>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/serde_synth.wado//Point", ref null "core:serde//DeserializeError"];  // TypeId(149)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(136)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(150)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(137)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(151)
 
-type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(138)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(152)
 
-type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(139)
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(153)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(140)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(154)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(141)
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(155)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(142)
+type "functype//core:prelude/primitive.wado/f64::fmt_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(156)
 
-type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(143)
+type "functype//core:prelude/primitive.wado/f64::inspect_into" = fn(f64, ref "core:prelude/format.wado//Formatter");  // TypeId(157)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/User^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_synth.wado//User", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(144)
+type "functype//core:prelude/primitive.wado/f64::fmt_fixed" = fn(f64, i32, ref "core:prelude/format.wado//Formatter");  // TypeId(158)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<bool>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(145)
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(159)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<i32>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(146)
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(160)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/Point^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_synth.wado//Point", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(147)
+type "functype//core:json/JsonSerializer^Serializer::serialize_i32" = fn(ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(161)
 
-type "functype//core:json/JsonStructSerializer^SerializeStruct::field<f64>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(148)
+type "functype//core:json/JsonSerializer^Serializer::serialize_f64" = fn(ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(162)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/Config^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_synth.wado//Config", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(149)
+type "functype//core:json/JsonSerializer^Serializer::serialize_bool" = fn(ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(163)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(150)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/User^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_synth.wado//User", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(164)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(151)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<bool>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", bool) -> ref null "core:serde//SerializeError";  // TypeId(165)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__Closure_3::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(152)
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<i32>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", i32) -> ref null "core:serde//SerializeError";  // TypeId(166)
 
-type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__Closure_4::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(153)
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/Point^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_synth.wado//Point", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(167)
+
+type "functype//core:json/JsonStructSerializer^SerializeStruct::field<f64>" = fn(ref "core:json//JsonStructSerializer", ref "core:prelude/string.wado//String", f64) -> ref null "core:serde//SerializeError";  // TypeId(168)
+
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/Config^Serialize::serialize<JsonSerializer>" = fn(ref "wado-compiler/tests/fixtures/serde_synth.wado//Config", ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(169)
+
+type "functype//core:json/JsonDeserializer^Deserializer::begin_struct" = fn(ref "core:json//JsonDeserializer", ref struct) -> [i32, ref null "core:json//JsonStructAccess", ref null "core:serde//DeserializeError"];  // TypeId(170)
+
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__Closure_2::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(171)
+
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__Closure_3::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(172)
+
+type "functype//wado-compiler/tests/fixtures/serde_synth.wado/__Closure_4::__call" = fn(ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//Option<i32>";  // TypeId(173)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -2281,6 +2363,67 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l190: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l190;
+                };
+            };
+        };
+    }
+}
+
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
+        return 1;
+    }
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l196: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l196;
+            };
+        };
+    };
+    return n;
+}
+
 fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     let mark: i32;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -2309,36 +2452,16 @@ fn "core:prelude/primitive.wado/fmt_float_special"(f, is_neg, kind, zero_repr) {
     "core:prelude/format.wado/Formatter::apply_padding"(f, mark);
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
-    }
-    return ((97 + v) - 10) & 255;
-}
-
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b196: block {
-        l197: loop {
+    b202: block {
+        l203: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -2359,23 +2482,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b196;
+                break b202;
             }
-            continue l197;
+            continue l203;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -2383,154 +2508,243 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/to_string<User>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_synth.wado/User^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_synth.wado/User^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Point>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_synth.wado/Point^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_synth.wado/Point^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<Config>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_synth.wado//Config";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_synth.wado//Config";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_synth.wado//Config";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_synth.wado/Config^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_synth.wado//Config"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Config,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_synth.wado/Config^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Config,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_synth.wado//Config" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Config,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Config,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Config,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_synth.wado//Config" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Config,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Config,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Config>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/serde_synth.wado/Config^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/serde_synth.wado/Config^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:json/core/json/from_string<User>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_synth.wado//User";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_synth.wado//User";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_synth.wado//User";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_synth.wado/User^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_synth.wado//User"(let __match_scrut_0: ref "core:prelude/types.wado//Result<User,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_synth.wado/User^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<User,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_synth.wado//User" {
+        let __cast_2: ref "core:prelude/types.wado//Result<User,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<User,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<User,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_synth.wado//User" {
+        let __cast_1: ref "core:prelude/types.wado//Result<User,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<User,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/from_string<Point>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "wado-compiler/tests/fixtures/serde_synth.wado//Point";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/serde_synth.wado//Point";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "wado-compiler/tests/fixtures/serde_synth.wado//Point";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/serde_synth.wado/Point^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/serde_synth.wado//Point"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Point,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/serde_synth.wado/Point^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Point,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_synth.wado//Point" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Point,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Point,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Point,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/serde_synth.wado//Point" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Point,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Point,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -2551,6 +2765,20 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
         __local_6 = f.buf;
         break __inline_String__internal_raw_bytes_0: __local_6.repr;
     }, offset, abs_val, digit_count);
+}
+
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
 }
 
 fn "core:prelude/primitive.wado/f64::fmt_into"(self, f) {
@@ -2811,6 +3039,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     }
 }
 
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
+}
+
 fn "core:prelude/string.wado/String::get_byte"(self, index) {
     return builtin::array_get_u8(self.repr, index);
 }
@@ -2891,7 +3133,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l257: loop {
+            l281: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -2899,7 +3141,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l257;
+                continue l281;
             };
         };
     };
@@ -2948,6 +3190,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     self.byte_index = self.byte_index + 3;
     code_10 = ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     return 0, code_10;
+}
+
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
@@ -3038,10 +3329,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b271: block {
-        l272: loop {
+    b302: block {
+        l303: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b271;
+                break b302;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -3065,7 +3356,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l272;
+            continue l303;
         };
     };
     self.pos = _hfs_pos_8;
@@ -3144,11 +3435,11 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
     _licm_used_22 = _licm_input_21.used;
     _licm_repr_23 = _licm_input_21.repr;
     _hfs_pos_27 = self.pos;
-    b280: block {
-        l281: loop {
+    b311: block {
+        l312: loop {
             __fused___inline_StrUtf8ByteIter_Iterator__next_2: block {
                 if __sroa___iter_3_index >= _licm_used_19 {
-                    break b280;
+                    break b311;
                 }
                 byte = builtin::array_get_u8(_licm_repr_20, __sroa___iter_3_index);
                 __sroa___iter_3_index = __sroa___iter_3_index + 1;
@@ -3183,7 +3474,7 @@ fn "core:json/JsonDeserializer::expect_literal"(self, lit) {
                 _hfs_pos_27 = _hfs_pos_27 + 1;
                 break __fused___inline_StrUtf8ByteIter_Iterator__next_2;
             };
-            continue l281;
+            continue l312;
         };
     };
     self.pos = _hfs_pos_27;
@@ -3202,130 +3493,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b287: block {
-        l288: loop {
-            if scan_pos >= _licm_used_90 {
-                break b287;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b318: block {
+        l319: loop {
+            if scan_pos >= _licm_used_56 {
+                break b318;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b287;
+                break b318;
             }
             scan_pos = scan_pos + 1;
-            continue l288;
+            continue l319;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -3334,22 +3597,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l295: loop {
+                l326: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l295;
+                    continue l326;
                 };
             };
         };
@@ -3357,71 +3620,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l298: loop {
+            l329: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l298;
+                continue l329;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b300: block {
-        l301: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b331: block {
+        l332: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b300;
+                break b331;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -3439,125 +3703,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l301;
+            continue l332;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -3565,87 +3772,71 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l326: loop {
+            l352: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l326;
+                continue l352;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -3700,25 +3891,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
     _licm_used_28 = _licm_input_27.used;
     _licm_repr_29 = _licm_input_27.repr;
     _hfs_pos_36 = self.pos;
-    b337: block {
-        l338: loop {
+    b359: block {
+        l360: loop {
             if _hfs_pos_36 >= _licm_used_28 {
-                break b337;
+                break b359;
             }
             b_1 = __inline_String__get_byte_3: block -> u8 {
                 __local_11 = _hfs_pos_36;
                 break __inline_String__get_byte_3: builtin::array_get_u8(_licm_repr_29, __local_11);
             };
-            if (if b_1 >= 48 -> i32 {
+            if (if 48 <= b_1 -> i32 {
                 b_1 <= 57;
             } else {
                 0;
             }) {
                 _hfs_pos_36 = _hfs_pos_36 + 1;
             } else {
-                break b337;
+                break b359;
             }
-            continue l338;
+            continue l360;
         };
     };
     self.pos = _hfs_pos_36;
@@ -3739,25 +3930,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
         _licm_used_31 = _licm_input_30.used;
         _licm_repr_32 = _licm_input_30.repr;
         _hfs_pos_37 = self.pos;
-        b344: block {
-            l345: loop {
+        b366: block {
+            l367: loop {
                 if _hfs_pos_37 >= _licm_used_31 {
-                    break b344;
+                    break b366;
                 }
                 b_2 = __inline_String__get_byte_7: block -> u8 {
                     __local_17 = _hfs_pos_37;
                     break __inline_String__get_byte_7: builtin::array_get_u8(_licm_repr_32, __local_17);
                 };
-                if (if b_2 >= 48 -> i32 {
+                if (if 48 <= b_2 -> i32 {
                     b_2 <= 57;
                 } else {
                     0;
                 }) {
                     _hfs_pos_37 = _hfs_pos_37 + 1;
                 } else {
-                    break b344;
+                    break b366;
                 }
-                continue l345;
+                continue l367;
             };
         };
         self.pos = _hfs_pos_37;
@@ -3798,25 +3989,25 @@ fn "core:json/JsonDeserializer::skip_number"(self) {
             _licm_used_34 = _licm_input_33.used;
             _licm_repr_35 = _licm_input_33.repr;
             _hfs_pos_38 = self.pos;
-            b355: block {
-                l356: loop {
+            b377: block {
+                l378: loop {
                     if _hfs_pos_38 >= _licm_used_34 {
-                        break b355;
+                        break b377;
                     }
                     b2 = __inline_String__get_byte_13: block -> u8 {
                         __local_26 = _hfs_pos_38;
                         break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_35, __local_26);
                     };
-                    if (if b2 >= 48 -> i32 {
+                    if (if 48 <= b2 -> i32 {
                         b2 <= 57;
                     } else {
                         0;
                     }) {
                         _hfs_pos_38 = _hfs_pos_38 + 1;
                     } else {
-                        break b355;
+                        break b377;
                     }
-                    continue l356;
+                    continue l378;
                 };
             };
             self.pos = _hfs_pos_38;
@@ -3910,16 +4101,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b365: block {
-        l366: loop {
+    b387: block {
+        l388: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b365;
+                break b387;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -3940,17 +4131,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b374: block {
-                        l375: loop {
+                    b396: block {
+                        l397: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b374;
+                                break b396;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -3960,9 +4151,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b374;
+                                break b396;
                             }
-                            continue l375;
+                            continue l397;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -3993,17 +4184,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b384: block {
-                            l385: loop {
+                        b406: block {
+                            l407: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b384;
+                                    break b406;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -4012,9 +4203,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b384;
+                                    break b406;
                                 }
-                                continue l385;
+                                continue l407;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -4052,9 +4243,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b365;
+                break b387;
             }
-            continue l366;
+            continue l388;
         };
     };
     self.pos = _hfs_pos_51;
@@ -4166,16 +4357,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
     _licm_used_49 = _licm_input_48.used;
     _licm_repr_50 = _licm_input_48.repr;
     _hfs_pos_57 = self.pos;
-    b400: block {
-        l401: loop {
+    b422: block {
+        l423: loop {
             if _hfs_pos_57 >= _licm_used_49 {
-                break b400;
+                break b422;
             }
             b_6 = __inline_String__get_byte_8: block -> u8 {
                 __local_32 = _hfs_pos_57;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_50, __local_32);
             };
-            if (if b_6 >= 48 -> i32 {
+            if (if 48 <= b_6 -> i32 {
                 b_6 <= 57;
             } else {
                 0;
@@ -4186,9 +4377,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                 total_digits = total_digits + 1;
                 _hfs_pos_57 = _hfs_pos_57 + 1;
             } else {
-                break b400;
+                break b422;
             }
-            continue l401;
+            continue l423;
         };
     };
     self.pos = _hfs_pos_57;
@@ -4210,16 +4401,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
         _licm_used_52 = _licm_input_51.used;
         _licm_repr_53 = _licm_input_51.repr;
         _hfs_pos_58 = self.pos;
-        b408: block {
-            l409: loop {
+        b430: block {
+            l431: loop {
                 if _hfs_pos_58 >= _licm_used_52 {
-                    break b408;
+                    break b430;
                 }
                 b_8 = __inline_String__get_byte_12: block -> u8 {
                     __local_38 = _hfs_pos_58;
                     break __inline_String__get_byte_12: builtin::array_get_u8(_licm_repr_53, __local_38);
                 };
-                if (if b_8 >= 48 -> i32 {
+                if (if 48 <= b_8 -> i32 {
                     b_8 <= 57;
                 } else {
                     0;
@@ -4231,9 +4422,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                     total_digits = total_digits + 1;
                     _hfs_pos_58 = _hfs_pos_58 + 1;
                 } else {
-                    break b408;
+                    break b430;
                 }
-                continue l409;
+                continue l431;
             };
         };
         self.pos = _hfs_pos_58;
@@ -4275,16 +4466,16 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
             _licm_used_55 = _licm_input_54.used;
             _licm_repr_56 = _licm_input_54.repr;
             _hfs_pos_59 = self.pos;
-            b420: block {
-                l421: loop {
+            b442: block {
+                l443: loop {
                     if _hfs_pos_59 >= _licm_used_55 {
-                        break b420;
+                        break b442;
                     }
                     b3 = __inline_String__get_byte_18: block -> u8 {
                         __local_47 = _hfs_pos_59;
                         break __inline_String__get_byte_18: builtin::array_get_u8(_licm_repr_56, __local_47);
                     };
-                    if (if b3 >= 48 -> i32 {
+                    if (if 48 <= b3 -> i32 {
                         b3 <= 57;
                     } else {
                         0;
@@ -4292,9 +4483,9 @@ fn "core:json/JsonDeserializer::parse_f64_direct"(self) {
                         exp = (exp * 10) + (b3 - 48);
                         _hfs_pos_59 = _hfs_pos_59 + 1;
                     } else {
-                        break b420;
+                        break b442;
                     }
-                    continue l421;
+                    continue l443;
                 };
             };
             self.pos = _hfs_pos_59;
@@ -4344,10 +4535,10 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
     _licm_used_12 = _licm_input_11.used;
     _licm_repr_13 = _licm_input_11.repr;
     _hfs_pos_14 = self.pos;
-    b431: block {
-        l432: loop {
+    b453: block {
+        l454: loop {
             if _hfs_pos_14 >= _licm_used_12 {
-                break b431;
+                break b453;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_5 = _hfs_pos_14;
@@ -4377,7 +4568,7 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
                 }
             }
             _hfs_pos_14 = _hfs_pos_14 + 1;
-            continue l432;
+            continue l454;
         };
     };
     self.pos = _hfs_pos_14;
@@ -4388,19 +4579,284 @@ fn "core:json/JsonDeserializer::skip_string"(self) {
 }
 
 fn "core:json/JsonDeserializer::skip_value"(self) {
-    let b: i32;
-    let r: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let c_4: i32;
-    let kr: ref null "core:serde//DeserializeError";
-    let e_6: ref "core:serde//DeserializeError";
-    let cr: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let vr: ref null "core:serde//DeserializeError";
-    let e_10: ref "core:serde//DeserializeError";
-    let c_11: i32;
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_4: char;
+    let __local_6: ref "core:serde//DeserializeError";
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_10: ref "core:serde//DeserializeError";
+    let __local_11: char;
     let __local_12: ref "core:prelude/string.wado//String";
     let __local_13: ref "core:prelude/format.wado//Formatter";
+    let __local_14: ref "core:prelude/string.wado//String";
+    let __local_15: i64;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: i32;
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/string.wado//String";
+    let __local_20: i32;
+    let __local_21: ref "core:prelude/string.wado//String";
+    let __local_22: i64;
+    let __local_23: ref "core:prelude/string.wado//String";
+    let __local_24: i32;
+    let __local_25: ref "core:prelude/string.wado//String";
+    let __local_26: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let __local_30: ref "core:prelude/string.wado//String";
+    let __local_31: ref "core:prelude/string.wado//String";
+    let __local_32: i32;
+    let __local_33: ref "core:prelude/string.wado//String";
+    let __local_34: i64;
+    let __local_35: ref "core:prelude/string.wado//String";
+    let __local_36: i64;
+    let __local_37: ref "core:prelude/string.wado//String";
+    let __local_38: i32;
+    let __local_39: ref "core:prelude/string.wado//String";
+    let __local_40: i64;
+    let __local_43: ref "core:prelude/string.wado//String";
+    let __local_44: i64;
+    "core:json/JsonDeserializer::skip_whitespace"(self);
+    if self.pos >= __inline_String__len_0: block -> i32 {
+        __local_14 = self.input;
+        break __inline_String__len_0: __local_14.used;
+    } {
+        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_15 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_15 };
+        });
+    }
+    b = __inline_String__get_byte_2: block -> u8 {
+        __local_16 = self.input;
+        __local_17 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_16.repr, __local_17);
+    } & 255;
+    if b == 34 {
+        return "core:json/JsonDeserializer::skip_string"(self);
+        unreachable;
+    } else if b == 116 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        unreachable;
+    } else if b == 102 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        unreachable;
+    } else if b == 110 {
+        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
+        unreachable;
+    } else if b == 91 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_3: block -> i32 {
+            __local_18 = self.input;
+            break __inline_String__len_3: __local_18.used;
+        } -> i32 {
+            __inline_String__get_byte_4: block -> u8 {
+                __local_19 = self.input;
+                __local_20 = self.pos;
+                break __inline_String__get_byte_4: builtin::array_get_u8(__local_19.repr, __local_20);
+            } == 93;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l469: loop {
+                let __match_scrut_5: ref null "core:serde//DeserializeError";
+                __match_scrut_5 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_5) {
+                } else if ref.is_null(__match_scrut_5) == 0 {
+                    let __cast_4: ref null "core:serde//DeserializeError";
+                    __cast_4 = ref.as_non_null(__match_scrut_5);
+                    __local_3 = ref.as_non_null(__cast_4);
+                    return __local_3;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_5: block -> i32 {
+                    __local_21 = self.input;
+                    break __inline_String__len_5: __local_21.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
+                        __local_22 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_22 };
+                    });
+                }
+                __local_4 = __inline_String__get_byte_7: block -> u8 {
+                    __local_23 = self.input;
+                    __local_24 = self.pos;
+                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_23.repr, __local_24);
+                } & 255;
+                if __local_4 == 93 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_4 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
+                        __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
+                        __local_26 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_25, offset: __local_26 };
+                    });
+                    unreachable;
+                }
+                continue l469;
+            };
+        };
+    } else if b == 123 {
+        self.pos = self.pos + 1;
+        "core:json/JsonDeserializer::skip_whitespace"(self);
+        if (if self.pos < __inline_String__len_9: block -> i32 {
+            __local_27 = self.input;
+            break __inline_String__len_9: __local_27.used;
+        } -> i32 {
+            __inline_String__get_byte_10: block -> u8 {
+                __local_28 = self.input;
+                __local_29 = self.pos;
+                break __inline_String__get_byte_10: builtin::array_get_u8(__local_28.repr, __local_29);
+            } == 125;
+        } else {
+            0;
+        }) {
+            self.pos = self.pos + 1;
+            return ref.null none;
+        }
+        block {
+            l479: loop {
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if (if self.pos >= __inline_String__len_11: block -> i32 {
+                    __local_30 = self.input;
+                    break __inline_String__len_11: __local_30.used;
+                } -> i32 {
+                    1;
+                } else {
+                    __inline_String__get_byte_12: block -> u8 {
+                        __local_31 = self.input;
+                        __local_32 = self.pos;
+                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_31.repr, __local_32);
+                    } != 34;
+                }) {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
+                        __local_33 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+                        __local_34 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_33, offset: __local_34 };
+                    });
+                }
+                let __match_scrut_1: ref null "core:serde//DeserializeError";
+                __match_scrut_1 = "core:json/JsonDeserializer::skip_string"(self);
+                if ref.is_null(__match_scrut_1) {
+                } else if ref.is_null(__match_scrut_1) == 0 {
+                    let __cast_1: ref null "core:serde//DeserializeError";
+                    __cast_1 = ref.as_non_null(__match_scrut_1);
+                    __local_6 = ref.as_non_null(__cast_1);
+                    return __local_6;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_2: ref null "core:serde//DeserializeError";
+                __match_scrut_2 = "core:json/JsonDeserializer::expect_char"(self, 58);
+                if ref.is_null(__match_scrut_2) {
+                } else if ref.is_null(__match_scrut_2) == 0 {
+                    let __cast_2: ref null "core:serde//DeserializeError";
+                    __cast_2 = ref.as_non_null(__match_scrut_2);
+                    __local_8 = ref.as_non_null(__cast_2);
+                    return __local_8;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                let __match_scrut_3: ref null "core:serde//DeserializeError";
+                __match_scrut_3 = "core:json/JsonDeserializer::skip_value"(self);
+                if ref.is_null(__match_scrut_3) {
+                } else if ref.is_null(__match_scrut_3) == 0 {
+                    let __cast_3: ref null "core:serde//DeserializeError";
+                    __cast_3 = ref.as_non_null(__match_scrut_3);
+                    __local_10 = ref.as_non_null(__cast_3);
+                    return __local_10;
+                    unreachable;
+                } else {
+                    unreachable;
+                }
+                "core:json/JsonDeserializer::skip_whitespace"(self);
+                if self.pos >= __inline_String__len_14: block -> i32 {
+                    __local_35 = self.input;
+                    break __inline_String__len_14: __local_35.used;
+                } {
+                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
+                        __local_36 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_36 };
+                    });
+                }
+                __local_11 = __inline_String__get_byte_16: block -> u8 {
+                    __local_37 = self.input;
+                    __local_38 = self.pos;
+                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_37.repr, __local_38);
+                } & 255;
+                if __local_11 == 125 {
+                    self.pos = self.pos + 1;
+                    return ref.null none;
+                    unreachable;
+                } else if __local_11 == 44 {
+                    self.pos = self.pos + 1;
+                } else {
+                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
+                        __local_39 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
+                        __local_40 = builtin::i64_extend_i32_s(self.pos);
+                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_39, offset: __local_40 };
+                    });
+                    unreachable;
+                }
+                continue l479;
+            };
+        };
+    } else {
+        if (if b == 45 -> i32 {
+            1;
+        } else if 48 <= b -> i32 {
+            b <= 57;
+        } else {
+            0;
+        }) {
+            "core:json/JsonDeserializer::skip_number"(self);
+            return ref.null none;
+        }
+        return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
+            __local_43 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
+                "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
+                __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
+                "core:prelude/primitive.wado/char^Display::fmt"(b, __local_13);
+                "core:prelude/string.wado/String::push"(__local_12, 39);
+                break __tmpl: __local_12;
+            };
+            __local_44 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
+        });
+        unreachable;
+    }
+}
+
+fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
+    let __local_2: ref "core:serde//DeserializeError";
+    let key_start: i32;
+    let has_escape: bool;
+    let b: i32;
+    let key_end: i32;
+    let __local_8: ref "core:serde//DeserializeError";
+    let __local_9: i32;
+    let idx_10: i32;
+    let __local_11: ref "core:prelude/string.wado//String";
+    let __local_12: ref "core:serde//DeserializeError";
+    let key: ref "core:prelude/string.wado//String";
+    let __local_15: ref "core:serde//DeserializeError";
+    let __local_16: i32;
+    let idx_17: i32;
     let __local_18: ref "core:prelude/string.wado//String";
     let __local_19: i64;
     let __local_20: ref "core:prelude/string.wado//String";
@@ -4411,464 +4867,244 @@ fn "core:json/JsonDeserializer::skip_value"(self) {
     let __local_25: ref "core:prelude/string.wado//String";
     let __local_26: i64;
     let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: i64;
-    let __local_31: ref "core:prelude/string.wado//String";
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i32;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
-    let __local_37: ref "core:prelude/string.wado//String";
-    let __local_38: i64;
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
-    let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_47: ref "core:prelude/string.wado//String";
-    let __local_48: i64;
-    let _hfs_pos_49: i32;
-    let _hfs_pos_50: i32;
-    "core:json/JsonDeserializer::skip_whitespace"(self);
-    if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_18 = self.input;
-        break __inline_String__len_0: __local_18.used;
-    } {
-        return ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_19 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
-        });
-    }
-    b = __inline_String__get_byte_2: block -> u8 {
-        __local_20 = self.input;
-        __local_21 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
-    };
-    if b == 34 {
-        return "core:json/JsonDeserializer::skip_string"(self);
-    }
-    if b == 116 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-    }
-    if b == 102 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-    }
-    if b == 110 {
-        return "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("null"), used: 4 });
-    }
-    if b == 91 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_3: block -> i32 {
-            __local_22 = self.input;
-            break __inline_String__len_3: __local_22.used;
-        } -> i32 {
-            __inline_String__get_byte_4: block -> u8 {
-                __local_23 = self.input;
-                __local_24 = self.pos;
-                break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
-            } == 93;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_49 = self.pos;
-        block {
-            l447: loop {
-                self.pos = _hfs_pos_49;
-                r = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_49 = self.pos;
-                if ref.is_null(r) == 0 {
-                    e_3 = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-                    self.pos = _hfs_pos_49;
-                    return e_3;
-                }
-                self.pos = _hfs_pos_49;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_49 = self.pos;
-                if _hfs_pos_49 >= __inline_String__len_5: block -> i32 {
-                    __local_25 = self.input;
-                    self.pos = _hfs_pos_49;
-                    break __inline_String__len_5: __local_25.used;
-                } {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__eof_6: block -> ref "core:serde//DeserializeError" {
-                        __local_26 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__eof_6: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
-                    });
-                }
-                c_4 = __inline_String__get_byte_7: block -> u8 {
-                    __local_27 = self.input;
-                    __local_28 = _hfs_pos_49;
-                    break __inline_String__get_byte_7: builtin::array_get_u8(__local_27.repr, __local_28);
-                };
-                if c_4 == 93 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                    self.pos = _hfs_pos_49;
-                    return ref.null none;
-                }
-                if c_4 == 44 {
-                    _hfs_pos_49 = _hfs_pos_49 + 1;
-                } else {
-                    self.pos = _hfs_pos_49;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_8: block -> ref "core:serde//DeserializeError" {
-                        __local_29 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or ']'"), used: 19 };
-                        __local_30 = builtin::i64_extend_i32_s(_hfs_pos_49);
-                        self.pos = _hfs_pos_49;
-                        break __inline_DeserializeError__malformed_8: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_29, offset: __local_30 };
-                    });
-                }
-                continue l447;
-            };
-        };
-        self.pos = _hfs_pos_49;
-    }
-    if b == 123 {
-        self.pos = self.pos + 1;
-        "core:json/JsonDeserializer::skip_whitespace"(self);
-        if (if self.pos < __inline_String__len_9: block -> i32 {
-            __local_31 = self.input;
-            break __inline_String__len_9: __local_31.used;
-        } -> i32 {
-            __inline_String__get_byte_10: block -> u8 {
-                __local_32 = self.input;
-                __local_33 = self.pos;
-                break __inline_String__get_byte_10: builtin::array_get_u8(__local_32.repr, __local_33);
-            } == 125;
-        } else {
-            0;
-        }) {
-            self.pos = self.pos + 1;
-            return ref.null none;
-        }
-        _hfs_pos_50 = self.pos;
-        block {
-            l456: loop {
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if (if _hfs_pos_50 >= __inline_String__len_11: block -> i32 {
-                    __local_34 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_11: __local_34.used;
-                } -> i32 {
-                    1;
-                } else {
-                    __inline_String__get_byte_12: block -> u8 {
-                        __local_35 = self.input;
-                        __local_36 = _hfs_pos_50;
-                        self.pos = _hfs_pos_50;
-                        break __inline_String__get_byte_12: builtin::array_get_u8(__local_35.repr, __local_36);
-                    } != 34;
-                }) {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_13: block -> ref "core:serde//DeserializeError" {
-                        __local_37 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-                        __local_38 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_13: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_37, offset: __local_38 };
-                    });
-                }
-                self.pos = _hfs_pos_50;
-                kr = "core:json/JsonDeserializer::skip_string"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(kr) == 0 {
-                    e_6 = value_copy "core:serde//DeserializeError"(ref.as_non_null(kr));
-                    self.pos = _hfs_pos_50;
-                    return e_6;
-                }
-                self.pos = _hfs_pos_50;
-                cr = "core:json/JsonDeserializer::expect_char"(self, 58);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(cr) == 0 {
-                    e_8 = value_copy "core:serde//DeserializeError"(ref.as_non_null(cr));
-                    self.pos = _hfs_pos_50;
-                    return e_8;
-                }
-                self.pos = _hfs_pos_50;
-                vr = "core:json/JsonDeserializer::skip_value"(self);
-                _hfs_pos_50 = self.pos;
-                if ref.is_null(vr) == 0 {
-                    e_10 = value_copy "core:serde//DeserializeError"(ref.as_non_null(vr));
-                    self.pos = _hfs_pos_50;
-                    return e_10;
-                }
-                self.pos = _hfs_pos_50;
-                "core:json/JsonDeserializer::skip_whitespace"(self);
-                _hfs_pos_50 = self.pos;
-                if _hfs_pos_50 >= __inline_String__len_14: block -> i32 {
-                    __local_39 = self.input;
-                    self.pos = _hfs_pos_50;
-                    break __inline_String__len_14: __local_39.used;
-                } {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__eof_15: block -> ref "core:serde//DeserializeError" {
-                        __local_40 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__eof_15: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
-                    });
-                }
-                c_11 = __inline_String__get_byte_16: block -> u8 {
-                    __local_41 = self.input;
-                    __local_42 = _hfs_pos_50;
-                    break __inline_String__get_byte_16: builtin::array_get_u8(__local_41.repr, __local_42);
-                };
-                if c_11 == 125 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                    self.pos = _hfs_pos_50;
-                    return ref.null none;
-                }
-                if c_11 == 44 {
-                    _hfs_pos_50 = _hfs_pos_50 + 1;
-                } else {
-                    self.pos = _hfs_pos_50;
-                    return ref.as_non_null(__inline_DeserializeError__malformed_17: block -> ref "core:serde//DeserializeError" {
-                        __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected ',' or '}'"), used: 19 };
-                        __local_44 = builtin::i64_extend_i32_s(_hfs_pos_50);
-                        self.pos = _hfs_pos_50;
-                        break __inline_DeserializeError__malformed_17: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_43, offset: __local_44 };
-                    });
-                }
-                continue l456;
-            };
-        };
-        self.pos = _hfs_pos_50;
-    }
-    if (if b == 45 -> i32 {
-        1;
-    } else if b >= 48 -> i32 {
-        b <= 57;
-    } else {
-        0;
-    }) {
-        "core:json/JsonDeserializer::skip_number"(self);
-        return ref.null none;
-    }
-    return ref.as_non_null(__inline_DeserializeError__malformed_20: block -> ref "core:serde//DeserializeError" {
-        __local_47 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-            __local_12 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(39), used: 0 };
-            "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected character '"), used: 22 });
-            __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
-            "core:prelude/primitive.wado/char^Display::fmt"(b & 255, __local_13);
-            "core:prelude/string.wado/String::push"(__local_12, 39);
-            break __tmpl: __local_12;
-        };
-        __local_48 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__malformed_20: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_47, offset: __local_48 };
-    });
-}
-
-fn "core:json/JsonStructAccess^DeserializeStruct::next_field"(self) {
-    let r_1: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let key_start: i32;
-    let has_escape: bool;
-    let b: i32;
-    let key_end: i32;
-    let r_7: ref null "core:serde//DeserializeError";
-    let e_8: ref "core:serde//DeserializeError";
-    let idx_9: ref "core:prelude/types.wado//Option<i32>";
-    let i_10: i32;
-    let key_r: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let key: ref "core:prelude/string.wado//String";
-    let r_13: ref null "core:serde//DeserializeError";
-    let e_14: ref "core:serde//DeserializeError";
-    let idx_15: ref "core:prelude/types.wado//Option<i32>";
-    let i_16: i32;
-    let e_17: ref "core:serde//DeserializeError";
-    let __local_25: ref "core:prelude/string.wado//String";
-    let __local_26: i64;
-    let __local_27: ref "core:prelude/string.wado//String";
-    let __local_28: i32;
-    let __local_29: ref "core:prelude/string.wado//String";
-    let __local_30: ref "core:prelude/string.wado//String";
-    let __local_31: i32;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: i64;
-    let __local_34: ref "core:prelude/string.wado//String";
-    let __local_35: ref "core:prelude/string.wado//String";
-    let __local_36: i32;
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_25 = self.de.input;
-        break __inline_String__len_0: __local_25.used;
+        __local_18 = self.de.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_26 };
+            __local_19 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_27 = self.de.input;
-        __local_28 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_27.repr, __local_28);
+        __local_20 = self.de.input;
+        __local_21 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } == 125 {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r_1 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r_1) == 0 {
-            e_2 = ref.as_non_null(r_1);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if (if self.de.pos >= __inline_String__len_3: block -> i32 {
-        __local_29 = self.de.input;
-        break __inline_String__len_3: __local_29.used;
+        __local_22 = self.de.input;
+        break __inline_String__len_3: __local_22.used;
     } -> i32 {
         1;
     } else {
         __inline_String__get_byte_4: block -> u8 {
-            __local_30 = self.de.input;
-            __local_31 = self.de.pos;
-            break __inline_String__get_byte_4: builtin::array_get_u8(__local_30.repr, __local_31);
+            __local_23 = self.de.input;
+            __local_24 = self.de.pos;
+            break __inline_String__get_byte_4: builtin::array_get_u8(__local_23.repr, __local_24);
         } != 34;
     }) {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_5: block -> ref "core:serde//DeserializeError" {
-            __local_32 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
-            __local_33 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_32, offset: __local_33 };
+            __local_25 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string key"), used: 19 };
+            __local_26 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__unexpected_type_5: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_25, offset: __local_26 };
         }) };
     }
     self.de.pos = self.de.pos + 1;
     key_start = self.de.pos;
     has_escape = 0;
-    b474: block {
-        l475: loop {
+    b501: block {
+        l502: loop {
             if self.de.pos >= __inline_String__len_6: block -> i32 {
-                __local_34 = self.de.input;
-                break __inline_String__len_6: __local_34.used;
+                __local_27 = self.de.input;
+                break __inline_String__len_6: __local_27.used;
             } {
-                break b474;
+                break b501;
             }
             b = __inline_String__get_byte_7: block -> u8 {
-                __local_35 = self.de.input;
-                __local_36 = self.de.pos;
-                break __inline_String__get_byte_7: builtin::array_get_u8(__local_35.repr, __local_36);
+                __local_28 = self.de.input;
+                __local_29 = self.de.pos;
+                break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
             };
             if b == 34 {
-                break b474;
+                break b501;
             }
             if b == 92 {
                 has_escape = 1;
-                break b474;
+                break b501;
             }
             self.de.pos = self.de.pos + 1;
-            continue l475;
+            continue l502;
         };
     };
     if has_escape == 0 {
         key_end = self.de.pos;
         self.de.pos = self.de.pos + 1;
-        r_7 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_7) == 0 {
-            e_8 = ref.as_non_null(r_7);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_8 };
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_1);
+            __local_8 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
+            unreachable;
+        } else {
+            unreachable;
         }
-        idx_9 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_0: ref "canonical//CanonicalClosure_0";
-            __indirect_call_0 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_0.func, __indirect_call_0.env, self.de.input, key_start, key_end);
+        let __match_scrut_2: ref "core:prelude/types.wado//Option<i32>";
+        __match_scrut_2 = block -> ref "core:prelude/types.wado//Option<i32>" {
+            let __indirect_call_2: ref "canonical//CanonicalClosure_0";
+            __indirect_call_2 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_2.func, __indirect_call_2.env, self.de.input, key_start, key_end);
         };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_9) {
-            i_10 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_9).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_10 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+        idx_10 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2) -> i32 {
+            let __cast_4: ref "core:prelude/types.wado//Option<i32>::Some";
+            __cast_4 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_2);
+            __local_9 = __cast_4.payload_0;
+            __local_9;
+        } else if __match_scrut_2.discriminant == 1 -> i32 {
+            -1;
+        } else {
+            unreachable;
+        });
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_10 } };
     }
     self.de.pos = key_start - 1;
-    key_r = "core:json/JsonDeserializer::read_json_string"(self.de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r) {
-        key = value_copy "core:prelude/string.wado//String"(ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(key_r).payload_0);
-        r_13 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
-        if ref.is_null(r_13) == 0 {
-            e_14 = ref.as_non_null(r_13);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_14 };
-        }
-        idx_15 = block -> ref "core:prelude/types.wado//Option<i32>" {
-            let __indirect_call_1: ref "canonical//CanonicalClosure_0";
-            __indirect_call_1 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
-            call_ref "functype/$canonical_closure_fn_0"(__indirect_call_1.func, __indirect_call_1.env, key, 0, key.used);
-        };
-        if ref.test "core:prelude/types.wado//Option<i32>::Some"(idx_15) {
-            i_16 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(idx_15).payload_0;
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: i_16 } };
-        }
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: -1 } };
+    key = value_copy "core:prelude/string.wado//String"(let __match_scrut_3: ref "core:prelude/types.wado//Result<String,DeserializeError>"; __match_scrut_3 = "core:json/JsonDeserializer::read_json_string"(self.de); (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_6: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_6 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_3);
+        __local_11 = __cast_6.payload_0;
+        __local_11;
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3) -> ref "core:prelude/string.wado//String" {
+        let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_3);
+        __local_12 = __cast_5.payload_0;
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_12 };
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    let __match_scrut_4: ref null "core:serde//DeserializeError";
+    __match_scrut_4 = "core:json/JsonDeserializer::expect_char"(self.de, 58);
+    if ref.is_null(__match_scrut_4) {
+    } else if ref.is_null(__match_scrut_4) == 0 {
+        let __cast_7: ref null "core:serde//DeserializeError";
+        __cast_7 = ref.as_non_null(__match_scrut_4);
+        __local_15 = ref.as_non_null(__cast_7);
+        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_15 };
+        unreachable;
+    } else {
+        unreachable;
     }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r) {
-        e_17 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(key_r).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_17 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    let __match_scrut_5: ref "core:prelude/types.wado//Option<i32>";
+    __match_scrut_5 = block -> ref "core:prelude/types.wado//Option<i32>" {
+        let __indirect_call_7: ref "canonical//CanonicalClosure_0";
+        __indirect_call_7 = ref.cast "canonical//CanonicalClosure_0"(self.lookup);
+        call_ref "functype/$canonical_closure_fn_0"(__indirect_call_7.func, __indirect_call_7.env, key, 0, key.used);
+    };
+    idx_17 = (if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5) -> i32 {
+        let __cast_9: ref "core:prelude/types.wado//Option<i32>::Some";
+        __cast_9 = ref.cast "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_5);
+        __local_16 = __cast_9.payload_0;
+        __local_16;
+    } else if __match_scrut_5.discriminant == 1 -> i32 {
+        -1;
+    } else {
+        unreachable;
+    });
+    return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: idx_17 } };
 }
 
 fn "core:json/JsonDeserializer^Deserializer::deserialize_bool"(self) {
-    let b: i32;
-    let r_2: ref null "core:serde//DeserializeError";
-    let e_3: ref "core:serde//DeserializeError";
-    let r_4: ref null "core:serde//DeserializeError";
-    let e_5: ref "core:serde//DeserializeError";
+    let b: char;
+    let __local_3: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:serde//DeserializeError";
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
     let __local_8: ref "core:prelude/string.wado//String";
-    let __local_9: i64;
+    let __local_9: i32;
     let __local_10: ref "core:prelude/string.wado//String";
-    let __local_11: i32;
-    let __local_12: ref "core:prelude/string.wado//String";
-    let __local_13: i64;
+    let __local_11: i64;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_8 = self.input;
-        break __inline_String__len_0: __local_8.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_9 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_9 };
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
         }) };
     }
     b = __inline_String__get_byte_2: block -> u8 {
-        __local_10 = self.input;
-        __local_11 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_10.repr, __local_11);
-    };
+        __local_8 = self.input;
+        __local_9 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_8.repr, __local_9);
+    } & 255;
     if b == 116 {
-        r_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
-        if ref.is_null(r_2) == 0 {
-            e_3 = ref.as_non_null(r_2);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_3 };
+        let __match_scrut_2: ref null "core:serde//DeserializeError";
+        __match_scrut_2 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("true"), used: 4 });
+        if ref.is_null(__match_scrut_2) {
+        } else if ref.is_null(__match_scrut_2) == 0 {
+            let __cast_2: ref null "core:serde//DeserializeError";
+            __cast_2 = ref.as_non_null(__match_scrut_2);
+            __local_3 = ref.as_non_null(__cast_2);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_3 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 1 };
-    }
-    if b == 102 {
-        r_4 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
-        if ref.is_null(r_4) == 0 {
-            e_5 = ref.as_non_null(r_4);
-            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
+        unreachable;
+    } else if b == 102 {
+        let __match_scrut_1: ref null "core:serde//DeserializeError";
+        __match_scrut_1 = "core:json/JsonDeserializer::expect_literal"(self, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("false"), used: 5 });
+        if ref.is_null(__match_scrut_1) {
+        } else if ref.is_null(__match_scrut_1) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_1);
+            __local_5 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: __local_5 };
+            unreachable;
+        } else {
+            unreachable;
         }
         return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Ok" { discriminant: 0, payload_0: 0 };
+        unreachable;
+    } else {
+        return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
+            __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
+            __local_11 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_10, offset: __local_11 };
+        }) };
+        unreachable;
     }
-    return struct.new "core:prelude/types.wado//Result<bool,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-        __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected bool"), used: 13 };
-        __local_13 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_12, offset: __local_13 };
-    }) };
+    unreachable;
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_struct"(self, lookup) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 123);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//DeserializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __local_5: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 123);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_5 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_5;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, struct.new "core:json//JsonStructAccess" { de: self, lookup: lookup, first: 1 }, ref.null none;
 }
@@ -4880,13 +5116,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l495: loop {
+            l529: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l495;
+                continue l529;
             };
         };
     };
@@ -4979,10 +5215,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_8 = content_len - 1;
         _licm_buf_29 = self.buf;
         _licm_repr_33 = _licm_buf_29.repr;
-        b505: block {
-            l506: loop {
+        b539: block {
+            l540: loop {
                 if i_8 < 0 {
-                    break b505;
+                    break b539;
                 }
                 index_14 = (start_pos + left_pad) + i_8;
                 value_15 = __inline_String__get_byte_2: block -> u8 {
@@ -4991,7 +5227,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_33, index_14, value_15);
                 i_8 = i_8 - 1;
-                continue l506;
+                continue l540;
             };
         };
         __for_1: block {
@@ -4999,14 +5235,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_30 = self.buf;
             _licm_repr_34 = _licm_buf_30.repr;
             block {
-                l509: loop {
+                l543: loop {
                     if j_9 >= left_pad {
                         break __for_1;
                     }
                     index_19 = start_pos + j_9;
                     builtin::array_set_u8(_licm_repr_34, index_19, fill_byte);
                     j_9 = j_9 + 1;
-                    continue l509;
+                    continue l543;
                 };
             };
         };
@@ -5016,10 +5252,10 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
         i_10 = content_len - 1;
         _licm_buf_31 = self.buf;
         _licm_repr_35 = _licm_buf_31.repr;
-        b511: block {
-            l512: loop {
+        b545: block {
+            l546: loop {
                 if i_10 < 0 {
-                    break b511;
+                    break b545;
                 }
                 index_22 = (start_pos + padding) + i_10;
                 value_23 = __inline_String__get_byte_5: block -> u8 {
@@ -5028,7 +5264,7 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
                 };
                 builtin::array_set_u8(_licm_repr_35, index_22, value_23);
                 i_10 = i_10 - 1;
-                continue l512;
+                continue l546;
             };
         };
         __for_2: block {
@@ -5036,14 +5272,14 @@ fn "core:prelude/format.wado/Formatter::apply_padding"(self, start_pos) {
             _licm_buf_32 = self.buf;
             _licm_repr_36 = _licm_buf_32.repr;
             block {
-                l515: loop {
+                l549: loop {
                     if j_11 >= padding {
                         break __for_2;
                     }
                     index_27 = start_pos + j_11;
                     builtin::array_set_u8(_licm_repr_36, index_27, fill_byte);
                     j_11 = j_11 + 1;
-                    continue l515;
+                    continue l549;
                 };
             };
         };
@@ -5147,8 +5383,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b534: block {
-        l535: loop {
+    b568: block {
+        l569: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -5173,9 +5409,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b534;
+                break b568;
             }
-            continue l535;
+            continue l569;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -5210,13 +5446,13 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l544: loop {
+            l578: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
                 i = i + 1;
-                continue l544;
+                continue l578;
             };
         };
     };
@@ -5343,8 +5579,8 @@ fn "wado-compiler/tests/fixtures/serde_synth.wado/Config^Deserialize::deserializ
         host = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
         port = 0;
         debug = 0;
-        b551: block {
-            l552: loop {
+        b585: block {
+            l586: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -5362,7 +5598,7 @@ fn "wado-compiler/tests/fixtures/serde_synth.wado/Config^Deserialize::deserializ
                                 host = __local_11;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_10).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_10).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_12 = __inline_i32_Deserialize__deserialize_JsonDeserializer__6: block -> ref "core:prelude/types.wado//Result<i32,DeserializeError>" {
@@ -5375,7 +5611,7 @@ fn "wado-compiler/tests/fixtures/serde_synth.wado/Config^Deserialize::deserializ
                                 port = __local_13;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_12).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_12).payload_0 };
                             }
                         } else if __idx == 2 {
                             __local_14 = __inline_bool_Deserialize__deserialize_JsonDeserializer__8: block -> ref "core:prelude/types.wado//Result<bool,DeserializeError>" {
@@ -5388,27 +5624,27 @@ fn "wado-compiler/tests/fixtures/serde_synth.wado/Config^Deserialize::deserializ
                                 debug = __local_15;
                                 seen = seen | 4;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__local_14).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__local_14).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b551;
+                        break b585;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l552;
+                continue l586;
             };
         };
         if (seen & 7) != 7 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_synth.wado//Config" { host: host, port: port, debug: debug }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_synth.wado//Config" { host: host, port: port, debug: debug } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<Config,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 
@@ -5457,8 +5693,8 @@ fn "wado-compiler/tests/fixtures/serde_synth.wado/User^Deserialize::deserialize<
         user_name = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
         age = 0;
         active = 0;
-        b563: block {
-            l564: loop {
+        b597: block {
+            l598: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -5476,7 +5712,7 @@ fn "wado-compiler/tests/fixtures/serde_synth.wado/User^Deserialize::deserialize<
                                 user_name = __local_11;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_10).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__local_10).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_12 = __inline_i32_Deserialize__deserialize_JsonDeserializer__6: block -> ref "core:prelude/types.wado//Result<i32,DeserializeError>" {
@@ -5489,7 +5725,7 @@ fn "wado-compiler/tests/fixtures/serde_synth.wado/User^Deserialize::deserialize<
                                 age = __local_13;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_12).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__local_12).payload_0 };
                             }
                         } else if __idx == 2 {
                             __local_14 = __inline_bool_Deserialize__deserialize_JsonDeserializer__8: block -> ref "core:prelude/types.wado//Result<bool,DeserializeError>" {
@@ -5502,27 +5738,27 @@ fn "wado-compiler/tests/fixtures/serde_synth.wado/User^Deserialize::deserialize<
                                 active = __local_15;
                                 seen = seen | 4;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__local_14).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<bool,DeserializeError>::Err"(__local_14).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b563;
+                        break b597;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l564;
+                continue l598;
             };
         };
         if (seen & 7) != 7 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_synth.wado//User" { user_name: user_name, age: age, active: active }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_synth.wado//User" { user_name: user_name, age: age, active: active } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<User,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 
@@ -5552,8 +5788,8 @@ fn "wado-compiler/tests/fixtures/serde_synth.wado/Point^Deserialize::deserialize
         seen = 0;
         x = 0;
         y = 0;
-        b575: block {
-            l576: loop {
+        b609: block {
+            l610: loop {
                 __next = "core:json/JsonStructAccess^DeserializeStruct::next_field"(sd);
                 __pattern_temp_1 = __next;
                 if ref.test "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok"(__pattern_temp_1) {
@@ -5571,7 +5807,7 @@ fn "wado-compiler/tests/fixtures/serde_synth.wado/Point^Deserialize::deserialize
                                 x = __local_10;
                                 seen = seen | 1;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__local_9).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__local_9).payload_0 };
                             }
                         } else if __idx == 1 {
                             __local_11 = __inline_f64_Deserialize__deserialize_JsonDeserializer__5: block -> ref "core:prelude/types.wado//Result<f64,DeserializeError>" {
@@ -5584,27 +5820,27 @@ fn "wado-compiler/tests/fixtures/serde_synth.wado/Point^Deserialize::deserialize
                                 y = __local_12;
                                 seen = seen | 2;
                             } else {
-                                return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__local_11).payload_0;
+                                return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<f64,DeserializeError>::Err"(__local_11).payload_0 };
                             }
                         } else {
                             drop("core:json/JsonDeserializer::skip_value"(sd.de));
                         }
                     } else {
-                        break b575;
+                        break b609;
                     }
                 } else {
-                    return 1, ref.null none, ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0;
+                    return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: ref.cast "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err"(__next).payload_0 };
                 }
-                continue l576;
+                continue l610;
             };
         };
         if (seen & 3) != 3 {
-            return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 };
+            return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 1, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("required field missing"), used: 22 }, offset: -1_i64 } };
         }
         drop("core:json/JsonDeserializer::expect_char"(sd.de, 125));
-        return 0, struct.new "wado-compiler/tests/fixtures/serde_synth.wado//Point" { x: x, y: y }, ref.null none;
+        return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "wado-compiler/tests/fixtures/serde_synth.wado//Point" { x: x, y: y } };
     } else {
-        return 1, ref.null none, struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 };
+        return struct.new "core:prelude/types.wado//Result<Point,DeserializeError>::Err" { discriminant: 1, payload_0: struct.new "core:serde//DeserializeError" { kind: 9, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("begin_struct failed"), used: 19 }, offset: -1_i64 } };
     }
 }
 

--- a/wado-compiler/tests/fixtures.golden/static_method_in_generic_context.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/static_method_in_generic_context.wir.wado
@@ -50,131 +50,166 @@ struct wado-compiler/tests/fixtures/static_method_in_generic_context.wado//Foo {
     mut value: i32,
 }
 
-variant core:prelude/types.wado//Result<Foo,DeserializeError> {  // TypeId(9)
+variant core:prelude/types.wado//Option<char> {  // TypeId(9)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(10)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Result<Foo,DeserializeError> {  // TypeId(11)
     Ok(ref "wado-compiler/tests/fixtures/static_method_in_generic_context.wado//Foo"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Foo,DeserializeError>::Ok {  // TypeId(10)
+struct core:prelude/types.wado//Result<Foo,DeserializeError>::Ok {  // TypeId(12)
     discriminant: i32,
     payload_0: ref "wado-compiler/tests/fixtures/static_method_in_generic_context.wado//Foo",
 }
 
-struct core:prelude/types.wado//Result<Foo,DeserializeError>::Err {  // TypeId(11)
+struct core:prelude/types.wado//Result<Foo,DeserializeError>::Err {  // TypeId(13)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(12)
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(14)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(13)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(15)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(14)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(16)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(15)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(17)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(16)
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(18)
+    discriminant: i32,
+    payload_0: char,
+}
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(17)
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(19)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(18)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(20)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(19)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(21)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(20)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(22)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(21)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(23)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(22)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(24)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(23)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(25)
 
-type "functype//wado-compiler/tests/fixtures/static_method_in_generic_context.wado/__test_0_roundtrip" = fn();  // TypeId(24)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(26)
 
-type "functype//wado-compiler/tests/fixtures/static_method_in_generic_context.wado/__cm_export____test_0_roundtrip" = fn();  // TypeId(25)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(27)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(26)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(28)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(27)
+type "functype//wado-compiler/tests/fixtures/static_method_in_generic_context.wado/__test_0_roundtrip" = fn();  // TypeId(29)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(28)
+type "functype//wado-compiler/tests/fixtures/static_method_in_generic_context.wado/__cm_export____test_0_roundtrip" = fn();  // TypeId(30)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(29)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(31)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(30)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(32)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(31)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(33)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(32)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(34)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(33)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(35)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(34)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(36)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(35)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(37)
 
-type "functype//core:json/hex_digit" = fn(i32) -> char;  // TypeId(36)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(38)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(37)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(39)
 
-type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(38)
+type "functype//core:prelude/primitive.wado/write_base_digits" = fn(ref builtin::array<u8>, i32, i64, i32, i32, bool);  // TypeId(40)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(39)
+type "functype//core:prelude/primitive.wado/count_digits_base" = fn(i64, i32) -> i32;  // TypeId(41)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(40)
+type "functype//core:json/write_escaped_string" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(42)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(41)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(43)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(42)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(44)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(43)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(45)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(44)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(46)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(45)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(47)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(46)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(48)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(47)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(49)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(48)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(50)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(49)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(51)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(50)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(52)
 
-type "functype//wado-compiler/tests/fixtures/static_method_in_generic_context.wado/Foo^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Foo,DeserializeError>";  // TypeId(51)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(53)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(52)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(54)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(53)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(55)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(54)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(56)
 
-type "functype//core:json/core/json/from_string<Foo>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/static_method_in_generic_context.wado//Foo", ref null "core:serde//DeserializeError"];  // TypeId(55)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(57)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(56)
+type "functype//wado-compiler/tests/fixtures/static_method_in_generic_context.wado/Foo^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Foo,DeserializeError>";  // TypeId(58)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(57)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(59)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(58)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(60)
 
-type "functype//core:json/core/json/to_string<Foo>" = fn(i32) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(59)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(61)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(60)
+type "functype//core:json/core/json/from_string<Foo>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "wado-compiler/tests/fixtures/static_method_in_generic_context.wado//Foo", ref null "core:serde//DeserializeError"];  // TypeId(62)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(61)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(63)
 
-type "functype//wado-compiler/tests/fixtures/static_method_in_generic_context.wado/Foo^Serialize::serialize<JsonSerializer>" = fn(i32, ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(62)
+type "functype//core:json/core/json/to_string<Foo>" = fn(i32) -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//SerializeError"];  // TypeId(64)
+
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(65)
+
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(66)
+
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(67)
+
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(68)
+
+type "functype//core:prelude/primitive.wado/i64::fmt_base" = fn(i64, bool, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(69)
+
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(70)
+
+type "functype//core:prelude/primitive.wado/i32^LowerHex::fmt" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(71)
+
+type "functype//wado-compiler/tests/fixtures/static_method_in_generic_context.wado/Foo^Serialize::serialize<JsonSerializer>" = fn(i32, ref "core:prelude/string.wado//String") -> ref null "core:serde//SerializeError";  // TypeId(72)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -341,10 +376,6 @@ fn "core:internal/panic"(message) {
     unreachable;
 }
 
-fn "core:internal/unreachable"() {
-    unreachable;
-}
-
 fn "core:internal/cm_lower_list_u8"(data, len) {
     let ptr: i32;
     ptr = "mem/realloc"(0, 0, 1, len);
@@ -428,36 +459,77 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/hex_digit"(v) {
-    if v < 10 {
-        return (48 + v) & 255;
+fn "core:prelude/primitive.wado/write_base_digits"(arr, offset, abs_val, digit_count, base, upper) {
+    let base64: i64;
+    let pos: i32;
+    let temp: i64;
+    let digit: i32;
+    let ch: i32;
+    base64 = builtin::i64_extend_i32_s(base);
+    pos = offset + digit_count;
+    if abs_val == 0_i64 {
+        builtin::array_set_u8(arr, offset, 48);
+    } else {
+        __for_3: block {
+            temp = abs_val;
+            block {
+                l19: loop {
+                    if temp <= 0_i64 {
+                        break __for_3;
+                    }
+                    pos = pos - 1;
+                    digit = builtin::i32_wrap_i64(temp % base64);
+                    ch = (if digit < 10 -> i32 {
+                        48 + digit;
+                    } else if upper -> i32 {
+                        (65 + digit) - 10;
+                    } else {
+                        (97 + digit) - 10;
+                    });
+                    builtin::array_set_u8(arr, pos, ch & 255);
+                    temp = temp / base64;
+                    continue l19;
+                };
+            };
+        };
     }
-    return ((97 + v) - 10) & 255;
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
+fn "core:prelude/primitive.wado/count_digits_base"(val, base) {
+    let base64: i64;
+    let n: i32;
+    let t: i64;
+    if val == 0_i64 {
         return 1;
     }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
+    base64 = builtin::i64_extend_i32_s(base);
+    n = 0;
+    __for_4: block {
+        t = val;
+        block {
+            l25: loop {
+                if t <= 0_i64 {
+                    break __for_4;
+                }
+                n = n + 1;
+                t = t / base64;
+                continue l25;
+            };
+        };
+    };
+    return n;
 }
 
 fn "core:json/write_escaped_string"(buf, s) {
     let __iter_2: ref "core:prelude/string.wado//StrCharIter";
     let c: char;
-    let code: i32;
-    let hi: i32;
-    let lo: i32;
+    let __local_4: i32;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: ref "core:prelude/format.wado//Formatter";
     "core:prelude/string.wado/String::push"(buf, 34);
     __iter_2 = struct.new "core:prelude/string.wado//StrCharIter" { repr: s.repr, used: s.used, byte_index: 0 };
-    b21: block {
-        l22: loop {
+    b27: block {
+        l28: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -478,23 +550,25 @@ fn "core:json/write_escaped_string"(buf, s) {
                 } else if c == 9 {
                     "core:prelude/string.wado/String::push"(buf, 92);
                     "core:prelude/string.wado/String::push"(buf, 116);
-                } else if c <u 32 {
-                    "core:prelude/string.wado/String::push"(buf, 92);
-                    "core:prelude/string.wado/String::push"(buf, 117);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    "core:prelude/string.wado/String::push"(buf, 48);
-                    code = c;
-                    hi = (code >> 4) & 15;
-                    lo = code & 15;
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(hi));
-                    "core:prelude/string.wado/String::push"(buf, "core:json/hex_digit"(lo));
                 } else {
-                    "core:prelude/string.wado/String::push"(buf, c);
+                    if c <u 32 {
+                        __local_4 = c;
+                        "core:prelude/string.wado/String::push_str"(buf, __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(18), used: 0 };
+                            "core:prelude/string.wado/String::push"(__local_5, 92);
+                            "core:prelude/string.wado/String::push"(__local_5, 117);
+                            __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 48, align: 2, sign_plus: 0, zero_pad: 1, width: 4, precision: -1, indent: 0, buf: __local_5 };
+                            "core:prelude/primitive.wado/i32^LowerHex::fmt"(__local_4, __local_6);
+                            break __tmpl: __local_5;
+                        });
+                    } else {
+                        "core:prelude/string.wado/String::push"(buf, c);
+                    }
                 }
             } else {
-                break b21;
+                break b27;
             }
-            continue l22;
+            continue l28;
         };
     };
     "core:prelude/string.wado/String::push"(buf, 34);
@@ -502,60 +576,135 @@ fn "core:json/write_escaped_string"(buf, s) {
 
 fn "core:json/core/json/from_string<Foo>"(input) {
     let de: ref "core:json//JsonDeserializer";
-    let r: ref "core:prelude/types.wado//Result<Foo,DeserializeError>";
+    let __local_2: ref "wado-compiler/tests/fixtures/static_method_in_generic_context.wado//Foo";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "wado-compiler/tests/fixtures/static_method_in_generic_context.wado//Foo";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    r = "wado-compiler/tests/fixtures/static_method_in_generic_context.wado/Foo^Deserialize::deserialize<JsonDeserializer>"(de);
-    if ref.test "core:prelude/types.wado//Result<Foo,DeserializeError>::Ok"(r) {
-        v = value_copy "wado-compiler/tests/fixtures/static_method_in_generic_context.wado//Foo"(ref.cast "core:prelude/types.wado//Result<Foo,DeserializeError>::Ok"(r).payload_0);
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "wado-compiler/tests/fixtures/static_method_in_generic_context.wado//Foo"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Foo,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/static_method_in_generic_context.wado/Foo^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Foo,DeserializeError>::Ok"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/static_method_in_generic_context.wado//Foo" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Foo,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Foo,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Foo,DeserializeError>::Err"(__match_scrut_0) -> ref "wado-compiler/tests/fixtures/static_method_in_generic_context.wado//Foo" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Foo,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Foo,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if ref.test "core:prelude/types.wado//Result<Foo,DeserializeError>::Err"(r) {
-        e = value_copy "core:serde//DeserializeError"(ref.cast "core:prelude/types.wado//Result<Foo,DeserializeError>::Err"(r).payload_0);
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:json/core/json/to_string<Foo>"(value) {
     let ser: ref "core:json//JsonSerializer";
-    let r: ref null "core:serde//SerializeError";
-    let e: ref "core:serde//SerializeError";
+    let __local_3: ref "core:serde//SerializeError";
     ser = struct.new "core:json//JsonSerializer" { buf: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 } };
-    r = "wado-compiler/tests/fixtures/static_method_in_generic_context.wado/Foo^Serialize::serialize<JsonSerializer>"(value, ser.buf);
-    if ref.is_null(r) == 0 {
-        e = value_copy "core:serde//SerializeError"(ref.as_non_null(r));
-        return 1, ref.null none, e;
+    let __match_scrut_0: ref null "core:serde//SerializeError";
+    __match_scrut_0 = "wado-compiler/tests/fixtures/static_method_in_generic_context.wado/Foo^Serialize::serialize<JsonSerializer>"(value, ser.buf);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//SerializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_3 = ref.as_non_null(__cast_1);
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
     }
     return 0, ser.buf, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -578,6 +727,20 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     }, offset, abs_val, digit_count);
 }
 
+fn "core:prelude/primitive.wado/i64::fmt_base"(self, is_negative, f, base, upper, prefix) {
+    let abs_val: i64;
+    let digit_count: i32;
+    let offset: i32;
+    let __local_9: ref "core:prelude/string.wado//String";
+    abs_val = self;
+    digit_count = "core:prelude/primitive.wado/count_digits_base"(abs_val, base);
+    offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, prefix, digit_count);
+    "core:prelude/primitive.wado/write_base_digits"(__inline_String__internal_raw_bytes_0: block -> ref builtin::array<u8> {
+        __local_9 = f.buf;
+        break __inline_String__internal_raw_bytes_0: __local_9.repr;
+    }, offset, abs_val, digit_count, base, upper);
+}
+
 fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
     let s: ref "core:prelude/string.wado//String";
     let c: char;
@@ -589,6 +752,20 @@ fn "core:prelude/primitive.wado/char^Display::fmt"(self, f) {
         "core:prelude/string.wado/String::push"(s, self);
         "core:prelude/format.wado/Formatter::pad"(f, s);
     }
+}
+
+fn "core:prelude/primitive.wado/i32^LowerHex::fmt"(self, f) {
+    let v: i32;
+    let is_neg: bool;
+    let abs_val: i64;
+    v = self;
+    is_neg = v < 0;
+    abs_val = (if is_neg -> i64 {
+        0_i64 - builtin::i64_extend_i32_s(v);
+    } else {
+        builtin::i64_extend_i32_s(v);
+    });
+    "core:prelude/primitive.wado/i64::fmt_base"(abs_val, is_neg, f, 16, 0, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 });
 }
 
 fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
@@ -654,7 +831,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l45: loop {
+            l67: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -662,7 +839,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l45;
+                continue l67;
             };
         };
     };
@@ -713,6 +890,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     return 0, code_10;
 }
 
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
+}
+
 fn "core:prelude/string.wado/String::push"(self, c) {
     let code: u32;
     code = c;
@@ -751,10 +977,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b56: block {
-        l57: loop {
+    b85: block {
+        l86: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b56;
+                break b85;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -778,7 +1004,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l57;
+            continue l86;
         };
     };
     self.pos = _hfs_pos_8;
@@ -796,130 +1022,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b65: block {
-        l66: loop {
-            if scan_pos >= _licm_used_90 {
-                break b65;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b94: block {
+        l95: loop {
+            if scan_pos >= _licm_used_56 {
+                break b94;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b65;
+                break b94;
             }
             scan_pos = scan_pos + 1;
-            continue l66;
+            continue l95;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -928,22 +1126,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l73: loop {
+                l102: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l73;
+                    continue l102;
                 };
             };
         };
@@ -951,71 +1149,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l76: loop {
+            l105: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l76;
+                continue l105;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b78: block {
-        l79: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b107: block {
+        l108: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b78;
+                break b107;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -1033,125 +1232,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l79;
+            continue l108;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -1159,87 +1301,71 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l104: loop {
+            l128: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l104;
+                continue l128;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -1250,13 +1376,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l114: loop {
+            l134: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l114;
+                continue l134;
             };
         };
     };
@@ -1393,8 +1519,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b137: block {
-        l138: loop {
+    b157: block {
+        l158: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -1419,9 +1545,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b137;
+                break b157;
             }
-            continue l138;
+            continue l158;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);

--- a/wado-compiler/tests/fixtures.golden/string-truncate-panic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/string-truncate-panic.wir.wado
@@ -369,7 +369,7 @@ fn "core:prelude/string.wado/String::truncate"(self, byte_len) {
             "core:prelude/string.wado/String::push"(__local_10, 58);
             __local_11 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_10 };
             __local_17 = __local_11;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(358, __local_17);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(397, __local_17);
             "core:prelude/string.wado/String::push"(__local_10, 58);
             "core:prelude/string.wado/String::push"(__local_10, 32);
             "core:prelude/string.wado/String::push_str"(__local_10, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative length"), used: 15 });
@@ -407,7 +407,7 @@ condition: byte_len >= 0
                 "core:prelude/string.wado/String::push"(__local_12, 58);
                 __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
                 __local_28 = __local_13;
-                "core:prelude/primitive.wado/i32::fmt_decimal"(363, __local_28);
+                "core:prelude/primitive.wado/i32::fmt_decimal"(402, __local_28);
                 "core:prelude/string.wado/String::push"(__local_12, 58);
                 "core:prelude/string.wado/String::push"(__local_12, 32);
                 "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("not on a UTF-8 character boundary"), used: 33 });

--- a/wado-compiler/tests/fixtures.golden/variadic_deserialize.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variadic_deserialize.wir.wado
@@ -47,213 +47,259 @@ struct tuple//[i32, String] {  // TypeId(7)
     mut 1: ref "core:prelude/string.wado//String",
 }
 
-variant core:prelude/types.wado//Option<i32> {  // TypeId(8)
+variant core:prelude/types.wado//Option<char> {  // TypeId(8)
+    Some(char),
+    None,
+}
+
+struct core:prelude/types.wado//Option<char>::Some {  // TypeId(9)
+    discriminant: i32,
+    payload_0: char,
+}
+
+variant core:prelude/types.wado//Option<i32> {  // TypeId(10)
     Some(i32),
     None,
 }
 
-struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(9)
+struct core:prelude/types.wado//Option<i32>::Some {  // TypeId(11)
     discriminant: i32,
     payload_0: i32,
 }
 
-variant core:prelude/types.wado//Option<String> {  // TypeId(10)
+variant core:prelude/types.wado//Option<String> {  // TypeId(12)
     Some(ref "core:prelude/string.wado//String"),
     None,
 }
 
-variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(11)
+variant core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError> {  // TypeId(13)
+    Ok(ref "tuple//[i32, String]"),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Ok {  // TypeId(14)
+    discriminant: i32,
+    payload_0: ref "tuple//[i32, String]",
+}
+
+struct core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err {  // TypeId(15)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<String,DeserializeError> {  // TypeId(16)
     Ok(ref "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(12)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Ok {  // TypeId(17)
     discriminant: i32,
     payload_0: ref "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(13)
+struct core:prelude/types.wado//Result<String,DeserializeError>::Err {  // TypeId(18)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(14)
+variant core:prelude/types.wado//Result<char,DeserializeError> {  // TypeId(19)
+    Ok(char),
+    Err(ref "core:serde//DeserializeError"),
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Ok {  // TypeId(20)
+    discriminant: i32,
+    payload_0: char,
+}
+
+struct core:prelude/types.wado//Result<char,DeserializeError>::Err {  // TypeId(21)
+    discriminant: i32,
+    payload_0: ref "core:serde//DeserializeError",
+}
+
+variant core:prelude/types.wado//Result<i32,DeserializeError> {  // TypeId(22)
     Ok(i32),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(15)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Ok {  // TypeId(23)
     discriminant: i32,
     payload_0: i32,
 }
 
-struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(16)
+struct core:prelude/types.wado//Result<i32,DeserializeError>::Err {  // TypeId(24)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError> {  // TypeId(17)
+variant core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError> {  // TypeId(25)
     Ok(ref "core:json//JsonSeqAccess"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Ok {  // TypeId(18)
+struct core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Ok {  // TypeId(26)
     discriminant: i32,
     payload_0: ref "core:json//JsonSeqAccess",
 }
 
-struct core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err {  // TypeId(19)
+struct core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err {  // TypeId(27)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<String>,DeserializeError> {  // TypeId(20)
+variant core:prelude/types.wado//Result<Option<String>,DeserializeError> {  // TypeId(28)
     Ok(ref null "core:prelude/string.wado//String"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok {  // TypeId(21)
+struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok {  // TypeId(29)
     discriminant: i32,
     payload_0: ref null "core:prelude/string.wado//String",
 }
 
-struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err {  // TypeId(22)
+struct core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err {  // TypeId(30)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(23)
+variant core:prelude/types.wado//Result<Option<i32>,DeserializeError> {  // TypeId(31)
     Ok(ref "core:prelude/types.wado//Option<i32>"),
     Err(ref "core:serde//DeserializeError"),
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(24)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok {  // TypeId(32)
     discriminant: i32,
     payload_0: ref "core:prelude/types.wado//Option<i32>",
 }
 
-struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(25)
+struct core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err {  // TypeId(33)
     discriminant: i32,
     payload_0: ref "core:serde//DeserializeError",
 }
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(26)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(34)
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(27)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(35)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(28)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(36)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(29)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(37)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(30)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(38)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(31)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(39)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(32)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(40)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(33)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(41)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(34)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(42)
 
-type "functype//wado-compiler/tests/fixtures/variadic_deserialize.wado/__test_0_tuple_deserialize_via_variadic_impl" = fn();  // TypeId(35)
+type "functype//wado-compiler/tests/fixtures/variadic_deserialize.wado/__test_0_tuple_deserialize_via_variadic_impl" = fn();  // TypeId(43)
 
-type "functype//wado-compiler/tests/fixtures/variadic_deserialize.wado/__cm_export____test_0_tuple_deserialize_via_variadic_impl" = fn();  // TypeId(36)
+type "functype//wado-compiler/tests/fixtures/variadic_deserialize.wado/__cm_export____test_0_tuple_deserialize_via_variadic_impl" = fn();  // TypeId(44)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(37)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(45)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(38)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(46)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(39)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(47)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(40)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(48)
 
-type "functype//core:internal/unreachable" = fn();  // TypeId(41)
+type "functype//core:internal/unreachable" = fn();  // TypeId(49)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(42)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(50)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(43)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(51)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(44)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(52)
 
-type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(45)
+type "functype//core:prelude/fpfmt.wado/pow10_fine" = fn(i32) -> u64;  // TypeId(53)
 
-type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(46)
+type "functype//core:prelude/fpfmt.wado/uscale" = fn(u64, u64, u64, i32) -> u64;  // TypeId(54)
 
-type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(47)
+type "functype//core:prelude/fpfmt.wado/pack64" = fn(u64, i32) -> f64;  // TypeId(55)
 
-type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(48)
+type "functype//core:prelude/fpfmt.wado/parse" = fn(u64, i32) -> f64;  // TypeId(56)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(49)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(57)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(50)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(58)
 
-type "functype//core:json/utf8_sequence_length" = fn(i32) -> i32;  // TypeId(51)
+type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(59)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(52)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(60)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(53)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(61)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(54)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(62)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(55)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(63)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(56)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(64)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(57)
+type "functype//core:prelude/string.wado/String::char_at_byte" = fn(ref "core:prelude/string.wado//String", i32) -> ref "core:prelude/types.wado//Option<char>";  // TypeId(65)
 
-type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(58)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(66)
 
-type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(59)
+type "functype//core:json/JsonDeserializer::skip_whitespace" = fn(ref "core:json//JsonDeserializer");  // TypeId(67)
 
-type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(60)
+type "functype//core:json/JsonDeserializer::expect_char" = fn(ref "core:json//JsonDeserializer", i32) -> ref null "core:serde//DeserializeError";  // TypeId(68)
 
-type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(61)
+type "functype//core:json/JsonDeserializer::read_json_string" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(69)
 
-type "functype//core:json/JsonDeserializer^Deserializer::begin_seq" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>";  // TypeId(62)
+type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<char,DeserializeError>";  // TypeId(70)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(63)
+type "functype//core:json/JsonDeserializer::parse_i32_direct" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(71)
 
-type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(64)
+type "functype//core:json/JsonDeserializer^Deserializer::begin_seq" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>";  // TypeId(72)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(65)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(73)
 
-type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(66)
+type "functype//core:prelude/format.wado/Formatter::pad" = fn(ref "core:prelude/format.wado//Formatter", ref "core:prelude/string.wado//String");  // TypeId(74)
 
-type "functype//wado-compiler/tests/fixtures/variadic_deserialize.wado/String^Deserialize::deserialize_next_element_from_seq<JsonSeqAccess>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(67)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(75)
 
-type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<String>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";  // TypeId(68)
+type "functype//core:prelude/format.wado/String^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(76)
 
-type "functype//wado-compiler/tests/fixtures/variadic_deserialize.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(69)
+type "functype//wado-compiler/tests/fixtures/variadic_deserialize.wado/Tuple<i32,String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>";  // TypeId(77)
 
-type "functype//wado-compiler/tests/fixtures/variadic_deserialize.wado/i32^Deserialize::deserialize_next_element_from_seq<JsonSeqAccess>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(70)
+type "functype//wado-compiler/tests/fixtures/variadic_deserialize.wado/String^Deserialize::deserialize_next_element_from_seq<JsonSeqAccess>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(78)
 
-type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(71)
+type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<String>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>";  // TypeId(79)
 
-type "functype//wado-compiler/tests/fixtures/variadic_deserialize.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(72)
+type "functype//wado-compiler/tests/fixtures/variadic_deserialize.wado/String^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<String,DeserializeError>";  // TypeId(80)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(73)
+type "functype//wado-compiler/tests/fixtures/variadic_deserialize.wado/i32^Deserialize::deserialize_next_element_from_seq<JsonSeqAccess>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(81)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(74)
+type "functype//core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>" = fn(ref "core:json//JsonSeqAccess") -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>";  // TypeId(82)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(75)
+type "functype//wado-compiler/tests/fixtures/variadic_deserialize.wado/i32^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> ref "core:prelude/types.wado//Result<i32,DeserializeError>";  // TypeId(83)
 
-type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(76)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(84)
 
-type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(77)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(85)
 
-type "functype//core:json/core/json/from_string<Tuple<i32,String>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "tuple//[i32, String]", ref null "core:serde//DeserializeError"];  // TypeId(78)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(86)
 
-type "functype//core:prelude/primitive.wado/char::from_u32" = fn(u32) -> [i32, char];  // TypeId(79)
+type "functype//core:prelude/fpfmt.wado/pow10_coarse" = fn(i32) -> [u64, u64];  // TypeId(87)
 
-type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(80)
+type "functype//core:prelude/fpfmt.wado/mul_pow10" = fn(i32) -> [u64, u64];  // TypeId(88)
 
-type "functype//core:json/JsonDeserializer::read_unicode_escape" = fn(ref "core:json//JsonDeserializer") -> [i32, char, ref null "core:serde//DeserializeError"];  // TypeId(81)
+type "functype//core:json/core/json/from_string<Tuple<i32,String>>" = fn(ref "core:prelude/string.wado//String") -> [i32, ref null "tuple//[i32, String]", ref null "core:serde//DeserializeError"];  // TypeId(89)
 
-type "functype//wado-compiler/tests/fixtures/variadic_deserialize.wado/Tuple<i32,String>^Deserialize::deserialize<JsonDeserializer>" = fn(ref "core:json//JsonDeserializer") -> [i32, ref null "tuple//[i32, String]", ref null "core:serde//DeserializeError"];  // TypeId(82)
+type "functype//core:prelude/string.wado/StrCharIter^Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(90)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(83)
+type "functype//core:prelude/primitive.wado/char::is_hexdigit" = fn(char) -> bool;  // TypeId(91)
 
-type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(84)
+type "functype//core:prelude/primitive.wado/char::hex_digit_value" = fn(char) -> i32;  // TypeId(92)
+
+type "functype//core:prelude/primitive.wado/char::len_utf8" = fn(char) -> i32;  // TypeId(93)
+
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(94)
+
+type "functype//core:prelude/primitive.wado/char^Display::fmt" = fn(char, ref "core:prelude/format.wado//Formatter");  // TypeId(95)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -840,64 +886,118 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
     }
 }
 
-fn "core:json/utf8_sequence_length"(leading_byte) {
-    if leading_byte < 128 {
-        return 1;
-    }
-    if leading_byte < 224 {
-        return 2;
-    }
-    if leading_byte < 240 {
-        return 3;
-    }
-    return 4;
-}
-
 fn "core:json/core/json/from_string<Tuple<i32,String>>"(input) {
     let de: ref "core:json//JsonDeserializer";
+    let __local_2: ref "tuple//[i32, String]";
+    let __local_3: ref "core:serde//DeserializeError";
     let v: ref "tuple//[i32, String]";
-    let e: ref "core:serde//DeserializeError";
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
     de = struct.new "core:json//JsonDeserializer" { input: input, pos: 0 };
-    let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "tuple//[i32, String]";
-    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "wado-compiler/tests/fixtures/variadic_deserialize.wado/Tuple<i32,String>^Deserialize::deserialize<JsonDeserializer>"(de);
-    if __sroa_r_discriminant == 0 {
-        v = __sroa_r_case0_payload_0;
-        "core:json/JsonDeserializer::skip_whitespace"(de);
-        if de.pos < __inline_String__len_0: block -> i32 {
-            __local_7 = de.input;
-            break __inline_String__len_0: __local_7.used;
-        } {
-            return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
-                __local_8 = builtin::i64_extend_i32_s(de.pos);
-                break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_8 };
-            });
-        }
-        return 0, v, ref.null none;
+    v = value_copy "tuple//[i32, String]"(let __match_scrut_0: ref "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>"; __match_scrut_0 = "wado-compiler/tests/fixtures/variadic_deserialize.wado/Tuple<i32,String>^Deserialize::deserialize<JsonDeserializer>"(de); (if ref.test "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Ok"(__match_scrut_0) -> ref "tuple//[i32, String]" {
+        let __cast_2: ref "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Ok";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Ok"(__match_scrut_0);
+        __local_2 = __cast_2.payload_0;
+        __local_2;
+    } else if ref.test "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err"(__match_scrut_0) -> ref "tuple//[i32, String]" {
+        let __cast_1: ref "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err";
+        __cast_1 = ref.cast "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err"(__match_scrut_0);
+        __local_3 = __cast_1.payload_0;
+        return 1, ref.null none, __local_3;
+        unreachable;
+    } else {
+        unreachable;
+    }));
+    "core:json/JsonDeserializer::skip_whitespace"(de);
+    if de.pos < __inline_String__len_0: block -> i32 {
+        __local_5 = de.input;
+        break __inline_String__len_0: __local_5.used;
+    } {
+        return 1, ref.null none, ref.as_non_null(__inline_DeserializeError__trailing_1: block -> ref "core:serde//DeserializeError" {
+            __local_6 = builtin::i64_extend_i32_s(de.pos);
+            break __inline_DeserializeError__trailing_1: struct.new "core:serde//DeserializeError" { kind: 7, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("trailing data after value"), used: 25 }, offset: __local_6 };
+        });
     }
-    if __sroa_r_discriminant == 1 {
-        e = __sroa_r_case1_payload_0;
-        return 1, ref.null none, e;
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return 0, v, ref.null none;
 }
 
 fn "core:prelude/primitive.wado/char::from_u32"(value) {
     if value >u 1114111 {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
     if (if value >=u 55296 -> i32 {
         value <=u 57343;
     } else {
         0;
     }) {
-        return 1, 0;
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
     }
-    return 0, value;
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: value };
+}
+
+fn "core:prelude/primitive.wado/char::is_hexdigit"(self) {
+    let c: char;
+    c = self;
+    return (if (if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) -> i32 {
+        1;
+    } else if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    });
+}
+
+fn "core:prelude/primitive.wado/char::hex_digit_value"(self) {
+    let c: char;
+    c = self;
+    if (if c >= 48 -> i32 {
+        c <= 57;
+    } else {
+        0;
+    }) {
+        return c - 48;
+    }
+    if (if c >= 97 -> i32 {
+        c <= 102;
+    } else {
+        0;
+    }) {
+        return (c - 97) + 10;
+    }
+    if (if c >= 65 -> i32 {
+        c <= 70;
+    } else {
+        0;
+    }) {
+        return (c - 65) + 10;
+    }
+    "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("char::hex_digit_value: not a hex digit"), used: 38 });
+    unreachable;
+}
+
+fn "core:prelude/primitive.wado/char::len_utf8"(self) {
+    let cp: i32;
+    cp = self;
+    if cp < 128 {
+        return 1;
+    }
+    if cp < 2048 {
+        return 2;
+    }
+    if cp < 65536 {
+        return 3;
+    }
+    return 4;
 }
 
 fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
@@ -996,7 +1096,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l97: loop {
+            l108: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -1004,7 +1104,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l97;
+                continue l108;
             };
         };
     };
@@ -1055,6 +1155,55 @@ fn "core:prelude/string.wado/StrCharIter^Iterator::next"(self) {
     return 0, code_10;
 }
 
+fn "core:prelude/string.wado/String::char_at_byte"(self, byte_index) {
+    let b0: u8;
+    let b1_3: u32;
+    let code_4: u32;
+    let b1_5: u32;
+    let b2_6: u32;
+    let code_7: u32;
+    let b1_8: u32;
+    let b2_9: u32;
+    let b3: u32;
+    let code_11: u32;
+    let __local_12: u32;
+    if byte_index >= self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b0 = builtin::array_get_u8(self.repr, byte_index);
+    if b0 <u 128 {
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: __inline_char__from_u32_unchecked_0: block -> char {
+            __local_12 = b0;
+            break __inline_char__from_u32_unchecked_0: __local_12;
+        } };
+    }
+    if b0 <u 224 {
+        if (byte_index + 2) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_3 = builtin::array_get_u8(self.repr, byte_index + 1);
+        code_4 = ((b0 & 31) << 6) | (b1_3 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_4 };
+    }
+    if b0 <u 240 {
+        if (byte_index + 3) > self.used {
+            return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+        }
+        b1_5 = builtin::array_get_u8(self.repr, byte_index + 1);
+        b2_6 = builtin::array_get_u8(self.repr, byte_index + 2);
+        code_7 = (((b0 & 15) << 12) | ((b1_5 & 63) << 6)) | (b2_6 & 63);
+        return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_7 };
+    }
+    if (byte_index + 4) > self.used {
+        return struct.new "core:prelude/types.wado//Option<char>" { 1 };
+    }
+    b1_8 = builtin::array_get_u8(self.repr, byte_index + 1);
+    b2_9 = builtin::array_get_u8(self.repr, byte_index + 2);
+    b3 = builtin::array_get_u8(self.repr, byte_index + 3);
+    code_11 = ((((b0 & 7) << 18) | ((b1_8 & 63) << 12)) | ((b2_9 & 63) << 6)) | (b3 & 63);
+    return struct.new "core:prelude/types.wado//Option<char>::Some" { discriminant: 0, payload_0: code_11 };
+}
+
 fn "core:prelude/string.wado/String::push"(self, c) {
     let code: u32;
     code = c;
@@ -1093,10 +1242,10 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
     _licm_used_6 = _licm_input_5.used;
     _licm_repr_7 = _licm_input_5.repr;
     _hfs_pos_8 = self.pos;
-    b108: block {
-        l109: loop {
+    b126: block {
+        l127: loop {
             if _hfs_pos_8 >= _licm_used_6 {
-                break b108;
+                break b126;
             }
             b = __inline_String__get_byte_1: block -> u8 {
                 __local_4 = _hfs_pos_8;
@@ -1120,7 +1269,7 @@ fn "core:json/JsonDeserializer::skip_whitespace"(self) {
                 self.pos = _hfs_pos_8;
                 return;
             }
-            continue l109;
+            continue l127;
         };
     };
     self.pos = _hfs_pos_8;
@@ -1184,130 +1333,102 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
     let start_9: i32;
     let i_10: i32;
     let b: i32;
-    let esc: i32;
-    let c_14: char;
-    let e: ref "core:serde//DeserializeError";
-    let seq_len: i32;
-    let b0_17: u32;
-    let b1_18: u32;
-    let code_19: u32;
-    let c_20: char;
-    let b0_21: u32;
-    let b1_22: u32;
-    let b2_23: u32;
-    let code_24: u32;
-    let c_25: char;
-    let b0_26: u32;
-    let b1_27: u32;
-    let b2_28: u32;
-    let b3: u32;
-    let code_30: u32;
-    let c_31: char;
-    let __local_32: ref "core:prelude/string.wado//String";
-    let __local_33: ref "core:prelude/format.wado//Formatter";
-    let __local_39: ref "core:prelude/string.wado//String";
-    let __local_40: i64;
-    let __local_41: ref "core:prelude/string.wado//String";
-    let __local_42: i32;
+    let esc: char;
+    let __local_13: char;
+    let __local_14: ref "core:serde//DeserializeError";
+    let __local_15: char;
+    let __local_16: ref "core:prelude/string.wado//String";
+    let __local_17: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: i64;
+    let __local_20: ref "core:prelude/string.wado//String";
+    let __local_21: i32;
+    let __local_22: ref "core:prelude/string.wado//String";
+    let __local_23: i64;
+    let __local_27: ref "core:prelude/string.wado//String";
+    let __local_28: ref "core:prelude/string.wado//String";
+    let __local_29: i32;
+    let index_32: i32;
+    let value_33: u8;
+    let __local_35: i32;
+    let __local_36: i32;
+    let index_38: i32;
+    let value_39: u8;
+    let __local_41: i32;
+    let __local_42: ref "core:prelude/string.wado//String";
     let __local_43: ref "core:prelude/string.wado//String";
-    let __local_44: i64;
-    let __local_48: ref "core:prelude/string.wado//String";
-    let __local_49: ref "core:prelude/string.wado//String";
-    let __local_50: i32;
-    let index_53: i32;
-    let value_54: u8;
-    let __local_56: i32;
-    let __local_57: i32;
-    let index_59: i32;
-    let value_60: u8;
-    let __local_62: i32;
-    let __local_63: ref "core:prelude/string.wado//String";
-    let __local_64: ref "core:prelude/string.wado//String";
-    let __local_65: i32;
-    let __local_66: ref "core:prelude/string.wado//String";
-    let __local_67: i64;
-    let __local_68: ref "core:prelude/string.wado//String";
-    let __local_69: i32;
-    let __local_72: ref "core:prelude/string.wado//String";
-    let __local_73: i64;
-    let __local_74: ref "core:prelude/string.wado//String";
-    let __local_75: i64;
-    let __local_76: ref "core:prelude/string.wado//String";
-    let __local_77: i32;
-    let __local_78: ref "core:prelude/string.wado//String";
-    let __local_79: i32;
-    let __local_80: ref "core:prelude/string.wado//String";
-    let __local_81: i32;
-    let __local_82: ref "core:prelude/string.wado//String";
-    let __local_83: i32;
-    let __local_84: ref "core:prelude/string.wado//String";
-    let __local_85: i32;
-    let __local_86: ref "core:prelude/string.wado//String";
-    let __local_87: i32;
-    let __local_88: i64;
-    let _licm_input_89: ref "core:prelude/string.wado//String";
-    let _licm_used_90: i32;
-    let _licm_repr_91: ref builtin::array<u8>;
-    let _licm_input_92: ref "core:prelude/string.wado//String";
-    let _licm_repr_93: ref builtin::array<u8>;
-    let _licm_repr_94: ref builtin::array<u8>;
-    let _licm_input_95: ref "core:prelude/string.wado//String";
-    let _licm_repr_96: ref builtin::array<u8>;
-    let _licm_repr_97: ref builtin::array<u8>;
-    let _hfs_pos_98: i32;
+    let __local_44: i32;
+    let __local_45: ref "core:prelude/string.wado//String";
+    let __local_46: i64;
+    let __local_47: ref "core:prelude/string.wado//String";
+    let __local_48: i32;
+    let __local_51: ref "core:prelude/string.wado//String";
+    let __local_52: i64;
+    let __local_53: i64;
+    let __local_54: i64;
+    let _licm_input_55: ref "core:prelude/string.wado//String";
+    let _licm_used_56: i32;
+    let _licm_repr_57: ref builtin::array<u8>;
+    let _licm_input_58: ref "core:prelude/string.wado//String";
+    let _licm_repr_59: ref builtin::array<u8>;
+    let _licm_repr_60: ref builtin::array<u8>;
+    let _licm_input_61: ref "core:prelude/string.wado//String";
+    let _licm_repr_62: ref builtin::array<u8>;
+    let _licm_repr_63: ref builtin::array<u8>;
+    let _hfs_pos_64: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self);
     if self.pos >= __inline_String__len_0: block -> i32 {
-        __local_39 = self.input;
-        break __inline_String__len_0: __local_39.used;
+        __local_18 = self.input;
+        break __inline_String__len_0: __local_18.used;
     } {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_40 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_40 };
+            __local_19 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_19 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_41 = self.input;
-        __local_42 = self.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_41.repr, __local_42);
+        __local_20 = self.input;
+        __local_21 = self.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_20.repr, __local_21);
     } != 34 {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__unexpected_type_3: block -> ref "core:serde//DeserializeError" {
-            __local_43 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
-            __local_44 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_43, offset: __local_44 };
+            __local_22 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("expected string"), used: 15 };
+            __local_23 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__unexpected_type_3: struct.new "core:serde//DeserializeError" { kind: 0, message: __local_22, offset: __local_23 };
         }) };
     }
     self.pos = self.pos + 1;
     prefix_start = self.pos;
     scan_pos = self.pos;
-    _licm_input_89 = self.input;
-    _licm_used_90 = _licm_input_89.used;
-    _licm_repr_91 = _licm_input_89.repr;
-    b119: block {
-        l120: loop {
-            if scan_pos >= _licm_used_90 {
-                break b119;
+    _licm_input_55 = self.input;
+    _licm_used_56 = _licm_input_55.used;
+    _licm_repr_57 = _licm_input_55.repr;
+    b137: block {
+        l138: loop {
+            if scan_pos >= _licm_used_56 {
+                break b137;
             }
-            sb = builtin::array_get_u8(_licm_repr_91, scan_pos);
+            sb = builtin::array_get_u8(_licm_repr_57, scan_pos);
             if (if sb == 34 -> i32 {
                 1;
             } else {
                 sb == 92;
             }) {
-                break b119;
+                break b137;
             }
             scan_pos = scan_pos + 1;
-            continue l120;
+            continue l138;
         };
     };
     prefix_len = scan_pos - prefix_start;
     if (if scan_pos < __inline_String__len_6: block -> i32 {
-        __local_48 = self.input;
-        break __inline_String__len_6: __local_48.used;
+        __local_27 = self.input;
+        break __inline_String__len_6: __local_27.used;
     } -> i32 {
         __inline_String__get_byte_7: block -> u8 {
-            __local_49 = self.input;
-            __local_50 = scan_pos;
-            break __inline_String__get_byte_7: builtin::array_get_u8(__local_49.repr, __local_50);
+            __local_28 = self.input;
+            __local_29 = scan_pos;
+            break __inline_String__get_byte_7: builtin::array_get_u8(__local_28.repr, __local_29);
         } == 34;
     } else {
         0;
@@ -1316,22 +1437,22 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         start_6 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_5, prefix_len);
         __for_0: block {
             i_7 = 0;
-            _licm_input_92 = self.input;
-            _licm_repr_93 = result_5.repr;
-            _licm_repr_94 = _licm_input_92.repr;
+            _licm_input_58 = self.input;
+            _licm_repr_59 = result_5.repr;
+            _licm_repr_60 = _licm_input_58.repr;
             block {
-                l127: loop {
+                l145: loop {
                     if i_7 >= prefix_len {
                         break __for_0;
                     }
-                    index_53 = start_6 + i_7;
-                    value_54 = __inline_String__get_byte_10: block -> u8 {
-                        __local_56 = prefix_start + i_7;
-                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_94, __local_56);
+                    index_32 = start_6 + i_7;
+                    value_33 = __inline_String__get_byte_10: block -> u8 {
+                        __local_35 = prefix_start + i_7;
+                        break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_60, __local_35);
                     };
-                    builtin::array_set_u8(_licm_repr_93, index_53, value_54);
+                    builtin::array_set_u8(_licm_repr_59, index_32, value_33);
                     i_7 = i_7 + 1;
-                    continue l127;
+                    continue l145;
                 };
             };
         };
@@ -1339,71 +1460,72 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
         return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_5 };
     }
     result_8 = __inline_String__with_capacity_11: block -> ref "core:prelude/string.wado//String" {
-        __local_57 = prefix_len + 32;
-        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_57), used: 0 };
+        __local_36 = prefix_len + 32;
+        break __inline_String__with_capacity_11: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(__local_36), used: 0 };
     };
     start_9 = "core:prelude/string.wado/String::internal_reserve_uninit"(result_8, prefix_len);
     __for_1: block {
         i_10 = 0;
-        _licm_input_95 = self.input;
-        _licm_repr_96 = result_8.repr;
-        _licm_repr_97 = _licm_input_95.repr;
+        _licm_input_61 = self.input;
+        _licm_repr_62 = result_8.repr;
+        _licm_repr_63 = _licm_input_61.repr;
         block {
-            l130: loop {
+            l148: loop {
                 if i_10 >= prefix_len {
                     break __for_1;
                 }
-                index_59 = start_9 + i_10;
-                value_60 = __inline_String__get_byte_13: block -> u8 {
-                    __local_62 = prefix_start + i_10;
-                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_97, __local_62);
+                index_38 = start_9 + i_10;
+                value_39 = __inline_String__get_byte_13: block -> u8 {
+                    __local_41 = prefix_start + i_10;
+                    break __inline_String__get_byte_13: builtin::array_get_u8(_licm_repr_63, __local_41);
                 };
-                builtin::array_set_u8(_licm_repr_96, index_59, value_60);
+                builtin::array_set_u8(_licm_repr_62, index_38, value_39);
                 i_10 = i_10 + 1;
-                continue l130;
+                continue l148;
             };
         };
     };
     self.pos = scan_pos;
-    _hfs_pos_98 = self.pos;
-    b132: block {
-        l133: loop {
-            if _hfs_pos_98 >= __inline_String__len_14: block -> i32 {
-                __local_63 = self.input;
-                self.pos = _hfs_pos_98;
-                break __inline_String__len_14: __local_63.used;
+    _hfs_pos_64 = self.pos;
+    b150: block {
+        l151: loop {
+            if _hfs_pos_64 >= __inline_String__len_14: block -> i32 {
+                __local_42 = self.input;
+                self.pos = _hfs_pos_64;
+                break __inline_String__len_14: __local_42.used;
             } {
-                break b132;
+                break b150;
             }
             b = __inline_String__get_byte_15: block -> u8 {
-                __local_64 = self.input;
-                __local_65 = _hfs_pos_98;
-                break __inline_String__get_byte_15: builtin::array_get_u8(__local_64.repr, __local_65);
+                __local_43 = self.input;
+                __local_44 = _hfs_pos_64;
+                break __inline_String__get_byte_15: builtin::array_get_u8(__local_43.repr, __local_44);
             };
             if b == 34 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                self.pos = _hfs_pos_98;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                self.pos = _hfs_pos_64;
                 return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Ok" { discriminant: 0, payload_0: result_8 };
             }
             if b == 92 {
-                _hfs_pos_98 = _hfs_pos_98 + 1;
-                if _hfs_pos_98 >= __inline_String__len_16: block -> i32 {
-                    __local_66 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_16: __local_66.used;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
+                if _hfs_pos_64 >= __inline_String__len_16: block -> i32 {
+                    __local_45 = self.input;
+                    self.pos = _hfs_pos_64;
+                    break __inline_String__len_16: __local_45.used;
                 } {
-                    self.pos = _hfs_pos_98;
+                    self.pos = _hfs_pos_64;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_17: block -> ref "core:serde//DeserializeError" {
-                        __local_67 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_67 };
+                        __local_46 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_17: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_46 };
                     }) };
                 }
                 esc = __inline_String__get_byte_18: block -> u8 {
-                    __local_68 = self.input;
-                    __local_69 = _hfs_pos_98;
-                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_68.repr, __local_69);
-                };
+                    __local_47 = self.input;
+                    __local_48 = _hfs_pos_64;
+                    break __inline_String__get_byte_18: builtin::array_get_u8(__local_47.repr, __local_48);
+                } & 255;
+                self.pos = _hfs_pos_64;
                 if esc == 34 {
                     "core:prelude/string.wado/String::push"(result_8, 34);
                 } else if esc == 92 {
@@ -1421,125 +1543,68 @@ fn "core:json/JsonDeserializer::read_json_string"(self) {
                 } else if esc == 102 {
                     "core:prelude/string.wado/String::push"(result_8, 12);
                 } else if esc == 117 {
-                    self.pos = _hfs_pos_98;
-                    let __sroa_r_discriminant: i32;
-                    let __sroa_r_case0_payload_0: char;
-                    let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-                    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/JsonDeserializer::read_unicode_escape"(self);
-                    _hfs_pos_98 = self.pos;
-                    if __sroa_r_discriminant == 0 {
-                        c_14 = __sroa_r_case0_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_14);
-                    }
-                    if __sroa_r_discriminant == 1 {
-                        e = __sroa_r_case1_payload_0;
-                        self.pos = _hfs_pos_98;
-                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+                    let __match_scrut_1: ref "core:prelude/types.wado//Result<char,DeserializeError>";
+                    __match_scrut_1 = "core:json/JsonDeserializer::read_unicode_escape"(self);
+                    if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1) {
+                        let __cast_2: ref "core:prelude/types.wado//Result<char,DeserializeError>::Ok";
+                        __cast_2 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Ok"(__match_scrut_1);
+                        __local_13 = __cast_2.payload_0;
+                        "core:prelude/string.wado/String::push"(result_8, __local_13);
+                    } else if ref.test "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1) {
+                        let __cast_1: ref "core:prelude/types.wado//Result<char,DeserializeError>::Err";
+                        __cast_1 = ref.cast "core:prelude/types.wado//Result<char,DeserializeError>::Err"(__match_scrut_1);
+                        __local_14 = __cast_1.payload_0;
+                        return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: __local_14 };
+                        unreachable;
+                    } else {
+                        unreachable;
                     }
                 } else {
-                    self.pos = _hfs_pos_98;
                     return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_21: block -> ref "core:serde//DeserializeError" {
-                        __local_72 = __tmpl: block -> ref "core:prelude/string.wado//String" {
-                            __local_32 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
-                            "core:prelude/string.wado/String::push_str"(__local_32, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
-                            __local_33 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_32 };
-                            "core:prelude/primitive.wado/char^Display::fmt"(esc & 255, __local_33);
-                            "core:prelude/string.wado/String::push"(__local_32, 39);
-                            self.pos = _hfs_pos_98;
-                            break __tmpl: __local_32;
+                        __local_51 = __tmpl: block -> ref "core:prelude/string.wado//String" {
+                            __local_16 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(34), used: 0 };
+                            "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid escape '\\"), used: 17 });
+                            __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
+                            "core:prelude/primitive.wado/char^Display::fmt"(esc, __local_17);
+                            "core:prelude/string.wado/String::push"(__local_16, 39);
+                            self.pos = _hfs_pos_64;
+                            break __tmpl: __local_16;
                         };
-                        __local_73 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_72, offset: __local_73 };
+                        __local_52 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__malformed_21: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_51, offset: __local_52 };
                     }) };
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + 1;
+                _hfs_pos_64 = self.pos;
+                _hfs_pos_64 = _hfs_pos_64 + 1;
             } else {
-                seq_len = "core:json/utf8_sequence_length"(b);
-                if (_hfs_pos_98 + seq_len) > __inline_String__len_22: block -> i32 {
-                    __local_74 = self.input;
-                    self.pos = _hfs_pos_98;
-                    break __inline_String__len_22: __local_74.used;
-                } {
-                    self.pos = _hfs_pos_98;
-                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
-                        __local_75 = builtin::i64_extend_i32_s(_hfs_pos_98);
-                        self.pos = _hfs_pos_98;
-                        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_75 };
+                let __match_scrut_2: ref "core:prelude/types.wado//Option<char>";
+                __match_scrut_2 = "core:prelude/string.wado/String::char_at_byte"(self.input, _hfs_pos_64);
+                if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2) {
+                    let __cast_3: ref "core:prelude/types.wado//Option<char>::Some";
+                    __cast_3 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_2);
+                    __local_15 = __cast_3.payload_0;
+                    "core:prelude/string.wado/String::push"(result_8, __local_15);
+                    _hfs_pos_64 = _hfs_pos_64 + "core:prelude/primitive.wado/char::len_utf8"(__local_15);
+                } else if __match_scrut_2.discriminant == 1 {
+                    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_22: block -> ref "core:serde//DeserializeError" {
+                        __local_53 = builtin::i64_extend_i32_s(_hfs_pos_64);
+                        self.pos = _hfs_pos_64;
+                        break __inline_DeserializeError__eof_22: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_53 };
                     }) };
-                }
-                if seq_len == 1 {
-                    "core:prelude/string.wado/String::push"(result_8, b & 255);
-                } else if seq_len == 2 {
-                    b0_17 = b;
-                    b1_18 = __inline_String__get_byte_24: block -> u8 {
-                        __local_76 = self.input;
-                        __local_77 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_24: builtin::array_get_u8(__local_76.repr, __local_77);
-                    };
-                    code_19 = ((b0_17 & 31) << 6) | (b1_18 & 63);
-                    let __sroa___pattern_temp_2_discriminant: i32;
-                    let __sroa___pattern_temp_2_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_19);
-                    if __sroa___pattern_temp_2_discriminant == 0 {
-                        c_20 = __sroa___pattern_temp_2_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_20);
-                    }
-                } else if seq_len == 3 {
-                    b0_21 = b;
-                    b1_22 = __inline_String__get_byte_25: block -> u8 {
-                        __local_78 = self.input;
-                        __local_79 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_25: builtin::array_get_u8(__local_78.repr, __local_79);
-                    };
-                    b2_23 = __inline_String__get_byte_26: block -> u8 {
-                        __local_80 = self.input;
-                        __local_81 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_26: builtin::array_get_u8(__local_80.repr, __local_81);
-                    };
-                    code_24 = (((b0_21 & 15) << 12) | ((b1_22 & 63) << 6)) | (b2_23 & 63);
-                    let __sroa___pattern_temp_3_discriminant: i32;
-                    let __sroa___pattern_temp_3_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_3_discriminant, __sroa___pattern_temp_3_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_24);
-                    if __sroa___pattern_temp_3_discriminant == 0 {
-                        c_25 = __sroa___pattern_temp_3_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_25);
-                    }
+                    unreachable;
                 } else {
-                    b0_26 = b;
-                    b1_27 = __inline_String__get_byte_27: block -> u8 {
-                        __local_82 = self.input;
-                        __local_83 = _hfs_pos_98 + 1;
-                        break __inline_String__get_byte_27: builtin::array_get_u8(__local_82.repr, __local_83);
-                    };
-                    b2_28 = __inline_String__get_byte_28: block -> u8 {
-                        __local_84 = self.input;
-                        __local_85 = _hfs_pos_98 + 2;
-                        break __inline_String__get_byte_28: builtin::array_get_u8(__local_84.repr, __local_85);
-                    };
-                    b3 = __inline_String__get_byte_29: block -> u8 {
-                        __local_86 = self.input;
-                        __local_87 = _hfs_pos_98 + 3;
-                        break __inline_String__get_byte_29: builtin::array_get_u8(__local_86.repr, __local_87);
-                    };
-                    code_30 = ((((b0_26 & 7) << 18) | ((b1_27 & 63) << 12)) | ((b2_28 & 63) << 6)) | (b3 & 63);
-                    let __sroa___pattern_temp_4_discriminant: i32;
-                    let __sroa___pattern_temp_4_payload_0: char;
-                    multivalue_bind [__sroa___pattern_temp_4_discriminant, __sroa___pattern_temp_4_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code_30);
-                    if __sroa___pattern_temp_4_discriminant == 0 {
-                        c_31 = __sroa___pattern_temp_4_payload_0;
-                        "core:prelude/string.wado/String::push"(result_8, c_31);
-                    }
+                    unreachable;
                 }
-                _hfs_pos_98 = _hfs_pos_98 + seq_len;
             }
-            continue l133;
+            continue l151;
         };
     };
-    self.pos = _hfs_pos_98;
-    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_30: block -> ref "core:serde//DeserializeError" {
-        __local_88 = builtin::i64_extend_i32_s(self.pos);
-        break __inline_DeserializeError__eof_30: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_88 };
+    self.pos = _hfs_pos_64;
+    return struct.new "core:prelude/types.wado//Result<String,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_23: block -> ref "core:serde//DeserializeError" {
+        __local_54 = builtin::i64_extend_i32_s(self.pos);
+        break __inline_DeserializeError__eof_23: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_54 };
     }) };
 }
 
@@ -1547,87 +1612,71 @@ fn "core:json/JsonDeserializer::read_unicode_escape"(self) {
     let start: i32;
     let code: u32;
     let i: i32;
-    let b: u32;
     let c: char;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: i64;
-    let __local_10: i32;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i64;
-    let __local_13: ref "core:prelude/string.wado//String";
-    let __local_14: i64;
-    let _licm_input_15: ref "core:prelude/string.wado//String";
-    let _licm_pos_16: i32;
-    let _licm_repr_17: ref builtin::array<u8>;
+    let __local_5: char;
+    let __local_6: ref "core:prelude/string.wado//String";
+    let __local_7: i64;
+    let __local_9: i32;
+    let __local_10: ref "core:prelude/string.wado//String";
+    let __local_11: i64;
+    let __local_12: ref "core:prelude/string.wado//String";
+    let __local_13: i64;
+    let _licm_input_14: ref "core:prelude/string.wado//String";
+    let _licm_pos_15: i32;
+    let _licm_repr_16: ref builtin::array<u8>;
     self.pos = self.pos + 1;
     start = self.pos;
     if (self.pos + 4) > __inline_String__len_0: block -> i32 {
-        __local_7 = self.input;
-        break __inline_String__len_0: __local_7.used;
+        __local_6 = self.input;
+        break __inline_String__len_0: __local_6.used;
     } {
-        return 1, 0, ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_8 = builtin::i64_extend_i32_s(self.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_8 };
-        });
+        return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
+            __local_7 = builtin::i64_extend_i32_s(self.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_7 };
+        }) };
     }
     code = 0;
     __for_2: block {
         i = 0;
-        _licm_input_15 = self.input;
-        _licm_pos_16 = self.pos;
-        _licm_repr_17 = _licm_input_15.repr;
+        _licm_input_14 = self.input;
+        _licm_pos_15 = self.pos;
+        _licm_repr_16 = _licm_input_14.repr;
         block {
-            l158: loop {
+            l171: loop {
                 if i >= 4 {
                     break __for_2;
                 }
-                b = __inline_String__get_byte_2: block -> u8 {
-                    __local_10 = _licm_pos_16 + i;
-                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_17, __local_10);
-                };
-                code = code * 16;
-                if (if b >=u 48 -> i32 {
-                    b <=u 57;
-                } else {
-                    0;
-                }) {
-                    code = (code + b) - 48;
-                } else if (if b >=u 97 -> i32 {
-                    b <=u 102;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 97;
-                } else if (if b >=u 65 -> i32 {
-                    b <=u 70;
-                } else {
-                    0;
-                }) {
-                    code = ((code + 10) + b) - 65;
-                } else {
-                    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
-                        __local_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
-                        __local_12 = builtin::i64_extend_i32_s(start);
-                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_11, offset: __local_12 };
-                    });
+                c = __inline_String__get_byte_2: block -> u8 {
+                    __local_9 = _licm_pos_15 + i;
+                    break __inline_String__get_byte_2: builtin::array_get_u8(_licm_repr_16, __local_9);
+                } & 255;
+                if "core:prelude/primitive.wado/char::is_hexdigit"(c) == 0 {
+                    return struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_3: block -> ref "core:serde//DeserializeError" {
+                        __local_10 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode escape"), used: 22 };
+                        __local_11 = builtin::i64_extend_i32_s(start);
+                        break __inline_DeserializeError__malformed_3: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_10, offset: __local_11 };
+                    }) };
                 }
+                code = (code * 16) + "core:prelude/primitive.wado/char::hex_digit_value"(c);
                 i = i + 1;
-                continue l158;
+                continue l171;
             };
         };
     };
     self.pos = self.pos + 3;
-    let __sroa___pattern_temp_0_discriminant: i32;
-    let __sroa___pattern_temp_0_payload_0: char;
-    multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/primitive.wado/char::from_u32"(code);
-    if __sroa___pattern_temp_0_discriminant == 0 {
-        c = __sroa___pattern_temp_0_payload_0;
-        return 0, c, ref.null none;
-    }
-    return 1, 0, ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
-        __local_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
-        __local_14 = builtin::i64_extend_i32_s(start);
-        break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_13, offset: __local_14 };
+    return let __match_scrut_0: ref "core:prelude/types.wado//Option<char>", __match_scrut_0 = "core:prelude/primitive.wado/char::from_u32"(code), (if ref.test "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0) -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        let __cast_1: ref "core:prelude/types.wado//Option<char>::Some";
+        __cast_1 = ref.cast "core:prelude/types.wado//Option<char>::Some"(__match_scrut_0);
+        __local_5 = __cast_1.payload_0;
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_5 };
+    } else if __match_scrut_0.discriminant == 1 -> ref "core:prelude/types.wado//Result<char,DeserializeError>" {
+        struct.new "core:prelude/types.wado//Result<char,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__malformed_4: block -> ref "core:serde//DeserializeError" {
+            __local_12 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("invalid unicode codepoint"), used: 25 };
+            __local_13 = builtin::i64_extend_i32_s(start);
+            break __inline_DeserializeError__malformed_4: struct.new "core:serde//DeserializeError" { kind: 6, message: __local_12, offset: __local_13 };
+        }) };
+    } else {
+        unreachable;
     });
 }
 
@@ -1717,16 +1766,16 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
     _licm_used_47 = _licm_input_46.used;
     _licm_repr_48 = _licm_input_46.repr;
     _hfs_pos_51 = self.pos;
-    b172: block {
-        l173: loop {
+    b181: block {
+        l182: loop {
             if _hfs_pos_51 >= _licm_used_47 {
-                break b172;
+                break b181;
             }
             b = __inline_String__get_byte_8: block -> u8 {
                 __local_28 = _hfs_pos_51;
                 break __inline_String__get_byte_8: builtin::array_get_u8(_licm_repr_48, __local_28);
             };
-            if (if b >= 48 -> i32 {
+            if (if 48 <= b -> i32 {
                 b <= 57;
             } else {
                 0;
@@ -1747,17 +1796,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 if b == 46 {
                     _hfs_pos_51 = _hfs_pos_51 + 1;
                     _hfs_pos_49 = _hfs_pos_51;
-                    b181: block {
-                        l182: loop {
+                    b190: block {
+                        l191: loop {
                             if _hfs_pos_49 >= _licm_used_47 {
                                 self.pos = _hfs_pos_51;
-                                break b181;
+                                break b190;
                             }
                             b2 = __inline_String__get_byte_10: block -> u8 {
                                 __local_31 = _hfs_pos_49;
                                 break __inline_String__get_byte_10: builtin::array_get_u8(_licm_repr_48, __local_31);
                             };
-                            if (if b2 >= 48 -> i32 {
+                            if (if 48 <= b2 -> i32 {
                                 b2 <= 57;
                             } else {
                                 0;
@@ -1767,9 +1816,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                 _hfs_pos_49 = _hfs_pos_49 + 1;
                             } else {
                                 self.pos = _hfs_pos_51;
-                                break b181;
+                                break b190;
                             }
-                            continue l182;
+                            continue l191;
                         };
                     };
                     _hfs_pos_51 = _hfs_pos_49;
@@ -1800,17 +1849,17 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                             }
                         }
                         _hfs_pos_50 = _hfs_pos_51;
-                        b191: block {
-                            l192: loop {
+                        b200: block {
+                            l201: loop {
                                 if _hfs_pos_50 >= _licm_used_47 {
                                     self.pos = _hfs_pos_51;
-                                    break b191;
+                                    break b200;
                                 }
                                 b3 = __inline_String__get_byte_16: block -> u8 {
                                     __local_40 = _hfs_pos_50;
                                     break __inline_String__get_byte_16: builtin::array_get_u8(_licm_repr_48, __local_40);
                                 };
-                                if (if b3 >= 48 -> i32 {
+                                if (if 48 <= b3 -> i32 {
                                     b3 <= 57;
                                 } else {
                                     0;
@@ -1819,9 +1868,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                                     _hfs_pos_50 = _hfs_pos_50 + 1;
                                 } else {
                                     self.pos = _hfs_pos_51;
-                                    break b191;
+                                    break b200;
                                 }
-                                continue l192;
+                                continue l201;
                             };
                         };
                         _hfs_pos_51 = _hfs_pos_50;
@@ -1859,9 +1908,9 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
                 self.pos = _hfs_pos_51;
                 return struct.new "core:prelude/types.wado//Result<i32,DeserializeError>::Ok" { discriminant: 0, payload_0: builtin::i32_trunc_f64_s(v_signed) };
             } else {
-                break b172;
+                break b181;
             }
-            continue l173;
+            continue l182;
         };
     };
     self.pos = _hfs_pos_51;
@@ -1872,12 +1921,18 @@ fn "core:json/JsonDeserializer::parse_i32_direct"(self) {
 }
 
 fn "core:json/JsonDeserializer^Deserializer::begin_seq"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e: ref "core:serde//DeserializeError";
-    r = "core:json/JsonDeserializer::expect_char"(self, 91);
-    if ref.is_null(r) == 0 {
-        e = ref.as_non_null(r);
-        return struct.new "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err" { discriminant: 1, payload_0: e };
+    let __local_2: ref "core:serde//DeserializeError";
+    let __match_scrut_0: ref null "core:serde//DeserializeError";
+    __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self, 91);
+    if ref.is_null(__match_scrut_0) {
+    } else if ref.is_null(__match_scrut_0) == 0 {
+        let __cast_1: ref null "core:serde//DeserializeError";
+        __cast_1 = ref.as_non_null(__match_scrut_0);
+        __local_2 = ref.as_non_null(__cast_1);
+        return struct.new "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+        unreachable;
+    } else {
+        unreachable;
     }
     return struct.new "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:json//JsonSeqAccess" { de: self, first: 1 } };
 }
@@ -1889,13 +1944,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l204: loop {
+            l214: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l204;
+                continue l214;
             };
         };
     };
@@ -2032,8 +2087,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
         break __inline_StrCharIter_IntoIterator__into_iter_1: __local_7;
     };
     _licm_buf_33 = f.buf;
-    b227: block {
-        l228: loop {
+    b237: block {
+        l238: loop {
             let __sroa___pattern_temp_0_discriminant: i32;
             let __sroa___pattern_temp_0_payload_0: char;
             multivalue_bind [__sroa___pattern_temp_0_discriminant, __sroa___pattern_temp_0_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_2);
@@ -2058,9 +2113,9 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     "core:prelude/string.wado/String::push"(_licm_buf_33, c);
                 }
             } else {
-                break b227;
+                break b237;
             }
-            continue l228;
+            continue l238;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
@@ -2085,7 +2140,7 @@ fn "wado-compiler/tests/fixtures/variadic_deserialize.wado/Tuple<i32,String>^Des
         let __cast_1: ref "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err";
         __cast_1 = ref.cast "core:prelude/types.wado//Result<JsonSeqAccess,DeserializeError>::Err"(__match_scrut_0);
         __local_2 = __cast_1.payload_0;
-        return 1, ref.null none, __local_2;
+        return struct.new "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
         unreachable;
     } else {
         unreachable;
@@ -2099,7 +2154,7 @@ fn "wado-compiler/tests/fixtures/variadic_deserialize.wado/Tuple<i32,String>^Des
         let __cast_3: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Err";
         __cast_3 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_1);
         __local_5 = __cast_3.payload_0;
-        return 1, ref.null none, __local_5;
+        return struct.new "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_5 };
         unreachable;
     } else {
         unreachable;
@@ -2112,7 +2167,7 @@ fn "wado-compiler/tests/fixtures/variadic_deserialize.wado/Tuple<i32,String>^Des
         let __cast_5: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
         __cast_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_2);
         __local_10 = __cast_5.payload_0;
-        return 1, ref.null none, __local_10;
+        return struct.new "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_10 };
         unreachable;
     } else {
         unreachable;
@@ -2124,12 +2179,12 @@ fn "wado-compiler/tests/fixtures/variadic_deserialize.wado/Tuple<i32,String>^Des
         let __cast_7: ref null "core:serde//DeserializeError";
         __cast_7 = ref.as_non_null(__match_scrut_3);
         __local_8 = ref.as_non_null(__cast_7);
-        return 1, ref.null none, __local_8;
+        return struct.new "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_8 };
         unreachable;
     } else {
         unreachable;
     }
-    return 0, tuple, ref.null none;
+    return struct.new "core:prelude/types.wado//Result<Tuple<i32,String>,DeserializeError>::Ok" { discriminant: 0, payload_0: tuple };
 }
 
 fn "wado-compiler/tests/fixtures/variadic_deserialize.wado/String^Deserialize::deserialize_next_element_from_seq<JsonSeqAccess>"(seq) {
@@ -2159,51 +2214,58 @@ fn "wado-compiler/tests/fixtures/variadic_deserialize.wado/String^Deserialize::d
 }
 
 fn "core:json/JsonSeqAccess^DeserializeSeq::next_element<String>"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let elem: ref "core:prelude/types.wado//Result<String,DeserializeError>";
-    let v: ref "core:prelude/string.wado//String";
-    let e_5: ref "core:serde//DeserializeError";
-    let __local_9: ref "core:prelude/string.wado//String";
-    let __local_10: i64;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i32;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __local_3: ref "core:prelude/string.wado//String";
+    let __local_4: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_9 = self.de.input;
-        break __inline_String__len_0: __local_9.used;
+        __local_5 = self.de.input;
+        break __inline_String__len_0: __local_5.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_10 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_10 };
+            __local_6 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_6 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_11 = self.de.input;
-        __local_12 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_11.repr, __local_12);
+        __local_7 = self.de.input;
+        __local_8 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_7.repr, __local_8);
     } == 93 {
         return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: ref.null none };
     }
     if self.first == 0 {
-        r = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r) == 0 {
-            e_2 = ref.as_non_null(r);
-            return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
-    elem = "wado-compiler/tests/fixtures/variadic_deserialize.wado/String^Deserialize::deserialize<JsonDeserializer>"(self.de);
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(elem) {
-        v = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(elem).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: v };
-    }
-    if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(elem) {
-        e_5 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(elem).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return let __match_scrut_1: ref "core:prelude/types.wado//Result<String,DeserializeError>", __match_scrut_1 = "wado-compiler/tests/fixtures/variadic_deserialize.wado/String^Deserialize::deserialize<JsonDeserializer>"(self.de), (if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>" {
+        let __cast_3: ref "core:prelude/types.wado//Result<String,DeserializeError>::Ok";
+        __cast_3 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Ok"(__match_scrut_1);
+        __local_3 = __cast_3.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Ok" { discriminant: 0, payload_0: __local_3 };
+    } else if ref.test "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<String>,DeserializeError>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<String,DeserializeError>::Err";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<String,DeserializeError>::Err"(__match_scrut_1);
+        __local_4 = __cast_2.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<String>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_4 };
+    } else {
+        unreachable;
+    });
 }
 
 fn "wado-compiler/tests/fixtures/variadic_deserialize.wado/String^Deserialize::deserialize<JsonDeserializer>"(d) {
@@ -2239,51 +2301,58 @@ fn "wado-compiler/tests/fixtures/variadic_deserialize.wado/i32^Deserialize::dese
 }
 
 fn "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(self) {
-    let r: ref null "core:serde//DeserializeError";
-    let e_2: ref "core:serde//DeserializeError";
-    let elem: ref "core:prelude/types.wado//Result<i32,DeserializeError>";
-    let v: i32;
-    let e_5: ref "core:serde//DeserializeError";
-    let __local_9: ref "core:prelude/string.wado//String";
-    let __local_10: i64;
-    let __local_11: ref "core:prelude/string.wado//String";
-    let __local_12: i32;
+    let __local_2: ref "core:serde//DeserializeError";
+    let __local_3: i32;
+    let __local_4: ref "core:serde//DeserializeError";
+    let __local_5: ref "core:prelude/string.wado//String";
+    let __local_6: i64;
+    let __local_7: ref "core:prelude/string.wado//String";
+    let __local_8: i32;
     "core:json/JsonDeserializer::skip_whitespace"(self.de);
     if self.de.pos >= __inline_String__len_0: block -> i32 {
-        __local_9 = self.de.input;
-        break __inline_String__len_0: __local_9.used;
+        __local_5 = self.de.input;
+        break __inline_String__len_0: __local_5.used;
     } {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__inline_DeserializeError__eof_1: block -> ref "core:serde//DeserializeError" {
-            __local_10 = builtin::i64_extend_i32_s(self.de.pos);
-            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_10 };
+            __local_6 = builtin::i64_extend_i32_s(self.de.pos);
+            break __inline_DeserializeError__eof_1: struct.new "core:serde//DeserializeError" { kind: 8, message: struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("unexpected end of input"), used: 23 }, offset: __local_6 };
         }) };
     }
     if __inline_String__get_byte_2: block -> u8 {
-        __local_11 = self.de.input;
-        __local_12 = self.de.pos;
-        break __inline_String__get_byte_2: builtin::array_get_u8(__local_11.repr, __local_12);
+        __local_7 = self.de.input;
+        __local_8 = self.de.pos;
+        break __inline_String__get_byte_2: builtin::array_get_u8(__local_7.repr, __local_8);
     } == 93 {
         return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>" { 1 } };
     }
     if self.first == 0 {
-        r = "core:json/JsonDeserializer::expect_char"(self.de, 44);
-        if ref.is_null(r) == 0 {
-            e_2 = ref.as_non_null(r);
-            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_2 };
+        let __match_scrut_0: ref null "core:serde//DeserializeError";
+        __match_scrut_0 = "core:json/JsonDeserializer::expect_char"(self.de, 44);
+        if ref.is_null(__match_scrut_0) {
+        } else if ref.is_null(__match_scrut_0) == 0 {
+            let __cast_1: ref null "core:serde//DeserializeError";
+            __cast_1 = ref.as_non_null(__match_scrut_0);
+            __local_2 = ref.as_non_null(__cast_1);
+            return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_2 };
+            unreachable;
+        } else {
+            unreachable;
         }
     }
     self.first = 0;
-    elem = "wado-compiler/tests/fixtures/variadic_deserialize.wado/i32^Deserialize::deserialize<JsonDeserializer>"(self.de);
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(elem) {
-        v = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(elem).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: v } };
-    }
-    if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(elem) {
-        e_5 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(elem).payload_0;
-        return struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: e_5 };
-    }
-    "core:internal/unreachable"();
-    unreachable;
+    return let __match_scrut_1: ref "core:prelude/types.wado//Result<i32,DeserializeError>", __match_scrut_1 = "wado-compiler/tests/fixtures/variadic_deserialize.wado/i32^Deserialize::deserialize<JsonDeserializer>"(self.de), (if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>" {
+        let __cast_3: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Ok";
+        __cast_3 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Ok"(__match_scrut_1);
+        __local_3 = __cast_3.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: __local_3 } };
+    } else if ref.test "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_1) -> ref "core:prelude/types.wado//Result<Option<i32>,DeserializeError>" {
+        let __cast_2: ref "core:prelude/types.wado//Result<i32,DeserializeError>::Err";
+        __cast_2 = ref.cast "core:prelude/types.wado//Result<i32,DeserializeError>::Err"(__match_scrut_1);
+        __local_4 = __cast_2.payload_0;
+        struct.new "core:prelude/types.wado//Result<Option<i32>,DeserializeError>::Err" { discriminant: 1, payload_0: __local_4 };
+    } else {
+        unreachable;
+    });
 }
 
 fn "wado-compiler/tests/fixtures/variadic_deserialize.wado/i32^Deserialize::deserialize<JsonDeserializer>"(d) {

--- a/wado-compiler/tests/format.fixtures.golden/all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/all.lower.wado
@@ -11561,6 +11561,41 @@ pub fn String::chars(self: &String) -> StrCharIter {
     return StrCharIter { repr: self.repr, used: self.used, byte_index: 0 };
 }
 
+pub fn String::char_at_byte(self: &String, byte_index: i32) -> Option<char> {
+    if (byte_index >= self.used) {
+        return null;
+    }
+    let b0: u8 = core::builtin::array_get_u8(self.repr, byte_index);
+    if (b0 < 0x80) {
+        return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(b0 as u32));
+    }
+    if (b0 < 0xE0) {
+        if ((byte_index + 2) > self.used) {
+            return null;
+        }
+        let b1: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 1)) as u32;
+        let code: u32 = (((b0 as u32 & 0x1F) << 6) | (b1 & 0x3F));
+        return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(code));
+    }
+    if (b0 < 0xF0) {
+        if ((byte_index + 3) > self.used) {
+            return null;
+        }
+        let b1: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 1)) as u32;
+        let b2: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 2)) as u32;
+        let code: u32 = ((((b0 as u32 & 0x0F) << 12) | ((b1 & 0x3F) << 6)) | (b2 & 0x3F));
+        return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(code));
+    }
+    if ((byte_index + 4) > self.used) {
+        return null;
+    }
+    let b1: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 1)) as u32;
+    let b2: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 2)) as u32;
+    let b3: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 3)) as u32;
+    let code: u32 = (((((b0 as u32 & 0x07) << 18) | ((b1 & 0x3F) << 12)) | ((b2 & 0x3F) << 6)) | (b3 & 0x3F));
+    return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(code));
+}
+
 pub fn String::push(self: &mut String, c: char) {
     let code: u32 = c as u32;
     if core::builtin::unlikely(((self.used + 4) > core::builtin::array_len(self.repr))) {
@@ -11607,7 +11642,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 358 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 397 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -11636,7 +11671,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 363 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 402 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -12127,7 +12162,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 738 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 777 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -12172,7 +12207,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 741 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 780 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -12269,7 +12304,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 793 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 832 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -12314,7 +12349,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 796 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 835 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -12375,7 +12410,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 819 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 858 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");

--- a/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
@@ -10718,6 +10718,41 @@ pub fn String::chars(self: &String) -> StrCharIter {
     return StrCharIter { repr: self.repr, used: self.used, byte_index: 0 };
 }
 
+pub fn String::char_at_byte(self: &String, byte_index: i32) -> Option<char> {
+    if (byte_index >= self.used) {
+        return null;
+    }
+    let b0: u8 = core::builtin::array_get_u8(self.repr, byte_index);
+    if (b0 < 0x80) {
+        return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(b0 as u32));
+    }
+    if (b0 < 0xE0) {
+        if ((byte_index + 2) > self.used) {
+            return null;
+        }
+        let b1: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 1)) as u32;
+        let code: u32 = (((b0 as u32 & 0x1F) << 6) | (b1 & 0x3F));
+        return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(code));
+    }
+    if (b0 < 0xF0) {
+        if ((byte_index + 3) > self.used) {
+            return null;
+        }
+        let b1: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 1)) as u32;
+        let b2: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 2)) as u32;
+        let code: u32 = ((((b0 as u32 & 0x0F) << 12) | ((b1 & 0x3F) << 6)) | (b2 & 0x3F));
+        return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(code));
+    }
+    if ((byte_index + 4) > self.used) {
+        return null;
+    }
+    let b1: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 1)) as u32;
+    let b2: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 2)) as u32;
+    let b3: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 3)) as u32;
+    let code: u32 = (((((b0 as u32 & 0x07) << 18) | ((b1 & 0x3F) << 12)) | ((b2 & 0x3F) << 6)) | (b3 & 0x3F));
+    return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(code));
+}
+
 pub fn String::push(self: &mut String, c: char) {
     let code: u32 = c as u32;
     if core::builtin::unlikely(((self.used + 4) > core::builtin::array_len(self.repr))) {
@@ -10764,7 +10799,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 358 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 397 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -10793,7 +10828,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 363 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 402 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -11284,7 +11319,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 738 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 777 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -11329,7 +11364,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 741 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 780 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -11426,7 +11461,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 793 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 832 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -11471,7 +11506,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 796 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 835 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -11532,7 +11567,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 819 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 858 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");

--- a/wado-compiler/tests/format.fixtures.golden/ops.all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.all.lower.wado
@@ -10045,6 +10045,41 @@ pub fn String::chars(self: &String) -> StrCharIter {
     return StrCharIter { repr: self.repr, used: self.used, byte_index: 0 };
 }
 
+pub fn String::char_at_byte(self: &String, byte_index: i32) -> Option<char> {
+    if (byte_index >= self.used) {
+        return null;
+    }
+    let b0: u8 = core::builtin::array_get_u8(self.repr, byte_index);
+    if (b0 < 0x80) {
+        return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(b0 as u32));
+    }
+    if (b0 < 0xE0) {
+        if ((byte_index + 2) > self.used) {
+            return null;
+        }
+        let b1: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 1)) as u32;
+        let code: u32 = (((b0 as u32 & 0x1F) << 6) | (b1 & 0x3F));
+        return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(code));
+    }
+    if (b0 < 0xF0) {
+        if ((byte_index + 3) > self.used) {
+            return null;
+        }
+        let b1: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 1)) as u32;
+        let b2: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 2)) as u32;
+        let code: u32 = ((((b0 as u32 & 0x0F) << 12) | ((b1 & 0x3F) << 6)) | (b2 & 0x3F));
+        return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(code));
+    }
+    if ((byte_index + 4) > self.used) {
+        return null;
+    }
+    let b1: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 1)) as u32;
+    let b2: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 2)) as u32;
+    let b3: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 3)) as u32;
+    let code: u32 = (((((b0 as u32 & 0x07) << 18) | ((b1 & 0x3F) << 12)) | ((b2 & 0x3F) << 6)) | (b3 & 0x3F));
+    return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(code));
+}
+
 pub fn String::push(self: &mut String, c: char) {
     let code: u32 = c as u32;
     if core::builtin::unlikely(((self.used + 4) > core::builtin::array_len(self.repr))) {
@@ -10091,7 +10126,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 358 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 397 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -10120,7 +10155,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 363 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 402 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -10611,7 +10646,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 738 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 777 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -10656,7 +10691,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 741 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 780 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -10753,7 +10788,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 793 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 832 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -10798,7 +10833,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 796 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 835 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -10859,7 +10894,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 819 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 858 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");

--- a/wado-compiler/tests/format.fixtures.golden/ops.mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.mess.lower.wado
@@ -10045,6 +10045,41 @@ pub fn String::chars(self: &String) -> StrCharIter {
     return StrCharIter { repr: self.repr, used: self.used, byte_index: 0 };
 }
 
+pub fn String::char_at_byte(self: &String, byte_index: i32) -> Option<char> {
+    if (byte_index >= self.used) {
+        return null;
+    }
+    let b0: u8 = core::builtin::array_get_u8(self.repr, byte_index);
+    if (b0 < 0x80) {
+        return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(b0 as u32));
+    }
+    if (b0 < 0xE0) {
+        if ((byte_index + 2) > self.used) {
+            return null;
+        }
+        let b1: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 1)) as u32;
+        let code: u32 = (((b0 as u32 & 0x1F) << 6) | (b1 & 0x3F));
+        return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(code));
+    }
+    if (b0 < 0xF0) {
+        if ((byte_index + 3) > self.used) {
+            return null;
+        }
+        let b1: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 1)) as u32;
+        let b2: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 2)) as u32;
+        let code: u32 = ((((b0 as u32 & 0x0F) << 12) | ((b1 & 0x3F) << 6)) | (b2 & 0x3F));
+        return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(code));
+    }
+    if ((byte_index + 4) > self.used) {
+        return null;
+    }
+    let b1: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 1)) as u32;
+    let b2: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 2)) as u32;
+    let b3: u32 = core::builtin::array_get_u8(self.repr, (byte_index + 3)) as u32;
+    let code: u32 = (((((b0 as u32 & 0x07) << 18) | ((b1 & 0x3F) << 12)) | ((b2 & 0x3F) << 6)) | (b3 & 0x3F));
+    return Option<char>::Some("core::prelude/primitive.wado::char::from_u32_unchecked"(code));
+}
+
 pub fn String::push(self: &mut String, c: char) {
     let code: u32 = c as u32;
     if core::builtin::unlikely(((self.used + 4) > core::builtin::array_len(self.repr))) {
@@ -10091,7 +10126,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 358 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 397 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -10120,7 +10155,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 363 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 402 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -10611,7 +10646,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 738 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 777 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -10656,7 +10691,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 741 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 780 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -10753,7 +10788,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 793 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 832 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -10798,7 +10833,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 796 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 835 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -10859,7 +10894,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 819 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 858 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");


### PR DESCRIPTION
## Summary

Quality refactor of `wado-compiler/lib/core/json.wado`:

- Convert paired `if let Ok/Err` + `unreachable()` patterns to `match`.
- Convert `if b == 't' ... if b == 'f' ...` dispatch chains in
  `skip_value`, `deserialize_bool`, `deserialize_any`, and `begin_variant`
  to `match` on `char`, along with the escape decoder in
  `read_json_string`.
- Use `?` for fail-fast error propagation in place of the manual
  `if let Err(e) = r { return Err(e); }` boilerplate.
- Omit the redundant `Result::<T, E>::` / `Option::<T>::` turbofish in
  variant construction; the enclosing return type supplies inference
  (158 occurrences simplified, 0 remaining).
- Use comparison chains (`'0' as i32 <= b <= '9' as i32`) for digit
  range checks.
- Drop the local `utf8_sequence_length` helper: introduce
  `String::char_at_byte` in `core:prelude/string.wado` and use it
  together with `char::len_utf8` inside the JSON string decoder, so the
  slow path no longer hand-rolls UTF-8 decoding.
- Drop the local `hex_digit` helper; use template-string `{code:04x}`
  formatting in `write_escaped_string`.
- Change `JsonDeserializer::expect_literal` to take `String` by value —
  the reference is unnecessary and the pattern optimizes well.

Net change: **+493 / -665** lines in `json.wado` (before counting
regenerated goldens), with no behavioral differences.

## Test plan

- [x] `cargo build -p wado-compiler`
- [x] `WADO_FULL_TEST=1 cargo test -p wado-compiler --test e2e serde_json` — 125/125 pass across O0/O1/O2/O3/Os.
- [x] `cargo test -p wado-compiler --test e2e` — 5025/5025 pass.
- [ ] `mise run on-task-done` (running; `mise run test` phase reached, golden fixtures already regenerated and included in the commit).

https://claude.ai/code/session_01M2YAMyyZ3qaJpxgSE6nDCN