### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
     if: always()
     needs: [test-core, test-wado, test-e2e-o0, test-e2e-o1, test-e2e-o3, test-e2e-os, check-wasm32]
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Check all jobs passed
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/wado-lang/wado/security/code-scanning/1](https://github.com/wado-lang/wado/security/code-scanning/1)

Add an explicit `permissions` block to the `test` job in `.github/workflows/ci.yml` so the `GITHUB_TOKEN` is restricted for that job.  
For this job, the safest non-breaking minimal permission is:

```yml
permissions: {}
```

This disables all token scopes for the job, which is appropriate because the job only runs shell logic over `needs.*.result` values and does not need repository/API access.

**Exact region to change:** in `.github/workflows/ci.yml`, within job `test:` (around lines 188–193), insert `permissions: {}` after `runs-on` (or before `steps`, same indentation level as `runs-on`/`steps`).

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
