### PR TITLE
Simplify data section extraction and upgrade Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
           MISE_VERBOSE: ${{ runner.debug }}
 
       - run: mise run clippy-fix
-      - run: mise run update-bundled
       - run: cargo build --bin wado --bin wado-dev-tools
       - run: mise run update-golden-fixtures
       - run: mise run update-golden-format-fixtures

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94"
+channel = "1.95"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]

--- a/wado-cli/src/dump.rs
+++ b/wado-cli/src/dump.rs
@@ -671,10 +671,8 @@ fn extract_world_from_data_section(source: &str) -> Option<String> {
     let marker = "\n__DATA__\n";
     let data = if let Some(pos) = source.find(marker) {
         &source[pos + marker.len()..]
-    } else if let Some(stripped) = source.strip_prefix("__DATA__\n") {
-        stripped
     } else {
-        return None;
+        source.strip_prefix("__DATA__\n")?
     };
     let json: serde_json::Value = serde_json::from_str(data.trim()).ok()?;
     // Old format: explicit "world" key

--- a/wado-dev-tools/src/data_section.rs
+++ b/wado-dev-tools/src/data_section.rs
@@ -25,10 +25,8 @@ pub fn extract_world_from_data_section(source: &str) -> Option<String> {
     let marker = "\n__DATA__\n";
     let data = if let Some(pos) = source.find(marker) {
         &source[pos + marker.len()..]
-    } else if let Some(stripped) = source.strip_prefix("__DATA__\n") {
-        stripped
     } else {
-        return None;
+        source.strip_prefix("__DATA__\n")?
     };
     let json: serde_json::Value = serde_json::from_str(data.trim()).ok()?;
     if let Some(world) = json.get("world").and_then(|v| v.as_str()) {


### PR DESCRIPTION
## Summary
This PR refactors the data section extraction logic to be more concise and updates the Rust toolchain version, along with a CI workflow adjustment.

## Key Changes
- **Simplified conditional logic**: Refactored the `extract_world_from_data_section` function in both `wado-cli` and `wado-dev-tools` to use the `?` operator instead of nested if-else statements. The logic now directly applies `strip_prefix` in the else branch, reducing code duplication and improving readability.
- **Rust toolchain upgrade**: Updated `rust-toolchain.toml` from version 1.94 to 1.95
- **CI workflow cleanup**: Removed the `mise run update-bundled` step from the CI pipeline

## Implementation Details
The refactoring consolidates three branches into two by eliminating the intermediate `else if` clause. The new implementation:
- First checks for the newline-prefixed marker (`\n__DATA__\n`)
- Falls back to attempting `strip_prefix("__DATA__\n")` with the `?` operator for early return on failure
- Maintains identical behavior while reducing nesting and improving code clarity

https://claude.ai/code/session_01JNGuhYpY4xLRiYYE16AUCu