### PR TITLE
feat(compiler): introduce AstId / AstPtr for LSP-friendly queries

### DIFF
--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -134,13 +134,22 @@ This means a simple **"recompute on file change, cache per-document"** model is 
 
 ### Target Architecture (remaining work)
 
-- Introduce stable `AstId` (module-local, parse-stable) and `AstPtr` (position-resolvable).
+- ✅ **Phase 1 (done):** Introduce stable `AstId` (module-local, parse-stable) and `AstPtr` (position-resolvable). Parser assigns dense, deterministic IDs to symbol-bearing AST nodes; `Module::ast_id_at(line, column)` provides innermost-containing-node lookup.
 - Rework `SymbolTable` / `TypeTable` to be keyed by `AstId` rather than consumed during TIR construction.
 - Split `resolve` into: (a) _annotate_ AST with `SymbolTable`/`TypeTable` (no lowering), (b) _lower_ to TIR as a later phase.
 - Expose a query API: `position → AstId`, `AstId → Symbol`, `AstId → ResolvedType`, `Symbol → defining AstId + source URI`.
 - Add a **lightweight analysis entry point** (parse + bind + resolve, no monomorphize/lower/codegen) for LSP use.
 - Add source URI to `Symbol` so cross-file definition results can be returned.
 - LSP caches analysis results per document and invalidates on change.
+
+### Phase 1 follow-up notes
+
+Follow-up PRs should cover:
+
+- `SymbolTable`/`TypeTable` → AstId-keyed storage.
+- `resolve` split into _annotate_ (AST-preserving) and _lower_ (AST→TIR).
+- Extend `AstId` coverage to `Expr`, `Stmt`, `Type` when TypeTable refactor lands.
+- LSP-side caching layer that consumes `Module::ast_id_at` for hover/go-to-def.
 
 ### Future: Incremental Analysis (salsa)
 

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -3,6 +3,72 @@
 use crate::hashmap::IndexSet;
 use crate::token::Span;
 
+/// Module-local, parse-stable identifier for AST nodes that bear semantic
+/// significance (items, named members, parameters).
+///
+/// The parser assigns ids in DFS order starting from `0`; ids for a given
+/// module are densely packed in `0..Module::ast_id_count()`.
+///
+/// Synthetic nodes that did not originate from a parse (e.g. compiler-built
+/// builtins or test fixtures) use [`AstId::SYNTHETIC`] and do not participate
+/// in position-based lookups.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AstId(pub u32);
+
+impl AstId {
+    /// Sentinel id for AST nodes that were not produced by the parser
+    /// (compiler-synthesised builtins, test fixtures, etc.). These nodes do
+    /// not appear in `Module::ast_id_count()` accounting and are excluded
+    /// from position lookups.
+    pub const SYNTHETIC: AstId = AstId(u32::MAX);
+}
+
+/// Discriminator for the kind of AST node an [`AstPtr`] points to.
+///
+/// Mirrors the shape of `Item` and the named members reachable from items
+/// (struct fields, enum/variant cases, params, etc.). Used to disambiguate
+/// nodes that share a span (e.g. a single-field struct and its sole field
+/// at the same opening brace position).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AstNodeKind {
+    Function,
+    Struct,
+    Enum,
+    Variant,
+    Flags,
+    Trait,
+    Newtype,
+    Effect,
+    Global,
+    Resource,
+    World,
+    Impl,
+    Use,
+    Test,
+    TupleType,
+    StructField,
+    EnumCase,
+    VariantCase,
+    FlagsVariant,
+    EffectMethod,
+    AssocTypeDecl,
+    AssocConst,
+    AssocTypeBinding,
+    GenericParam,
+    Param,
+}
+
+/// Position-resolvable pointer to an AST node.
+///
+/// Pairs an [`AstNodeKind`] with the source [`Span`] of the node. Two pointers
+/// compare equal iff both halves match, which is sufficient as a stable
+/// identity within a single module version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AstPtr {
+    pub kind: AstNodeKind,
+    pub span: Span,
+}
+
 #[derive(Debug, Clone)]
 pub struct Module {
     pub items: Vec<Item>,
@@ -15,6 +81,10 @@ pub struct Module {
     data_section: Option<String>,
     /// Paths referenced by `#include_str` and `#include_bytes` literals, collected during parsing.
     include_paths: IndexSet<String>,
+    /// Total number of [`AstId`]s allocated for this module during parsing.
+    /// Real ids occupy the range `0..ast_id_count`; synthetic nodes use
+    /// [`AstId::SYNTHETIC`] and are not counted.
+    ast_id_count: u32,
 }
 
 /// Inner attribute like `#![no_prelude]`, `#![wasm_module("mem")]`, or
@@ -70,6 +140,7 @@ impl Module {
             shebang: None,
             data_section: None,
             include_paths: IndexSet::default(),
+            ast_id_count: 0,
         }
     }
 
@@ -80,6 +151,7 @@ impl Module {
         shebang: Option<String>,
         data_section: Option<String>,
         include_paths: IndexSet<String>,
+        ast_id_count: u32,
     ) -> Self {
         Self {
             items,
@@ -87,9 +159,170 @@ impl Module {
             shebang,
             data_section,
             include_paths,
+            ast_id_count,
         }
     }
 
+    /// Returns the total number of [`AstId`]s allocated for this module.
+    /// Real ids occupy `0..ast_id_count()`; synthetic nodes are not counted.
+    pub fn ast_id_count(&self) -> u32 {
+        self.ast_id_count
+    }
+
+    /// Find the [`AstId`] of the smallest id-bearing AST node whose span
+    /// contains the given 1-based `(line, column)` position.
+    ///
+    /// Synthetic nodes ([`AstId::SYNTHETIC`]) are excluded. Returns `None`
+    /// if no id-bearing node contains the position.
+    pub fn ast_id_at(&self, line: usize, column: usize) -> Option<AstId> {
+        let mut best: Option<(AstId, Span)> = None;
+        let mut visitor = |id: AstId, span: Span| {
+            if id == AstId::SYNTHETIC || !span_contains(span, line, column) {
+                return;
+            }
+            match best {
+                None => best = Some((id, span)),
+                Some((_, current)) if span_byte_len(span) <= span_byte_len(current) => {
+                    best = Some((id, span));
+                }
+                _ => {}
+            }
+        };
+        for item in &self.items {
+            visit_item_ids(item, &mut visitor);
+        }
+        best.map(|(id, _)| id)
+    }
+}
+
+/// Returns true if `(line, column)` lies in `[span.line:column, span.end_line:end_column)`.
+fn span_contains(span: Span, line: usize, column: usize) -> bool {
+    if line < span.line || line > span.end_line {
+        return false;
+    }
+    if line == span.line && column < span.column {
+        return false;
+    }
+    if line == span.end_line && column >= span.end_column {
+        return false;
+    }
+    true
+}
+
+fn span_byte_len(span: Span) -> usize {
+    span.end.saturating_sub(span.start)
+}
+
+fn visit_item_ids(item: &Item, f: &mut impl FnMut(AstId, Span)) {
+    match item {
+        Item::Use(u) => f(u.id, u.span),
+        Item::Function(func) => visit_function_ids(func, f),
+        Item::Effect(e) => {
+            f(e.id, e.span);
+            for m in &e.methods {
+                visit_effect_method_ids(m, f);
+            }
+        }
+        Item::Struct(s) => {
+            f(s.id, s.span);
+            for p in &s.type_params {
+                f(p.id, p.span);
+            }
+            for field in &s.fields {
+                f(field.id, field.span);
+            }
+        }
+        Item::Enum(e) => {
+            f(e.id, e.span);
+            for p in &e.type_params {
+                f(p.id, p.span);
+            }
+            for case in &e.cases {
+                f(case.id, case.span);
+            }
+        }
+        Item::Variant(v) => {
+            f(v.id, v.span);
+            for p in &v.type_params {
+                f(p.id, p.span);
+            }
+            for case in &v.cases {
+                f(case.id, case.span);
+            }
+        }
+        Item::Flags(fl) => {
+            f(fl.id, fl.span);
+            for v in &fl.flags {
+                f(v.id, v.span);
+            }
+        }
+        Item::Newtype(n) => {
+            f(n.id, n.span);
+            for p in &n.type_params {
+                f(p.id, p.span);
+            }
+        }
+        Item::TupleTypeDecl(t) => f(t.id, t.span),
+        Item::Impl(i) => {
+            f(i.id, i.span);
+            for p in &i.type_params {
+                f(p.id, p.span);
+            }
+            for binding in &i.associated_types {
+                f(binding.id, binding.span);
+            }
+            for c in &i.constants {
+                f(c.id, c.span);
+            }
+            for m in &i.methods {
+                visit_function_ids(m, f);
+            }
+        }
+        Item::Trait(t) => {
+            f(t.id, t.span);
+            for p in &t.type_params {
+                f(p.id, p.span);
+            }
+            for assoc in &t.associated_types {
+                f(assoc.id, assoc.span);
+            }
+            for m in &t.methods {
+                visit_function_ids(m, f);
+            }
+        }
+        Item::Resource(r) => {
+            f(r.id, r.span);
+            for p in &r.type_params {
+                f(p.id, p.span);
+            }
+            for m in &r.methods {
+                visit_effect_method_ids(m, f);
+            }
+        }
+        Item::World(w) => f(w.id, w.span),
+        Item::Test(t) => f(t.id, t.span),
+        Item::Global(g) => f(g.id, g.span),
+    }
+}
+
+fn visit_function_ids(func: &Function, f: &mut impl FnMut(AstId, Span)) {
+    f(func.id, func.span);
+    for p in &func.type_params {
+        f(p.id, p.span);
+    }
+    for param in &func.params {
+        f(param.id, param.span);
+    }
+}
+
+fn visit_effect_method_ids(method: &EffectMethod, f: &mut impl FnMut(AstId, Span)) {
+    f(method.id, method.span);
+    for param in &method.params {
+        f(param.id, param.span);
+    }
+}
+
+impl Module {
     /// Returns the inner attributes.
     pub fn inner_attributes(&self) -> &[InnerAttribute] {
         &self.inner_attributes
@@ -184,6 +417,7 @@ pub enum Item {
 /// Test declaration: `test "name" { ... }` or `test { ... }`
 #[derive(Debug, Clone)]
 pub struct TestDecl {
+    pub id: AstId,
     /// Attributes applied to this test (e.g., `#[expect_trap]`).
     pub attributes: Vec<Attribute>,
     /// Optional test name (string literal). If None, identified by <file:line>.
@@ -196,6 +430,7 @@ pub struct TestDecl {
 /// or `pub global mut name: Type = expr;`
 #[derive(Debug, Clone)]
 pub struct GlobalDecl {
+    pub id: AstId,
     pub name: String,
     /// Span of the identifier token alone (for LSP name-targeted queries).
     pub name_span: Span,
@@ -351,6 +586,7 @@ impl CmImport {
 /// Resource declaration like `resource Foo;` or `resource Foo<T> { fn method(...); }`
 #[derive(Debug, Clone)]
 pub struct ResourceDecl {
+    pub id: AstId,
     pub name: String,
     pub is_pub: bool,
     /// Generic type parameters: `resource Future<T> { ... }`
@@ -372,6 +608,7 @@ pub struct ResourceDecl {
 /// ```
 #[derive(Debug, Clone)]
 pub struct WorldDecl {
+    pub id: AstId,
     pub name: String,
     pub is_pub: bool,
     pub attrs: Vec<Attribute>,
@@ -450,6 +687,7 @@ pub struct ImportAttributes {
 /// `pub use {items} from "source"` (re-export)
 #[derive(Debug, Clone)]
 pub struct UseDecl {
+    pub id: AstId,
     /// Whether this is a public re-export
     pub is_pub: bool,
     /// Import source (e.g., "core:cli", "wasi:filesystem", "./utils.wado")
@@ -463,6 +701,7 @@ pub struct UseDecl {
 
 #[derive(Debug, Clone)]
 pub struct Function {
+    pub id: AstId,
     pub name: String,
     /// Span of the function name identifier alone (for LSP name-targeted queries).
     pub name_span: Span,
@@ -496,6 +735,7 @@ pub enum SelfKind {
 
 #[derive(Debug, Clone)]
 pub struct Param {
+    pub id: AstId,
     pub name: String,
     /// Span of the parameter name identifier (or `self` token for self params).
     pub name_span: Span,
@@ -1293,6 +1533,7 @@ impl std::fmt::Display for StoresEntry {
 // Placeholder types for future implementation
 #[derive(Debug, Clone)]
 pub struct EffectDecl {
+    pub id: AstId,
     pub name: String,
     /// Span of the effect name identifier.
     pub name_span: Span,
@@ -1304,6 +1545,7 @@ pub struct EffectDecl {
 
 #[derive(Debug, Clone)]
 pub struct EffectMethod {
+    pub id: AstId,
     pub name: String,
     /// Span of the method name identifier.
     pub name_span: Span,
@@ -1335,6 +1577,7 @@ pub struct TraitBound {
 /// Effect parameter declaration: `<effect E>` — represents a set of effects
 #[derive(Debug, Clone)]
 pub struct GenericParam {
+    pub id: AstId,
     pub name: String,
     /// Span of the type parameter name identifier.
     pub name_span: Span,
@@ -1351,6 +1594,7 @@ pub struct GenericParam {
 
 #[derive(Debug, Clone)]
 pub struct StructDecl {
+    pub id: AstId,
     pub name: String,
     /// Span of the struct name identifier.
     pub name_span: Span,
@@ -1365,6 +1609,7 @@ pub struct StructDecl {
 
 #[derive(Debug, Clone)]
 pub struct StructField {
+    pub id: AstId,
     pub name: String,
     /// Span of the field name identifier.
     pub name_span: Span,
@@ -1377,6 +1622,7 @@ pub struct StructField {
 
 #[derive(Debug, Clone)]
 pub struct EnumDecl {
+    pub id: AstId,
     pub name: String,
     /// Span of the enum name identifier.
     pub name_span: Span,
@@ -1393,6 +1639,7 @@ pub struct EnumDecl {
 /// Unlike `VariantCase`, enum cases have no payload.
 #[derive(Debug, Clone)]
 pub struct EnumCase {
+    pub id: AstId,
     pub name: String,
     /// Span of the case name identifier.
     pub name_span: Span,
@@ -1411,6 +1658,7 @@ pub struct EnumCase {
 /// ```
 #[derive(Debug, Clone)]
 pub struct FlagsDecl {
+    pub id: AstId,
     pub name: String,
     /// Span of the flags name identifier.
     pub name_span: Span,
@@ -1422,6 +1670,7 @@ pub struct FlagsDecl {
 
 #[derive(Debug, Clone)]
 pub struct FlagsVariant {
+    pub id: AstId,
     pub name: String,
     /// Span of the flag member name identifier.
     pub name_span: Span,
@@ -1439,6 +1688,7 @@ pub struct FlagsVariant {
 /// ```
 #[derive(Debug, Clone)]
 pub struct VariantDecl {
+    pub id: AstId,
     pub name: String,
     /// Span of the variant name identifier.
     pub name_span: Span,
@@ -1460,6 +1710,7 @@ pub struct VariantDecl {
 /// - Struct payloads: `Named({ w: f64 })` → payload is `Some({ w: f64 })`
 #[derive(Debug, Clone)]
 pub struct VariantCase {
+    pub id: AstId,
     pub name: String,
     /// Span of the case name identifier.
     pub name_span: Span,
@@ -1473,6 +1724,7 @@ pub struct VariantCase {
 
 #[derive(Debug, Clone)]
 pub struct Newtype {
+    pub id: AstId,
     pub name: String,
     /// Span of the newtype name identifier.
     pub name_span: Span,
@@ -1489,6 +1741,7 @@ pub struct Newtype {
 /// This is a type-system anchor that generates no code.
 #[derive(Debug, Clone)]
 pub struct TupleTypeDecl {
+    pub id: AstId,
     pub is_pub: bool,
     pub attrs: Vec<Attribute>,
     pub span: Span,
@@ -1497,6 +1750,7 @@ pub struct TupleTypeDecl {
 /// Associated type declaration in a trait: `type Output;` or `type Output: Trait1 + Trait2;`
 #[derive(Debug, Clone)]
 pub struct AssociatedTypeDecl {
+    pub id: AstId,
     pub name: String,
     /// Trait bounds on this associated type (e.g., `SerializeSeq` in `type SeqSerializer: SerializeSeq;`
     /// or `Iterator<Item = Self::Item>` in `type Iter: Iterator<Item = Self::Item>;`)
@@ -1507,6 +1761,7 @@ pub struct AssociatedTypeDecl {
 /// Associated type binding in an impl block: `type Output = T;`
 #[derive(Debug, Clone)]
 pub struct AssociatedTypeBinding {
+    pub id: AstId,
     pub name: String,
     pub ty: Type,
     pub span: Span,
@@ -1516,6 +1771,7 @@ pub struct AssociatedTypeBinding {
 /// These are compile-time constants that are inlined at every use site.
 #[derive(Debug, Clone)]
 pub struct AssociatedConst {
+    pub id: AstId,
     pub name: String,
     pub is_pub: bool,
     pub ty: Type,
@@ -1526,6 +1782,7 @@ pub struct AssociatedConst {
 /// Trait declaration: `trait Foo { type Output; fn method(&self) -> Self::Output; }`
 #[derive(Debug, Clone)]
 pub struct TraitDecl {
+    pub id: AstId,
     pub name: String,
     /// Span of the trait name identifier.
     pub name_span: Span,
@@ -1541,6 +1798,7 @@ pub struct TraitDecl {
 
 #[derive(Debug, Clone)]
 pub struct ImplBlock {
+    pub id: AstId,
     /// Generic type parameters: `impl<T> Box<T> { ... }`
     pub type_params: Vec<GenericParam>,
     /// The trait being implemented, if any: `impl Trait for Type`
@@ -1555,4 +1813,132 @@ pub struct ImplBlock {
     /// `impl Trait for Type;` — synthesis request (compiler generates the body)
     pub is_synthesize_request: bool,
     pub span: Span,
+}
+
+#[cfg(test)]
+mod ast_id_tests {
+    use super::*;
+    use crate::hashmap::IndexSet;
+    use crate::lexer::Lexer;
+    use crate::parser::Parser;
+
+    fn parse(source: &str) -> Module {
+        let tokens = Lexer::new(source).tokenize().expect("lex");
+        let mut parser = Parser::new(tokens);
+        parser.parse().expect("parse")
+    }
+
+    const SAMPLE: &str = r#"
+use { println } from "core:cli";
+
+global COUNT: i32 = 0;
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+enum Color { Red, Green, Blue }
+
+variant Shape {
+    Circle(f64),
+    Square,
+}
+
+flags Perms { Read, Write }
+
+trait Greet {
+    fn hello(&self) -> String;
+}
+
+impl Point {
+    fn origin() -> Point {
+        return Point { x: 0, y: 0 };
+    }
+}
+
+fn add(a: i32, b: i32) -> i32 {
+    return a + b;
+}
+
+test "addition" {
+    assert add(1, 2) == 3;
+}
+"#;
+
+    #[test]
+    fn parse_assigns_stable_ids() {
+        let m1 = parse(SAMPLE);
+        let m2 = parse(SAMPLE);
+        assert_eq!(m1.ast_id_count(), m2.ast_id_count());
+        assert!(m1.ast_id_count() > 0);
+
+        let mut ids_1 = Vec::new();
+        for item in &m1.items {
+            visit_item_ids(item, &mut |id, _| ids_1.push(id));
+        }
+        let mut ids_2 = Vec::new();
+        for item in &m2.items {
+            visit_item_ids(item, &mut |id, _| ids_2.push(id));
+        }
+        assert_eq!(ids_1, ids_2);
+    }
+
+    #[test]
+    fn ids_are_dense_and_unique() {
+        let m = parse(SAMPLE);
+        let mut ids: Vec<AstId> = Vec::new();
+        for item in &m.items {
+            visit_item_ids(item, &mut |id, _| ids.push(id));
+        }
+        assert!(!ids.is_empty());
+
+        let mut seen: IndexSet<AstId> = IndexSet::default();
+        for id in &ids {
+            assert!(seen.insert(*id), "duplicate id: {id:?}");
+            assert_ne!(*id, AstId::SYNTHETIC);
+            assert!(
+                id.0 < m.ast_id_count(),
+                "id {} out of range (count={})",
+                id.0,
+                m.ast_id_count()
+            );
+        }
+        for i in 0..m.ast_id_count() {
+            assert!(seen.contains(&AstId(i)), "missing id {i} in dense range");
+        }
+    }
+
+    #[test]
+    fn ast_id_at_returns_innermost_node() {
+        let src = "struct Point {\n    x: i32,\n    y: i32,\n}\n";
+        let m = parse(src);
+        let struct_id = m.items.iter().find_map(|it| match it {
+            Item::Struct(s) => Some(s.id),
+            _ => None,
+        });
+        let field_ids: Vec<AstId> = m
+            .items
+            .iter()
+            .flat_map(|it| match it {
+                Item::Struct(s) => s.fields.iter().map(|f| f.id).collect::<Vec<_>>(),
+                _ => vec![],
+            })
+            .collect();
+        assert_eq!(field_ids.len(), 2);
+
+        // Position inside the `x: i32` field span returns the field id, not the struct.
+        let at_field = m.ast_id_at(2, 5);
+        assert_eq!(at_field, Some(field_ids[0]));
+
+        // Position inside the struct but outside any field (e.g. the struct name).
+        let at_struct_name = m.ast_id_at(1, 9);
+        assert_eq!(at_struct_name, struct_id);
+    }
+
+    #[test]
+    fn ast_id_at_outside_returns_none() {
+        let m = parse("fn add(a: i32, b: i32) -> i32 { return a + b; }\n");
+        assert_eq!(m.ast_id_at(42, 1), None);
+    }
 }

--- a/wado-compiler/src/builtin_registry.rs
+++ b/wado-compiler/src/builtin_registry.rs
@@ -268,6 +268,7 @@ mod tests {
         let mut registry = BuiltinRegistry::new();
 
         let func = Function {
+            id: crate::ast::AstId::SYNTHETIC,
             name: "stream_new".to_string(),
             name_span: make_span(),
             is_pub: false,
@@ -303,6 +304,7 @@ mod tests {
         let mut registry = BuiltinRegistry::new();
 
         let func = Function {
+            id: crate::ast::AstId::SYNTHETIC,
             name: "unreachable".to_string(),
             name_span: make_span(),
             is_pub: false,
@@ -333,6 +335,7 @@ mod tests {
         let mut registry = BuiltinRegistry::new();
 
         let func = Function {
+            id: crate::ast::AstId::SYNTHETIC,
             name: "stream_write".to_string(),
             name_span: make_span(),
             is_pub: false,
@@ -342,6 +345,7 @@ mod tests {
             attrs: vec![],
             params: vec![
                 Param {
+                    id: crate::ast::AstId::SYNTHETIC,
                     name: "tx".to_string(),
                     name_span: make_span(),
                     ty: Type::Named(NamedType {
@@ -353,6 +357,7 @@ mod tests {
                     span: make_span(),
                 },
                 Param {
+                    id: crate::ast::AstId::SYNTHETIC,
                     name: "ptr".to_string(),
                     name_span: make_span(),
                     ty: Type::Named(NamedType {
@@ -364,6 +369,7 @@ mod tests {
                     span: make_span(),
                 },
                 Param {
+                    id: crate::ast::AstId::SYNTHETIC,
                     name: "len".to_string(),
                     name_span: make_span(),
                     ty: Type::Named(NamedType {

--- a/wado-compiler/src/desugar.rs
+++ b/wado-compiler/src/desugar.rs
@@ -77,6 +77,7 @@ pub fn desugar_module(module: &Module) -> Module {
         module.shebang().map(String::from),
         module.data_section().map(String::from),
         module.include_paths().clone(),
+        module.ast_id_count(),
     )
 }
 
@@ -159,6 +160,7 @@ fn desugar_item(item: &Item, ctx: &mut DesugarContext) -> Item {
 
 fn desugar_global(global: &GlobalDecl, _ctx: &mut DesugarContext) -> GlobalDecl {
     GlobalDecl {
+        id: global.id,
         name: global.name.clone(),
         name_span: global.name_span,
         ty: global.ty.clone(),
@@ -172,6 +174,7 @@ fn desugar_global(global: &GlobalDecl, _ctx: &mut DesugarContext) -> GlobalDecl 
 
 fn desugar_function(func: &Function, ctx: &mut DesugarContext) -> Function {
     Function {
+        id: func.id,
         name: func.name.clone(),
         name_span: func.name_span,
         is_pub: func.is_pub,
@@ -190,6 +193,7 @@ fn desugar_function(func: &Function, ctx: &mut DesugarContext) -> Function {
 
 fn desugar_test(test: &TestDecl, ctx: &mut DesugarContext) -> TestDecl {
     TestDecl {
+        id: test.id,
         attributes: test.attributes.clone(),
         name: test.name.clone(),
         body: desugar_block(&test.body, ctx),
@@ -199,6 +203,7 @@ fn desugar_test(test: &TestDecl, ctx: &mut DesugarContext) -> TestDecl {
 
 fn desugar_impl(impl_block: &ImplBlock, ctx: &mut DesugarContext) -> ImplBlock {
     ImplBlock {
+        id: impl_block.id,
         type_params: impl_block.type_params.clone(),
         trait_type: impl_block.trait_type.clone(),
         ty: impl_block.ty.clone(),
@@ -216,6 +221,7 @@ fn desugar_impl(impl_block: &ImplBlock, ctx: &mut DesugarContext) -> ImplBlock {
 
 fn desugar_trait(trait_decl: &TraitDecl, ctx: &mut DesugarContext) -> TraitDecl {
     TraitDecl {
+        id: trait_decl.id,
         name: trait_decl.name.clone(),
         name_span: trait_decl.name_span,
         is_pub: trait_decl.is_pub,

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -40,6 +40,7 @@ pub mod wir_visitor;
 pub mod world_registry;
 
 pub use analyze::Analyzer;
+pub use ast::{AstId, AstNodeKind, AstPtr};
 pub use bind::{BindError, Binder};
 pub use compiler_host::{
     Code, CompilerHost, Diagnostic, DiagnosticSpan, LogLevel, Severity, SourceError,

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -38,6 +38,10 @@ pub struct Parser {
     /// Inner attributes parsed before items. Retained even if parsing fails later,
     /// so callers can check `has_todo()` after a parse error.
     parsed_inner_attributes: Vec<InnerAttribute>,
+    /// Next [`AstId`] to allocate. Allocated densely starting from `0` in DFS
+    /// parse order so that re-parsing the same source produces the same id
+    /// sequence.
+    next_ast_id: u32,
 }
 
 #[derive(Debug)]
@@ -84,6 +88,7 @@ impl Parser {
             data_section: None,
             include_paths: crate::hashmap::IndexSet::default(),
             parsed_inner_attributes: Vec::new(),
+            next_ast_id: 0,
         }
     }
 
@@ -102,7 +107,16 @@ impl Parser {
             data_section,
             include_paths: crate::hashmap::IndexSet::default(),
             parsed_inner_attributes: Vec::new(),
+            next_ast_id: 0,
         }
+    }
+
+    /// Allocate a fresh [`AstId`] for an AST node currently being constructed.
+    /// Ids are dense in `0..next_ast_id` and assigned in parse order.
+    fn alloc_ast_id(&mut self) -> crate::ast::AstId {
+        let id = crate::ast::AstId(self.next_ast_id);
+        self.next_ast_id += 1;
+        id
     }
 
     /// Returns true if the parsed inner attributes include `#![TODO]`.
@@ -175,6 +189,7 @@ impl Parser {
             self.shebang.take(),
             self.data_section.take(),
             std::mem::take(&mut self.include_paths),
+            self.next_ast_id,
         ))
     }
 
@@ -445,6 +460,7 @@ impl Parser {
 
     /// Parse test declaration: `[#[attr]] test "name" { ... }` or `[#[attr]] test { ... }`
     fn parse_test_decl(&mut self, attributes: Vec<Attribute>) -> ParseResult<TestDecl> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         // Consume the "test" identifier (contextual keyword)
         self.advance();
@@ -462,6 +478,7 @@ impl Parser {
         let end_span = body.span;
 
         Ok(TestDecl {
+            id,
             attributes,
             name,
             body,
@@ -475,6 +492,7 @@ impl Parser {
         is_pub: bool,
         attributes: Vec<Attribute>,
     ) -> ParseResult<GlobalDecl> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         self.expect(&TokenKind::Global)?;
 
@@ -501,6 +519,7 @@ impl Parser {
         self.expect(&TokenKind::Semicolon)?;
 
         Ok(GlobalDecl {
+            id,
             name,
             name_span,
             ty,
@@ -675,6 +694,7 @@ impl Parser {
         is_pub: bool,
         attrs: Vec<Attribute>,
     ) -> ParseResult<ResourceDecl> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         self.expect(&TokenKind::Resource)?;
         let name = self.consume_ident()?;
@@ -700,6 +720,7 @@ impl Parser {
         };
 
         Ok(ResourceDecl {
+            id,
             name,
             is_pub,
             type_params,
@@ -719,6 +740,7 @@ impl Parser {
     /// - Effect functions: `Effect::{func1, func2}` or `Effect::{func1 as alias}`
     /// - Wildcard: `_` (no braces needed)
     fn parse_use_decl(&mut self, is_pub: bool) -> ParseResult<UseDecl> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         self.expect(&TokenKind::Use)?;
 
@@ -759,6 +781,7 @@ impl Parser {
         let end_span = semicolon.span;
 
         Ok(UseDecl {
+            id,
             is_pub,
             source,
             items,
@@ -904,6 +927,7 @@ impl Parser {
         is_async: bool,
         attrs: Vec<Attribute>,
     ) -> ParseResult<Function> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         self.expect(&TokenKind::Fn)?;
 
@@ -939,6 +963,7 @@ impl Parser {
             .map_or(start_span, |b| start_span.merge(&b.span));
 
         Ok(Function {
+            id,
             name,
             name_span,
             is_pub,
@@ -960,6 +985,7 @@ impl Parser {
     }
 
     fn parse_param(&mut self) -> ParseResult<Param> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
 
         // Handle &self and &mut self for methods
@@ -990,6 +1016,7 @@ impl Parser {
                     Type::Reference(Box::new(self_type))
                 };
                 return Ok(Param {
+                    id,
                     name: "self".to_string(),
                     name_span: self_span,
                     ty,
@@ -1033,6 +1060,7 @@ impl Parser {
         let ty = self.parse_type()?;
 
         Ok(Param {
+            id,
             name,
             name_span,
             ty,
@@ -3381,6 +3409,7 @@ impl Parser {
         is_pub: bool,
         attrs: Vec<Attribute>,
     ) -> ParseResult<EffectDecl> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         self.expect(&TokenKind::Effect)?;
         let (name, name_span) = self.consume_ident_with_span()?;
@@ -3394,6 +3423,7 @@ impl Parser {
         let end_span = self.expect(&TokenKind::RBrace)?.span;
 
         Ok(EffectDecl {
+            id,
             name,
             name_span,
             is_pub,
@@ -3407,6 +3437,7 @@ impl Parser {
         // Parse any attributes on the method (e.g., #[cm("...")])
         let attrs = self.parse_attributes()?;
 
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
 
         // Check for async keyword
@@ -3436,6 +3467,7 @@ impl Parser {
         self.expect(&TokenKind::Semicolon)?;
 
         Ok(EffectMethod {
+            id,
             name,
             name_span,
             is_async,
@@ -3508,6 +3540,7 @@ impl Parser {
             };
 
             params.push(crate::ast::GenericParam {
+                id: self.alloc_ast_id(),
                 name,
                 name_span,
                 is_effect,
@@ -3578,6 +3611,7 @@ impl Parser {
         is_pub: bool,
         attrs: Vec<Attribute>,
     ) -> ParseResult<StructDecl> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         self.expect(&TokenKind::Struct)?;
         let (name, name_span) = self.consume_ident_with_span()?;
@@ -3592,6 +3626,7 @@ impl Parser {
         let end_span = self.expect(&TokenKind::RBrace)?.span;
 
         Ok(StructDecl {
+            id,
             name,
             name_span,
             is_pub,
@@ -3607,6 +3642,7 @@ impl Parser {
 
         while !self.check(&TokenKind::RBrace) && !self.is_at_end() {
             let attrs = self.parse_attributes()?;
+            let id = self.alloc_ast_id();
             let start_span = self.peek().span;
             let is_pub = if self.check(&TokenKind::Pub) {
                 self.advance();
@@ -3621,6 +3657,7 @@ impl Parser {
             let ty = self.parse_type()?;
 
             fields.push(StructField {
+                id,
                 name,
                 name_span,
                 is_pub,
@@ -3638,6 +3675,7 @@ impl Parser {
     }
 
     fn parse_enum_decl(&mut self, is_pub: bool, attrs: Vec<Attribute>) -> ParseResult<EnumDecl> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         self.expect(&TokenKind::Enum)?;
         let (name, name_span) = self.consume_ident_with_span()?;
@@ -3659,6 +3697,7 @@ impl Parser {
         let end_span = self.expect(&TokenKind::RBrace)?.span;
 
         Ok(EnumDecl {
+            id,
             name,
             name_span,
             is_pub,
@@ -3670,11 +3709,13 @@ impl Parser {
     }
 
     fn parse_enum_case(&mut self, attrs: Vec<Attribute>) -> ParseResult<EnumCase> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         let (name, name_span) = self.consume_ident_with_span()?;
 
         // Enum cases have no payload (unlike variant cases)
         Ok(EnumCase {
+            id,
             name,
             name_span,
             attrs,
@@ -3690,6 +3731,7 @@ impl Parser {
     /// }
     /// ```
     fn parse_flags_decl(&mut self, is_pub: bool, attrs: Vec<Attribute>) -> ParseResult<FlagsDecl> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         self.expect(&TokenKind::Flags)?;
         let (name, name_span) = self.consume_ident_with_span()?;
@@ -3699,9 +3741,11 @@ impl Parser {
         let mut flags = Vec::new();
         while !self.check(&TokenKind::RBrace) && !self.is_at_end() {
             let flag_attrs = self.parse_attributes()?;
+            let flag_id = self.alloc_ast_id();
             let flag_span = self.peek().span;
             let (flag_name, flag_name_span) = self.consume_ident_with_span()?;
             flags.push(FlagsVariant {
+                id: flag_id,
                 name: flag_name,
                 name_span: flag_name_span,
                 attrs: flag_attrs,
@@ -3716,6 +3760,7 @@ impl Parser {
         let end_span = self.expect(&TokenKind::RBrace)?.span;
 
         Ok(FlagsDecl {
+            id,
             name,
             name_span,
             is_pub,
@@ -3737,6 +3782,7 @@ impl Parser {
         is_pub: bool,
         attrs: Vec<Attribute>,
     ) -> ParseResult<VariantDecl> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         self.expect(&TokenKind::Variant)?;
         let (name, name_span) = self.consume_ident_with_span()?;
@@ -3758,6 +3804,7 @@ impl Parser {
         let end_span = self.expect(&TokenKind::RBrace)?.span;
 
         Ok(VariantDecl {
+            id,
             name,
             name_span,
             is_pub,
@@ -3769,6 +3816,7 @@ impl Parser {
     }
 
     fn parse_variant_case(&mut self, attrs: Vec<Attribute>) -> ParseResult<VariantCase> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         let (name, name_span) = self.consume_ident_with_span()?;
 
@@ -3794,6 +3842,7 @@ impl Parser {
         };
 
         Ok(VariantCase {
+            id,
             name,
             name_span,
             payload,
@@ -3808,11 +3857,13 @@ impl Parser {
         let start_span = self.peek().span;
         // peek past `type` to see if next token is `[` (tuple type decl)
         if self.peek_nth(1).kind == TokenKind::LBracket {
+            let id = self.alloc_ast_id();
             self.expect(&TokenKind::Type)?;
             // Parse `[..T]` as a type (will be a Tuple containing TypePackSpread)
             let _ty = self.parse_type()?;
             let end_span = self.expect(&TokenKind::Semicolon)?.span;
             return Ok(Item::TupleTypeDecl(TupleTypeDecl {
+                id,
                 is_pub,
                 attrs,
                 span: start_span.merge(&end_span),
@@ -3822,6 +3873,7 @@ impl Parser {
     }
 
     fn parse_newtype(&mut self, is_pub: bool, attrs: Vec<Attribute>) -> ParseResult<Newtype> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         self.expect(&TokenKind::Type)?;
         let (name, name_span) = self.consume_ident_with_span()?;
@@ -3831,6 +3883,7 @@ impl Parser {
         self.expect(&TokenKind::Semicolon)?;
 
         Ok(Newtype {
+            id,
             name,
             name_span,
             is_pub,
@@ -3842,6 +3895,7 @@ impl Parser {
     }
 
     fn parse_impl_block(&mut self) -> ParseResult<ImplBlock> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         self.expect(&TokenKind::Impl)?;
 
@@ -3871,6 +3925,7 @@ impl Parser {
                 ));
             }
             return Ok(ImplBlock {
+                id,
                 type_params,
                 trait_type,
                 ty,
@@ -3899,6 +3954,7 @@ impl Parser {
                 let assoc_ty = self.parse_type()?;
                 let end = self.expect(&TokenKind::Semicolon)?.span;
                 associated_types.push(AssociatedTypeBinding {
+                    id: self.alloc_ast_id(),
                     name: assoc_name,
                     ty: assoc_ty,
                     span: type_span.merge(&end),
@@ -3922,6 +3978,7 @@ impl Parser {
                     let const_value = self.parse_expr()?;
                     let end = self.expect(&TokenKind::Semicolon)?.span;
                     constants.push(AssociatedConst {
+                        id: self.alloc_ast_id(),
                         name: const_name,
                         is_pub,
                         ty: const_ty,
@@ -3938,6 +3995,7 @@ impl Parser {
         let end_span = self.expect(&TokenKind::RBrace)?.span;
 
         Ok(ImplBlock {
+            id,
             type_params,
             trait_type,
             ty,
@@ -3993,6 +4051,7 @@ impl Parser {
                 let bounds = self.parse_trait_bounds()?;
                 if !type_params.iter().any(|p| p.name == param_name) {
                     type_params.push(crate::ast::GenericParam {
+                        id: self.alloc_ast_id(),
                         name: param_name.clone(),
                         name_span: param_name_span,
                         is_effect: false,
@@ -4035,6 +4094,7 @@ impl Parser {
     /// }
     /// ```
     fn parse_trait_decl(&mut self, is_pub: bool, attrs: Vec<Attribute>) -> ParseResult<TraitDecl> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         self.expect(&TokenKind::Trait)?;
 
@@ -4063,6 +4123,7 @@ impl Parser {
                 };
                 let end = self.expect(&TokenKind::Semicolon)?.span;
                 associated_types.push(AssociatedTypeDecl {
+                    id: self.alloc_ast_id(),
                     name: assoc_name,
                     bounds,
                     span: type_span.merge(&end),
@@ -4078,6 +4139,7 @@ impl Parser {
         let end_span = self.expect(&TokenKind::RBrace)?.span;
 
         Ok(TraitDecl {
+            id,
             name,
             name_span,
             is_pub,
@@ -4099,6 +4161,7 @@ impl Parser {
     /// }
     /// ```
     fn parse_world_decl(&mut self, is_pub: bool, attrs: Vec<Attribute>) -> ParseResult<WorldDecl> {
+        let id = self.alloc_ast_id();
         let start_span = self.peek().span;
         self.expect(&TokenKind::World)?;
         let name = self.consume_ident()?;
@@ -4130,6 +4193,7 @@ impl Parser {
         let end_span = self.expect(&TokenKind::RBrace)?.span;
 
         Ok(WorldDecl {
+            id,
             name,
             is_pub,
             attrs,

--- a/wado-compiler/src/resolver/trait_env.rs
+++ b/wado-compiler/src/resolver/trait_env.rs
@@ -564,6 +564,7 @@ mod tests {
 
     fn type_param(name: &str) -> GenericParam {
         GenericParam {
+            id: crate::ast::AstId::SYNTHETIC,
             name: name.to_string(),
             name_span: dummy_span(),
             is_effect: false,
@@ -589,6 +590,7 @@ mod tests {
 
     fn impl_block(type_params: Vec<GenericParam>, trait_type: Type, self_type: Type) -> ImplBlock {
         ImplBlock {
+            id: crate::ast::AstId::SYNTHETIC,
             type_params,
             trait_type: Some(trait_type),
             ty: self_type,

--- a/wado-compiler/src/token.rs
+++ b/wado-compiler/src/token.rs
@@ -204,7 +204,7 @@ pub struct Token {
     pub span: Span,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Span {
     pub start: usize,
     pub end: usize,

--- a/wado-compiler/src/world_registry.rs
+++ b/wado-compiler/src/world_registry.rs
@@ -194,6 +194,7 @@ mod tests {
         let mut registry = WorldRegistry::new();
 
         let world = WorldDecl {
+            id: crate::ast::AstId::SYNTHETIC,
             name: "Command".to_string(),
             is_pub: false,
             attrs: vec![Attribute {


### PR DESCRIPTION
## Summary

Phase 1 of the LSP-friendly compiler architecture refactor described in `wado-compiler/AGENTS.md`. Adds a module-local, parse-stable identifier to every symbol-bearing AST node so that downstream phases (`SymbolTable`, `TypeTable`, resolver, LSP) can key semantic information by `AstId` instead of re-walking the AST.

- `AstId(u32)` newtype with `AstId::SYNTHETIC` sentinel for non-parser nodes (compiler-built builtins, test fixtures).
- Parser allocates ids in DFS order, densely packed in `0..N`.
- `Module::ast_id_count()` exposes the upper bound; `Module::ast_id_at(line, column)` returns the innermost id-bearing node containing a position.
- `AstPtr { kind, span }` + `AstNodeKind` enum for future position ↔ node lookups.
- `desugar` preserves ids when reconstructing items; `Span` gains `Eq`/`Hash` for `AstPtr` derives.
- Unit tests verify parse stability, id density, uniqueness, and position lookups.

This is purely additive: no semantic tables are keyed by `AstId` yet, and resolver / TIR / codegen are unchanged.

## Follow-ups (separate PRs)

- Rekey `SymbolTable` / `TypeTable` by `AstId`.
- Split `resolve` into _annotate_ (AST-preserving) and _lower_ (AST → TIR).
- Extend `AstId` coverage to `Expr` / `Stmt` / `Type` when the `TypeTable` refactor lands.
- LSP-side cache layer consuming `Module::ast_id_at` for hover / go-to-def.

## Notes

While running `mise run on-task-done`, I hit a pre-existing multithreaded SIGSEGV in the `wado-dev-tools golden-dump` pipeline that reproduces on `main` without these changes (crashes in `sysmalloc` during TIR clones at high worker counts). Worked around locally by running the golden-fixture generation under `taskset -c 0-3`. Worth filing separately — not addressed here.

## Test plan

- [x] `cargo build` (all crates)
- [x] `mise run clippy-fix` — clean
- [x] `mise run update-golden-fixtures` (via taskset) — 768 generated, diff-clean against HEAD
- [x] `mise run update-golden-format-fixtures` — clean
- [x] `mise run update-gale-golden` — clean
- [x] `mise run doc-stdlib` — clean
- [x] `mise run format` — clean
- [x] `mise run test` — all Rust crate tests pass, including 4 new `ast_id_tests`
- [x] `mise run test-wado` — 1735 lib tests + 10 benchmark tests pass

https://claude.ai/code/session_01C3ias5FDaxMiXF7j5doEWz