### PR TITLE
feat(http): support response trailers end-to-end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -1916,9 +1916,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2030,13 +2030,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
  "log",
  "rustc-hash",
  "smallvec",
@@ -2608,9 +2608,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -2860,9 +2860,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3616,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3629,14 +3629,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ bytes = { version = "1" }
 futures = { version = "0.3" }
 http = { version = "1" }
 http-body-util = { version = "0.1" }
-hyper = { version = "1", features = ["http1", "server"] }
-hyper-util = { version = "0.1", features = ["tokio", "http1", "server"] }
+hyper = { version = "1", features = ["http1", "http2", "server"] }
+hyper-util = { version = "0.1", features = ["tokio", "http1", "http2", "server", "server-auto"] }
 assert_cmd = { version = "2" }
 heck = { version = "0.5" }
 lexopt = { version = "0.3.1" }

--- a/example/http-bin.wado
+++ b/example/http-bin.wado
@@ -339,6 +339,7 @@ export async fn handle(request: Request) -> Result<Response, ErrorCode> with Mon
     let resp_headers = Fields::new();
     resp_headers.append("server", #file.as_bytes() as FieldValue);
     resp_headers.append("content-type", content_type.as_bytes() as FieldValue);
+    resp_headers.append("trailer", "server-timing".as_bytes() as FieldValue);
     if let Some(a) = allow {
         resp_headers.append("allow", a.as_bytes() as FieldValue);
     }
@@ -348,14 +349,23 @@ export async fn handle(request: Request) -> Result<Response, ErrorCode> with Mon
     task return Result::Ok(response);
 
     body_tx.write(body_str.as_bytes());
-
     body_tx.drop();
-    trailers_tx.write(Result::Ok(null));
+
+    // Server-Timing trailer carries the handler's wall-clock time so curious
+    // clients can see it without re-running. Only delivered to clients that
+    // sent `TE: trailers` per RFC 7230 §4.3.
+    let elapsed = MonotonicClock::now() - start_mark;
+    let elapsed_ms = (elapsed as f64) / 1_000_000.0;
+    let trailers = Trailers::new();
+    trailers.append(
+        "server-timing",
+        `app;dur={elapsed_ms:0.3f}`.as_bytes() as FieldValue,
+    );
+    trailers_tx.write(Result::Ok(Option::Some(trailers as Trailers)));
 
     // Access log: emit request summary as JSON to stderr after the
     // response body has been written out. `log_stderr` appends its own
     // newline so we don't add one here.
-    let elapsed = MonotonicClock::now() - start_mark;
     log_stderr(json::to_string(&AccessLog {
         method: method_name(method),
         path,

--- a/example/http-bin.wado
+++ b/example/http-bin.wado
@@ -356,12 +356,12 @@ export async fn handle(request: Request) -> Result<Response, ErrorCode> with Mon
     // sent `TE: trailers` per RFC 7230 §4.3.
     let elapsed = MonotonicClock::now() - start_mark;
     let elapsed_ms = (elapsed as f64) / 1_000_000.0;
-    let trailers = Trailers::new();
+    let trailers = Trailers::new() as Trailers;
     trailers.append(
         "server-timing",
         `app;dur={elapsed_ms:0.3f}`.as_bytes() as FieldValue,
     );
-    trailers_tx.write(Result::Ok(Option::Some(trailers as Trailers)));
+    trailers_tx.write(Result::Ok(Option::Some(trailers)));
 
     // Access log: emit request summary as JSON to stderr after the
     // response body has been written out. `log_stderr` appends its own

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -237,32 +237,35 @@ async fn handle_http_request(
     let http_req = http::Request::from_parts(parts, body);
     let (wasi_req, io) = WasiRequest::from_http(http_req);
 
-    let result = store
-        .run_concurrent(
-            async |store| -> Result<Result<http::Response<Collected<Bytes>>, Option<HttpErrorCode>>> {
-                let handler = pin!(async {
-                    let res = match service.handle(store, wasi_req).await? {
-                        Ok(res) => res,
-                        Err(err) => return anyhow::Ok(Err(Some(err))),
-                    };
-                    let res = store.with(|store| res.into_http(store, async { Ok(()) }))?;
-                    let (parts, body) = res.into_parts();
-                    let collected = BodyExt::collect(body)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("failed to collect response body: {e}"))?;
-                    anyhow::Ok(Ok(http::Response::from_parts(parts, collected)))
-                });
-                let io = pin!(async {
-                    io.await
-                        .map_err(|e| anyhow::anyhow!("request body I/O: {e}"))
-                });
-                match select(handler, io).await {
-                    Either::Left((result, _)) => result,
-                    Either::Right((result, _)) => result.map(|()| Err(None)),
-                }
-            },
-        )
-        .await;
+    let result =
+        store
+            .run_concurrent(
+                async |store| -> Result<
+                    Result<http::Response<Collected<Bytes>>, Option<HttpErrorCode>>,
+                > {
+                    let handler = pin!(async {
+                        let res = match service.handle(store, wasi_req).await? {
+                            Ok(res) => res,
+                            Err(err) => return anyhow::Ok(Err(Some(err))),
+                        };
+                        let res = store.with(|store| res.into_http(store, async { Ok(()) }))?;
+                        let (parts, body) = res.into_parts();
+                        let collected = BodyExt::collect(body)
+                            .await
+                            .map_err(|e| anyhow::anyhow!("failed to collect response body: {e}"))?;
+                        anyhow::Ok(Ok(http::Response::from_parts(parts, collected)))
+                    });
+                    let io = pin!(async {
+                        io.await
+                            .map_err(|e| anyhow::anyhow!("request body I/O: {e}"))
+                    });
+                    match select(handler, io).await {
+                        Either::Left((result, _)) => result,
+                        Either::Right((result, _)) => result.map(|()| Err(None)),
+                    }
+                },
+            )
+            .await;
 
     let result = match result {
         Ok(Ok(inner)) => inner,

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::fmt::Write as _;
 use std::net::SocketAddr;
 use std::pin::pin;
@@ -7,11 +8,12 @@ use std::sync::Arc;
 use anyhow::Result;
 use bytes::Bytes;
 use futures::future::{Either, select};
-use http_body_util::{BodyExt, Full};
-use hyper::server::conn::http1;
+use http_body_util::combinators::BoxBody;
+use http_body_util::{BodyExt, Collected, Full};
 use hyper::service::service_fn;
 use hyper::{Request as HyperRequest, Response as HyperResponse};
-use hyper_util::rt::TokioIo;
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::server::conn::auto;
 use lexopt::Arg::Value;
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
@@ -212,12 +214,17 @@ fn create_http_state() -> HttpWasiState {
 /// — handler completing first is the normal case (a guest may never consume
 /// the request body, in which case the I/O future only resolves when the
 /// request resource is dropped).
+///
+/// The success body is returned as a `Collected<Bytes>` (boxed) rather than
+/// `Full<Bytes>` so that response trailers written by the guest survive the
+/// hop into hyper. `Full<Bytes>` carries no trailer frames, which would silently
+/// strip e.g. `Server-Timing` written via `trailers_tx.write(Some(...))`.
 async fn handle_http_request(
     engine: &Engine,
     component: &Component,
     linker: &Linker<HttpWasiState>,
     req: HyperRequest<hyper::body::Incoming>,
-) -> Result<HyperResponse<Full<Bytes>>> {
+) -> Result<HyperResponse<BoxBody<Bytes, Infallible>>> {
     type HttpErrorCode = wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
 
     let state = create_http_state();
@@ -232,7 +239,7 @@ async fn handle_http_request(
 
     let result = store
         .run_concurrent(
-            async |store| -> Result<Result<http::Response<Bytes>, Option<HttpErrorCode>>> {
+            async |store| -> Result<Result<http::Response<Collected<Bytes>>, Option<HttpErrorCode>>> {
                 let handler = pin!(async {
                     let res = match service.handle(store, wasi_req).await? {
                         Ok(res) => res,
@@ -240,11 +247,10 @@ async fn handle_http_request(
                     };
                     let res = store.with(|store| res.into_http(store, async { Ok(()) }))?;
                     let (parts, body) = res.into_parts();
-                    let body = BodyExt::collect(body)
+                    let collected = BodyExt::collect(body)
                         .await
-                        .map_err(|e| anyhow::anyhow!("failed to collect response body: {e}"))?
-                        .to_bytes();
-                    anyhow::Ok(Ok(http::Response::from_parts(parts, body)))
+                        .map_err(|e| anyhow::anyhow!("failed to collect response body: {e}"))?;
+                    anyhow::Ok(Ok(http::Response::from_parts(parts, collected)))
                 });
                 let io = pin!(async {
                     io.await
@@ -264,28 +270,32 @@ async fn handle_http_request(
             eprintln!("Handler trapped: {e:?}");
             return Ok(HyperResponse::builder()
                 .status(500)
-                .body(Full::new(Bytes::from(format!("Handler trapped:\n{e:?}"))))?);
+                .body(error_body(format!("Handler trapped:\n{e:?}")))?);
         }
         Err(e) => {
             eprintln!("Handler trapped: {e:?}");
             return Ok(HyperResponse::builder()
                 .status(500)
-                .body(Full::new(Bytes::from(format!("Handler trapped:\n{e:?}"))))?);
+                .body(error_body(format!("Handler trapped:\n{e:?}")))?);
         }
     };
 
     match result {
         Ok(res) => {
             let (parts, body) = res.into_parts();
-            Ok(HyperResponse::from_parts(parts, Full::new(body)))
+            Ok(HyperResponse::from_parts(parts, BoxBody::new(body)))
         }
         Err(Some(error_code)) => Ok(HyperResponse::builder()
             .status(500)
-            .body(Full::new(Bytes::from(format!("{error_code:?}"))))?),
+            .body(error_body(format!("{error_code:?}")))?),
         Err(None) => Ok(HyperResponse::builder()
             .status(500)
-            .body(Full::new(Bytes::from("Handler returned error")))?),
+            .body(error_body("Handler returned error".to_string()))?),
     }
+}
+
+fn error_body(msg: String) -> BoxBody<Bytes, Infallible> {
+    BoxBody::new(Full::new(Bytes::from(msg)))
 }
 
 async fn run_http_server(wasm: Vec<u8>, addr: &str) -> Result<()> {
@@ -324,7 +334,13 @@ async fn run_http_server(wasm: Vec<u8>, addr: &str) -> Result<()> {
                 }
             });
 
-            if let Err(e) = http1::Builder::new().serve_connection(io, service).await {
+            // Auto-detect HTTP/1.1 vs h2c (HTTP/2 cleartext, prior-knowledge)
+            // by sniffing the connection preface. HTTP/1 callers see normal
+            // behavior; h2c clients (e.g. `curl --http2-prior-knowledge`) get
+            // trailers without needing the `TE: trailers` handshake hyper
+            // requires on the HTTP/1 path.
+            let builder = auto::Builder::new(TokioExecutor::new());
+            if let Err(e) = builder.serve_connection(io, service).await {
                 eprintln!("Error serving {remote_addr}: {e}");
             }
         });

--- a/wado-compiler/src/wir_build/canonical_abi.rs
+++ b/wado-compiler/src/wir_build/canonical_abi.rs
@@ -5,7 +5,7 @@
 //! These methods are part of `FunctionTranslator`; see `translate.rs` for
 //! the struct definition and the primary translation dispatch.
 
-use crate::tir::{CallArg, FunctionRef, PrimitiveType, ResolvedType, TirExpr, TypeId};
+use crate::tir::{CallArg, FunctionRef, PrimitiveType, ResolvedType, TirExpr, TirExprKind, TypeId};
 use crate::wir::{
     CanonicalIntrinsic, CmFuturePayload, CmScalarType, CmStreamPayload, WirFuncId, WirInstr,
     WirType,
@@ -151,9 +151,20 @@ impl FunctionTranslator<'_, '_> {
                 Some(self.emit_future_read(handle, result_type_id, payload))
             }
             "future-write" => {
-                let value_arg = self.translate_expr(&args[0].expr);
-                let value_type_id = args[0].expr.type_id;
+                let value_expr = &args[0].expr;
+                let value_type_id = value_expr.type_id;
                 let payload = self.cm_future_payload(receiver.type_id);
+                // Variant-shaped futures (used for trailers): pattern-match on
+                // TIR because general variant→CM lowering is not yet implemented.
+                if let Some(resource_expr) = match_ok_some_resource(value_expr) {
+                    let resource_handle = self.translate_expr(resource_expr);
+                    return Some(self.emit_future_write_ok_some_resource(handle, resource_handle));
+                }
+                if match_ok_none(value_expr) {
+                    return Some(self.emit_future_write_ok_none(handle));
+                }
+                // Scalar primitives are evaluated and lowered generically.
+                let value_arg = self.translate_expr(value_expr);
                 Some(self.emit_future_write(handle, value_arg, value_type_id, payload))
             }
             "future-cancel-read" => {
@@ -774,11 +785,14 @@ impl FunctionTranslator<'_, '_> {
         }
     }
 
-    /// Emit WIR for `FutureWritable<T>::write(value)`.
+    /// Emit WIR for `FutureWritable<T>::write(value)` for scalar value types.
     ///
-    /// Dispatches to a type-specific emitter based on `value_type_id`:
-    /// - Scalar numeric types (i8–i64, u8–u64, bool, char): `emit_future_write_scalar`
-    /// - `Result<Option<R>, E>::Ok(null)` pattern: `emit_future_write_ok_none`
+    /// The variant-shaped futures (`Result<Option<R>, E>::Ok(None)` and
+    /// `::Ok(Some(<resource>))`) are dispatched at the call site in
+    /// `try_translate_canonical_method` because they require TIR-level
+    /// pattern matching. Anything else panics — silently writing `Ok(None)`
+    /// for an unrecognized shape produces wrong runtime behavior with no
+    /// diagnostic.
     fn emit_future_write(
         &mut self,
         handle: WirInstr,
@@ -786,7 +800,6 @@ impl FunctionTranslator<'_, '_> {
         value_type_id: TypeId,
         payload: CmFuturePayload,
     ) -> WirInstr {
-        // Check if the value type is a scalar numeric type
         if let ResolvedType::Primitive(
             PrimitiveType::I8
             | PrimitiveType::I16
@@ -803,8 +816,12 @@ impl FunctionTranslator<'_, '_> {
             return self.emit_future_write_scalar(handle, value, value_type_id, payload);
         }
 
-        // Fallback: Result<Option<R>, E>::Ok(null) pattern (trailers)
-        self.emit_future_write_ok_none(handle)
+        panic!(
+            "[WIR] FutureWritable::write: unsupported value of type_id={value_type_id:?}. \
+             Currently supported: scalar primitives (i8..i64, u8..u64, bool, char), \
+             Result::Ok(Option::None), Result::Ok(Option::Some(<resource>)). \
+             General variant→CM lowering is not yet implemented."
+        );
     }
 
     /// Emit WIR to write a scalar numeric value into a `FutureWritable` handle.
@@ -1163,5 +1180,226 @@ impl FunctionTranslator<'_, '_> {
         })));
 
         WirInstr::Seq(seq)
+    }
+
+    /// Emit WIR for `FutureWritable::write(Result::Ok(Option::Some(handle)))`,
+    /// the trailer-shape future used to deliver a Fields resource.
+    ///
+    /// CM layout written to the buffer for `result<option<own<R>>, error-code>`:
+    /// - offset 0:  result disc (u8) = 0 (Ok)
+    /// - offsets 1-7: padding (payload align = 8 because error-code contains
+    ///   cases with `option<u64>` payload — overall align is 8)
+    /// - offset 8:  option disc (u8) = 1 (Some)
+    /// - offsets 9-11: padding
+    /// - offset 12: own<R> resource handle (u32)
+    fn emit_future_write_ok_some_resource(
+        &mut self,
+        handle: WirInstr,
+        resource_handle: WirInstr,
+    ) -> WirInstr {
+        let Some(realloc_id) = self.ctx.func_map.get("builtin/realloc").cloned() else {
+            panic!("[WIR] emit_future_write_ok_some_resource: builtin/realloc not registered");
+        };
+        let future_write_id = self.ctx.ensure_canonical(
+            CanonicalIntrinsic::FutureWrite(CmFuturePayload::Trailers),
+            vec![WirType::I32, WirType::I32],
+            vec![WirType::I32],
+        );
+        let ws_new_id = self.ctx.ensure_canonical(
+            CanonicalIntrinsic::WaitableSetNew,
+            vec![],
+            vec![WirType::I32],
+        );
+        let w_join_id = self.ctx.ensure_canonical(
+            CanonicalIntrinsic::WaitableJoin,
+            vec![WirType::I32, WirType::I32],
+            vec![],
+        );
+        let ws_wait_id = self.ctx.ensure_canonical(
+            CanonicalIntrinsic::WaitableSetWait,
+            vec![WirType::I32, WirType::I32],
+            vec![WirType::I32],
+        );
+
+        self.local_counter += 1;
+        let suffix = self.local_counter;
+        let ptr_name = format!("__fw_write_ptr_{suffix}");
+        let handle_name = format!("__fw_handle_{suffix}");
+        let result_name = format!("__fw_result_{suffix}");
+        let evt_name = format!("__fw_evt_{suffix}");
+        let resource_name = format!("__fw_resource_{suffix}");
+
+        const BUF_SIZE: i32 = 40;
+        const BUF_ALIGN: i32 = 8;
+
+        let mut seq = vec![];
+
+        for (name, ty) in [
+            (&ptr_name, WirType::I32),
+            (&handle_name, WirType::I32),
+            (&result_name, WirType::I32),
+            (&resource_name, WirType::I32),
+        ] {
+            seq.push(WirInstr::DeclareLocal {
+                name: name.clone(),
+                ty,
+            });
+        }
+
+        seq.push(WirInstr::LocalSet {
+            name: handle_name.clone(),
+            value: Box::new(handle),
+        });
+
+        seq.push(WirInstr::LocalSet {
+            name: resource_name.clone(),
+            value: Box::new(resource_handle),
+        });
+
+        seq.push(WirInstr::LocalSet {
+            name: ptr_name.clone(),
+            value: Box::new(WirInstr::Call {
+                func_id: realloc_id.clone(),
+                args: vec![
+                    WirInstr::I32Const(0),
+                    WirInstr::I32Const(0),
+                    WirInstr::I32Const(BUF_ALIGN),
+                    WirInstr::I32Const(BUF_SIZE),
+                ],
+            }),
+        });
+
+        for i in 0..(BUF_SIZE / 8) {
+            seq.push(WirInstr::I64Store {
+                offset: u64::from((i * 8).cast_unsigned()),
+                align: 3,
+                addr: Box::new(WirInstr::LocalGet {
+                    name: ptr_name.clone(),
+                    result_ty: WirType::I32,
+                }),
+                value: Box::new(WirInstr::I64Const(0)),
+            });
+        }
+
+        seq.push(WirInstr::I32Store8 {
+            offset: 8,
+            align: 0,
+            addr: Box::new(WirInstr::LocalGet {
+                name: ptr_name.clone(),
+                result_ty: WirType::I32,
+            }),
+            value: Box::new(WirInstr::I32Const(1)),
+        });
+
+        seq.push(WirInstr::I32Store {
+            offset: 12,
+            align: 2,
+            addr: Box::new(WirInstr::LocalGet {
+                name: ptr_name.clone(),
+                result_ty: WirType::I32,
+            }),
+            value: Box::new(WirInstr::LocalGet {
+                name: resource_name,
+                result_ty: WirType::I32,
+            }),
+        });
+
+        seq.push(WirInstr::LocalSet {
+            name: result_name.clone(),
+            value: Box::new(WirInstr::Call {
+                func_id: future_write_id,
+                args: vec![
+                    WirInstr::LocalGet {
+                        name: handle_name.clone(),
+                        result_ty: WirType::I32,
+                    },
+                    WirInstr::LocalGet {
+                        name: ptr_name.clone(),
+                        result_ty: WirType::I32,
+                    },
+                ],
+            }),
+        });
+
+        seq.push(self.emit_future_write_blocked_wait(
+            &handle_name,
+            &result_name,
+            &evt_name,
+            &realloc_id,
+            &ws_new_id,
+            &w_join_id,
+            &ws_wait_id,
+        ));
+
+        seq.push(WirInstr::Drop(Box::new(WirInstr::Call {
+            func_id: realloc_id,
+            args: vec![
+                WirInstr::LocalGet {
+                    name: ptr_name,
+                    result_ty: WirType::I32,
+                },
+                WirInstr::I32Const(BUF_SIZE),
+                WirInstr::I32Const(BUF_ALIGN),
+                WirInstr::I32Const(0),
+            ],
+        })));
+
+        WirInstr::Seq(seq)
+    }
+}
+
+/// Detect `Result::Ok(Option::Some(<inner>))` at TIR level and return `<inner>`.
+///
+/// Used to special-case future writes that deliver a single resource handle
+/// (e.g. trailers) via the `Result<Option<own<R>>, _>` shape, since general
+/// variant→CM-buffer lowering is not yet implemented.
+fn match_ok_some_resource(expr: &TirExpr) -> Option<&TirExpr> {
+    let TirExprKind::VariantConstruct {
+        case_name: outer,
+        payload: Some(outer_payload),
+        ..
+    } = &expr.kind
+    else {
+        return None;
+    };
+    if outer != "Ok" {
+        return None;
+    }
+    let TirExprKind::VariantConstruct {
+        case_name: inner,
+        payload: Some(inner_payload),
+        ..
+    } = &outer_payload.kind
+    else {
+        return None;
+    };
+    if inner != "Some" {
+        return None;
+    }
+    Some(inner_payload)
+}
+
+/// Detect `Result::Ok(Option::None)` or `Result::Ok(null)` at TIR level.
+/// `null` stays as `TirExprKind::Null` in TIR (coerced to `Option::None` later).
+fn match_ok_none(expr: &TirExpr) -> bool {
+    let TirExprKind::VariantConstruct {
+        case_name: outer,
+        payload: Some(outer_payload),
+        ..
+    } = &expr.kind
+    else {
+        return false;
+    };
+    if outer != "Ok" {
+        return false;
+    }
+    match &outer_payload.kind {
+        TirExprKind::Null => true,
+        TirExprKind::VariantConstruct {
+            case_name: inner,
+            payload,
+            ..
+        } => inner == "None" && payload.is_none(),
+        _ => false,
     }
 }

--- a/wado-compiler/tests/fixtures.golden/http-response-trailers.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-response-trailers.wir.wado
@@ -920,13 +920,17 @@ condition: trailers.has(\"x-request-id\" as FieldName)
     let __fw_write_ptr_3: i32;
     let __fw_handle_3: i32;
     let __fw_result_3: i32;
+    let __fw_resource_3: i32;
     __fw_handle_3 = trailers_tx;
+    __fw_resource_3 = trailers;
     __fw_write_ptr_3 = "mem/realloc"(0, 0, 8, 40);
     builtin::store_i64(__fw_write_ptr_3, 0_i64);
     builtin::store_i64[8](__fw_write_ptr_3, 0_i64);
     builtin::store_i64[16](__fw_write_ptr_3, 0_i64);
     builtin::store_i64[24](__fw_write_ptr_3, 0_i64);
     builtin::store_i64[32](__fw_write_ptr_3, 0_i64);
+    builtin::store_u8[8](__fw_write_ptr_3, 1);
+    builtin::store_i32[12](__fw_write_ptr_3, __fw_resource_3);
     __fw_result_3 = "wasi/future-write"(__fw_handle_3, __fw_write_ptr_3);
     if __fw_result_3 == -1 {
         let __fw_evt_3: i32;


### PR DESCRIPTION
## Summary

Enables HTTP response trailers (e.g. `Server-Timing`) to flow from a Wado guest all the way to real HTTP clients. Three coordinated changes were needed because each layer was silently dropping the trailer:

- **Compiler** (`wir_build/canonical_abi.rs`): `FutureWritable::write` previously emitted a zero-init `Ok(None)` for any non-scalar value, silently discarding trailer payloads. Added TIR pattern-matching at the canonical-ABI call site for `Result::Ok(Option::Some(<resource>))` and `Result::Ok(Option::None)`, routing each to a specialized emitter. Anything else now **panics with a clear diagnostic** instead of miscompiling to `Ok(None)`.
- **serve glue** (`wado-cli/src/serve.rs`): response bodies were collected into `Full<Bytes>`, which cannot carry trailer frames. Switched to `BoxBody<Bytes, Infallible>` wrapping `Collected<Bytes>` so trailer frames survive the hop into hyper.
- **h2c** (`wado-cli/src/serve.rs`): replaced `http1::Builder` with `hyper_util::server::conn::auto::Builder` so HTTP/1.1 and h2c (HTTP/2 cleartext, prior-knowledge) are both served on the same port. HTTP/2 has no `TE: trailers` handshake requirement, so `curl --http2-prior-knowledge` sees trailers without any client-side changes. HTTP/1 callers still need `TE: trailers` per hyper's strict RFC 7230 enforcement.

Demonstrated in `example/http-bin.wado`: emits `server-timing: app;dur=<ms>` measured across the full handler lifetime including the post-`task return` body/trailer write phase.

## Known limitations left behind

- `lift_result_option_resource` (the `future-read` side) uses offsets 0/4/8 which happens to work only for `Ok(None)`. Reading `Ok(Some(handle))` back would misdecode — not hit today but worth noting.
- `emit_future_write` supports scalar primitives plus the two explicit variant shapes above. Everything else panics. A general variant→CM-buffer lowering is future work.

## Test plan

- [x] `cargo test -p wado-compiler --test e2e -- http` — all 325 HTTP e2e tests pass (the ones using `Result::Ok(null)` still round-trip via the `Ok(None)` detector).
- [x] `curl --http2-prior-knowledge http://127.0.0.1:8080/get` against `example/http-bin.wado` shows `server-timing: app;dur=<ms>` trailer after the body.
- [x] `curl -H 'TE: trailers' http://127.0.0.1:8080/get` (HTTP/1.1) also shows the trailer.
- [x] Default `curl http://127.0.0.1:8080/get` (HTTP/1.1, no TE) returns body normally with no trailer — expected behavior per RFC 7230 §4.3.
- [ ] Run `mise run on-task-done` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)