### PR TITLE
LSP tier 1: semantic tokens, go-to-definition, hover + compiler unparse API

### DIFF
--- a/docs/cheatsheet-stdlib-core.md
+++ b/docs/cheatsheet-stdlib-core.md
@@ -227,16 +227,16 @@ pub trait Iterator {
     fn next(&mut self) -> Option<Self::Item>;
     fn collect(&mut self) -> Array<Self::Item>;
     fn count(&mut self) -> i32;
-    fn map<U>(&self, f: Fn(Self::Item) -> U) -> IterMap<Self, U>;
-    fn fold<Acc>(&mut self, init: Acc, f: Fn(Acc, Self::Item) -> Acc) -> Acc;
-    fn find(&mut self, pred: Fn(Self::Item) -> bool) -> Option<Self::Item>;
-    fn any(&mut self, pred: Fn(Self::Item) -> bool) -> bool;
-    fn all(&mut self, pred: Fn(Self::Item) -> bool) -> bool;
+    fn map<U>(&self, f: fn(Self::Item) -> U) -> IterMap<Self, U>;
+    fn fold<Acc>(&mut self, init: Acc, f: fn(Acc, Self::Item) -> Acc) -> Acc;
+    fn find(&mut self, pred: fn(Self::Item) -> bool) -> Option<Self::Item>;
+    fn any(&mut self, pred: fn(Self::Item) -> bool) -> bool;
+    fn all(&mut self, pred: fn(Self::Item) -> bool) -> bool;
     fn last(&mut self) -> Option<Self::Item>;
     fn nth(&mut self, n: i32) -> Option<Self::Item>;
-    fn position(&mut self, pred: Fn(Self::Item) -> bool) -> Option<i32>;
-    fn reduce(&mut self, f: Fn(Self::Item, Self::Item) -> Self::Item) -> Option<Self::Item>;
-    fn filter(&self, pred: Fn(Self::Item) -> bool) -> IterFilter<Self>;
+    fn position(&mut self, pred: fn(Self::Item) -> bool) -> Option<i32>;
+    fn reduce(&mut self, f: fn(Self::Item, Self::Item) -> Self::Item) -> Option<Self::Item>;
+    fn filter(&self, pred: fn(Self::Item) -> bool) -> IterFilter<Self>;
     fn enumerate(&self) -> IterEnumerate<Self>;
     fn take(&self, n: i32) -> IterTake<Self>;
     fn skip(&self, n: i32) -> IterSkip<Self>;
@@ -380,16 +380,16 @@ pub trait Iterator {
     fn next(&mut self) -> Option<Self::Item>;
     fn collect(&mut self) -> Array<Self::Item>;
     fn count(&mut self) -> i32;
-    fn map<U>(&self, f: Fn(Self::Item) -> U) -> IterMap<Self, U>;
-    fn fold<Acc>(&mut self, init: Acc, f: Fn(Acc, Self::Item) -> Acc) -> Acc;
-    fn find(&mut self, pred: Fn(Self::Item) -> bool) -> Option<Self::Item>;
-    fn any(&mut self, pred: Fn(Self::Item) -> bool) -> bool;
-    fn all(&mut self, pred: Fn(Self::Item) -> bool) -> bool;
+    fn map<U>(&self, f: fn(Self::Item) -> U) -> IterMap<Self, U>;
+    fn fold<Acc>(&mut self, init: Acc, f: fn(Acc, Self::Item) -> Acc) -> Acc;
+    fn find(&mut self, pred: fn(Self::Item) -> bool) -> Option<Self::Item>;
+    fn any(&mut self, pred: fn(Self::Item) -> bool) -> bool;
+    fn all(&mut self, pred: fn(Self::Item) -> bool) -> bool;
     fn last(&mut self) -> Option<Self::Item>;
     fn nth(&mut self, n: i32) -> Option<Self::Item>;
-    fn position(&mut self, pred: Fn(Self::Item) -> bool) -> Option<i32>;
-    fn reduce(&mut self, f: Fn(Self::Item, Self::Item) -> Self::Item) -> Option<Self::Item>;
-    fn filter(&self, pred: Fn(Self::Item) -> bool) -> IterFilter<Self>;
+    fn position(&mut self, pred: fn(Self::Item) -> bool) -> Option<i32>;
+    fn reduce(&mut self, f: fn(Self::Item, Self::Item) -> Self::Item) -> Option<Self::Item>;
+    fn filter(&self, pred: fn(Self::Item) -> bool) -> IterFilter<Self>;
     fn enumerate(&self) -> IterEnumerate<Self>;
     fn take(&self, n: i32) -> IterTake<Self>;
     fn skip(&self, n: i32) -> IterSkip<Self>;
@@ -418,7 +418,7 @@ pub trait Step {
 ```wado
 pub struct IterMap<I: Iterator, U> {
     inner: I,
-    f: Fn(I::Item) -> U,
+    f: fn(I::Item) -> U,
 }
 
 impl Iterator for IterMap<I, U> {
@@ -433,7 +433,7 @@ impl IntoIterator for IterMap<I, U> {
 ```wado
 pub struct IterFilter<I: Iterator> {
     inner: I,
-    pred: Fn(I::Item) -> bool,
+    pred: fn(I::Item) -> bool,
 }
 
 impl Iterator for IterFilter<I> {
@@ -896,7 +896,7 @@ impl String {
     pub fn find(&self, pat: String) -> Option<i32>;
     pub fn rfind(&self, pat: String) -> Option<i32>;
     pub fn contains_char(&self, ch: char) -> bool;
-    pub fn find_char(&self, pred: Fn(char) -> bool) -> Option<i32>;
+    pub fn find_char(&self, pred: fn(char) -> bool) -> Option<i32>;
     pub fn insert(&mut self, byte_index: i32, ch: char);
     pub fn insert_str(&mut self, byte_index: i32, s: String);
     pub fn remove(&mut self, byte_index: i32) -> char;
@@ -959,7 +959,7 @@ impl Iterator for StrCharIter {
 ```wado
 pub struct IterMap<I: Iterator, U> {
     inner: I,
-    f: Fn(I::Item) -> U,
+    f: fn(I::Item) -> U,
 }
 
 impl Iterator for IterMap<I, U> {
@@ -974,7 +974,7 @@ impl IntoIterator for IterMap<I, U> {
 ```wado
 pub struct IterFilter<I: Iterator> {
     inner: I,
-    pred: Fn(I::Item) -> bool,
+    pred: fn(I::Item) -> bool,
 }
 
 impl Iterator for IterFilter<I> {
@@ -1095,8 +1095,8 @@ impl Array {
     pub fn contains(&self, value: &T) -> bool;
     pub fn slice(&self, start: i32, end: i32) -> ArraySlice<T>;
     pub fn iter(&self) -> ArrayIter<T>;
-    pub fn sort_by(&mut self, cmp: Fn(&T, &T) -> Ordering);
-    pub fn sorted_by(&self, cmp: Fn(&T, &T) -> Ordering) -> Array<T>;
+    pub fn sort_by(&mut self, cmp: fn(&T, &T) -> Ordering);
+    pub fn sorted_by(&self, cmp: fn(&T, &T) -> Ordering) -> Array<T>;
     pub fn windows(&self, size: i32) -> WindowsIter<T>;
     pub fn chunks(&self, size: i32) -> ChunksIter<T>;
     pub fn sort(&mut self);

--- a/docs/cheatsheet-stdlib-core.md
+++ b/docs/cheatsheet-stdlib-core.md
@@ -2411,23 +2411,22 @@ RFC 1950 (zlib format) is supported except for preset dictionaries (FDICT);
 streams with FDICT set will return `ZlibError::PresetDictionaryNotSupported`.
 
 Features:
-
-- Adler-32 and CRC-32 checksums (with combine operations)
-- DEFLATE inflate (decompression) with dynamic/fixed Huffman and stored blocks
-- DEFLATE deflate (compression) with fixed and dynamic Huffman codes + LZ77
-- Compression levels 0-9 with strategy selection
-- zlib and gzip format support
-- Streaming deflate/inflate API
+  - Adler-32 and CRC-32 checksums (with combine operations)
+  - DEFLATE inflate (decompression) with dynamic/fixed Huffman and stored blocks
+  - DEFLATE deflate (compression) with fixed and dynamic Huffman codes + LZ77
+  - Compression levels 0-9 with strategy selection
+  - zlib and gzip format support
+  - Streaming deflate/inflate API
 
 Usage - Compression:
-let input: Array<u8> = [...];
-let compressed = zlib_compress(&input);
-let compressed_fast = compress2(&input, Z_BEST_SPEED);
-let compressed_best = compress2(&input, Z_BEST_COMPRESSION);
+  let input: Array<u8> = [...];
+  let compressed = zlib_compress(&input);
+  let compressed_fast = compress2(&input, Z_BEST_SPEED);
+  let compressed_best = compress2(&input, Z_BEST_COMPRESSION);
 
 Usage - Decompression:
-let decompressed = inflate_zlib(&compressed);
-let decompressed_gz = inflate_gzip(&gzipped_data);
+  let decompressed = inflate_zlib(&compressed);
+  let decompressed_gz = inflate_gzip(&gzipped_data);
 
 ### Globals
 

--- a/docs/cheatsheet-stdlib-core.md
+++ b/docs/cheatsheet-stdlib-core.md
@@ -2411,22 +2411,23 @@ RFC 1950 (zlib format) is supported except for preset dictionaries (FDICT);
 streams with FDICT set will return `ZlibError::PresetDictionaryNotSupported`.
 
 Features:
-  - Adler-32 and CRC-32 checksums (with combine operations)
-  - DEFLATE inflate (decompression) with dynamic/fixed Huffman and stored blocks
-  - DEFLATE deflate (compression) with fixed and dynamic Huffman codes + LZ77
-  - Compression levels 0-9 with strategy selection
-  - zlib and gzip format support
-  - Streaming deflate/inflate API
+
+- Adler-32 and CRC-32 checksums (with combine operations)
+- DEFLATE inflate (decompression) with dynamic/fixed Huffman and stored blocks
+- DEFLATE deflate (compression) with fixed and dynamic Huffman codes + LZ77
+- Compression levels 0-9 with strategy selection
+- zlib and gzip format support
+- Streaming deflate/inflate API
 
 Usage - Compression:
-  let input: Array<u8> = [...];
-  let compressed = zlib_compress(&input);
-  let compressed_fast = compress2(&input, Z_BEST_SPEED);
-  let compressed_best = compress2(&input, Z_BEST_COMPRESSION);
+let input: Array<u8> = [...];
+let compressed = zlib_compress(&input);
+let compressed_fast = compress2(&input, Z_BEST_SPEED);
+let compressed_best = compress2(&input, Z_BEST_COMPRESSION);
 
 Usage - Decompression:
-  let decompressed = inflate_zlib(&compressed);
-  let decompressed_gz = inflate_gzip(&gzipped_data);
+let decompressed = inflate_zlib(&compressed);
+let decompressed_gz = inflate_gzip(&gzipped_data);
 
 ### Globals
 

--- a/docs/stdlib-core.md
+++ b/docs/stdlib-core.md
@@ -491,25 +491,25 @@ Collects remaining elements into an Array.
 
 Counts the number of remaining elements in the iterator.
 
-##### `fn map<U>(&self, f: Fn(Self::Item) -> U) -> IterMap<Self, U>`
+##### `fn map<U>(&self, f: fn(Self::Item) -> U) -> IterMap<Self, U>`
 
 Transforms each element using a function.
 
-##### `fn fold<Acc>(&mut self, init: Acc, f: Fn(Acc, Self::Item) -> Acc) -> Acc`
+##### `fn fold<Acc>(&mut self, init: Acc, f: fn(Acc, Self::Item) -> Acc) -> Acc`
 
 Like `reduce`, but takes an explicit initial accumulator instead of using the first element.
 Always returns a value (unlike `reduce`, which returns None for empty iterators).
 
-##### `fn find(&mut self, pred: Fn(Self::Item) -> bool) -> Option<Self::Item>`
+##### `fn find(&mut self, pred: fn(Self::Item) -> bool) -> Option<Self::Item>`
 
 Returns the first element for which `pred` returns true, advancing the iterator up to that point.
 
-##### `fn any(&mut self, pred: Fn(Self::Item) -> bool) -> bool`
+##### `fn any(&mut self, pred: fn(Self::Item) -> bool) -> bool`
 
 Returns true if `pred` returns true for at least one element (∃). False for empty iterators.
 Short-circuits: stops advancing the iterator as soon as a matching element is found.
 
-##### `fn all(&mut self, pred: Fn(Self::Item) -> bool) -> bool`
+##### `fn all(&mut self, pred: fn(Self::Item) -> bool) -> bool`
 
 Returns true if `pred` returns true for every element (∀). True for empty iterators.
 Short-circuits: stops advancing the iterator as soon as a non-matching element is found.
@@ -522,16 +522,16 @@ Advances the entire iterator and returns the last element, or None if empty.
 
 Returns the nth element (0-indexed), advancing the iterator up to and including it.
 
-##### `fn position(&mut self, pred: Fn(Self::Item) -> bool) -> Option<i32>`
+##### `fn position(&mut self, pred: fn(Self::Item) -> bool) -> Option<i32>`
 
 Returns the 0-based index of the first element for which `pred` returns true, or None.
 
-##### `fn reduce(&mut self, f: Fn(Self::Item, Self::Item) -> Self::Item) -> Option<Self::Item>`
+##### `fn reduce(&mut self, f: fn(Self::Item, Self::Item) -> Self::Item) -> Option<Self::Item>`
 
 Reduces elements to a single value without an initial accumulator.
 Returns None if the iterator is empty.
 
-##### `fn filter(&self, pred: Fn(Self::Item) -> bool) -> IterFilter<Self>`
+##### `fn filter(&self, pred: fn(Self::Item) -> bool) -> IterFilter<Self>`
 
 Returns an adapter that skips elements for which `pred` returns false.
 
@@ -838,25 +838,25 @@ Collects remaining elements into an Array.
 
 Counts the number of remaining elements in the iterator.
 
-##### `fn map<U>(&self, f: Fn(Self::Item) -> U) -> IterMap<Self, U>`
+##### `fn map<U>(&self, f: fn(Self::Item) -> U) -> IterMap<Self, U>`
 
 Transforms each element using a function.
 
-##### `fn fold<Acc>(&mut self, init: Acc, f: Fn(Acc, Self::Item) -> Acc) -> Acc`
+##### `fn fold<Acc>(&mut self, init: Acc, f: fn(Acc, Self::Item) -> Acc) -> Acc`
 
 Like `reduce`, but takes an explicit initial accumulator instead of using the first element.
 Always returns a value (unlike `reduce`, which returns None for empty iterators).
 
-##### `fn find(&mut self, pred: Fn(Self::Item) -> bool) -> Option<Self::Item>`
+##### `fn find(&mut self, pred: fn(Self::Item) -> bool) -> Option<Self::Item>`
 
 Returns the first element for which `pred` returns true, advancing the iterator up to that point.
 
-##### `fn any(&mut self, pred: Fn(Self::Item) -> bool) -> bool`
+##### `fn any(&mut self, pred: fn(Self::Item) -> bool) -> bool`
 
 Returns true if `pred` returns true for at least one element (∃). False for empty iterators.
 Short-circuits: stops advancing the iterator as soon as a matching element is found.
 
-##### `fn all(&mut self, pred: Fn(Self::Item) -> bool) -> bool`
+##### `fn all(&mut self, pred: fn(Self::Item) -> bool) -> bool`
 
 Returns true if `pred` returns true for every element (∀). True for empty iterators.
 Short-circuits: stops advancing the iterator as soon as a non-matching element is found.
@@ -869,16 +869,16 @@ Advances the entire iterator and returns the last element, or None if empty.
 
 Returns the nth element (0-indexed), advancing the iterator up to and including it.
 
-##### `fn position(&mut self, pred: Fn(Self::Item) -> bool) -> Option<i32>`
+##### `fn position(&mut self, pred: fn(Self::Item) -> bool) -> Option<i32>`
 
 Returns the 0-based index of the first element for which `pred` returns true, or None.
 
-##### `fn reduce(&mut self, f: Fn(Self::Item, Self::Item) -> Self::Item) -> Option<Self::Item>`
+##### `fn reduce(&mut self, f: fn(Self::Item, Self::Item) -> Self::Item) -> Option<Self::Item>`
 
 Reduces elements to a single value without an initial accumulator.
 Returns None if the iterator is empty.
 
-##### `fn filter(&self, pred: Fn(Self::Item) -> bool) -> IterFilter<Self>`
+##### `fn filter(&self, pred: fn(Self::Item) -> bool) -> IterFilter<Self>`
 
 Returns an adapter that skips elements for which `pred` returns false.
 
@@ -934,7 +934,7 @@ Generic map iterator adapter that wraps any Iterator.
 
 ##### `inner: I`
 
-##### `f: Fn(I::Item) -> U`
+##### `f: fn(I::Item) -> U`
 
 ##### `impl Iterator for IterMap<I, U>`
 
@@ -950,7 +950,7 @@ Generic filter iterator adapter that wraps any Iterator.
 
 ##### `inner: I`
 
-##### `pred: Fn(I::Item) -> bool`
+##### `pred: fn(I::Item) -> bool`
 
 ##### `impl Iterator for IterFilter<I>`
 
@@ -1744,7 +1744,7 @@ Returns the byte index of the last occurrence of `pat`, or None.
 
 Returns true if the string contains the given character.
 
-##### `pub fn find_char(&self, pred: Fn(char) -> bool) -> Option<i32>`
+##### `pub fn find_char(&self, pred: fn(char) -> bool) -> Option<i32>`
 
 Returns the byte index of the first character matching the predicate, or None.
 
@@ -1874,7 +1874,7 @@ Generic map iterator adapter that wraps any Iterator.
 
 ##### `inner: I`
 
-##### `f: Fn(I::Item) -> U`
+##### `f: fn(I::Item) -> U`
 
 ##### `impl Iterator for IterMap<I, U>`
 
@@ -1890,7 +1890,7 @@ Generic filter iterator adapter that wraps any Iterator.
 
 ##### `inner: I`
 
-##### `pred: Fn(I::Item) -> bool`
+##### `pred: fn(I::Item) -> bool`
 
 ##### `impl Iterator for IterFilter<I>`
 
@@ -2073,11 +2073,11 @@ Returns true if the array contains the given value.
 
 ##### `pub fn iter(&self) -> ArrayIter<T>`
 
-##### `pub fn sort_by(&mut self, cmp: Fn(&T, &T) -> Ordering)`
+##### `pub fn sort_by(&mut self, cmp: fn(&T, &T) -> Ordering)`
 
 In-place sort with comparator. Stable, O(n log n) worst case.
 
-##### `pub fn sorted_by(&self, cmp: Fn(&T, &T) -> Ordering) -> Array<T>`
+##### `pub fn sorted_by(&self, cmp: fn(&T, &T) -> Ordering) -> Array<T>`
 
 ##### `pub fn windows(&self, size: i32) -> WindowsIter<T>`
 

--- a/wado-cli/src/lsp.rs
+++ b/wado-cli/src/lsp.rs
@@ -33,6 +33,15 @@ pub async fn run() {
                                 "openClose": true,
                                 "change": 1, // Full sync
                             },
+                            "definitionProvider": true,
+                            "hoverProvider": true,
+                            "semanticTokensProvider": {
+                                "legend": {
+                                    "tokenTypes": wado_lsp::semantic_tokens::TOKEN_TYPES,
+                                    "tokenModifiers": wado_lsp::semantic_tokens::TOKEN_MODIFIERS,
+                                },
+                                "full": true,
+                            },
                         },
                         "serverInfo": {
                             "name": "wado-lsp",
@@ -97,6 +106,104 @@ pub async fn run() {
                         {
                             eprintln!("wado-lsp: {e}");
                         }
+                    }
+                }
+            }
+            "textDocument/definition" => {
+                if let Some(id) = id {
+                    let uri = params
+                        .get("textDocument")
+                        .and_then(|td| td.get("uri"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    let line = params
+                        .get("position")
+                        .and_then(|p| p.get("line"))
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0) as u32;
+                    let character = params
+                        .get("position")
+                        .and_then(|p| p.get("character"))
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0) as u32;
+                    let position = wado_lsp::Position { line, character };
+                    let result = match engine.definition(uri, position) {
+                        Some(def) => json!({
+                            "uri": def.uri,
+                            "range": {
+                                "start": {
+                                    "line": def.range.start.line,
+                                    "character": def.range.start.character,
+                                },
+                                "end": {
+                                    "line": def.range.end.line,
+                                    "character": def.range.end.character,
+                                },
+                            },
+                        }),
+                        None => Value::Null,
+                    };
+                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
+                        eprintln!("wado-lsp: {e}");
+                        break;
+                    }
+                }
+            }
+            "textDocument/hover" => {
+                if let Some(id) = id {
+                    let uri = params
+                        .get("textDocument")
+                        .and_then(|td| td.get("uri"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    let line = params
+                        .get("position")
+                        .and_then(|p| p.get("line"))
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0) as u32;
+                    let character = params
+                        .get("position")
+                        .and_then(|p| p.get("character"))
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0) as u32;
+                    let position = wado_lsp::Position { line, character };
+                    let result = match engine.hover(uri, position) {
+                        Some(hover) => json!({
+                            "contents": {
+                                "kind": "markdown",
+                                "value": hover.contents,
+                            },
+                            "range": {
+                                "start": {
+                                    "line": hover.range.start.line,
+                                    "character": hover.range.start.character,
+                                },
+                                "end": {
+                                    "line": hover.range.end.line,
+                                    "character": hover.range.end.character,
+                                },
+                            },
+                        }),
+                        None => Value::Null,
+                    };
+                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
+                        eprintln!("wado-lsp: {e}");
+                        break;
+                    }
+                }
+            }
+            "textDocument/semanticTokens/full" => {
+                if let Some(id) = id {
+                    let uri = params
+                        .get("textDocument")
+                        .and_then(|td| td.get("uri"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    let data = engine.semantic_tokens(uri);
+                    let result = json!({ "data": data });
+                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
+                        eprintln!("wado-lsp: {e}");
+                        break;
                     }
                 }
             }

--- a/wado-cli/tests/lsp.rs
+++ b/wado-cli/tests/lsp.rs
@@ -324,7 +324,7 @@ fn lsp_unknown_method_returns_error() {
     let _init_resp = session.read_message();
 
     let id = session.send_request(
-        "textDocument/hover",
+        "textDocument/unknownMethod",
         json!({
             "textDocument": { "uri": "file:///tmp/test.wado" },
             "position": { "line": 0, "character": 0 }

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -117,7 +117,7 @@ Tests for standard library logic live alongside implementations in `lib/`. These
 
 This crate must compile for `wasm32-unknown-unknown`. Do not use OS-dependent `std` modules in production code. CI enforces this with a wasm32 build check.
 
-## Refactoring Plan: Toward LSP-Friendly, Salsa-Ready Architecture
+## Refactoring Plan: LSP-Friendly Compiler Architecture
 
 ### Motivation
 
@@ -125,14 +125,15 @@ The current pipeline (`parse → bind → desugar → load → analyze → resol
 
 - TIR is a transformed tree, losing 1:1 correspondence with source AST. `position → type` / `position → symbol` queries have no direct path.
 - AST declarations carry a single `Span` covering the whole item, not the name identifier. LSP features (go-to-definition, rename, hover) need the name span.
-- The pipeline is monolithic: producing diagnostics for one file re-runs the entire compilation. No incremental story, no per-function caching.
 - Symbols lack source-file/URI info, so cross-file navigation cannot be assembled.
 
-Roslyn and rust-analyzer both solve this by keeping the **AST (or a lossless syntax tree) as the source of truth** and attaching semantic information via queries (`SemanticModel.GetTypeInfo(node)`, salsa queries keyed by `AstId`). Wado should move in the same direction.
+### Design Context
 
-### Target Architecture (two-step)
+Coding agents write most of the code, so keystroke-level incremental analysis is low priority. However humans read code extensively, so full navigation and comprehension features (hover, go-to-definition, find-references, semantic tokens) are essential. Occasional human editing means some completion support is desirable but not critical.
 
-**Step 1 — Attach semantic info to AST (non-salsa, hand-rolled).**
+This means a simple **"recompute on file change, cache per-document"** model is sufficient: parse + bind + resolve runs once per `didChange`/`didSave` (typically tens of milliseconds for a single file), and results are cached until the next change. No demand-driven incremental framework (salsa) is needed at this scale.
+
+### Target Architecture
 
 - Introduce stable `AstId` (module-local, parse-stable) and `AstPtr` (position-resolvable).
 - Add `name_span: Span` to every AST declaration (fn, struct, enum, variant, flags, trait, newtype, impl method, global, let, param).
@@ -141,28 +142,22 @@ Roslyn and rust-analyzer both solve this by keeping the **AST (or a lossless syn
 - Expose a query API: `position → AstId`, `AstId → Symbol`, `AstId → ResolvedType`, `Symbol → defining AstId + source URI`.
 - Add a **lightweight analysis entry point** (parse + bind + resolve, no monomorphize/lower/codegen) for LSP use.
 - Add source URI to `Symbol` so cross-file definition results can be returned.
+- LSP caches analysis results per document and invalidates on change.
 
-**Step 2 — Wrap in salsa (demand-driven, incremental).**
+### Future: Incremental Analysis (salsa)
 
-- Make each phase a salsa query (`parse`, `module_symbols`, `resolve_function_body`, `type_of`, …).
-- Per-function body type inference, cached; invalidation driven by input changes.
-- TIR generation becomes lazy, only materialized for codegen or when requested.
-- LSP reuses the same query functions; no separate code path.
-
-Step 1 is a stepping stone, not throwaway: `AstId`, query API shape, phase separation all carry forward. Salsa wrapping is mostly mechanical once the data flow is untangled.
+If the project grows to hundreds of files and per-file reanalysis becomes a bottleneck, the architecture above is designed to be wrappable in salsa queries with minimal restructuring. This is not planned for the foreseeable future.
 
 ### Principles
 
 - **AST is the source of truth.** Semantic info is attached, not substituted.
-- **Lowering is demand-driven.** TIR / monomorphization / codegen only run when their output is actually needed.
 - **Every semantic entity points back to source.** `Symbol`, `ResolvedType`, TIR nodes carry `AstId` (and transitively `Span` + URI).
 - **The `codegen.rs` principle still holds.** Codegen consumes TIR without knowledge of earlier phases; what changes is how and when TIR is produced.
 
 ### Scope Boundaries
 
 - This plan does **not** change the language, `Package` format, or codegen output.
-- Batch compilation (`wado compile`) continues to work by driving the queries end-to-end.
-- Diagnostics format is unchanged; only how they are computed and cached changes.
+- Batch compilation (`wado compile`) continues to work by driving the query chain end-to-end.
 
 ### `name_span` Convention
 

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -116,3 +116,50 @@ Tests for standard library logic live alongside implementations in `lib/`. These
 ## Wasm Compatibility
 
 This crate must compile for `wasm32-unknown-unknown`. Do not use OS-dependent `std` modules in production code. CI enforces this with a wasm32 build check.
+
+## Refactoring Plan: Toward LSP-Friendly, Salsa-Ready Architecture
+
+### Motivation
+
+The current pipeline (`parse → bind → desugar → load → analyze → resolve → TIR → monomorphize → lower → optimize → codegen`) treats **resolve as AST → TIR lowering**. This is fine for batch compilation but hostile to LSP:
+
+- TIR is a transformed tree, losing 1:1 correspondence with source AST. `position → type` / `position → symbol` queries have no direct path.
+- AST declarations carry a single `Span` covering the whole item, not the name identifier. LSP features (go-to-definition, rename, hover) need the name span.
+- The pipeline is monolithic: producing diagnostics for one file re-runs the entire compilation. No incremental story, no per-function caching.
+- Symbols lack source-file/URI info, so cross-file navigation cannot be assembled.
+
+Roslyn and rust-analyzer both solve this by keeping the **AST (or a lossless syntax tree) as the source of truth** and attaching semantic information via queries (`SemanticModel.GetTypeInfo(node)`, salsa queries keyed by `AstId`). Wado should move in the same direction.
+
+### Target Architecture (two-step)
+
+**Step 1 — Attach semantic info to AST (non-salsa, hand-rolled).**
+
+- Introduce stable `AstId` (module-local, parse-stable) and `AstPtr` (position-resolvable).
+- Add `name_span: Span` to every AST declaration (fn, struct, enum, variant, flags, trait, newtype, impl method, global, let, param).
+- Rework `SymbolTable` / `TypeTable` to be keyed by `AstId` rather than consumed during TIR construction.
+- Split `resolve` into: (a) *annotate* AST with `SymbolTable`/`TypeTable` (no lowering), (b) *lower* to TIR as a later phase.
+- Expose a query API: `position → AstId`, `AstId → Symbol`, `AstId → ResolvedType`, `Symbol → defining AstId + source URI`.
+- Add a **lightweight analysis entry point** (parse + bind + resolve, no monomorphize/lower/codegen) for LSP use.
+- Add source URI to `Symbol` so cross-file definition results can be returned.
+
+**Step 2 — Wrap in salsa (demand-driven, incremental).**
+
+- Make each phase a salsa query (`parse`, `module_symbols`, `resolve_function_body`, `type_of`, …).
+- Per-function body type inference, cached; invalidation driven by input changes.
+- TIR generation becomes lazy, only materialized for codegen or when requested.
+- LSP reuses the same query functions; no separate code path.
+
+Step 1 is a stepping stone, not throwaway: `AstId`, query API shape, phase separation all carry forward. Salsa wrapping is mostly mechanical once the data flow is untangled.
+
+### Principles
+
+- **AST is the source of truth.** Semantic info is attached, not substituted.
+- **Lowering is demand-driven.** TIR / monomorphization / codegen only run when their output is actually needed.
+- **Every semantic entity points back to source.** `Symbol`, `ResolvedType`, TIR nodes carry `AstId` (and transitively `Span` + URI).
+- **The `codegen.rs` principle still holds.** Codegen consumes TIR without knowledge of earlier phases; what changes is how and when TIR is produced.
+
+### Scope Boundaries
+
+- This plan does **not** change the language, `Package` format, or codegen output.
+- Batch compilation (`wado compile`) continues to work by driving the queries end-to-end.
+- Diagnostics format is unchanged; only how they are computed and cached changes.

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -163,3 +163,12 @@ Step 1 is a stepping stone, not throwaway: `AstId`, query API shape, phase separ
 - This plan does **not** change the language, `Package` format, or codegen output.
 - Batch compilation (`wado compile`) continues to work by driving the queries end-to-end.
 - Diagnostics format is unchanged; only how they are computed and cached changes.
+
+### `name_span` Convention
+
+Every AST declaration must carry a `name_span: Span` covering **only the name identifier**, in addition to the existing `span` (which covers the whole item).
+
+- Why: LSP features (go-to-definition, hover target, rename, semantic token for declaration name) need to highlight/click the name alone. The item-wide `span` is too coarse; lexer heuristics to recover the name position are fragile and duplicated in wado-lsp.
+- Where: `Function`, `Struct`, `Enum` (and each enum member), `Variant` (and each variant case), `Flags` (and each flag member), `Trait`, `Newtype`, `Effect`, `Global`, `Impl` method, `LetStatement` binding, function/closure `Parameter`, generic `TypeParameter`.
+- Parser responsibility: capture the span at the identifier token at parse time. Do not reconstruct from `span` later.
+- Independent of the larger refactor: `name_span` can land first on its own; it is a pure additive change with immediate LSP benefit.

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -137,7 +137,7 @@ Roslyn and rust-analyzer both solve this by keeping the **AST (or a lossless syn
 - Introduce stable `AstId` (module-local, parse-stable) and `AstPtr` (position-resolvable).
 - Add `name_span: Span` to every AST declaration (fn, struct, enum, variant, flags, trait, newtype, impl method, global, let, param).
 - Rework `SymbolTable` / `TypeTable` to be keyed by `AstId` rather than consumed during TIR construction.
-- Split `resolve` into: (a) *annotate* AST with `SymbolTable`/`TypeTable` (no lowering), (b) *lower* to TIR as a later phase.
+- Split `resolve` into: (a) _annotate_ AST with `SymbolTable`/`TypeTable` (no lowering), (b) _lower_ to TIR as a later phase.
 - Expose a query API: `position → AstId`, `AstId → Symbol`, `AstId → ResolvedType`, `Symbol → defining AstId + source URI`.
 - Add a **lightweight analysis entry point** (parse + bind + resolve, no monomorphize/lower/codegen) for LSP use.
 - Add source URI to `Symbol` so cross-file definition results can be returned.

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -6,12 +6,13 @@ use crate::ast::{
     AssertStmt, AssignExpr, AttrArg, Attribute, BinaryExpr, BinaryOp, Block, BreakStmt, CallExpr,
     CastExpr, ClosureExpr, ComparisonChainExpr, CompoundAssignExpr, CompoundAssignOp, Condition,
     ConditionElement, EffectDecl, EffectMethod, EnumCase, EnumDecl, Expr, ExprStmt,
-    FieldAccessExpr, ForOfStmt, ForStmt, Function, FunctionType, GlobalDecl, IfExpr, IfStmt,
-    ImplBlock, ImportAttributes, IndexExpr, Item, LabeledBlockStmt, LetStmt, Literal, LoopStmt,
-    MatchArm, MatchExpr, MethodCallExpr, Module, Newtype, Param, Pattern, ResourceDecl, ReturnStmt,
-    SelfKind, StaticMethodCallExpr, Stmt, StructDecl, StructField, StructLiteralExpr,
-    TemplateStringExpr, TestDecl, TraitDecl, TupleLiteralExpr, TupleTypeDecl, Type, UnaryExpr,
-    UnaryOp, UseDecl, UseItem, UseItemSimple, VariantCase, VariantDecl, WhileStmt, WorldDecl,
+    FieldAccessExpr, FlagsDecl, ForOfStmt, ForStmt, Function, FunctionType, GenericParam,
+    GlobalDecl, IfExpr, IfStmt, ImplBlock, ImportAttributes, IndexExpr, Item, LabeledBlockStmt,
+    LetStmt, Literal, LoopStmt, MatchArm, MatchExpr, MethodCallExpr, Module, Newtype, Param,
+    Pattern, ResourceDecl, ReturnStmt, SelfKind, StaticMethodCallExpr, Stmt, StoresEntry,
+    StructDecl, StructField, StructLiteralExpr, TemplateStringExpr, TestDecl, TraitDecl,
+    TupleLiteralExpr, TupleTypeDecl, Type, UnaryExpr, UnaryOp, UseDecl, UseItem, UseItemSimple,
+    VariantCase, VariantDecl, WhileStmt, WorldDecl,
 };
 use crate::comment::{Comment, CommentKind, CommentMap};
 use crate::hashmap::IndexSet;
@@ -3514,7 +3515,7 @@ pub fn unparse_type_into(ty: &Type, output: &mut String) {
             output.push('>');
         }
         Type::Function(f) => {
-            output.push_str("Fn(");
+            output.push_str("fn(");
             for (i, param) in f.params.iter().enumerate() {
                 if i > 0 {
                     output.push_str(", ");
@@ -3523,6 +3524,7 @@ pub fn unparse_type_into(ty: &Type, output: &mut String) {
             }
             output.push_str(") -> ");
             unparse_type_into(&f.return_type, output);
+            unparse_fn_type_with_clause_into(&f.effects, &f.stores, output);
         }
         Type::Tuple(types) => {
             output.push('[');
@@ -3595,6 +3597,271 @@ fn unparse_literal_into(lit: &Literal, output: &mut String) {
             output.push_str("\")");
         }
     }
+}
+
+/// Signature-only unparsers for AST declarations.
+///
+/// These produce a single-line textual signature suitable for hover, completion
+/// detail, document symbols, etc. — without emitting the body, attributes, or
+/// surrounding indentation. They are stateless (no `CommentMap` required) and
+/// match the canonical source syntax of the language.
+pub fn unparse_function_signature(f: &Function) -> String {
+    let mut out = String::new();
+    unparse_function_signature_into(f, &mut out);
+    out
+}
+
+pub fn unparse_function_signature_into(f: &Function, output: &mut String) {
+    if f.is_pub {
+        output.push_str("pub ");
+    }
+    if f.is_export {
+        output.push_str("export ");
+    }
+    if f.is_async {
+        output.push_str("async ");
+    }
+    output.push_str("fn ");
+    output.push_str(&f.name);
+    unparse_generic_params_into(&f.type_params, output);
+    output.push('(');
+    for (i, param) in f.params.iter().enumerate() {
+        if i > 0 {
+            output.push_str(", ");
+        }
+        unparse_param_into(param, output);
+    }
+    output.push(')');
+    if let Some(ret) = &f.return_type
+        && !matches!(ret, Type::Named(n) if n.name == "()")
+    {
+        output.push_str(" -> ");
+        unparse_type_into(ret, output);
+    }
+    unparse_with_clause_into(&f.effects, &f.stores, output);
+}
+
+pub fn unparse_struct_header(s: &StructDecl) -> String {
+    let mut out = String::new();
+    if s.is_pub {
+        out.push_str("pub ");
+    }
+    out.push_str("struct ");
+    out.push_str(&s.name);
+    unparse_generic_params_into(&s.type_params, &mut out);
+    out
+}
+
+pub fn unparse_enum_header(e: &EnumDecl) -> String {
+    let mut out = String::new();
+    if e.is_pub {
+        out.push_str("pub ");
+    }
+    out.push_str("enum ");
+    out.push_str(&e.name);
+    unparse_generic_params_into(&e.type_params, &mut out);
+    out
+}
+
+pub fn unparse_variant_header(v: &VariantDecl) -> String {
+    let mut out = String::new();
+    if v.is_pub {
+        out.push_str("pub ");
+    }
+    out.push_str("variant ");
+    out.push_str(&v.name);
+    unparse_generic_params_into(&v.type_params, &mut out);
+    out
+}
+
+pub fn unparse_flags_header(fl: &FlagsDecl) -> String {
+    let mut out = String::new();
+    if fl.is_pub {
+        out.push_str("pub ");
+    }
+    out.push_str("flags ");
+    out.push_str(&fl.name);
+    out
+}
+
+pub fn unparse_trait_header(t: &TraitDecl) -> String {
+    let mut out = String::new();
+    if t.is_pub {
+        out.push_str("pub ");
+    }
+    out.push_str("trait ");
+    out.push_str(&t.name);
+    unparse_generic_params_into(&t.type_params, &mut out);
+    out
+}
+
+pub fn unparse_newtype_signature(n: &Newtype) -> String {
+    let mut out = String::new();
+    if n.is_pub {
+        out.push_str("pub ");
+    }
+    out.push_str("type ");
+    out.push_str(&n.name);
+    unparse_generic_params_into(&n.type_params, &mut out);
+    out.push_str(" = ");
+    unparse_type_into(&n.ty, &mut out);
+    out
+}
+
+pub fn unparse_global_signature(g: &GlobalDecl) -> String {
+    let mut out = String::new();
+    if g.is_pub {
+        out.push_str("pub ");
+    }
+    out.push_str("global ");
+    if g.mutable {
+        out.push_str("mut ");
+    }
+    out.push_str(&g.name);
+    out.push_str(": ");
+    unparse_type_into(&g.ty, &mut out);
+    out
+}
+
+pub fn unparse_generic_params_into(params: &[GenericParam], output: &mut String) {
+    if params.is_empty() {
+        return;
+    }
+    output.push('<');
+    for (i, param) in params.iter().enumerate() {
+        if i > 0 {
+            output.push_str(", ");
+        }
+        if param.is_effect {
+            output.push_str("effect ");
+        }
+        if param.is_pack {
+            output.push_str("..");
+        }
+        output.push_str(&param.name);
+        if !param.bounds.is_empty() {
+            output.push_str(": ");
+            for (j, bound) in param.bounds.iter().enumerate() {
+                if j > 0 {
+                    output.push_str(" + ");
+                }
+                output.push_str(&bound.name);
+                if !bound.assoc_types.is_empty() {
+                    output.push('<');
+                    for (k, assoc) in bound.assoc_types.iter().enumerate() {
+                        if k > 0 {
+                            output.push_str(", ");
+                        }
+                        output.push_str(&assoc.name);
+                        output.push_str(" = ");
+                        unparse_type_into(&assoc.ty, output);
+                    }
+                    output.push('>');
+                }
+            }
+        }
+        if let Some(default_type) = &param.default {
+            output.push_str(" = ");
+            unparse_type_into(default_type, output);
+        }
+    }
+    output.push('>');
+}
+
+pub fn unparse_param_into(param: &Param, output: &mut String) {
+    match param.self_kind {
+        SelfKind::Ref => {
+            output.push_str("&self");
+            return;
+        }
+        SelfKind::MutRef => {
+            output.push_str("&mut self");
+            return;
+        }
+        SelfKind::None => {}
+    }
+    if param.name == "self" {
+        if let Type::Reference(inner) = &param.ty
+            && matches!(inner.as_ref(), Type::Named(n) if n.name == "Self")
+        {
+            output.push_str("&self");
+            return;
+        }
+        if let Type::MutReference(inner) = &param.ty
+            && matches!(inner.as_ref(), Type::Named(n) if n.name == "Self")
+        {
+            output.push_str("&mut self");
+            return;
+        }
+    }
+    if param.is_mut {
+        output.push_str("mut ");
+    }
+    output.push_str(&param.name);
+    output.push_str(": ");
+    unparse_type_into(&param.ty, output);
+}
+
+pub fn unparse_with_clause_into(effects: &[String], stores: &[String], output: &mut String) {
+    if effects.is_empty() && stores.is_empty() {
+        return;
+    }
+    output.push_str(" with ");
+    if !effects.is_empty() {
+        output.push_str(&effects.join(", "));
+        if !stores.is_empty() {
+            output.push_str(", ");
+        }
+    }
+    if !stores.is_empty() {
+        output.push_str("stores[");
+        output.push_str(&stores.join(", "));
+        output.push(']');
+    }
+}
+
+/// with-clause for function-type position (`stores[0, 1]` with positional indices).
+fn unparse_fn_type_with_clause_into(
+    effects: &[String],
+    stores: &[StoresEntry],
+    output: &mut String,
+) {
+    if effects.is_empty() && stores.is_empty() {
+        return;
+    }
+    output.push_str(" with ");
+    if !effects.is_empty() {
+        output.push_str(&effects.join(", "));
+        if !stores.is_empty() {
+            output.push_str(", ");
+        }
+    }
+    if !stores.is_empty() {
+        output.push_str("stores[");
+        let entries: Vec<String> = stores.iter().map(ToString::to_string).collect();
+        output.push_str(&entries.join(", "));
+        output.push(']');
+    }
+}
+
+pub fn unparse_enum_case(enum_name: &str, case: &EnumCase) -> String {
+    format!("{enum_name}::{}", case.name)
+}
+
+pub fn unparse_variant_case(variant_name: &str, case: &VariantCase) -> String {
+    let mut out = format!("{variant_name}::{}", case.name);
+    if let Some(payload) = &case.payload {
+        out.push('(');
+        unparse_type_into(payload, &mut out);
+        out.push(')');
+    }
+    out
+}
+
+pub fn unparse_struct_field(struct_name: &str, field: &StructField) -> String {
+    let mut out = format!("{struct_name}.{}: ", field.name);
+    unparse_type_into(&field.ty, &mut out);
+    out
 }
 
 use crate::lexer::is_valid_ident;

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -17,7 +17,7 @@ Language service engine for the Wado compiler toolchain.
 | `src/diagnostics.rs`     | Compiler `Diagnostic` to LSP-compatible `Diagnostic` conversion |
 | `src/semantic_tokens.rs` | Semantic token computation (lexer + AST classification)         |
 | `src/definition.rs`      | Go-to-definition (single-file, AST-level name resolution)       |
-| `src/hover.rs`           | Hover info (AST-level signature formatting)                     |
+| `src/hover.rs`           | Hover info (delegates signature rendering to `wado_compiler::unparse`) |
 
 ### Engine
 

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -11,10 +11,13 @@ Language service engine for the Wado compiler toolchain.
 
 ## Architecture
 
-| File                 | Role                                                            |
-| -------------------- | --------------------------------------------------------------- |
-| `src/lib.rs`         | `Engine` struct: document management + query dispatch           |
-| `src/diagnostics.rs` | Compiler `Diagnostic` to LSP-compatible `Diagnostic` conversion |
+| File                     | Role                                                            |
+| ------------------------ | --------------------------------------------------------------- |
+| `src/lib.rs`             | `Engine` struct: document management + query dispatch           |
+| `src/diagnostics.rs`     | Compiler `Diagnostic` to LSP-compatible `Diagnostic` conversion |
+| `src/semantic_tokens.rs` | Semantic token computation (lexer + AST classification)         |
+| `src/definition.rs`      | Go-to-definition (single-file, AST-level name resolution)       |
+| `src/hover.rs`           | Hover info (AST-level signature formatting)                     |
 
 ### Engine
 
@@ -70,7 +73,7 @@ Progress tracker for LSP 3.18 feature kinds. Each item represents a protocol kin
 ### Language Features — Navigation
 
 - [ ] `textDocument/declaration`
-- [ ] `textDocument/definition`
+- [x] `textDocument/definition` (single-file, AST-level)
 - [ ] `textDocument/typeDefinition`
 - [ ] `textDocument/implementation`
 - [ ] `textDocument/references`
@@ -79,7 +82,7 @@ Progress tracker for LSP 3.18 feature kinds. Each item represents a protocol kin
 
 ### Language Features — Comprehension
 
-- [ ] `textDocument/hover`
+- [x] `textDocument/hover` (single-file, AST-level signatures)
 - [ ] `textDocument/signatureHelp`
 - [ ] `textDocument/documentHighlight`
 - [ ] `textDocument/documentLink`
@@ -93,7 +96,7 @@ Progress tracker for LSP 3.18 feature kinds. Each item represents a protocol kin
 - [ ] `textDocument/documentSymbol`
 - [ ] `textDocument/foldingRange`
 - [ ] `textDocument/selectionRange`
-- [ ] `textDocument/semanticTokens` (full / delta / range)
+- [x] `textDocument/semanticTokens` (full only, lexer+AST classification)
 - [ ] `textDocument/linkedEditingRange`
 
 ### Language Features — Editing

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -11,12 +11,12 @@ Language service engine for the Wado compiler toolchain.
 
 ## Architecture
 
-| File                     | Role                                                            |
-| ------------------------ | --------------------------------------------------------------- |
-| `src/lib.rs`             | `Engine` struct: document management + query dispatch           |
-| `src/diagnostics.rs`     | Compiler `Diagnostic` to LSP-compatible `Diagnostic` conversion |
-| `src/semantic_tokens.rs` | Semantic token computation (lexer + AST classification)         |
-| `src/definition.rs`      | Go-to-definition (single-file, AST-level name resolution)       |
+| File                     | Role                                                                   |
+| ------------------------ | ---------------------------------------------------------------------- |
+| `src/lib.rs`             | `Engine` struct: document management + query dispatch                  |
+| `src/diagnostics.rs`     | Compiler `Diagnostic` to LSP-compatible `Diagnostic` conversion        |
+| `src/semantic_tokens.rs` | Semantic token computation (lexer + AST classification)                |
+| `src/definition.rs`      | Go-to-definition (single-file, AST-level name resolution)              |
 | `src/hover.rs`           | Hover info (delegates signature rendering to `wado_compiler::unparse`) |
 
 ### Engine

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -37,3 +37,92 @@ Language service engine for the Wado compiler toolchain.
 ## References
 
 See [lsp.md](lsp.md) for the specification of the latest LSP.
+
+## TODO: LSP Feature Implementation
+
+Progress tracker for LSP 3.18 feature kinds. Each item represents a protocol kind (request/notification group), not individual fields or options.
+
+### Server Lifecycle
+
+- [x] `initialize` / `initialized`
+- [x] `shutdown` / `exit`
+- [ ] `client/registerCapability` / `client/unregisterCapability`
+- [ ] `$/setTrace` / `$/logTrace`
+- [ ] `$/cancelRequest`
+
+### Text Document Synchronization
+
+- [x] `textDocument/didOpen`
+- [x] `textDocument/didChange` (Full sync only)
+- [x] `textDocument/didClose`
+- [ ] `textDocument/didChange` (Incremental sync)
+- [ ] `textDocument/willSave`
+- [ ] `textDocument/willSaveWaitUntil`
+- [ ] `textDocument/didSave`
+- [ ] `textDocument/didRename`
+
+### Diagnostics
+
+- [x] `textDocument/publishDiagnostics` (push)
+- [ ] `textDocument/diagnostic` (pull)
+- [ ] `workspace/diagnostic` (pull)
+
+### Language Features — Navigation
+
+- [ ] `textDocument/declaration`
+- [ ] `textDocument/definition`
+- [ ] `textDocument/typeDefinition`
+- [ ] `textDocument/implementation`
+- [ ] `textDocument/references`
+- [ ] `textDocument/callHierarchy` (prepare / incomingCalls / outgoingCalls)
+- [ ] `textDocument/typeHierarchy` (prepare / supertypes / subtypes)
+
+### Language Features — Comprehension
+
+- [ ] `textDocument/hover`
+- [ ] `textDocument/signatureHelp`
+- [ ] `textDocument/documentHighlight`
+- [ ] `textDocument/documentLink`
+- [ ] `textDocument/codeLens`
+- [ ] `textDocument/inlayHint`
+- [ ] `textDocument/inlineValue`
+- [ ] `textDocument/moniker`
+
+### Language Features — Structure
+
+- [ ] `textDocument/documentSymbol`
+- [ ] `textDocument/foldingRange`
+- [ ] `textDocument/selectionRange`
+- [ ] `textDocument/semanticTokens` (full / delta / range)
+- [ ] `textDocument/linkedEditingRange`
+
+### Language Features — Editing
+
+- [ ] `textDocument/completion`
+- [ ] `textDocument/codeAction`
+- [ ] `textDocument/formatting`
+- [ ] `textDocument/rangeFormatting`
+- [ ] `textDocument/onTypeFormatting`
+- [ ] `textDocument/rename` / `textDocument/prepareRename`
+- [ ] `textDocument/inlineCompletion`
+- [ ] `textDocument/documentColor` / `textDocument/colorPresentation`
+
+### Workspace Features
+
+- [ ] `workspace/symbol`
+- [ ] `workspace/configuration`
+- [ ] `workspace/didChangeConfiguration`
+- [ ] `workspace/workspaceFolders` / `workspace/didChangeWorkspaceFolders`
+- [ ] `workspace/didChangeWatchedFiles`
+- [ ] `workspace/executeCommand`
+- [ ] `workspace/applyEdit`
+- [ ] `workspace/textDocumentContent`
+- [ ] File operations (`willCreateFiles` / `didCreateFiles` / `willRenameFiles` / `didRenameFiles` / `willDeleteFiles` / `didDeleteFiles`)
+
+### Window Features
+
+- [ ] `window/showMessage` / `window/showMessageRequest`
+- [ ] `window/showDocument`
+- [ ] `window/logMessage`
+- [ ] `window/workDoneProgress` (create / cancel)
+- [ ] `telemetry/event`

--- a/wado-lsp/src/definition.rs
+++ b/wado-lsp/src/definition.rs
@@ -1,0 +1,368 @@
+use wado_compiler::ast::{self, Expr, Item, Stmt};
+use wado_compiler::lexer::Lexer;
+use wado_compiler::token::{Span, Token, TokenKind};
+
+use crate::diagnostics::{Position, Range};
+
+/// Result of a go-to-definition query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DefinitionResult {
+    /// URI of the document containing the definition.
+    pub uri: String,
+    /// Range of the definition.
+    pub range: Range,
+}
+
+/// Find the definition location for the identifier at the given position.
+///
+/// Uses AST-level resolution within the entry file: finds the token at the cursor,
+/// then scans all declarations for a matching name.
+pub fn find_definition(source: &str, position: Position, uri: &str) -> Option<DefinitionResult> {
+    // 1. Lex to find the token at cursor position
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().ok()?;
+    let ident_name = find_ident_at_position(&tokens, position)?;
+
+    // 2. Parse to get AST
+    let pr = wado_compiler::parse(source).ok()?;
+
+    // 3. Collect all definitions from AST
+    let defs = collect_definitions(&pr.ast);
+
+    // 4. Find matching definition
+    let def = defs.iter().find(|d| d.name == ident_name)?;
+
+    Some(DefinitionResult {
+        uri: uri.to_string(),
+        range: span_to_range(&def.span),
+    })
+}
+
+/// Find the identifier name at the given cursor position.
+fn find_ident_at_position(tokens: &[Token], position: Position) -> Option<String> {
+    let target_line = position.line as usize + 1; // LSP 0-based → compiler 1-based
+    let target_col = position.character as usize + 1;
+
+    for token in tokens {
+        if let TokenKind::Ident(ref name) = token.kind
+            && token.span.line == target_line
+            && target_col >= token.span.column
+            && target_col < token.span.column + (token.span.end - token.span.start)
+        {
+            return Some(name.clone());
+        }
+        // Also handle contextual keywords used as identifiers
+        if let Some(name) = token.kind.as_ident_name()
+            && token.span.line == target_line
+            && target_col >= token.span.column
+            && target_col < token.span.column + (token.span.end - token.span.start)
+        {
+            if !matches!(
+                token.kind,
+                TokenKind::Ident(_)
+                    | TokenKind::Flags
+                    | TokenKind::Type
+                    | TokenKind::Of
+                    | TokenKind::From
+            ) {
+                continue; // Skip real keywords
+            }
+            return Some(name.to_string());
+        }
+    }
+    None
+}
+
+/// A definition found in the AST.
+struct Definition {
+    name: String,
+    span: Span,
+}
+
+/// Collect all top-level and nested definitions from the AST module.
+fn collect_definitions(module: &ast::Module) -> Vec<Definition> {
+    let mut defs = Vec::new();
+    for item in &module.items {
+        collect_item_defs(&mut defs, item);
+    }
+    defs
+}
+
+fn collect_item_defs(defs: &mut Vec<Definition>, item: &Item) {
+    match item {
+        Item::Function(f) => {
+            defs.push(Definition {
+                name: f.name.clone(),
+                span: f.span,
+            });
+            // Collect parameter definitions
+            for param in &f.params {
+                if param.self_kind == ast::SelfKind::None {
+                    defs.push(Definition {
+                        name: param.name.clone(),
+                        span: param.span,
+                    });
+                }
+            }
+            // Collect let bindings inside the function body
+            if let Some(body) = &f.body {
+                collect_block_defs(defs, body);
+            }
+        }
+        Item::Struct(s) => {
+            defs.push(Definition {
+                name: s.name.clone(),
+                span: s.span,
+            });
+            for field in &s.fields {
+                defs.push(Definition {
+                    name: field.name.clone(),
+                    span: field.span,
+                });
+            }
+        }
+        Item::Enum(e) => {
+            defs.push(Definition {
+                name: e.name.clone(),
+                span: e.span,
+            });
+            for case in &e.cases {
+                defs.push(Definition {
+                    name: case.name.clone(),
+                    span: case.span,
+                });
+            }
+        }
+        Item::Variant(v) => {
+            defs.push(Definition {
+                name: v.name.clone(),
+                span: v.span,
+            });
+            for case in &v.cases {
+                defs.push(Definition {
+                    name: case.name.clone(),
+                    span: case.span,
+                });
+            }
+        }
+        Item::Flags(f) => {
+            defs.push(Definition {
+                name: f.name.clone(),
+                span: f.span,
+            });
+            for flag in &f.flags {
+                defs.push(Definition {
+                    name: flag.name.clone(),
+                    span: flag.span,
+                });
+            }
+        }
+        Item::Trait(t) => {
+            defs.push(Definition {
+                name: t.name.clone(),
+                span: t.span,
+            });
+            for method in &t.methods {
+                defs.push(Definition {
+                    name: method.name.clone(),
+                    span: method.span,
+                });
+            }
+        }
+        Item::Newtype(n) => {
+            defs.push(Definition {
+                name: n.name.clone(),
+                span: n.span,
+            });
+        }
+        Item::Impl(imp) => {
+            for method in &imp.methods {
+                defs.push(Definition {
+                    name: method.name.clone(),
+                    span: method.span,
+                });
+                if let Some(body) = &method.body {
+                    collect_block_defs(defs, body);
+                }
+            }
+        }
+        Item::Effect(e) => {
+            defs.push(Definition {
+                name: e.name.clone(),
+                span: e.span,
+            });
+            for method in &e.methods {
+                defs.push(Definition {
+                    name: method.name.clone(),
+                    span: method.span,
+                });
+            }
+        }
+        Item::Global(g) => {
+            defs.push(Definition {
+                name: g.name.clone(),
+                span: g.span,
+            });
+        }
+        Item::Use(_)
+        | Item::Resource(_)
+        | Item::World(_)
+        | Item::Test(_)
+        | Item::TupleTypeDecl(_) => {}
+    }
+}
+
+fn collect_block_defs(defs: &mut Vec<Definition>, block: &ast::Block) {
+    for stmt in &block.stmts {
+        collect_stmt_defs(defs, stmt);
+    }
+}
+
+fn collect_stmt_defs(defs: &mut Vec<Definition>, stmt: &Stmt) {
+    match stmt {
+        Stmt::Let(l) => {
+            if let Some(name) = pattern_name(&l.pattern) {
+                defs.push(Definition { name, span: l.span });
+            }
+        }
+        Stmt::If(i) => {
+            collect_block_defs(defs, &i.then_block);
+            if let Some(else_block) = &i.else_block {
+                collect_block_defs(defs, else_block);
+            }
+        }
+        Stmt::While(w) => collect_block_defs(defs, &w.body),
+        Stmt::For(f) => {
+            if let Some(init) = &f.init {
+                collect_stmt_defs(defs, init);
+            }
+            collect_block_defs(defs, &f.body);
+        }
+        Stmt::ForOf(fo) => {
+            if let Some(name) = pattern_name(&fo.binding) {
+                defs.push(Definition {
+                    name,
+                    span: fo.span,
+                });
+            }
+            collect_block_defs(defs, &fo.body);
+        }
+        Stmt::Loop(l) => collect_block_defs(defs, &l.body),
+        Stmt::Match(m) => {
+            for arm in &m.arms {
+                collect_expr_defs(defs, &arm.body);
+            }
+        }
+        Stmt::LabeledBlock(lb) => collect_block_defs(defs, &lb.block),
+        _ => {}
+    }
+}
+
+fn collect_expr_defs(defs: &mut Vec<Definition>, expr: &Expr) {
+    match expr {
+        Expr::Block(b) => collect_block_defs(defs, b),
+        Expr::If(i) => {
+            collect_block_defs(defs, &i.then_block);
+            if let Some(else_block) = &i.else_block {
+                collect_block_defs(defs, else_block);
+            }
+        }
+        Expr::Match(m) => {
+            for arm in &m.arms {
+                collect_expr_defs(defs, &arm.body);
+            }
+        }
+        Expr::Closure(c) => {
+            for param in &c.params {
+                // Closure params don't have spans in the AST, skip for now
+                let _ = param;
+            }
+            collect_expr_defs(defs, &c.body);
+        }
+        Expr::LabeledBlock(lb) => collect_block_defs(defs, &lb.block),
+        _ => {}
+    }
+}
+
+/// Extract the simple identifier name from a pattern, if it is a simple ident pattern.
+fn pattern_name(pattern: &ast::Pattern) -> Option<String> {
+    match pattern {
+        ast::Pattern::Ident(name) | ast::Pattern::MutIdent(name) => Some(name.clone()),
+        _ => None,
+    }
+}
+
+/// Convert a compiler Span (1-based) to an LSP Range (0-based).
+fn span_to_range(span: &Span) -> Range {
+    Range {
+        start: Position {
+            line: span.line.saturating_sub(1) as u32,
+            character: span.column.saturating_sub(1) as u32,
+        },
+        end: Position {
+            line: span.end_line.saturating_sub(1) as u32,
+            // end column not available in Span, use start + length
+            character: span.column.saturating_sub(1) as u32 + (span.end - span.start) as u32,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_function_definition() {
+        let source = "fn greet() {}\nfn main() { greet(); }";
+        // Click on `greet` in the call at line 1, char 12
+        let pos = Position {
+            line: 1,
+            character: 12,
+        };
+        let result = find_definition(source, pos, "file:///test.wado");
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.range.start.line, 0); // fn greet is on line 0
+    }
+
+    #[test]
+    fn test_find_struct_definition() {
+        let source = "struct Point { x: i32, y: i32 }\nfn foo(p: Point) {}";
+        // Click on `Point` in the param type at line 1, char 10
+        let pos = Position {
+            line: 1,
+            character: 10,
+        };
+        let result = find_definition(source, pos, "file:///test.wado");
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.range.start.line, 0); // struct Point is on line 0
+    }
+
+    #[test]
+    fn test_no_definition_for_unknown() {
+        let source = "fn foo() { bar(); }";
+        let pos = Position {
+            line: 0,
+            character: 11,
+        };
+        let result = find_definition(source, pos, "file:///test.wado");
+        assert!(result.is_none()); // bar is not defined
+    }
+
+    #[test]
+    fn test_find_ident_at_position() {
+        let source = "fn foo() {}";
+        let mut lexer = Lexer::new(source);
+        let tokens = lexer.tokenize().unwrap();
+        // `foo` is at column 3 (0-based), line 0 (0-based)
+        let name = find_ident_at_position(
+            &tokens,
+            Position {
+                line: 0,
+                character: 3,
+            },
+        );
+        assert_eq!(name.as_deref(), Some("foo"));
+    }
+}

--- a/wado-lsp/src/hover.rs
+++ b/wado-lsp/src/hover.rs
@@ -1,0 +1,449 @@
+use wado_compiler::ast::{self, Item, Stmt, Type};
+use wado_compiler::lexer::Lexer;
+use wado_compiler::token::{Token, TokenKind};
+
+use crate::diagnostics::{Position, Range};
+
+/// Result of a hover query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HoverResult {
+    /// Markdown content to display.
+    pub contents: String,
+    /// Range of the hovered token.
+    pub range: Range,
+}
+
+/// Compute hover information for the identifier at the given position.
+///
+/// Returns a markdown string describing the symbol (signature, type, kind).
+pub fn find_hover(source: &str, position: Position) -> Option<HoverResult> {
+    // 1. Lex to find the token at cursor position
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().ok()?;
+    let (ident_name, token_range) = find_ident_at_position(&tokens, position)?;
+
+    // 2. Parse to get AST
+    let pr = wado_compiler::parse(source).ok()?;
+
+    // 3. Find matching declaration and format hover info
+    let info = find_symbol_info(&pr.ast, &ident_name)?;
+
+    Some(HoverResult {
+        contents: format!("```wado\n{info}\n```"),
+        range: token_range,
+    })
+}
+
+/// Find the identifier name and range at the given cursor position.
+fn find_ident_at_position(tokens: &[Token], position: Position) -> Option<(String, Range)> {
+    let target_line = position.line as usize + 1;
+    let target_col = position.character as usize + 1;
+
+    for token in tokens {
+        let name = match &token.kind {
+            TokenKind::Ident(name) => name.clone(),
+            _ => continue,
+        };
+
+        if token.span.line == target_line
+            && target_col >= token.span.column
+            && target_col < token.span.column + (token.span.end - token.span.start)
+        {
+            let range = Range {
+                start: Position {
+                    line: (token.span.line - 1) as u32,
+                    character: (token.span.column - 1) as u32,
+                },
+                end: Position {
+                    line: (token.span.line - 1) as u32,
+                    character: (token.span.column - 1 + token.span.end - token.span.start) as u32,
+                },
+            };
+            return Some((name, range));
+        }
+    }
+    None
+}
+
+/// Find the declaration info for a symbol name in the AST.
+fn find_symbol_info(module: &ast::Module, name: &str) -> Option<String> {
+    for item in &module.items {
+        if let Some(info) = item_info(item, name) {
+            return Some(info);
+        }
+    }
+    None
+}
+
+fn item_info(item: &Item, name: &str) -> Option<String> {
+    match item {
+        Item::Function(f) if f.name == name => Some(format_function_sig(f)),
+        Item::Struct(s) if s.name == name => Some(format_struct_sig(s)),
+        Item::Enum(e) if e.name == name => Some(format_enum_sig(e)),
+        Item::Variant(v) if v.name == name => Some(format_variant_sig(v)),
+        Item::Flags(fl) if fl.name == name => Some(format!("flags {name}")),
+        Item::Trait(t) if t.name == name => Some(format_trait_sig(t)),
+        Item::Newtype(n) if n.name == name => Some(format!("type {name} = {}", format_type(&n.ty))),
+        Item::Effect(e) if e.name == name => Some(format!("effect {name}")),
+        Item::Global(g) if g.name == name => {
+            let mut s = String::new();
+            if g.is_pub {
+                s.push_str("pub ");
+            }
+            s.push_str("global ");
+            if g.mutable {
+                s.push_str("mut ");
+            }
+            s.push_str(&format!("{name}: {}", format_type(&g.ty)));
+            Some(s)
+        }
+        // Check inside impl blocks for methods
+        Item::Impl(imp) => {
+            for method in &imp.methods {
+                if method.name == name {
+                    return Some(format_function_sig(method));
+                }
+            }
+            None
+        }
+        // Check enum/variant cases
+        Item::Enum(e) => {
+            for case in &e.cases {
+                if case.name == name {
+                    return Some(format!("{}::{}", e.name, case.name));
+                }
+            }
+            None
+        }
+        Item::Variant(v) => {
+            for case in &v.cases {
+                if case.name == name {
+                    let payload = case
+                        .payload
+                        .as_ref()
+                        .map(|ty| format!("({})", format_type(ty)))
+                        .unwrap_or_default();
+                    return Some(format!("{}::{}{}", v.name, case.name, payload));
+                }
+            }
+            None
+        }
+        Item::Struct(s) => {
+            for field in &s.fields {
+                if field.name == name {
+                    return Some(format!(
+                        "{}.{}: {}",
+                        s.name,
+                        field.name,
+                        format_type(&field.ty)
+                    ));
+                }
+            }
+            None
+        }
+        // Check inside trait for methods
+        Item::Trait(t) => {
+            for method in &t.methods {
+                if method.name == name {
+                    return Some(format_function_sig(method));
+                }
+            }
+            None
+        }
+        // Check function params and let bindings
+        Item::Function(f) => {
+            for param in &f.params {
+                if param.name == name && param.self_kind == ast::SelfKind::None {
+                    return Some(format!("{name}: {}", format_type(&param.ty)));
+                }
+            }
+            if let Some(body) = &f.body {
+                return find_let_info(body, name);
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn find_let_info(block: &ast::Block, name: &str) -> Option<String> {
+    for stmt in &block.stmts {
+        if let Stmt::Let(l) = stmt
+            && pattern_matches(&l.pattern, name)
+        {
+            if let Some(ty) = &l.ty {
+                let mut s = String::new();
+                if l.is_mut {
+                    s.push_str("let mut ");
+                } else {
+                    s.push_str("let ");
+                }
+                s.push_str(&format!("{name}: {}", format_type(ty)));
+                return Some(s);
+            }
+            // No type annotation — can't say much without type inference
+            let mut s = String::new();
+            if l.is_mut {
+                s.push_str("let mut ");
+            } else {
+                s.push_str("let ");
+            }
+            s.push_str(name);
+            return Some(s);
+        }
+    }
+    None
+}
+
+fn pattern_matches(pattern: &ast::Pattern, name: &str) -> bool {
+    match pattern {
+        ast::Pattern::Ident(n) | ast::Pattern::MutIdent(n) => n == name,
+        _ => false,
+    }
+}
+
+// --- Type formatting ---
+
+fn format_type(ty: &Type) -> String {
+    match ty {
+        Type::Named(n) => n.name.clone(),
+        Type::Generic(g) => {
+            let args: Vec<String> = g.args.iter().map(format_type).collect();
+            format!("{}<{}>", g.name, args.join(", "))
+        }
+        Type::NamespacedGeneric(ng) => {
+            let args: Vec<String> = ng.args.iter().map(format_type).collect();
+            format!("{}::{}<{}>", ng.namespace, ng.name, args.join(", "))
+        }
+        Type::Function(ft) => {
+            let params: Vec<String> = ft.params.iter().map(format_type).collect();
+            format!(
+                "fn({}) -> {}",
+                params.join(", "),
+                format_type(&ft.return_type)
+            )
+        }
+        Type::Tuple(types) => {
+            let elems: Vec<String> = types.iter().map(format_type).collect();
+            format!("[{}]", elems.join(", "))
+        }
+        Type::Reference(inner) => format!("&{}", format_type(inner)),
+        Type::MutReference(inner) => format!("&mut {}", format_type(inner)),
+        Type::TypePackSpread(name, _) => format!("..{name}"),
+    }
+}
+
+fn format_function_sig(f: &ast::Function) -> String {
+    let mut sig = String::new();
+    if f.is_pub {
+        sig.push_str("pub ");
+    }
+    if f.is_export {
+        sig.push_str("export ");
+    }
+    if f.is_async {
+        sig.push_str("async ");
+    }
+    sig.push_str("fn ");
+    sig.push_str(&f.name);
+
+    // Generic params
+    if !f.type_params.is_empty() {
+        sig.push('<');
+        let params: Vec<String> = f
+            .type_params
+            .iter()
+            .map(|tp| {
+                let mut s = String::new();
+                if tp.is_effect {
+                    s.push_str("effect ");
+                }
+                if tp.is_pack {
+                    s.push_str("..");
+                }
+                s.push_str(&tp.name);
+                if !tp.bounds.is_empty() {
+                    s.push_str(": ");
+                    let bounds: Vec<&str> = tp.bounds.iter().map(|b| b.name.as_str()).collect();
+                    s.push_str(&bounds.join(" + "));
+                }
+                s
+            })
+            .collect();
+        sig.push_str(&params.join(", "));
+        sig.push('>');
+    }
+
+    sig.push('(');
+    let params: Vec<String> = f
+        .params
+        .iter()
+        .map(|p| {
+            if p.self_kind == ast::SelfKind::Ref {
+                "&self".to_string()
+            } else if p.self_kind == ast::SelfKind::MutRef {
+                "&mut self".to_string()
+            } else {
+                format!("{}: {}", p.name, format_type(&p.ty))
+            }
+        })
+        .collect();
+    sig.push_str(&params.join(", "));
+    sig.push(')');
+
+    if let Some(ret) = &f.return_type {
+        sig.push_str(" -> ");
+        sig.push_str(&format_type(ret));
+    }
+
+    if !f.effects.is_empty() {
+        sig.push_str(" with ");
+        sig.push_str(&f.effects.join(", "));
+    }
+
+    sig
+}
+
+fn format_struct_sig(s: &ast::StructDecl) -> String {
+    let mut sig = String::new();
+    if s.is_pub {
+        sig.push_str("pub ");
+    }
+    sig.push_str("struct ");
+    sig.push_str(&s.name);
+    if !s.type_params.is_empty() {
+        sig.push('<');
+        let params: Vec<&str> = s.type_params.iter().map(|tp| tp.name.as_str()).collect();
+        sig.push_str(&params.join(", "));
+        sig.push('>');
+    }
+    sig
+}
+
+fn format_enum_sig(e: &ast::EnumDecl) -> String {
+    let mut sig = String::new();
+    if e.is_pub {
+        sig.push_str("pub ");
+    }
+    sig.push_str("enum ");
+    sig.push_str(&e.name);
+    if !e.type_params.is_empty() {
+        sig.push('<');
+        let params: Vec<&str> = e.type_params.iter().map(|tp| tp.name.as_str()).collect();
+        sig.push_str(&params.join(", "));
+        sig.push('>');
+    }
+    sig
+}
+
+fn format_variant_sig(v: &ast::VariantDecl) -> String {
+    let mut sig = String::new();
+    if v.is_pub {
+        sig.push_str("pub ");
+    }
+    sig.push_str("variant ");
+    sig.push_str(&v.name);
+    if !v.type_params.is_empty() {
+        sig.push('<');
+        let params: Vec<&str> = v.type_params.iter().map(|tp| tp.name.as_str()).collect();
+        sig.push_str(&params.join(", "));
+        sig.push('>');
+    }
+    sig
+}
+
+fn format_trait_sig(t: &ast::TraitDecl) -> String {
+    let mut sig = String::new();
+    if t.is_pub {
+        sig.push_str("pub ");
+    }
+    sig.push_str("trait ");
+    sig.push_str(&t.name);
+    if !t.type_params.is_empty() {
+        sig.push('<');
+        let params: Vec<&str> = t.type_params.iter().map(|tp| tp.name.as_str()).collect();
+        sig.push_str(&params.join(", "));
+        sig.push('>');
+    }
+    sig
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hover_function() {
+        let source = "fn add(a: i32, b: i32) -> i32 { return a + b; }";
+        let result = find_hover(
+            source,
+            Position {
+                line: 0,
+                character: 3,
+            },
+        );
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert!(result.contents.contains("fn add(a: i32, b: i32) -> i32"));
+    }
+
+    #[test]
+    fn test_hover_struct() {
+        let source = "struct Point { x: i32, y: i32 }";
+        let result = find_hover(
+            source,
+            Position {
+                line: 0,
+                character: 7,
+            },
+        );
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert!(result.contents.contains("struct Point"));
+    }
+
+    #[test]
+    fn test_hover_variable_usage() {
+        // Clicking on `a` in the function body should show its type from the param
+        let source = "fn foo(a: i32) { return a; }";
+        let result = find_hover(
+            source,
+            Position {
+                line: 0,
+                character: 24,
+            },
+        );
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert!(result.contents.contains("a: i32"));
+    }
+
+    #[test]
+    fn test_hover_no_result() {
+        let source = "fn foo() {}";
+        // Cursor on whitespace
+        let result = find_hover(
+            source,
+            Position {
+                line: 0,
+                character: 2,
+            },
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_hover_generic_function() {
+        let source = "fn identity<T>(x: T) -> T { return x; }";
+        let result = find_hover(
+            source,
+            Position {
+                line: 0,
+                character: 3,
+            },
+        );
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert!(result.contents.contains("fn identity<T>(x: T) -> T"));
+    }
+}

--- a/wado-lsp/src/hover.rs
+++ b/wado-lsp/src/hover.rs
@@ -1,6 +1,7 @@
-use wado_compiler::ast::{self, Item, Stmt, Type};
+use wado_compiler::ast::{self, Item, Stmt};
 use wado_compiler::lexer::Lexer;
 use wado_compiler::token::{Token, TokenKind};
+use wado_compiler::unparse;
 
 use crate::diagnostics::{Position, Range};
 
@@ -14,18 +15,12 @@ pub struct HoverResult {
 }
 
 /// Compute hover information for the identifier at the given position.
-///
-/// Returns a markdown string describing the symbol (signature, type, kind).
 pub fn find_hover(source: &str, position: Position) -> Option<HoverResult> {
-    // 1. Lex to find the token at cursor position
     let mut lexer = Lexer::new(source);
     let tokens = lexer.tokenize().ok()?;
     let (ident_name, token_range) = find_ident_at_position(&tokens, position)?;
 
-    // 2. Parse to get AST
     let pr = wado_compiler::parse(source).ok()?;
-
-    // 3. Find matching declaration and format hover info
     let info = find_symbol_info(&pr.ast, &ident_name)?;
 
     Some(HoverResult {
@@ -34,7 +29,6 @@ pub fn find_hover(source: &str, position: Position) -> Option<HoverResult> {
     })
 }
 
-/// Find the identifier name and range at the given cursor position.
 fn find_ident_at_position(tokens: &[Token], position: Position) -> Option<(String, Range)> {
     let target_line = position.line as usize + 1;
     let target_col = position.character as usize + 1;
@@ -65,7 +59,6 @@ fn find_ident_at_position(tokens: &[Token], position: Position) -> Option<(Strin
     None
 }
 
-/// Find the declaration info for a symbol name in the AST.
 fn find_symbol_info(module: &ast::Module, name: &str) -> Option<String> {
     for item in &module.items {
         if let Some(info) = item_info(item, name) {
@@ -77,84 +70,52 @@ fn find_symbol_info(module: &ast::Module, name: &str) -> Option<String> {
 
 fn item_info(item: &Item, name: &str) -> Option<String> {
     match item {
-        Item::Function(f) if f.name == name => Some(format_function_sig(f)),
-        Item::Struct(s) if s.name == name => Some(format_struct_sig(s)),
-        Item::Enum(e) if e.name == name => Some(format_enum_sig(e)),
-        Item::Variant(v) if v.name == name => Some(format_variant_sig(v)),
-        Item::Flags(fl) if fl.name == name => Some(format!("flags {name}")),
-        Item::Trait(t) if t.name == name => Some(format_trait_sig(t)),
-        Item::Newtype(n) if n.name == name => Some(format!("type {name} = {}", format_type(&n.ty))),
+        Item::Function(f) if f.name == name => Some(unparse::unparse_function_signature(f)),
+        Item::Struct(s) if s.name == name => Some(unparse::unparse_struct_header(s)),
+        Item::Enum(e) if e.name == name => Some(unparse::unparse_enum_header(e)),
+        Item::Variant(v) if v.name == name => Some(unparse::unparse_variant_header(v)),
+        Item::Flags(fl) if fl.name == name => Some(unparse::unparse_flags_header(fl)),
+        Item::Trait(t) if t.name == name => Some(unparse::unparse_trait_header(t)),
+        Item::Newtype(n) if n.name == name => Some(unparse::unparse_newtype_signature(n)),
         Item::Effect(e) if e.name == name => Some(format!("effect {name}")),
-        Item::Global(g) if g.name == name => {
-            let mut s = String::new();
-            if g.is_pub {
-                s.push_str("pub ");
-            }
-            s.push_str("global ");
-            if g.mutable {
-                s.push_str("mut ");
-            }
-            s.push_str(&format!("{name}: {}", format_type(&g.ty)));
-            Some(s)
-        }
-        // Check inside impl blocks for methods
+        Item::Global(g) if g.name == name => Some(unparse::unparse_global_signature(g)),
         Item::Impl(imp) => {
             for method in &imp.methods {
                 if method.name == name {
-                    return Some(format_function_sig(method));
+                    return Some(unparse::unparse_function_signature(method));
                 }
             }
             None
         }
-        // Check enum/variant cases
-        Item::Enum(e) => {
-            for case in &e.cases {
-                if case.name == name {
-                    return Some(format!("{}::{}", e.name, case.name));
-                }
-            }
-            None
-        }
-        Item::Variant(v) => {
-            for case in &v.cases {
-                if case.name == name {
-                    let payload = case
-                        .payload
-                        .as_ref()
-                        .map(|ty| format!("({})", format_type(ty)))
-                        .unwrap_or_default();
-                    return Some(format!("{}::{}{}", v.name, case.name, payload));
-                }
-            }
-            None
-        }
-        Item::Struct(s) => {
-            for field in &s.fields {
-                if field.name == name {
-                    return Some(format!(
-                        "{}.{}: {}",
-                        s.name,
-                        field.name,
-                        format_type(&field.ty)
-                    ));
-                }
-            }
-            None
-        }
-        // Check inside trait for methods
+        Item::Enum(e) => e
+            .cases
+            .iter()
+            .find(|c| c.name == name)
+            .map(|c| unparse::unparse_enum_case(&e.name, c)),
+        Item::Variant(v) => v
+            .cases
+            .iter()
+            .find(|c| c.name == name)
+            .map(|c| unparse::unparse_variant_case(&v.name, c)),
+        Item::Struct(s) => s
+            .fields
+            .iter()
+            .find(|f| f.name == name)
+            .map(|f| unparse::unparse_struct_field(&s.name, f)),
         Item::Trait(t) => {
             for method in &t.methods {
                 if method.name == name {
-                    return Some(format_function_sig(method));
+                    return Some(unparse::unparse_function_signature(method));
                 }
             }
             None
         }
-        // Check function params and let bindings
         Item::Function(f) => {
             for param in &f.params {
                 if param.name == name && param.self_kind == ast::SelfKind::None {
-                    return Some(format!("{name}: {}", format_type(&param.ty)));
+                    let mut out = String::new();
+                    unparse::unparse_param_into(param, &mut out);
+                    return Some(out);
                 }
             }
             if let Some(body) = &f.body {
@@ -171,25 +132,14 @@ fn find_let_info(block: &ast::Block, name: &str) -> Option<String> {
         if let Stmt::Let(l) = stmt
             && pattern_matches(&l.pattern, name)
         {
+            let mut out = String::new();
+            out.push_str(if l.is_mut { "let mut " } else { "let " });
+            out.push_str(name);
             if let Some(ty) = &l.ty {
-                let mut s = String::new();
-                if l.is_mut {
-                    s.push_str("let mut ");
-                } else {
-                    s.push_str("let ");
-                }
-                s.push_str(&format!("{name}: {}", format_type(ty)));
-                return Some(s);
+                out.push_str(": ");
+                unparse::unparse_type_into(ty, &mut out);
             }
-            // No type annotation — can't say much without type inference
-            let mut s = String::new();
-            if l.is_mut {
-                s.push_str("let mut ");
-            } else {
-                s.push_str("let ");
-            }
-            s.push_str(name);
-            return Some(s);
+            return Some(out);
         }
     }
     None
@@ -200,172 +150,6 @@ fn pattern_matches(pattern: &ast::Pattern, name: &str) -> bool {
         ast::Pattern::Ident(n) | ast::Pattern::MutIdent(n) => n == name,
         _ => false,
     }
-}
-
-// --- Type formatting ---
-
-fn format_type(ty: &Type) -> String {
-    match ty {
-        Type::Named(n) => n.name.clone(),
-        Type::Generic(g) => {
-            let args: Vec<String> = g.args.iter().map(format_type).collect();
-            format!("{}<{}>", g.name, args.join(", "))
-        }
-        Type::NamespacedGeneric(ng) => {
-            let args: Vec<String> = ng.args.iter().map(format_type).collect();
-            format!("{}::{}<{}>", ng.namespace, ng.name, args.join(", "))
-        }
-        Type::Function(ft) => {
-            let params: Vec<String> = ft.params.iter().map(format_type).collect();
-            format!(
-                "fn({}) -> {}",
-                params.join(", "),
-                format_type(&ft.return_type)
-            )
-        }
-        Type::Tuple(types) => {
-            let elems: Vec<String> = types.iter().map(format_type).collect();
-            format!("[{}]", elems.join(", "))
-        }
-        Type::Reference(inner) => format!("&{}", format_type(inner)),
-        Type::MutReference(inner) => format!("&mut {}", format_type(inner)),
-        Type::TypePackSpread(name, _) => format!("..{name}"),
-    }
-}
-
-fn format_function_sig(f: &ast::Function) -> String {
-    let mut sig = String::new();
-    if f.is_pub {
-        sig.push_str("pub ");
-    }
-    if f.is_export {
-        sig.push_str("export ");
-    }
-    if f.is_async {
-        sig.push_str("async ");
-    }
-    sig.push_str("fn ");
-    sig.push_str(&f.name);
-
-    // Generic params
-    if !f.type_params.is_empty() {
-        sig.push('<');
-        let params: Vec<String> = f
-            .type_params
-            .iter()
-            .map(|tp| {
-                let mut s = String::new();
-                if tp.is_effect {
-                    s.push_str("effect ");
-                }
-                if tp.is_pack {
-                    s.push_str("..");
-                }
-                s.push_str(&tp.name);
-                if !tp.bounds.is_empty() {
-                    s.push_str(": ");
-                    let bounds: Vec<&str> = tp.bounds.iter().map(|b| b.name.as_str()).collect();
-                    s.push_str(&bounds.join(" + "));
-                }
-                s
-            })
-            .collect();
-        sig.push_str(&params.join(", "));
-        sig.push('>');
-    }
-
-    sig.push('(');
-    let params: Vec<String> = f
-        .params
-        .iter()
-        .map(|p| {
-            if p.self_kind == ast::SelfKind::Ref {
-                "&self".to_string()
-            } else if p.self_kind == ast::SelfKind::MutRef {
-                "&mut self".to_string()
-            } else {
-                format!("{}: {}", p.name, format_type(&p.ty))
-            }
-        })
-        .collect();
-    sig.push_str(&params.join(", "));
-    sig.push(')');
-
-    if let Some(ret) = &f.return_type {
-        sig.push_str(" -> ");
-        sig.push_str(&format_type(ret));
-    }
-
-    if !f.effects.is_empty() {
-        sig.push_str(" with ");
-        sig.push_str(&f.effects.join(", "));
-    }
-
-    sig
-}
-
-fn format_struct_sig(s: &ast::StructDecl) -> String {
-    let mut sig = String::new();
-    if s.is_pub {
-        sig.push_str("pub ");
-    }
-    sig.push_str("struct ");
-    sig.push_str(&s.name);
-    if !s.type_params.is_empty() {
-        sig.push('<');
-        let params: Vec<&str> = s.type_params.iter().map(|tp| tp.name.as_str()).collect();
-        sig.push_str(&params.join(", "));
-        sig.push('>');
-    }
-    sig
-}
-
-fn format_enum_sig(e: &ast::EnumDecl) -> String {
-    let mut sig = String::new();
-    if e.is_pub {
-        sig.push_str("pub ");
-    }
-    sig.push_str("enum ");
-    sig.push_str(&e.name);
-    if !e.type_params.is_empty() {
-        sig.push('<');
-        let params: Vec<&str> = e.type_params.iter().map(|tp| tp.name.as_str()).collect();
-        sig.push_str(&params.join(", "));
-        sig.push('>');
-    }
-    sig
-}
-
-fn format_variant_sig(v: &ast::VariantDecl) -> String {
-    let mut sig = String::new();
-    if v.is_pub {
-        sig.push_str("pub ");
-    }
-    sig.push_str("variant ");
-    sig.push_str(&v.name);
-    if !v.type_params.is_empty() {
-        sig.push('<');
-        let params: Vec<&str> = v.type_params.iter().map(|tp| tp.name.as_str()).collect();
-        sig.push_str(&params.join(", "));
-        sig.push('>');
-    }
-    sig
-}
-
-fn format_trait_sig(t: &ast::TraitDecl) -> String {
-    let mut sig = String::new();
-    if t.is_pub {
-        sig.push_str("pub ");
-    }
-    sig.push_str("trait ");
-    sig.push_str(&t.name);
-    if !t.type_params.is_empty() {
-        sig.push('<');
-        let params: Vec<&str> = t.type_params.iter().map(|tp| tp.name.as_str()).collect();
-        sig.push_str(&params.join(", "));
-        sig.push('>');
-    }
-    sig
 }
 
 #[cfg(test)]
@@ -404,7 +188,6 @@ mod tests {
 
     #[test]
     fn test_hover_variable_usage() {
-        // Clicking on `a` in the function body should show its type from the param
         let source = "fn foo(a: i32) { return a; }";
         let result = find_hover(
             source,
@@ -421,7 +204,6 @@ mod tests {
     #[test]
     fn test_hover_no_result() {
         let source = "fn foo() {}";
-        // Cursor on whitespace
         let result = find_hover(
             source,
             Position {

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -1,9 +1,14 @@
+mod definition;
 mod diagnostics;
+mod hover;
+pub mod semantic_tokens;
 
 use indexmap::IndexMap;
 use wado_compiler::{CompilerHost, CompilerOptions, Diagnostic as CompilerDiagnostic, LogLevel};
 
+pub use definition::DefinitionResult;
 pub use diagnostics::{Diagnostic, Position, Range, Severity};
+pub use hover::HoverResult;
 
 /// Protocol-agnostic language service engine.
 ///
@@ -38,6 +43,38 @@ impl Engine {
     #[must_use]
     pub fn get_document(&self, uri: &str) -> Option<&str> {
         self.documents.get(uri).map(String::as_str)
+    }
+
+    /// Find the definition of the symbol at the given position.
+    ///
+    /// Returns the location of the definition, or `None` if not found.
+    /// Currently resolves definitions within the same file only (AST-level).
+    #[must_use]
+    pub fn definition(&self, uri: &str, position: Position) -> Option<DefinitionResult> {
+        let source = self.documents.get(uri)?;
+        definition::find_definition(source, position, uri)
+    }
+
+    /// Compute hover information for the symbol at the given position.
+    ///
+    /// Returns markdown content describing the symbol, or `None` if not found.
+    #[must_use]
+    pub fn hover(&self, uri: &str, position: Position) -> Option<HoverResult> {
+        let source = self.documents.get(uri)?;
+        hover::find_hover(source, position)
+    }
+
+    /// Compute semantic tokens for the given document.
+    ///
+    /// Returns delta-encoded token data for LSP `textDocument/semanticTokens/full`.
+    /// This is a lightweight operation (lex + parse only, no compilation).
+    #[must_use]
+    pub fn semantic_tokens(&self, uri: &str) -> Vec<u32> {
+        let Some(source) = self.documents.get(uri) else {
+            return Vec::new();
+        };
+        let tokens = semantic_tokens::compute(source);
+        semantic_tokens::delta_encode(&tokens)
     }
 
     /// Compute diagnostics for the given document.

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -1,0 +1,697 @@
+use indexmap::IndexMap;
+use wado_compiler::ast::{self, Expr, Item, Stmt, Type};
+use wado_compiler::lexer::Lexer;
+use wado_compiler::token::{Token, TokenKind};
+
+/// LSP semantic token type indices (must match `TOKEN_TYPES` order).
+pub mod token_type {
+    pub const NAMESPACE: u32 = 0;
+    pub const TYPE: u32 = 1;
+    pub const TYPE_PARAMETER: u32 = 2;
+    pub const PARAMETER: u32 = 3;
+    pub const VARIABLE: u32 = 4;
+    pub const PROPERTY: u32 = 5;
+    pub const ENUM_MEMBER: u32 = 6;
+    pub const FUNCTION: u32 = 7;
+    pub const METHOD: u32 = 8;
+    pub const KEYWORD: u32 = 9;
+    pub const COMMENT: u32 = 10;
+    pub const STRING: u32 = 11;
+    pub const NUMBER: u32 = 12;
+    pub const OPERATOR: u32 = 13;
+}
+
+/// Token type legend for LSP capability declaration.
+pub const TOKEN_TYPES: &[&str] = &[
+    "namespace",
+    "type",
+    "typeParameter",
+    "parameter",
+    "variable",
+    "property",
+    "enumMember",
+    "function",
+    "method",
+    "keyword",
+    "comment",
+    "string",
+    "number",
+    "operator",
+];
+
+/// Token modifier legend for LSP capability declaration.
+pub const TOKEN_MODIFIERS: &[&str] = &["declaration", "definition", "readonly"];
+
+/// A semantic token with absolute position (before delta encoding).
+#[derive(Debug, Clone)]
+pub struct SemanticToken {
+    pub line: u32,
+    pub start_char: u32,
+    pub length: u32,
+    pub token_type: u32,
+    pub modifiers: u32,
+}
+
+/// Compute semantic tokens for a Wado source string.
+pub fn compute(source: &str) -> Vec<SemanticToken> {
+    // 1. Lex
+    let mut lexer = Lexer::new(source);
+    let tokens = match lexer.tokenize() {
+        Ok(t) => t,
+        Err(_) => return Vec::new(),
+    };
+    let (_, comments, _) = lexer.into_parts();
+
+    // 2. Parse (best-effort)
+    let ast_types = match wado_compiler::parse(source) {
+        Ok(pr) => collect_type_spans(&pr.ast),
+        Err(_) => TypeSpans::default(),
+    };
+
+    // 3. Classify lexer tokens
+    let mut result = Vec::new();
+    for i in 0..tokens.len() {
+        if let Some(st) = classify_token(&tokens, i, &ast_types) {
+            result.push(st);
+        }
+    }
+
+    // 4. Add comments
+    for comment in &comments {
+        let line = comment.span.line.saturating_sub(1) as u32;
+        let start_char = comment.span.column.saturating_sub(1) as u32;
+        let length = (comment.span.end - comment.span.start) as u32;
+        result.push(SemanticToken {
+            line,
+            start_char,
+            length,
+            token_type: token_type::COMMENT,
+            modifiers: 0,
+        });
+    }
+
+    // 5. Sort by position
+    result.sort_by(|a, b| a.line.cmp(&b.line).then(a.start_char.cmp(&b.start_char)));
+    result
+}
+
+/// Delta-encode semantic tokens for LSP response.
+pub fn delta_encode(tokens: &[SemanticToken]) -> Vec<u32> {
+    let mut data = Vec::with_capacity(tokens.len() * 5);
+    let mut prev_line = 0u32;
+    let mut prev_start = 0u32;
+
+    for token in tokens {
+        let delta_line = token.line - prev_line;
+        let delta_start = if delta_line == 0 {
+            token.start_char - prev_start
+        } else {
+            token.start_char
+        };
+
+        data.push(delta_line);
+        data.push(delta_start);
+        data.push(token.length);
+        data.push(token.token_type);
+        data.push(token.modifiers);
+
+        prev_line = token.line;
+        prev_start = token.start_char;
+    }
+    data
+}
+
+// --- AST-based type span collection ---
+
+/// Spans collected from the AST for identifier refinement.
+#[derive(Default)]
+struct TypeSpans {
+    /// byte start → token type for identifiers that are types/params/etc.
+    map: IndexMap<usize, u32>,
+}
+
+impl TypeSpans {
+    fn insert(&mut self, start: usize, token_type: u32) {
+        self.map.insert(start, token_type);
+    }
+
+    fn get(&self, start: usize) -> Option<u32> {
+        self.map.get(&start).copied()
+    }
+}
+
+/// Walk the AST and collect spans for type names, type parameters, etc.
+fn collect_type_spans(module: &ast::Module) -> TypeSpans {
+    let mut spans = TypeSpans::default();
+    for item in &module.items {
+        visit_item(&mut spans, item);
+    }
+    spans
+}
+
+fn visit_item(spans: &mut TypeSpans, item: &Item) {
+    match item {
+        Item::Function(f) => visit_function(spans, f),
+        Item::Struct(s) => {
+            visit_generic_params(spans, &s.type_params);
+            for field in &s.fields {
+                visit_type(spans, &field.ty);
+            }
+        }
+        Item::Enum(e) => {
+            visit_generic_params(spans, &e.type_params);
+        }
+        Item::Variant(v) => {
+            visit_generic_params(spans, &v.type_params);
+            for case in &v.cases {
+                if let Some(ty) = &case.payload {
+                    visit_type(spans, ty);
+                }
+            }
+        }
+        Item::Flags(_) => {}
+        Item::Newtype(n) => {
+            visit_generic_params(spans, &n.type_params);
+            visit_type(spans, &n.ty);
+        }
+        Item::Impl(imp) => {
+            visit_generic_params(spans, &imp.type_params);
+            if let Some(trait_ty) = &imp.trait_type {
+                visit_type(spans, trait_ty);
+            }
+            visit_type(spans, &imp.ty);
+            for method in &imp.methods {
+                visit_function(spans, method);
+            }
+        }
+        Item::Trait(t) => {
+            visit_generic_params(spans, &t.type_params);
+            for method in &t.methods {
+                visit_function(spans, method);
+            }
+        }
+        Item::Effect(e) => {
+            for method in &e.methods {
+                for param in &method.params {
+                    visit_type(spans, &param.ty);
+                }
+                if let Some(ret) = &method.return_type {
+                    visit_type(spans, ret);
+                }
+            }
+        }
+        Item::Global(g) => {
+            visit_type(spans, &g.ty);
+            visit_expr(spans, &g.initializer);
+        }
+        Item::Use(_)
+        | Item::Resource(_)
+        | Item::World(_)
+        | Item::Test(_)
+        | Item::TupleTypeDecl(_) => {}
+    }
+}
+
+fn visit_function(spans: &mut TypeSpans, f: &ast::Function) {
+    visit_generic_params(spans, &f.type_params);
+    for param in &f.params {
+        visit_type(spans, &param.ty);
+    }
+    if let Some(ret) = &f.return_type {
+        visit_type(spans, ret);
+    }
+    if let Some(body) = &f.body {
+        visit_block(spans, body);
+    }
+}
+
+fn visit_generic_params(spans: &mut TypeSpans, params: &[ast::GenericParam]) {
+    for param in params {
+        spans.insert(param.span.start, token_type::TYPE_PARAMETER);
+        for bound in &param.bounds {
+            spans.insert(bound.span.start, token_type::TYPE);
+        }
+    }
+}
+
+fn visit_type(spans: &mut TypeSpans, ty: &Type) {
+    match ty {
+        Type::Named(n) => {
+            spans.insert(n.span.start, token_type::TYPE);
+        }
+        Type::Generic(g) => {
+            spans.insert(g.span.start, token_type::TYPE);
+            for arg in &g.args {
+                visit_type(spans, arg);
+            }
+        }
+        Type::NamespacedGeneric(ng) => {
+            // The span covers the whole `ns::name<args>`, but the namespace part is useful
+            for arg in &ng.args {
+                visit_type(spans, arg);
+            }
+        }
+        Type::Function(ft) => {
+            for param in &ft.params {
+                visit_type(spans, param);
+            }
+            visit_type(spans, &ft.return_type);
+        }
+        Type::Tuple(types) => {
+            for t in types {
+                visit_type(spans, t);
+            }
+        }
+        Type::Reference(inner) | Type::MutReference(inner) => {
+            visit_type(spans, inner);
+        }
+        Type::TypePackSpread(_, _) => {}
+    }
+}
+
+fn visit_block(spans: &mut TypeSpans, block: &ast::Block) {
+    for stmt in &block.stmts {
+        visit_stmt(spans, stmt);
+    }
+}
+
+fn visit_stmt(spans: &mut TypeSpans, stmt: &Stmt) {
+    match stmt {
+        Stmt::Let(l) => {
+            if let Some(ty) = &l.ty {
+                visit_type(spans, ty);
+            }
+            if let Some(val) = &l.value {
+                visit_expr(spans, val);
+            }
+        }
+        Stmt::Expr(e) => visit_expr(spans, &e.expr),
+        Stmt::Return(r) => {
+            if let Some(val) = &r.value {
+                visit_expr(spans, val);
+            }
+        }
+        Stmt::TaskReturn(tr) => visit_expr(spans, &tr.value),
+        Stmt::If(i) => {
+            visit_condition(spans, &i.condition);
+            visit_block(spans, &i.then_block);
+            if let Some(else_block) = &i.else_block {
+                visit_block(spans, else_block);
+            }
+        }
+        Stmt::While(w) => {
+            visit_condition(spans, &w.condition);
+            visit_block(spans, &w.body);
+        }
+        Stmt::For(f) => {
+            if let Some(init) = &f.init {
+                visit_stmt(spans, init);
+            }
+            if let Some(cond) = &f.condition {
+                visit_condition(spans, cond);
+            }
+            if let Some(update) = &f.update {
+                visit_expr(spans, update);
+            }
+            visit_block(spans, &f.body);
+        }
+        Stmt::ForOf(fo) => {
+            visit_expr(spans, &fo.iterable);
+            visit_block(spans, &fo.body);
+        }
+        Stmt::Loop(l) => visit_block(spans, &l.body),
+        Stmt::Match(m) => visit_match(spans, m),
+        Stmt::Break(b) => {
+            if let Some(val) = &b.value {
+                visit_expr(spans, val);
+            }
+        }
+        Stmt::Continue(_) => {}
+        Stmt::Assert(a) => {
+            visit_expr(spans, &a.condition);
+            if let Some(msg) = &a.message {
+                visit_expr(spans, msg);
+            }
+        }
+        Stmt::LabeledBlock(lb) => visit_block(spans, &lb.block),
+    }
+}
+
+fn visit_condition(spans: &mut TypeSpans, cond: &ast::Condition) {
+    match cond {
+        ast::Condition::Expr(e) => visit_expr(spans, e),
+        ast::Condition::LetChain { elements, .. } => {
+            for elem in elements {
+                match elem {
+                    ast::ConditionElement::Let { expr, .. } => visit_expr(spans, expr),
+                    ast::ConditionElement::Expr(e) => visit_expr(spans, e),
+                }
+            }
+        }
+    }
+}
+
+fn visit_match(spans: &mut TypeSpans, m: &ast::MatchExpr) {
+    visit_expr(spans, &m.expr);
+    for arm in &m.arms {
+        if let Some(guard) = &arm.guard {
+            visit_expr(spans, guard);
+        }
+        visit_expr(spans, &arm.body);
+    }
+}
+
+fn visit_expr(spans: &mut TypeSpans, expr: &Expr) {
+    match expr {
+        Expr::Ident(_) | Expr::Literal(_) => {}
+        Expr::Binary(b) => {
+            visit_expr(spans, &b.left);
+            visit_expr(spans, &b.right);
+        }
+        Expr::Unary(u) => visit_expr(spans, &u.expr),
+        Expr::Assign(a) => {
+            visit_expr(spans, &a.target);
+            visit_expr(spans, &a.value);
+        }
+        Expr::CompoundAssign(ca) => {
+            visit_expr(spans, &ca.target);
+            visit_expr(spans, &ca.value);
+        }
+        Expr::ComparisonChain(cc) => {
+            visit_expr(spans, &cc.first);
+            for cmp in &cc.comparisons {
+                visit_expr(spans, &cmp.right);
+            }
+        }
+        Expr::Call(c) => {
+            visit_expr(spans, &c.callee);
+            for ty in &c.type_args {
+                visit_type(spans, ty);
+            }
+            for arg in &c.args {
+                visit_expr(spans, arg);
+            }
+        }
+        Expr::MethodCall(mc) => {
+            visit_expr(spans, &mc.receiver);
+            for ty in &mc.type_args {
+                visit_type(spans, ty);
+            }
+            for arg in &mc.args {
+                visit_expr(spans, arg);
+            }
+        }
+        Expr::StaticMethodCall(smc) => {
+            visit_type(spans, &smc.target_type);
+            for ty in &smc.type_args {
+                visit_type(spans, ty);
+            }
+            for arg in &smc.args {
+                visit_expr(spans, arg);
+            }
+        }
+        Expr::FieldAccess(fa) => visit_expr(spans, &fa.expr),
+        Expr::Index(idx) => {
+            visit_expr(spans, &idx.expr);
+            visit_expr(spans, &idx.index);
+        }
+        Expr::Block(b) => visit_block(spans, b),
+        Expr::If(i) => {
+            visit_condition(spans, &i.condition);
+            visit_block(spans, &i.then_block);
+            if let Some(else_block) = &i.else_block {
+                visit_block(spans, else_block);
+            }
+        }
+        Expr::Match(m) => visit_match(spans, m),
+        Expr::Matches(m) => visit_expr(spans, &m.expr),
+        Expr::Closure(c) => {
+            for param in &c.params {
+                if let Some(ty) = &param.ty {
+                    visit_type(spans, ty);
+                }
+            }
+            visit_expr(spans, &c.body);
+        }
+        Expr::TemplateString(ts) => {
+            for part in &ts.parts {
+                if let ast::TemplatePart::Interpolation { expr, .. } = part {
+                    visit_expr(spans, expr);
+                }
+            }
+        }
+        Expr::Cast(c) => {
+            visit_expr(spans, &c.expr);
+            visit_type(spans, &c.target_type);
+        }
+        Expr::StructLiteral(sl) => {
+            for field in &sl.fields {
+                visit_expr(spans, &field.value);
+            }
+        }
+        Expr::TupleLiteral(tl) => {
+            for elem in &tl.elements {
+                visit_expr(spans, elem);
+            }
+        }
+        Expr::LabeledBlock(lb) => visit_block(spans, &lb.block),
+        Expr::TryOp(t) => visit_expr(spans, &t.expr),
+        Expr::Spread(inner, _) => visit_expr(spans, inner),
+        Expr::Range(r) => {
+            visit_expr(spans, &r.start);
+            visit_expr(spans, &r.end);
+        }
+    }
+}
+
+// --- Lexer token classification ---
+
+fn classify_token(tokens: &[Token], index: usize, ast_types: &TypeSpans) -> Option<SemanticToken> {
+    let token = &tokens[index];
+    if token.kind == TokenKind::Eof {
+        return None;
+    }
+
+    let line = token.span.line.saturating_sub(1) as u32;
+    let start_char = token.span.column.saturating_sub(1) as u32;
+    let length = (token.span.end - token.span.start) as u32;
+    if length == 0 {
+        return None;
+    }
+
+    let (token_type, modifiers) = match &token.kind {
+        // Keywords
+        k if k.as_keyword_str().is_some() => (token_type::KEYWORD, 0),
+
+        // Identifiers
+        TokenKind::Ident(_) => classify_ident(tokens, index, ast_types),
+
+        // Literals
+        TokenKind::NumberLit(_) => (token_type::NUMBER, 0),
+        TokenKind::StringLit(_) | TokenKind::TemplateStringLit(_) | TokenKind::CharLit(_) => {
+            (token_type::STRING, 0)
+        }
+
+        // Operators
+        TokenKind::Plus
+        | TokenKind::Minus
+        | TokenKind::Star
+        | TokenKind::Slash
+        | TokenKind::Percent
+        | TokenKind::EqEq
+        | TokenKind::NotEq
+        | TokenKind::Lt
+        | TokenKind::LtEq
+        | TokenKind::Gt
+        | TokenKind::GtEq
+        | TokenKind::And
+        | TokenKind::Or
+        | TokenKind::Not
+        | TokenKind::Caret
+        | TokenKind::Tilde
+        | TokenKind::LtLt
+        | TokenKind::GtGt
+        | TokenKind::Eq
+        | TokenKind::PlusEq
+        | TokenKind::MinusEq
+        | TokenKind::StarEq
+        | TokenKind::SlashEq
+        | TokenKind::PercentEq
+        | TokenKind::AmpEq
+        | TokenKind::PipeEq
+        | TokenKind::CaretEq
+        | TokenKind::ShlEq
+        | TokenKind::ShrEq
+        | TokenKind::Arrow
+        | TokenKind::FatArrow
+        | TokenKind::DotDotLt
+        | TokenKind::DotDotEq => (token_type::OPERATOR, 0),
+
+        // Punctuation — skip (don't emit semantic tokens for brackets, commas, etc.)
+        _ => return None,
+    };
+
+    Some(SemanticToken {
+        line,
+        start_char,
+        length,
+        token_type,
+        modifiers,
+    })
+}
+
+/// Classify an identifier using AST type spans + lexer context heuristics.
+fn classify_ident(tokens: &[Token], index: usize, ast_types: &TypeSpans) -> (u32, u32) {
+    let token = &tokens[index];
+
+    // 1. Check AST classification (types, type parameters)
+    if let Some(tt) = ast_types.get(token.span.start) {
+        return (tt, 0);
+    }
+
+    // 2. Look at previous token for declaration context
+    if let Some(prev) = prev_significant(tokens, index) {
+        match &prev.kind {
+            TokenKind::Fn => return (token_type::FUNCTION, 0),
+            TokenKind::Struct
+            | TokenKind::Enum
+            | TokenKind::Variant
+            | TokenKind::Trait
+            | TokenKind::Type
+            | TokenKind::Flags
+            | TokenKind::Resource
+            | TokenKind::World
+            | TokenKind::Effect => return (token_type::TYPE, 0),
+            TokenKind::Dot => {
+                // After `.`: method if followed by `(`, else property
+                if next_is(tokens, index, &TokenKind::LParen) {
+                    return (token_type::METHOD, 0);
+                }
+                return (token_type::PROPERTY, 0);
+            }
+            TokenKind::ColonColon => {
+                // After `::`: could be enum member or static method
+                if next_is(tokens, index, &TokenKind::LParen) {
+                    return (token_type::FUNCTION, 0);
+                }
+                if next_is(tokens, index, &TokenKind::ColonColon) {
+                    // Middle of a path like `A::B::C` - treat as type
+                    return (token_type::TYPE, 0);
+                }
+                return (token_type::ENUM_MEMBER, 0);
+            }
+            _ => {}
+        }
+    }
+
+    // 3. Check if followed by `(` → function call
+    if next_is(tokens, index, &TokenKind::LParen) {
+        return (token_type::FUNCTION, 0);
+    }
+
+    // 4. Default to variable
+    (token_type::VARIABLE, 0)
+}
+
+fn prev_significant(tokens: &[Token], index: usize) -> Option<&Token> {
+    if index > 0 {
+        Some(&tokens[index - 1])
+    } else {
+        None
+    }
+}
+
+fn next_is(tokens: &[Token], index: usize, kind: &TokenKind) -> bool {
+    tokens
+        .get(index + 1)
+        .is_some_and(|t| std::mem::discriminant(&t.kind) == std::mem::discriminant(kind))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_source() {
+        let tokens = compute("");
+        assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn test_keyword_classification() {
+        let tokens = compute("fn foo() {}");
+        // `fn` should be keyword
+        assert_eq!(tokens[0].token_type, token_type::KEYWORD);
+        // `foo` should be function
+        assert_eq!(tokens[1].token_type, token_type::FUNCTION);
+    }
+
+    #[test]
+    fn test_type_annotation() {
+        let tokens = compute("fn foo(x: i32) {}");
+        // `i32` at char 10 should be TYPE (from AST NamedType span)
+        let i32_token = tokens.iter().find(|t| t.start_char == 10).unwrap();
+        assert_eq!(i32_token.token_type, token_type::TYPE);
+        // `x` at char 7 should be VARIABLE (parameter, but no separate param detection yet)
+        let x_token = tokens.iter().find(|t| t.start_char == 7).unwrap();
+        assert!(
+            x_token.token_type == token_type::VARIABLE
+                || x_token.token_type == token_type::PARAMETER
+        );
+    }
+
+    #[test]
+    fn test_string_literal() {
+        let tokens = compute("let s = \"hello\";");
+        let string_token = tokens.iter().find(|t| t.token_type == token_type::STRING);
+        assert!(string_token.is_some());
+    }
+
+    #[test]
+    fn test_delta_encoding() {
+        let tokens = vec![
+            SemanticToken {
+                line: 0,
+                start_char: 0,
+                length: 2,
+                token_type: token_type::KEYWORD,
+                modifiers: 0,
+            },
+            SemanticToken {
+                line: 0,
+                start_char: 3,
+                length: 3,
+                token_type: token_type::FUNCTION,
+                modifiers: 0,
+            },
+            SemanticToken {
+                line: 1,
+                start_char: 4,
+                length: 1,
+                token_type: token_type::VARIABLE,
+                modifiers: 0,
+            },
+        ];
+        let data = delta_encode(&tokens);
+        assert_eq!(
+            data,
+            vec![
+                0,
+                0,
+                2,
+                token_type::KEYWORD,
+                0, // first token
+                0,
+                3,
+                3,
+                token_type::FUNCTION,
+                0, // same line, delta_start=3
+                1,
+                4,
+                1,
+                token_type::VARIABLE,
+                0, // next line, start_char=4
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **Semantic tokens** (`textDocument/semanticTokens/full`): 14 token types (namespace, type, typeParameter, parameter, variable, property, enumMember, function, method, keyword, comment, string, number, operator) via lexer + AST walk + delta encoding
- **Go-to-definition** (`textDocument/definition`): single-file, AST-level name resolution for functions, structs, enums, variants, flags, traits, newtypes, globals, impl methods, let bindings, and parameters
- **Hover** (`textDocument/hover`): signature display using canonical source syntax, delegated to new `wado-compiler/unparse` signature helpers
- **Compiler unparse API**: added stateless, `CommentMap`-free signature helpers (`unparse_function_signature`, `unparse_struct_header`, `unparse_enum_header`, etc.) reusable for hover, completion detail, and document symbols. Fixed `unparse_type_into` `Type::Function` rendering (`Fn(` → `fn(` + effects/stores)
- **Compiler refactoring plan**: documented salsa-ready architecture in `wado-compiler/AGENTS.md` (AstId, name_span convention, phase separation)
- **LSP TODO checklist**: comprehensive LSP 3.18 feature tracker in `wado-lsp/AGENTS.md`

## Test plan

- [x] wado-lsp unit tests: 21 passed (semantic tokens, definition, hover, diagnostics, engine)
- [x] wado-compiler lib tests: 324 passed (no regressions from unparse changes)
- [x] wado-cli LSP integration tests: 15 passed (initialize, shutdown, didOpen/didChange/didClose, definition, hover, semanticTokens, diagnostics, query subcommand)
- [x] clippy: 0 warnings
- [x] cargo fmt: clean

https://claude.ai/code/session_01Dy8bYmjAVLUt8mXn9SsqAo