### PR TITLE
wir_build: surface silent failures with panic! and fix stream-read binding

### DIFF
--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -5960,8 +5960,17 @@ fn synthesize_record_stream_reads(project: &mut Package) {
         return;
     }
 
-    // Generate binding functions for each element type
-    let entry_module = project.tir_modules.values().next().unwrap();
+    // Generate binding functions for each element type.
+    // Use the actual entry module — not `values().next()`, which returns the
+    // first module in the IndexMap and is not guaranteed to be the entry module.
+    // Calls synthesized by `rewrite_cm_resource_methods` target the entry module
+    // via `entry_call`, so the binding functions must live there for resolution
+    // to succeed in wir_build.
+    let entry_source = project.entry_module_source.clone();
+    let entry_module = project
+        .tir_modules
+        .get(&entry_source)
+        .expect("entry module must exist in tir_modules");
     let type_table = entry_module.type_table.clone();
     let mut new_functions: Vec<Rc<RefCell<TirFunction>>> = Vec::new();
 
@@ -5992,8 +6001,10 @@ fn synthesize_record_stream_reads(project: &mut Package) {
         new_functions.push(Rc::new(RefCell::new(func)));
     }
 
-    // Add generated functions to the entry module
-    let entry_module = project.tir_modules.values_mut().next().unwrap();
+    let entry_module = project
+        .tir_modules
+        .get_mut(&entry_source)
+        .expect("entry module must exist in tir_modules");
     for func in new_functions {
         entry_module.functions.push(func);
     }

--- a/wado-compiler/src/wir_build/context.rs
+++ b/wado-compiler/src/wir_build/context.rs
@@ -29,7 +29,6 @@ pub struct WirContext<'a> {
     /// Reference to the linked package data.
     pub package: &'a FlatPackage,
 
-    // === Type Registry ===
     /// All type definitions in registration order.
     pub types: Vec<WirTypeDef>,
     /// Map from fully-qualified type name to `WirTypeId`.
@@ -47,7 +46,6 @@ pub struct WirContext<'a> {
     /// Variant case type info: case WIR type index → (variant WIR type index, case index).
     pub variant_case_info: IndexMap<u32, (u32, u32)>,
 
-    // === Function Registry ===
     /// All function definitions (with optional bodies).
     pub functions: Vec<WirFunction>,
     /// Map from fully-qualified function name to `WirFuncId`.
@@ -55,7 +53,6 @@ pub struct WirContext<'a> {
     /// Function type index for each function (into types vec).
     pub func_type_ids: Vec<WirTypeId>,
 
-    // === Import Registry ===
     /// Core module imports.
     pub imports: Vec<WirImport>,
     /// Number of imported functions (these come before defined functions in Wasm).
@@ -63,7 +60,6 @@ pub struct WirContext<'a> {
     /// Map from import name to function index (for resolving call targets).
     pub import_func_map: IndexMap<String, WirFuncId>,
 
-    // === Other sections ===
     /// Global variables.
     pub globals: Vec<WirGlobal>,
     /// Map from qualified global name to index in `globals`.
@@ -79,7 +75,6 @@ pub struct WirContext<'a> {
     /// Name section entries.
     pub names: WirNames,
 
-    // === Canonical Closure Types ===
     /// Map from function signature string to canonical closure info.
     /// Key: stringified signature (e.g., "(i32, i32) -> i32")
     /// Value: (`canonical_fn_type_id`, `canonical_closure_struct_type_id`)
@@ -90,7 +85,6 @@ pub struct WirContext<'a> {
     /// Counter for canonical closure type naming.
     pub canonical_closure_counter: u32,
 
-    // === Scratch state ===
     /// Collected string literals (from all TIR modules).
     pub string_literals: Vec<String>,
     /// Collected bytes literals (from all TIR modules).
@@ -98,16 +92,13 @@ pub struct WirContext<'a> {
     /// Available WASI function names (computed during component generation).
     pub available_wasi_funcs: IndexSet<String>,
 
-    // === Wasm module tracking ===
     /// Map from `ModuleSource` to wasm module name (e.g., "mem").
     /// Functions/globals from these modules are extracted into separate wasm core modules.
     pub wasm_module_sources: IndexMap<ModuleSource, String>,
 
-    // === Function body translation helpers ===
     /// Pending function bodies: (function index in self.functions, `TirFunction` ref, `TypeTable` ref)
     pub pending_bodies: Vec<PendingFunctionBody>,
 
-    // === Canonical intrinsic registry ===
     /// CM canonical imports registered lazily by WIR synthesis functions via `ensure_canonical`.
     /// Key: structured canonical intrinsic (e.g., `FutureNew(Some(S32))`).
     /// Value: the `WirFuncId` for the registered import.
@@ -183,8 +174,6 @@ impl<'a> WirContext<'a> {
         }
     }
 
-    // === Type Registration ===
-
     /// Register a type definition and return its `WirTypeId`.
     pub fn register_type(&mut self, fq: String, typedef: WirTypeDef) -> WirTypeId {
         // Dedup: if the same fq name is already registered, return the existing type.
@@ -223,8 +212,6 @@ impl<'a> WirContext<'a> {
         )
     }
 
-    // === Function Registration ===
-
     /// Register a function import and return its `WirFuncId`.
     pub fn register_import_func(
         &mut self,
@@ -262,8 +249,6 @@ impl<'a> WirContext<'a> {
         func_id
     }
 
-    // === Data Section ===
-
     /// Register a string literal and return its data segment index.
     pub fn register_string_literal(&mut self, s: &str) -> u32 {
         if let Some(&idx) = self.string_literal_map.get(s) {
@@ -291,8 +276,6 @@ impl<'a> WirContext<'a> {
         self.bytes_literal_map.insert(b.to_vec(), idx);
         idx
     }
-
-    // === Helpers ===
 
     /// Build a string key for canonical closure type lookup.
     pub fn canonical_closure_key(params: &[WirType], results: &[WirType]) -> String {
@@ -823,8 +806,6 @@ impl<'a> WirContext<'a> {
         self.tuple_type_map.insert(elem_type_ids, type_id.clone());
         Some(type_id)
     }
-
-    // === Build Final WirPackage ===
 
     /// Consume this context and produce the final `WirPackage`.
     pub fn into_wir_package(self) -> WirPackage {

--- a/wado-compiler/src/wir_build/functions.rs
+++ b/wado-compiler/src/wir_build/functions.rs
@@ -466,9 +466,8 @@ fn register_exports(ctx: &mut WirContext<'_>) {
                 },
             });
         } else {
-            eprintln!("[WIR] Warning: export function '{core_func_name}' not found (fq: {fq})");
-            eprintln!(
-                "[WIR] Available functions: {:?}",
+            panic!(
+                "[WIR] export function '{core_func_name}' not found (fq: {fq}); available: {:?}",
                 ctx.func_map.keys().collect::<Vec<_>>()
             );
         }
@@ -603,8 +602,6 @@ fn translate_global_init(
         }
     }
 }
-
-// === Helpers ===
 
 /// Build a mangled function name from TIR function and module source.
 fn build_mangled_name(tir_func: &TirFunction, _module_source: &ModuleSource) -> String {

--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -1283,7 +1283,6 @@ impl FunctionTranslator<'_, '_> {
 
     fn translate_expr_inner(&mut self, expr: &TirExpr) -> WirInstr {
         match &expr.kind {
-            // === Literals ===
             TirExprKind::IntLiteral { value, .. } => match self.type_table.get(expr.type_id) {
                 ResolvedType::Primitive(PrimitiveType::I64 | PrimitiveType::U64) => {
                     WirInstr::I64Const(*value as i64)
@@ -1307,20 +1306,19 @@ impl FunctionTranslator<'_, '_> {
             TirExprKind::Null => {
                 // For Option types, construct a None variant struct.
                 if let Some(inner) = self.type_table.as_option(expr.type_id) {
-                    // If the inner type is unresolved (UNKNOWN), use unreachable
-                    // since we can't construct a concrete variant struct without
-                    // knowing the type. This only happens in error recovery paths.
                     if matches!(self.type_table.get(inner), ResolvedType::Unknown) {
-                        WirInstr::Unreachable
-                    } else {
-                        self.translate_variant_construct(
-                            expr.type_id, // variant_type
-                            1,            // case_index: None is case 1
-                            "None",
-                            None, // no payload
-                            expr.type_id,
-                        )
+                        panic!(
+                            "[WIR] Null with unresolved Option inner type (type_id={:?})",
+                            expr.type_id
+                        );
                     }
+                    self.translate_variant_construct(
+                        expr.type_id, // variant_type
+                        1,            // case_index: None is case 1
+                        "None",
+                        None, // no payload
+                        expr.type_id,
+                    )
                 } else {
                     // Non-Option null: emit ref.null as a placeholder value.
                     // Used by CM bindings for local initialization before conditional assignment.
@@ -1334,7 +1332,6 @@ impl FunctionTranslator<'_, '_> {
                 WirInstr::Nop
             }
 
-            // === Variables ===
             TirExprKind::Local { index, .. } => {
                 // Unit-type locals have no Wasm representation
                 if expr.type_id == TypeTable::UNIT {
@@ -1377,7 +1374,6 @@ impl FunctionTranslator<'_, '_> {
                 }
             }
 
-            // === Binary Operations ===
             TirExprKind::Binary { op, left, right } => {
                 // Short-circuit logical operators: defer right-side evaluation
                 if matches!(op, TirBinaryOp::And) {
@@ -1426,7 +1422,6 @@ impl FunctionTranslator<'_, '_> {
                 result
             }
 
-            // === Unary Operations ===
             TirExprKind::Unary { op, expr: inner } => match op {
                 TirUnaryOp::Ref | TirUnaryOp::MutRef => self.translate_expr(inner),
                 TirUnaryOp::Deref => self.translate_expr(inner),
@@ -1443,7 +1438,6 @@ impl FunctionTranslator<'_, '_> {
                 }
             },
 
-            // === Function Calls ===
             TirExprKind::Call { func, args, .. } => {
                 // Check for instruction-builtins first
                 let builtin = func
@@ -1483,12 +1477,11 @@ impl FunctionTranslator<'_, '_> {
                         args: translated_args,
                     }
                 } else {
-                    eprintln!(
+                    panic!(
                         "[WIR] unresolved Call: name={:?} builtin={:?}",
                         func.name.clone(),
                         builtin
                     );
-                    WirInstr::Unreachable
                 }
             }
             TirExprKind::MethodCall {
@@ -1533,32 +1526,32 @@ impl FunctionTranslator<'_, '_> {
                 }
             }
 
-            // === Struct Literal ===
             TirExprKind::StructLiteral { fields, .. } => {
                 let wir_type = self.ctx.type_id_to_wir_type(self.type_table, expr.type_id);
-                if let WirType::Ref { type_id, .. } = wir_type {
-                    // Unit-typed fields have no Wasm representation; skip them.
-                    let non_unit_fields: Vec<_> = fields
-                        .iter()
-                        .filter(|f| {
-                            !matches!(
-                                self.ctx
-                                    .type_id_to_wir_type(self.type_table, f.value.type_id),
-                                WirType::Unit
-                            )
-                        })
-                        .collect();
-                    let field_instrs: Vec<WirInstr> = non_unit_fields
-                        .iter()
-                        .map(|f| self.translate_expr(&f.value))
-                        .collect();
-                    self.struct_new(type_id, field_instrs)
-                } else {
-                    WirInstr::Unreachable
-                }
+                let WirType::Ref { type_id, .. } = wir_type else {
+                    panic!(
+                        "[WIR] StructLiteral expected Ref WirType, got {wir_type:?} (type_id={:?})",
+                        expr.type_id
+                    );
+                };
+                // Unit-typed fields have no Wasm representation; skip them.
+                let non_unit_fields: Vec<_> = fields
+                    .iter()
+                    .filter(|f| {
+                        !matches!(
+                            self.ctx
+                                .type_id_to_wir_type(self.type_table, f.value.type_id),
+                            WirType::Unit
+                        )
+                    })
+                    .collect();
+                let field_instrs: Vec<WirInstr> = non_unit_fields
+                    .iter()
+                    .map(|f| self.translate_expr(&f.value))
+                    .collect();
+                self.struct_new(type_id, field_instrs)
             }
 
-            // === Field Access ===
             TirExprKind::FieldAccess {
                 expr: receiver,
                 field_name,
@@ -1574,20 +1567,21 @@ impl FunctionTranslator<'_, '_> {
                 let wir_type = self
                     .ctx
                     .type_id_to_wir_type(self.type_table, receiver.type_id);
-                if let WirType::Ref { type_id, .. } = wir_type {
-                    let result_ty = self.struct_field_wir_type(&type_id, field_name);
-                    WirInstr::StructGet {
-                        type_id,
-                        field_name: field_name.clone(),
-                        expr: Box::new(recv),
-                        result_ty,
-                    }
-                } else {
-                    WirInstr::Unreachable
+                let WirType::Ref { type_id, .. } = wir_type else {
+                    panic!(
+                        "[WIR] FieldAccess receiver expected Ref WirType, got {wir_type:?} (field={field_name}, type_id={:?})",
+                        receiver.type_id
+                    );
+                };
+                let result_ty = self.struct_field_wir_type(&type_id, field_name);
+                WirInstr::StructGet {
+                    type_id,
+                    field_name: field_name.clone(),
+                    expr: Box::new(recv),
+                    result_ty,
                 }
             }
 
-            // === Assignment ===
             TirExprKind::Assign { target, value } => {
                 let val = self.translate_expr(value);
                 match &target.kind {
@@ -1645,11 +1639,13 @@ impl FunctionTranslator<'_, '_> {
                         let wir_type = self
                             .ctx
                             .type_id_to_wir_type(self.type_table, receiver.type_id);
-                        if let WirType::Ref { type_id, .. } = wir_type {
-                            self.struct_set(type_id, field_name.clone(), recv, val)
-                        } else {
-                            WirInstr::Unreachable
-                        }
+                        let WirType::Ref { type_id, .. } = wir_type else {
+                            panic!(
+                                "[WIR] FieldAccess assignment expected Ref receiver, got {wir_type:?} (field={field_name}, type_id={:?})",
+                                receiver.type_id
+                            );
+                        };
+                        self.struct_set(type_id, field_name.clone(), recv, val)
                     }
                     TirExprKind::Index {
                         expr: array_expr,
@@ -1662,7 +1658,6 @@ impl FunctionTranslator<'_, '_> {
                 }
             }
 
-            // === Cast ===
             TirExprKind::Cast {
                 expr: inner,
                 target_type,
@@ -1671,7 +1666,6 @@ impl FunctionTranslator<'_, '_> {
                 self.translate_cast(inner, inner.type_id, *target_type)
             }
 
-            // === Block ===
             TirExprKind::Block(block) => {
                 let body = if expr.type_id == TypeTable::UNIT {
                     self.translate_stmts(&block.stmts)
@@ -1681,7 +1675,6 @@ impl FunctionTranslator<'_, '_> {
                 WirInstr::Seq(body)
             }
 
-            // === If Expression ===
             TirExprKind::If {
                 condition,
                 then_branch,
@@ -1720,19 +1713,16 @@ impl FunctionTranslator<'_, '_> {
                 }
             }
 
-            // === Match Expression ===
             TirExprKind::Match {
                 expr: scrutinee,
                 arms,
             } => self.translate_match(scrutinee, arms, expr.type_id),
 
-            // === Index ===
             TirExprKind::Index {
                 expr: array_expr,
                 index: index_expr,
             } => self.translate_index(array_expr, index_expr),
 
-            // === Tuple Literal ===
             TirExprKind::TupleLiteral { elements } => {
                 let wir_type = self.ctx.type_id_to_wir_type(self.type_table, expr.type_id);
                 let wir_type_id = match &wir_type {
@@ -1751,24 +1741,27 @@ impl FunctionTranslator<'_, '_> {
                     }
                     _ => None,
                 };
-                if let Some(type_id) = wir_type_id {
-                    let non_unit_elements: Vec<_> = elements
-                        .iter()
-                        .filter(|e| {
-                            !matches!(
-                                self.ctx.type_id_to_wir_type(self.type_table, e.type_id),
-                                WirType::Unit
-                            )
-                        })
-                        .collect();
-                    let field_instrs: Vec<WirInstr> = non_unit_elements
-                        .iter()
-                        .map(|e| self.translate_expr(e))
-                        .collect();
-                    self.struct_new(type_id, field_instrs)
-                } else {
-                    WirInstr::Unreachable
-                }
+                let Some(type_id) = wir_type_id else {
+                    panic!(
+                        "[WIR] TupleLiteral could not resolve a tuple struct type (expr type_id={:?}, elements={})",
+                        expr.type_id,
+                        elements.len()
+                    );
+                };
+                let non_unit_elements: Vec<_> = elements
+                    .iter()
+                    .filter(|e| {
+                        !matches!(
+                            self.ctx.type_id_to_wir_type(self.type_table, e.type_id),
+                            WirType::Unit
+                        )
+                    })
+                    .collect();
+                let field_instrs: Vec<WirInstr> = non_unit_elements
+                    .iter()
+                    .map(|e| self.translate_expr(e))
+                    .collect();
+                self.struct_new(type_id, field_instrs)
             }
 
             TirExprKind::TupleSpread { .. }
@@ -1779,7 +1772,6 @@ impl FunctionTranslator<'_, '_> {
                 )
             }
 
-            // === Switch (lowered pattern matching) ===
             TirExprKind::Switch {
                 scrutinee,
                 min_value,
@@ -1787,7 +1779,6 @@ impl FunctionTranslator<'_, '_> {
                 default,
             } => self.translate_switch(scrutinee, *min_value, arms, default, expr.type_id),
 
-            // === Variant Operations (lowered) ===
             TirExprKind::VariantTag { expr: inner } => {
                 // Get discriminant field from variant base type
                 let val = self.translate_expr(inner);
@@ -1827,7 +1818,6 @@ impl FunctionTranslator<'_, '_> {
             ),
             TirExprKind::EnumConstruct { case_index, .. } => WirInstr::I32Const(*case_index as i32),
 
-            // === CM Raw Call ===
             TirExprKind::CmRawCall {
                 local_name, args, ..
             } => {
@@ -1878,15 +1868,13 @@ impl FunctionTranslator<'_, '_> {
                 }
             }
 
-            // === Closure ===
             TirExprKind::Closure { .. } => {
-                // Closure should be lowered to StructLiteral or ClosureToCanonical
-                // before reaching this point. If it's still here, emit unreachable.
-                WirInstr::Unreachable
+                panic!(
+                    "[WIR] Closure should be lowered to StructLiteral or ClosureToCanonical before WIR build"
+                );
             }
             TirExprKind::Capture { .. } => {
-                // Capture should be lowered to FieldAccess before reaching this point.
-                WirInstr::Unreachable
+                panic!("[WIR] Capture should be lowered to FieldAccess before WIR build");
             }
             TirExprKind::IndirectCall { callee, args } => {
                 self.translate_indirect_call(callee, args, expr.type_id)
@@ -1907,7 +1895,6 @@ impl FunctionTranslator<'_, '_> {
                 unreachable!("TemplateString should have been expanded before WIR build")
             }
 
-            // === Labeled Block Expression ===
             TirExprKind::LabeledBlock { label, block, .. } => {
                 let has_result = expr.type_id != TypeTable::UNIT;
                 self.label_stack.push(LabelEntry {
@@ -1983,8 +1970,7 @@ impl FunctionTranslator<'_, '_> {
         let string_type = self.ctx.struct_type_map.get(&string_struct_name).cloned();
 
         let (Some(array_type_id), Some(string_type_id)) = (u8_array_type, string_type) else {
-            // Types not registered — fall back to unreachable
-            return WirInstr::Unreachable;
+            panic!("[WIR] String literal: u8 array or String struct type not registered");
         };
 
         if byte_len == 0 {
@@ -2039,7 +2025,7 @@ impl FunctionTranslator<'_, '_> {
 
         let (Some(gc_array_type_id), Some(struct_type_id)) = (u8_array_type, array_struct_type)
         else {
-            return WirInstr::Unreachable;
+            panic!("[WIR] Bytes literal: u8 array or Array<u8> struct type not registered");
         };
 
         if byte_len == 0 {
@@ -2522,7 +2508,6 @@ impl FunctionTranslator<'_, '_> {
         result_type_id: TypeId,
     ) -> Option<WirInstr> {
         match builtin_name {
-            // === Memory Load Instructions ===
             "builtin::i32_load" => {
                 let addr = self.translate_expr(&args[0].expr);
                 Some(WirInstr::I32Load {
@@ -2557,7 +2542,6 @@ impl FunctionTranslator<'_, '_> {
                 })
             }
 
-            // === Memory Store Instructions ===
             "builtin::i32_store" => {
                 let addr = self.translate_expr(&args[0].expr);
                 let val = self.translate_expr(&args[1].expr);
@@ -2599,7 +2583,6 @@ impl FunctionTranslator<'_, '_> {
                 })
             }
 
-            // === Array GC Instructions ===
             "builtin::array_new" => {
                 // array.new_default: creates a new array of the given element type
                 let len = self.translate_expr(&args[0].expr);
@@ -2725,7 +2708,6 @@ impl FunctionTranslator<'_, '_> {
                 }
             }
 
-            // === Float Math (single-instruction) ===
             "builtin::f64_abs" => unary_f64!(self, args, WirInstr::F64Abs),
             "builtin::f64_ceil" => unary_f64!(self, args, WirInstr::F64Ceil),
             "builtin::f64_floor" => unary_f64!(self, args, WirInstr::F64Floor),
@@ -2745,14 +2727,12 @@ impl FunctionTranslator<'_, '_> {
             "builtin::f32_max" => binary_f32!(self, args, WirInstr::F32Max),
             "builtin::f32_copysign" => binary_f32!(self, args, WirInstr::F32Copysign),
 
-            // === Reference Identity ===
             "builtin::ref_eq" => {
                 let l = self.translate_expr(&args[0].expr);
                 let r = self.translate_expr(&args[1].expr);
                 Some(WirInstr::RefEq(Box::new(l), Box::new(r)))
             }
 
-            // === Bitwise/Integer ===
             "builtin::i32_and" => {
                 let l = self.translate_expr(&args[0].expr);
                 let r = self.translate_expr(&args[1].expr);
@@ -2787,7 +2767,6 @@ impl FunctionTranslator<'_, '_> {
                 Some(WirInstr::I64Popcnt(Box::new(o)))
             }
 
-            // === Reinterpretation ===
             "builtin::i64_reinterpret_f64" => {
                 let o = self.translate_expr(&args[0].expr);
                 Some(WirInstr::I64ReinterpretF64(Box::new(o)))
@@ -3968,7 +3947,6 @@ impl FunctionTranslator<'_, '_> {
                 ))
             }
 
-            // === Memory ===
             "builtin::memory_grow" => {
                 let o = self.translate_expr(&args[0].expr);
                 Some(WirInstr::MemoryGrow(Box::new(o)))
@@ -3985,7 +3963,6 @@ impl FunctionTranslator<'_, '_> {
                 })
             }
 
-            // === Control ===
             "builtin::unreachable" => Some(WirInstr::Unreachable),
             "builtin::likely" | "builtin::unlikely" => {
                 let likely = builtin_name == "builtin::likely";
@@ -4010,7 +3987,6 @@ impl FunctionTranslator<'_, '_> {
                 })
             }
 
-            // === Multi-value 128-bit integer operations ===
             "builtin::i64_add128" => {
                 let a_lo = Box::new(self.translate_expr(&args[0].expr));
                 let a_hi = Box::new(self.translate_expr(&args[1].expr));
@@ -4042,10 +4018,8 @@ impl FunctionTranslator<'_, '_> {
                 Some(self.wrap_multivalue_i64(WirInstr::I64MulWideS(a, b), result_type_id))
             }
 
-            // === No-op casts ===
             "builtin::i32_as_char" => Some(self.translate_expr(&args[0].expr)),
 
-            // === WASI call indirects ===
             "builtin::call_indirect_stdout_write_via_stream"
             | "builtin::call_indirect_stderr_write_via_stream" => {
                 // Wado uses stackful async: canon lower without async flag,
@@ -4233,10 +4207,7 @@ impl FunctionTranslator<'_, '_> {
                 Some(self.emit_drop_handle(CanonicalIntrinsic::FutureDropWritable(payload), handle))
             }
 
-            other => {
-                eprintln!("[WIR] unhandled canonical method: {other}");
-                None
-            }
+            other => panic!("[WIR] unhandled canonical method: {other}"),
         }
     }
 
@@ -4304,7 +4275,9 @@ impl FunctionTranslator<'_, '_> {
             .type_id_to_wir_type(self.type_table, result_type_id);
         let type_id = match wir_type {
             WirType::Ref { type_id, .. } => type_id,
-            _ => return WirInstr::Unreachable,
+            _ => panic!(
+                "[WIR] emit_stream_or_future_new expected Ref result type, got {wir_type:?} (result_type_id={result_type_id:?})"
+            ),
         };
 
         // Declare a temp local, call import → i64, split into [rx, tx] tuple
@@ -4360,7 +4333,7 @@ impl FunctionTranslator<'_, '_> {
         payload: CmFuturePayload,
     ) -> WirInstr {
         let Some(realloc_id) = self.ctx.func_map.get("builtin/realloc").cloned() else {
-            return WirInstr::Unreachable;
+            panic!("[WIR] emit_future_read: builtin/realloc not registered");
         };
         // future-read: (handle: i32, ptr: i32) -> i32
         let future_read_id = self.ctx.ensure_canonical(
@@ -4651,7 +4624,9 @@ impl FunctionTranslator<'_, '_> {
     fn lift_future_read_payload(&mut self, option_type_id: TypeId, ptr_name: &str) -> WirInstr {
         // option_type_id = Option<T>; extract T
         let Some(inner_t) = self.type_table.as_option(option_type_id) else {
-            return WirInstr::Unreachable;
+            panic!(
+                "[WIR] lift_future_read_payload: expected Option<T>, got type_id={option_type_id:?}"
+            );
         };
 
         // Check if T is a scalar numeric type (i32, i64, f32, f64, etc.)
@@ -4684,9 +4659,7 @@ impl FunctionTranslator<'_, '_> {
             }
         }
 
-        // Fallback: unsupported T type — emit unreachable
-        // (will trap at runtime if this code path is reached)
-        WirInstr::Unreachable
+        panic!("[WIR] lift_future_read_payload: unsupported payload type (inner_t={inner_t:?})");
     }
 
     /// Lift a scalar numeric value from CM linear memory at `ptr_name + 0`.
@@ -4883,7 +4856,7 @@ impl FunctionTranslator<'_, '_> {
         payload: CmFuturePayload,
     ) -> WirInstr {
         let Some(realloc_id) = self.ctx.func_map.get("builtin/realloc").cloned() else {
-            return WirInstr::Unreachable;
+            panic!("[WIR] emit_future_write_scalar: builtin/realloc not registered");
         };
         let future_write_id = self.ctx.ensure_canonical(
             CanonicalIntrinsic::FutureWrite(payload),
@@ -4898,14 +4871,16 @@ impl FunctionTranslator<'_, '_> {
 
         // Determine buffer size/alignment from the primitive type
         let ResolvedType::Primitive(prim) = self.type_table.get(value_type_id) else {
-            return WirInstr::Unreachable;
+            panic!(
+                "[WIR] emit_future_write_scalar: expected primitive type, got type_id={value_type_id:?}"
+            );
         };
         let (buf_size, buf_align): (i32, i32) = match prim {
             PrimitiveType::I8 | PrimitiveType::U8 | PrimitiveType::Bool => (1, 1),
             PrimitiveType::I16 | PrimitiveType::U16 => (2, 2),
             PrimitiveType::I32 | PrimitiveType::U32 | PrimitiveType::Char => (4, 4),
             PrimitiveType::I64 | PrimitiveType::U64 => (8, 8),
-            _ => return WirInstr::Unreachable,
+            other => panic!("[WIR] emit_future_write_scalar: unsupported primitive {other:?}"),
         };
 
         let mut seq = vec![];
@@ -4962,7 +4937,9 @@ impl FunctionTranslator<'_, '_> {
                 addr: Box::new(ptr()),
                 value: Box::new(value),
             },
-            _ => return WirInstr::Unreachable,
+            other => {
+                panic!("[WIR] emit_future_write_scalar: unsupported store primitive {other:?}")
+            }
         };
         seq.push(store_instr);
 
@@ -5090,7 +5067,7 @@ impl FunctionTranslator<'_, '_> {
     /// for the reader to consume the value before continuing.
     fn emit_future_write_ok_none(&mut self, handle: WirInstr) -> WirInstr {
         let Some(realloc_id) = self.ctx.func_map.get("builtin/realloc").cloned() else {
-            return WirInstr::Unreachable;
+            panic!("[WIR] emit_future_write_ok_none: builtin/realloc not registered");
         };
         let future_write_id = self.ctx.ensure_canonical(
             CanonicalIntrinsic::FutureWrite(CmFuturePayload::Trailers),
@@ -5236,8 +5213,7 @@ impl FunctionTranslator<'_, '_> {
         if let Some(element_type_id) = self.type_table.as_array(base_type_id) {
             self.build_array_get(arr, idx, base_type_id, element_type_id)
         } else {
-            // Not an array type — fallback
-            WirInstr::Unreachable
+            panic!("[WIR] translate_index: expected array type, got type_id={base_type_id:?}");
         }
     }
 
@@ -5257,7 +5233,9 @@ impl FunctionTranslator<'_, '_> {
             ..
         } = array_struct_wir
         else {
-            return WirInstr::Unreachable;
+            panic!(
+                "[WIR] build_array_get: expected Ref Array<T> struct, got {array_struct_wir:?} (array_type_id={array_type_id:?})"
+            );
         };
 
         // Get the raw GC array type
@@ -5269,7 +5247,9 @@ impl FunctionTranslator<'_, '_> {
             .or_else(|| self.ctx.array_type_map.get(&element_type_id))
             .cloned();
         let Some(raw_type) = raw_array_type else {
-            return WirInstr::Unreachable;
+            panic!(
+                "[WIR] build_array_get: raw GC array type not registered (element_type_id={element_type_id:?}, elem_name={elem_name})"
+            );
         };
 
         // StructGet field "repr" (field 0) to get raw array
@@ -6507,7 +6487,9 @@ impl FunctionTranslator<'_, '_> {
                     module_source.clone(),
                 )
             }
-            _ => return WirInstr::Unreachable,
+            other => panic!(
+                "[WIR] translate_variant_construct: expected Variant/GenericInstance, got {other:?} (variant_type={variant_type:?})"
+            ),
         };
 
         let fq = format!("{variant_module_source}//{variant_name}");
@@ -6525,15 +6507,16 @@ impl FunctionTranslator<'_, '_> {
         } else {
             // Fallback: try the base variant type
             let wir_type = self.ctx.type_id_to_wir_type(self.type_table, result_type);
-            if let WirType::Ref { type_id, .. } = wir_type {
-                let mut fields = vec![WirInstr::I32Const(case_index as i32)];
-                if let Some(payload_expr) = payload {
-                    fields.push(self.translate_expr(payload_expr));
-                }
-                self.struct_new(type_id, fields)
-            } else {
-                WirInstr::Unreachable
+            let WirType::Ref { type_id, .. } = wir_type else {
+                panic!(
+                    "[WIR] translate_variant_construct: case type {case_fq} not registered, and result type {result_type:?} is not a Ref ({wir_type:?})"
+                );
+            };
+            let mut fields = vec![WirInstr::I32Const(case_index as i32)];
+            if let Some(payload_expr) = payload {
+                fields.push(self.translate_expr(payload_expr));
             }
+            self.struct_new(type_id, fields)
         }
     }
 
@@ -6569,7 +6552,9 @@ impl FunctionTranslator<'_, '_> {
                     module_source.clone(),
                 )
             }
-            _ => return WirInstr::Unreachable,
+            other => panic!(
+                "[WIR] build_variant_case_wir: expected Variant/GenericInstance, got {other:?} (variant_type_id={variant_type_id:?})"
+            ),
         };
 
         let fq = format!("{variant_module_source}//{variant_name}");
@@ -6585,15 +6570,16 @@ impl FunctionTranslator<'_, '_> {
             let wir_type = self
                 .ctx
                 .type_id_to_wir_type(self.type_table, variant_type_id);
-            if let WirType::Ref { type_id, .. } = wir_type {
-                let mut fields = vec![WirInstr::I32Const(case_index as i32)];
-                if let Some(payload_instr) = payload {
-                    fields.push(payload_instr);
-                }
-                self.struct_new(type_id, fields)
-            } else {
-                WirInstr::Unreachable
+            let WirType::Ref { type_id, .. } = wir_type else {
+                panic!(
+                    "[WIR] build_variant_case_wir: case type {case_fq} not registered, and variant type {variant_type_id:?} is not a Ref ({wir_type:?})"
+                );
+            };
+            let mut fields = vec![WirInstr::I32Const(case_index as i32)];
+            if let Some(payload_instr) = payload {
+                fields.push(payload_instr);
             }
+            self.struct_new(type_id, fields)
         }
     }
 
@@ -6770,7 +6756,10 @@ impl FunctionTranslator<'_, '_> {
                 return_type,
                 ..
             } => (params.clone(), *return_type),
-            _ => return WirInstr::Unreachable,
+            other => panic!(
+                "[WIR] translate_indirect_call: expected Function type, got {other:?} (callee type_id={:?})",
+                callee.type_id
+            ),
         };
 
         // Compute canonical closure types directly by signature key
@@ -6785,12 +6774,15 @@ impl FunctionTranslator<'_, '_> {
                 vec![self.ctx.type_id_to_wir_type(self.type_table, return_type)]
             };
         let key = WirContext::canonical_closure_key(&param_wirs, &result_wirs);
-        let (fn_type_id, closure_struct_type_id) =
-            if let Some((ftid, stid)) = self.ctx.canonical_closure_types.get(&key) {
-                (ftid.clone(), stid.clone())
-            } else {
-                return WirInstr::Unreachable;
-            };
+        let (fn_type_id, closure_struct_type_id) = if let Some((ftid, stid)) =
+            self.ctx.canonical_closure_types.get(&key)
+        {
+            (ftid.clone(), stid.clone())
+        } else {
+            panic!(
+                "[WIR] translate_indirect_call: canonical closure type not registered for signature {key:?}"
+            );
+        };
 
         // Generate a temp local for the callee as canonical closure struct ref
         let temp_name = format!("__indirect_call_{}", self.local_counter);
@@ -6886,7 +6878,9 @@ impl FunctionTranslator<'_, '_> {
                 return_type,
                 ..
             } => (params.clone(), *return_type),
-            _ => return WirInstr::Unreachable,
+            other => panic!(
+                "[WIR] translate_closure_to_canonical: expected Function type, got {other:?} (target_fn_type={target_fn_type:?})"
+            ),
         };
 
         let param_wirs: Vec<WirType> = param_types
@@ -6905,7 +6899,9 @@ impl FunctionTranslator<'_, '_> {
         let struct_type_id = if let Some((_, stid)) = self.ctx.canonical_closure_types.get(&key) {
             stid.clone()
         } else {
-            return WirInstr::Unreachable;
+            panic!(
+                "[WIR] translate_closure_to_canonical: canonical closure type not registered for signature {key:?}"
+            );
         };
 
         // Look up the pre-registered wrapper function for this functor.
@@ -6915,7 +6911,9 @@ impl FunctionTranslator<'_, '_> {
         let wrapper_func_id = if let Some(id) = self.ctx.closure_wrapper_funcs.get(&functor_key) {
             id.clone()
         } else {
-            return WirInstr::Unreachable;
+            panic!(
+                "[WIR] translate_closure_to_canonical: closure wrapper function not registered for {functor_key:?}"
+            );
         };
 
         // Build: CanonicalClosure { env: functor_as_structref, func: ref.func $wrapper }

--- a/wado-compiler/src/wir_build/types.rs
+++ b/wado-compiler/src/wir_build/types.rs
@@ -476,8 +476,6 @@ fn register_raw_array_type(
     }
 }
 
-// === Phase implementations ===
-
 fn register_box_structs(ctx: &mut WirContext<'_>) {
     let type_table = &*ctx.package.type_table.borrow();
     for s in &ctx.package.structs {

--- a/wado-compiler/tests/fixtures.golden/wasi_filesystem_dir_ops.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wasi_filesystem_dir_ops.wir.wado
@@ -163,75 +163,83 @@ type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_b
 
 type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_export__run" = fn();  // TypeId(36)
 
-type "functype//core:cli/write_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(37)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_stream_read_DirectoryEntry" = fn(i32, i32) -> ref "core:prelude//Array<DirectoryEntry>";  // TypeId(37)
 
-type "functype//core:cli/println" = fn(ref "core:prelude/string.wado//String");  // TypeId(38)
+type "functype//core:cli/write_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(38)
 
-type "functype//core:cli/eprintln" = fn(ref "core:prelude/string.wado//String");  // TypeId(39)
+type "functype//core:cli/println" = fn(ref "core:prelude/string.wado//String");  // TypeId(39)
 
-type "functype//core:internal/memory_to_gc_array" = fn(i32, i32) -> ref builtin::array<u8>;  // TypeId(40)
+type "functype//core:cli/eprintln" = fn(ref "core:prelude/string.wado//String");  // TypeId(40)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(41)
+type "functype//core:internal/memory_to_gc_array" = fn(i32, i32) -> ref builtin::array<u8>;  // TypeId(41)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(42)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(42)
 
-type "functype//core:internal/wait_for_subtask" = fn(i32);  // TypeId(43)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(43)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(44)
+type "functype//core:internal/wait_for_subtask" = fn(i32);  // TypeId(44)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(45)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(45)
 
-type "functype//core:internal/cm_lower_string" = fn(ref "core:prelude/string.wado//String") -> i64;  // TypeId(46)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(46)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(47)
+type "functype//core:internal/cm_lower_string" = fn(ref "core:prelude/string.wado//String") -> i64;  // TypeId(47)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(48)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(48)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(49)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(49)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(50)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(50)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(51)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(51)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(52)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(52)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(53)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(53)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(54)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(54)
 
-type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(55)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(55)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(56)
+type "functype//core:prelude/string.wado/String^Eq::eq" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String") -> bool;  // TypeId(56)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(57)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(57)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(58)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(58)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(59)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(59)
 
-type "functype//core:prelude/Array<Tuple<Descriptor,String>>::push" = fn(ref "core:prelude//Array<Tuple<Descriptor,String>>", ref "tuple//[Descriptor, String]");  // TypeId(60)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(60)
 
-type "functype//core:prelude/array.wado/Array<Tuple<Descriptor,String>>::grow" = fn(ref "core:prelude//Array<Tuple<Descriptor,String>>");  // TypeId(61)
+type "functype//core:prelude/array.wado/Array<DirectoryEntry>::push" = fn(ref "core:prelude//Array<DirectoryEntry>", ref "wasi:filesystem/types.wado//DirectoryEntry");  // TypeId(61)
 
-type "functype//core:prelude/array.wado/ArrayIter<DirectoryEntry>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<DirectoryEntry>") -> ref null "wasi:filesystem/types.wado//DirectoryEntry";  // TypeId(62)
+type "functype//core:prelude/array.wado/Array<DirectoryEntry>::grow" = fn(ref "core:prelude//Array<DirectoryEntry>");  // TypeId(62)
 
-type "functype//wasi/future-drop-readable:transmission-filesystem" = fn(i32);  // TypeId(63)
+type "functype//core:prelude/Array<Tuple<Descriptor,String>>::push" = fn(ref "core:prelude//Array<Tuple<Descriptor,String>>", ref "tuple//[Descriptor, String]");  // TypeId(63)
 
-type "functype//wasi/stream-drop-readable:directory-entry" = fn(i32);  // TypeId(64)
+type "functype//core:prelude/array.wado/Array<Tuple<Descriptor,String>>::grow" = fn(ref "core:prelude//Array<Tuple<Descriptor,String>>");  // TypeId(64)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(65)
+type "functype//core:prelude/array.wado/ArrayIter<DirectoryEntry>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<DirectoryEntry>") -> ref null "wasi:filesystem/types.wado//DirectoryEntry";  // TypeId(65)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(66)
+type "functype//wasi/future-drop-readable:transmission-filesystem" = fn(i32);  // TypeId(66)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(67)
+type "functype//wasi/stream-drop-readable:directory-entry" = fn(i32);  // TypeId(67)
 
-type "functype//wasi/subtask-drop" = fn(i32);  // TypeId(68)
+type "functype//wasi/stream-read:directory-entry" = fn(i32, i32, i32) -> i32;  // TypeId(68)
 
-type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_read_directory" = fn(i32) -> [i32, i32];  // TypeId(69)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(69)
 
-type "functype//core:internal/cm_waitable_set_wait" = fn(i32) -> [i32, i32, u32];  // TypeId(70)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(70)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(71)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(71)
+
+type "functype//wasi/subtask-drop" = fn(i32);  // TypeId(72)
+
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_read_directory" = fn(i32) -> [i32, i32];  // TypeId(73)
+
+type "functype//core:internal/cm_waitable_set_wait" = fn(i32) -> [i32, i32, u32];  // TypeId(74)
+
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(75)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -249,6 +257,7 @@ import fn wasi/wasi:filesystem/Descriptor::remove_directory_at from "wasi/wasi:f
 import memory (1) from "mem/memory";
 import fn wasi/future-drop-readable:transmission-filesystem from "wasi/future-drop-readable:transmission-filesystem";
 import fn wasi/stream-drop-readable:directory-entry from "wasi/stream-drop-readable:directory-entry";
+import fn wasi/stream-read:directory-entry from "wasi/stream-read:directory-entry";
 import fn wasi/stream-drop-writable from "wasi/stream-drop-writable";
 import fn wasi/stream-new from "wasi/stream-new";
 import fn wasi/future-drop-readable:transmission-cli from "wasi/future-drop-readable:transmission-cli";
@@ -318,7 +327,7 @@ fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/run"() with Stdout
     found_subdir = 0;
     found_newdir = 0;
     entry_count = 0;
-    entries = unreachable;
+    entries = "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_stream_read_DirectoryEntry"(dir_stream, 100);
     __iter_13 = struct.new "core:prelude/array.wado//ArrayIter<DirectoryEntry>" { repr: entries.repr, used: entries.used, index: 0 };
     b5: block {
         l6: loop {
@@ -704,6 +713,87 @@ fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_export__run"(
     "wasi/task-return"(0);
 }
 
+fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_stream_read_DirectoryEntry"(handle, max) {
+    let byte_count: i32;
+    let ptr: i32;
+    let result: i32;
+    let count: i32;
+    let arr: ref "core:prelude//Array<DirectoryEntry>";
+    let i: i32;
+    let addr: i32;
+    let __vdisc: i32;
+    let __vresult: ref "wasi:filesystem/types.wado//DescriptorType";
+    let __disc: i32;
+    let __option_result: ref null "core:prelude/string.wado//String";
+    let __lifted_result_13: ref "core:prelude/string.wado//String";
+    let __struct_result: ref "wasi:filesystem/types.wado//DirectoryEntry";
+    let __local_18: i32;
+    let __local_19: i32;
+    let __local_20: ref builtin::array<u8>;
+    let __local_21: i32;
+    let __local_22: i32;
+    let __local_23: ref builtin::array<u8>;
+    byte_count = max * 24;
+    ptr = "mem/realloc"(0, 0, 4, byte_count);
+    result = "wasi/stream-read:directory-entry"(handle, ptr, max);
+    if result == -1 {
+        result = "core:internal/wait_for_blocked"(handle);
+    }
+    count = result >> 4;
+    arr = struct.new "core:prelude//Array<DirectoryEntry>" { repr: builtin::array_new<ref "wasi:filesystem/types.wado//DirectoryEntry">(count), used: 0 };
+    i = 0;
+    b102: block {
+        l103: loop {
+            if i >= count {
+                break b102;
+            }
+            addr = ptr + (i * 24);
+            __vdisc = builtin::load_u8(addr);
+            __vresult = ref.null none;
+            if __vdisc == 0 {
+                __vresult = struct.new "wasi:filesystem/types.wado//DescriptorType" { 0 };
+            } else if __vdisc == 1 {
+                __vresult = struct.new "wasi:filesystem/types.wado//DescriptorType" { 1 };
+            } else if __vdisc == 2 {
+                __vresult = struct.new "wasi:filesystem/types.wado//DescriptorType" { 2 };
+            } else if __vdisc == 3 {
+                __vresult = struct.new "wasi:filesystem/types.wado//DescriptorType" { 3 };
+            } else if __vdisc == 4 {
+                __vresult = struct.new "wasi:filesystem/types.wado//DescriptorType" { 4 };
+            } else if __vdisc == 5 {
+                __vresult = struct.new "wasi:filesystem/types.wado//DescriptorType" { 5 };
+            } else if __vdisc == 6 {
+                __vresult = struct.new "wasi:filesystem/types.wado//DescriptorType" { 6 };
+            } else {
+                __disc = builtin::load_u8(addr + 4);
+                __option_result = ref.null none;
+                if __disc != 0 {
+                    __option_result = ref.as_non_null(__inline_memory_to_gc_string_1: block -> ref "core:prelude/string.wado//String" {
+                        __local_18 = builtin::load_i32((addr + 4) + 4);
+                        __local_19 = builtin::load_i32(((addr + 4) + 4) + 4);
+                        __local_20 = "core:internal/memory_to_gc_array"(__local_18, __local_19);
+                        break __inline_memory_to_gc_string_1: struct.new "core:prelude/string.wado//String" { repr: __local_20, used: __local_19 };
+                    });
+                    drop("mem/realloc"(builtin::load_i32((addr + 4) + 4), builtin::load_i32(((addr + 4) + 4) + 4), 1, 0));
+                }
+                __vresult = struct.new "wasi:filesystem/types.wado//DescriptorType::Other" { discriminant: 7, payload_0: __option_result };
+            }
+            __lifted_result_13 = __inline_memory_to_gc_string_2: block -> ref "core:prelude/string.wado//String" {
+                __local_21 = builtin::load_i32(addr + 16);
+                __local_22 = builtin::load_i32((addr + 16) + 4);
+                __local_23 = "core:internal/memory_to_gc_array"(__local_21, __local_22);
+                break __inline_memory_to_gc_string_2: struct.new "core:prelude/string.wado//String" { repr: __local_23, used: __local_22 };
+            };
+            __struct_result = struct.new "wasi:filesystem/types.wado//DirectoryEntry" { type: __vresult, name: __lifted_result_13 };
+            "core:prelude/array.wado/Array<DirectoryEntry>::push"(arr, __struct_result);
+            i = i + 1;
+            continue l103;
+        };
+    };
+    drop("mem/realloc"(ptr, byte_count, 4, 0));
+    return arr;
+}
+
 fn "core:cli/write_to_stream"(tx, message, add_newline) {
     let bytes: ref builtin::array<u8>;
     let len: i32;
@@ -754,13 +844,13 @@ fn "core:internal/memory_to_gc_array"(ptr, len) {
     __for_0: block {
         i = 0;
         block {
-            l103: loop {
+            l115: loop {
                 if i >= len {
                     break __for_0;
                 }
                 builtin::array_set_u8(arr, i, builtin::load_u8(ptr + i) & 255);
                 i = i + 1;
-                continue l103;
+                continue l115;
             };
         };
     };
@@ -772,13 +862,13 @@ fn "core:internal/gc_array_to_memory"(arr, ptr, len) {
     __for_1: block {
         i = 0;
         block {
-            l106: loop {
+            l118: loop {
                 if i >= len {
                     break __for_1;
                 }
                 builtin::store_u8(ptr + i, builtin::array_get_u8(arr, i));
                 i = i + 1;
-                continue l106;
+                continue l118;
             };
         };
     };
@@ -815,16 +905,16 @@ fn "core:internal/wait_for_subtask"(packed) {
             "wasi/waitable-join"(__local_5, ws);
             break __inline_cm_waitable_join_0: __local_5;
         });
-        b110: block {
-            l111: loop {
+        b122: block {
+            l123: loop {
                 let __sroa_event_code: i32;
                 let __sroa_event_handle: i32;
                 let __sroa_event_payload: u32;
                 multivalue_bind [__sroa_event_code, __sroa_event_handle, __sroa_event_payload] = "core:internal/cm_waitable_set_wait"(ws);
                 if __sroa_event_payload == 2 {
-                    break b110;
+                    break b122;
                 }
-                continue l111;
+                continue l123;
             };
         };
         "wasi/subtask-drop"(subtask);
@@ -922,13 +1012,13 @@ fn "core:prelude/primitive.wado/count_digits_i64"(val) {
     __for_1: block {
         t = val;
         block {
-            l116: loop {
+            l128: loop {
                 if t <= 0_i64 {
                     break __for_1;
                 }
                 n = n + 1;
                 t = t / 10_i64;
-                continue l116;
+                continue l128;
             };
         };
     };
@@ -945,14 +1035,14 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
         __for_2: block {
             temp = abs_val;
             block {
-                l120: loop {
+                l132: loop {
                     if temp <= 0_i64 {
                         break __for_2;
                     }
                     pos = pos - 1;
                     builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(temp % 10_i64)) & 255);
                     temp = temp / 10_i64;
-                    continue l120;
+                    continue l132;
                 };
             };
         };
@@ -1042,7 +1132,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     __for_1: block {
         i = 0;
         block {
-            l129: loop {
+            l141: loop {
                 if i >= len {
                     break __for_1;
                 }
@@ -1050,7 +1140,7 @@ fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
                     return 0;
                 }
                 i = i + 1;
-                continue l129;
+                continue l141;
             };
         };
     };
@@ -1091,13 +1181,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l137: loop {
+            l149: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l137;
+                continue l149;
             };
         };
     };
@@ -1185,6 +1275,48 @@ fn "core:prelude/format.wado/Formatter::prepare_int_write"(self, is_negative, pr
     }
 }
 
+fn "core:prelude/array.wado/Array<DirectoryEntry>::push"(self, value) {
+    let used: i32;
+    used = self.used;
+    if builtin::unlikely(used >= builtin::array_len(self.repr)) {
+        "core:prelude/array.wado/Array<DirectoryEntry>::grow"(self);
+    }
+    builtin::array_set<ref "wasi:filesystem/types.wado//DirectoryEntry">(self.repr, used, value);
+    self.used = used + 1;
+}
+
+fn "core:prelude/array.wado/Array<DirectoryEntry>::grow"(self) {
+    let capacity: i32;
+    let new_capacity: i32;
+    let new_repr: ref builtin::array<DirectoryEntry>;
+    let old_repr: ref builtin::array<DirectoryEntry>;
+    let used: i32;
+    let i: i32;
+    let __local_7: i32;
+    capacity = builtin::array_len(self.repr);
+    new_capacity = __inline_i32_max_0: block -> i32 {
+        __local_7 = capacity * 2;
+        break __inline_i32_max_0: select i32(__local_7 > 4, __local_7, 4);
+    };
+    new_repr = builtin::array_new<ref "wasi:filesystem/types.wado//DirectoryEntry">(new_capacity);
+    old_repr = self.repr;
+    used = self.used;
+    __for_0: block {
+        i = 0;
+        block {
+            l170: loop {
+                if i >= used {
+                    break __for_0;
+                }
+                builtin::array_set<ref "wasi:filesystem/types.wado//DirectoryEntry">(new_repr, i, builtin::array_get<ref "wasi:filesystem/types.wado//DirectoryEntry">(old_repr, i));
+                i = i + 1;
+                continue l170;
+            };
+        };
+    };
+    self.repr = new_repr;
+}
+
 fn "core:prelude/Array<Tuple<Descriptor,String>>::push"(self, value) {
     let used: i32;
     used = self.used;
@@ -1214,13 +1346,13 @@ fn "core:prelude/array.wado/Array<Tuple<Descriptor,String>>::grow"(self) {
     __for_0: block {
         i = 0;
         block {
-            l158: loop {
+            l174: loop {
                 if i >= used {
                     break __for_0;
                 }
                 builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
                 i = i + 1;
-                continue l158;
+                continue l174;
             };
         };
     };


### PR DESCRIPTION
## Summary

Replaces silent fallback paths in `wir_build` (`eprintln!` + `WirInstr::Unreachable`, warning logs) with `panic!` so compiler bugs surface immediately instead of producing subtly broken WIR. Tightening this exposed a real bug in `synthesize_record_stream_reads`, which is also fixed here.

## Bug fixed: stream-read binding placed in the wrong module

`synthesize_record_stream_reads` was inserting the synthesized `__cm_stream_read_<T>` binding function into `project.tir_modules.values().next()` — the first module in `IndexMap` iteration order, which is **not** guaranteed to be the entry module. The matching call (emitted by `rewrite_cm_resource_methods` via `entry_call`) targets the entry module, so when the two modules differed, `wir_build` failed to resolve the call. Previously this was masked by the `eprintln!` + `Unreachable` fallback; with the new `panic!` it became visible.

Fix: look up the entry module via `project.entry_module_source` for both the read and the write of `tir_modules`.

The golden update in `wasi_filesystem_dir_ops.wir.wado` reflects the synthesized `__cm_stream_read_DirectoryEntry` binding now landing in the entry module where it belongs.

## Other changes

- `wir_build/translate.rs`, `wir_build/functions.rs`: convert remaining `eprintln!`-then-`Unreachable` and warning paths to `panic!` with contextual messages (unresolved calls, unresolved Option inner types, non-Ref struct/field receivers, missing builtin/canonical type registrations, missing export functions, etc.).
- `wir_build/{context,types,functions,translate}.rs`: drop `// === X ===` section divider comments per project convention.

## Test plan

- [x] `cargo test -p wado-compiler`
- [x] `mise run on-task-done`

🤖 Generated with [Claude Code](https://claude.com/claude-code)