### PR TITLE
Kiln: IDL-source `use`, supplementary inputs, unified semantics

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -98,4 +98,4 @@ It may include TODOs on WIP.
 - [URL Standard Library (`core:url`)](./wep-2026-04-10-url-stdlib.md)
 - [Default Arguments](./wep-2026-04-11-default-arguments.md)
 - [Effect Handler](./wep-2026-04-11-effect-handler.md)
-- [Kiln — Code Generation Framework](./wep-2026-04-12-kiln.md)
+- [Kiln — Keyed IDL Lowering Notation](./wep-2026-04-12-kiln.md)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -45,7 +45,7 @@ It may include TODOs on WIP.
 - [Type Stringification](./wep-2026-01-16-type-stringification.md)
 - [Template Format Specifiers](./wep-2026-01-17-template-format-specifiers.md)
 - [JSON Literal Compatibility](./wep-2026-01-18-json-literal-compatibility.md)
-- [JSON Module Import](./wep-2026-01-18-json-module-import.md)
+- [JSON Module Import](./wep-2026-01-18-json-module-import.md) (superseded by Kiln)
 - [Operator Overloading](./wep-2026-01-18-operator-overloading.md)
 - [Iterator-Based Literal Coercion](./wep-2026-01-18-iterator-based-literal-coercion.md)
 - [Effect System and Randomness in Collections](./wep-2026-01-20-effect-system-randomness.md)

--- a/docs/wep-2026-01-18-json-module-import.md
+++ b/docs/wep-2026-01-18-json-module-import.md
@@ -1,7 +1,9 @@
 # WEP: JSON Module Import
 
-**Date**: 2026-01-18
-**Status**: Proposed
+Date: 2026-01-18
+Status: Superseded by [Kiln — Keyed IDL Lowering Notation](./wep-2026-04-12-kiln.md)
+
+JSON compile-time import is no longer a compiler-level feature. The same user-visible syntax (`use config from "./config.json" with { ... }`) is now provided by a Kiln generator (e.g. `core:kiln-json`), which lowers JSON to a Wado module via the `wado:kiln/generator` world. Only the file-extension dispatch and cache logic live in the compiler; parsing, typing, and code emission all move to the generator. The sections below are preserved for historical context.
 
 ## Context
 

--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -452,5 +452,6 @@ The following are deliberately unresolved here; they will be decided during impl
 - [`wep-2026-03-02-include-str.md`](./wep-2026-03-02-include-str.md) — compile-time file inclusion, complementary to this WEP.
 - [`wep-2026-04-01-tide.md`](./wep-2026-04-01-tide.md) — the WebIDL/WIT binding generator, which remains Tier 0.
 - [`wep-2026-03-02-gale.md`](./wep-2026-03-02-gale.md) — the ANTLR grammar generator, to be migrated to this framework.
+- [`wep-2026-01-18-json-module-import.md`](./wep-2026-01-18-json-module-import.md) — superseded: JSON import becomes a Kiln generator.
 - [`wep-2026-01-14-compiler-pipeline-refactoring.md`](./wep-2026-01-14-compiler-pipeline-refactoring.md) — pipeline phases, into which Kiln is inserted.
 - [`research-code-generation.md`](./research-code-generation.md) — orthogonal research on generator-authoring ergonomics (reducing `out.push_str()` noise).

--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -23,7 +23,7 @@ In scope:
 - Users register code generators in `wado.toml` or inline at a `use` site.
 - Generators read schema files (`.proto`, `.graphql`, `.g4`, `.wit`, `.json`, custom IDLs, …) and emit `.wado` source files.
 - Generators are compiled to WebAssembly components and executed by the compiler via wasmtime.
-- Generated `.wado` files are written to a user-specified directory and are expected to be committed to version control.
+- Generated `.wado` files are written to `build/kiln/` by default and may be redirected to any directory. Committing them is recommended but not required; `build/kiln/` is commonly `.gitignore`-d.
 - Invocation is automatic: the compiler runs the relevant generators during `wado compile`, with content-addressed caching so unchanged inputs skip the generator.
 
 Out of scope:
@@ -35,21 +35,14 @@ Out of scope:
 
 ### Prior art (brief)
 
-Every language with a serious IDL story has picked one of a small number of designs, and the relevant design axes turn out to be:
-
-- **In-compiler plugin (Rust `proc_macro`, Roslyn, KSP)** — fast, IDE-friendly, but the generator runs with full host privileges and IDE freezes are a recurring problem.
-- **Out-of-process sandboxed plugin (Swift macros, protoc plugins)** — safer, cacheable, language-agnostic protocol.
-- **Pre-build arbitrary program (`build.rs`, `build_runner`)** — flexible, but unbounded and fragile; the user must remember to re-run it.
-- **Manual "on demand" generation (`go generate`)** — simplest, but output drifts from source and IDE integration is zero.
-
-Wado's constraints point firmly at the sandboxed-plugin design: generators are Wado programs compiled to Wasm components, which is exactly the execution model Wado already speaks. Wasmtime gives us deterministic sandboxing for free. The only question is the shape of the plugin contract, which is the subject of this WEP.
+Languages with a serious IDL story have landed on one of four designs: in-compiler plugins (Rust `proc_macro`, Roslyn, KSP — fast but full host privilege), out-of-process sandboxed plugins (Swift macros, protoc plugins — safer, cacheable), arbitrary pre-build programs (`build.rs`, `build_runner` — flexible but unsupervised), and manual on-demand generation (`go generate` — output drifts). Wado's constraints point at the sandboxed-plugin design: generators are Wado programs compiled to Wasm components, which is exactly the execution model Wado already speaks. The only question is the shape of the plugin contract, which is the subject of this WEP.
 
 ### What Wado already has that we build on
 
 - **`CompilerHost` abstraction** ([`wep-2026-01-16-source-provider-abstraction.md`](./wep-2026-01-16-source-provider-abstraction.md)) — `wado-compiler` is itself I/O-free. All source reads go through a trait implemented by `wado-cli`. Kiln reuses this boundary: generators never touch the filesystem directly; they call a host-provided `read-file` import that the compiler forwards to `CompilerHost`.
 - **`wado.toml` + `wado.lock`** ([`wep-2026-02-14-package-manifest.md`](./wep-2026-02-14-package-manifest.md)) — package manifest and lock file. We add a new `[build.generators]` section and record generator cache entries in the lock file.
-- **Wado → WIT mapping** ([`wep-2026-01-29-wit-wado-mapping.md`](./wep-2026-01-29-wit-wado-mapping.md)) — the mapping from Wado types to WIT records, variants, enums, flags, and resources. This lets a generator module declare its `Options` type as a plain Wado `struct`, and the compiler can read the resulting WIT `record` out of the generator's component binary to type-check options at manifest parse time.
-- **`#![generated]` module attribute** — already parsed by the compiler (see `wado-compiler/src/ast.rs`). It marks a module as machine-generated. Kiln emits this attribute with a `sources = [...]` array argument (and related keys) on every file it writes; see "Generated file header" below.
+- **Wado → WIT mapping** ([`wep-2026-01-29-wit-wado-mapping.md`](./wep-2026-01-29-wit-wado-mapping.md)) — lets a generator declare its `Options` type as a plain Wado `struct`; the compiler reads the corresponding WIT `record` from the component binary to type-check options at manifest parse time.
+- **`#![generated]` module attribute** — already parsed by the compiler. Kiln extends it with named arguments; see "Generated file header".
 
 ## Decision
 
@@ -58,26 +51,12 @@ Wado's constraints point firmly at the sandboxed-plugin design: generators are W
 Three principles drive every detail in this WEP:
 
 1. **Determinism by construction.** The `kiln` world provides no access to clocks, randomness, the network, environment variables, or ambient filesystems. A generator is a pure function `(inputs, options) → outputs + diagnostics`. Violating this requires rebuilding the compiler; it is not a runtime flag. This is the one thing in-compiler macro systems (Rust, Roslyn) cannot cleanly guarantee.
-2. **Every input is statically enumerable.** There is no `list-dir` host function and there is no glob in the manifest. Every file that feeds a generator must appear by literal path in `wado.toml` or in a `use ... with` declaration. This lets the LSP jump from the `use` site both to the generated `.wado` and to the original IDL, and lets `wado` precompute the full dependency graph before invoking any generator.
-3. **Single-file scripts are first-class.** Wado is designed so that a useful program can live in one `.wado` file with a shebang line. Kiln honors this: any generator configuration that can be written in `wado.toml` can also be written inline at the `use` site, with exactly the same schema. A user with a single-file script does not need to invent a `wado.toml` merely to consume a `.proto`.
+2. **Every input is statically enumerable.** No `list-dir` host function, no globs in the manifest. Every file that feeds a generator appears as a literal path in `wado.toml` or at a `use ... with` site. This lets the LSP jump to both the IDL and the generated `.wado`, and lets the compiler precompute the full dependency graph before any generator runs.
+3. **Single-file scripts are first-class.** Any generator configuration expressible in `wado.toml` works inline at a `use` site with the same schema and the same behavior, so a single `.wado` file with a shebang never needs a `wado.toml` just to consume a `.proto`.
 
 ### Overview
 
-A **generator** is a Wado module that exports the `wado:kiln/generator` world. The compiler builds the module to a `wasm32-wasip*` component (if necessary), caches it, runs it inside wasmtime, and collects its output. The generator reads schema files through a host-provided `read-file` import and emits a `response` record containing the `.wado` files to write and any diagnostics.
-
-A typical build proceeds as follows:
-
-1. `wado compile` parses `wado.toml` and all source files.
-2. From `[build.generators]` sections and `use ... with { generator: { ... } }` clauses, the compiler assembles the full list of generator invocations to perform.
-3. For each invocation, the compiler computes a cache key — the hash of the generator module's source distribution, the schema file contents, and the options — and looks it up in `wado.lock`. On a hit, it reuses the cached output.
-4. On a miss, the compiler instantiates the generator component in wasmtime, linking only `read-file` and `emit-diagnostic`. It calls the generator's exported `generate` function with a `request` record.
-5. The generator reads additional files via `read-file` (these are recorded in the cache key), builds its output, and returns a `response`.
-6. The compiler writes every file in the response to its configured output directory, stamps each file with a `#![generated(...)]` attribute naming the source IDL and the generator module, records the cache entry in `wado.lock`, and continues with normal compilation.
-7. If the generator traps or returns an error, the compiler surfaces the result as a regular compile error with the appropriate span.
-
-Generators are ordered **bottom-up through the build graph**: a generator that itself depends on another generator's output runs after its dependency. Circular dependencies between generators are a compile error.
-
-The rest of this WEP specifies the `kiln` world, the manifest and inline syntax, the caching model, the diagnostic extension, and the bootstrap relationship with existing pipelines.
+A **generator** is a Wado module that exports the `wado:kiln/generator` world. The compiler compiles it to a `wasm32-wasip*` component, caches it, runs it inside wasmtime, and persists its `response` record — a set of `.wado` files and optional diagnostics — to disk. Content-addressed caching keyed on schemas, options, and the generator's source hash ensures unchanged inputs skip the run. Invocations form a DAG (one generator may consume another's output); cycles are a compile error. The full sequence is specified in "Build pipeline integration" below.
 
 ### The `kiln` world
 
@@ -88,8 +67,8 @@ package wado:kiln;
 
 interface host {
     /// Read a file from the compiler's CompilerHost.
-    /// `path` is resolved relative to the package root that declared the generator
-    /// invocation (or the script file, in inline-use mode).
+    /// `path` is resolved relative to the invocation's declaration site
+    /// (the manifest directory, or the source file containing a `use ... with`).
     /// All calls are recorded by the compiler and contribute to the cache key.
     read-file: func(path: string) -> result<list<u8>, host-error>;
 
@@ -125,25 +104,30 @@ interface host {
 interface types {
     /// One schema file the compiler has pre-loaded for the generator.
     /// The file is always supplied by value so that the initial input
-    /// set is fully determined by the manifest / use-site declaration.
+    /// set is fully determined by the invocation declaration.
     record input-file {
         path: string,
         content: list<u8>,
     }
 
     /// The top-level request handed to the generator.
-    /// `options` is typed per-generator via the Wado->WIT mapping.
-    /// See "Options schema" below.
+    /// `primary` is the schema named by `from`; `inputs` is the list of
+    /// supplementary schemas (may be empty). `options` is typed
+    /// per-generator via the Wado->WIT mapping. See "Options schema" below.
     record request {
+        primary: input-file,
         inputs: list<input-file>,
         options: /* generator-defined */ any-options,
     }
 
-    /// One generated Wado file. `path` is relative to the output directory
-    /// configured in the manifest (or alongside the script in inline mode).
+    /// One generated Wado file. `path` is relative to the invocation's
+    /// output directory (defaults to `build/kiln/<invocation-id>/`).
+    /// Exactly one output file must be the entry module; supplementary
+    /// files are referenced from the entry via ordinary Wado `use`.
     record output-file {
         path: string,
         content: string,
+        is-entry: bool,
     }
 
     record response {
@@ -169,7 +153,7 @@ Notes on the shape:
 
 - There is no `write-file` import. All outputs are returned in the `response` record. This keeps the contract a pure function of its inputs and makes caching a straight hash comparison.
 - There is no `list-dir`, no `wasi:clocks`, no `wasi:random`, no `wasi:http`, no `wasi:sockets`, and no `wasi:cli/environment`. A generator that wants non-determinism has to work for it, and to work for it it would have to export a different world, which the compiler refuses to load.
-- `read-file` exists even though `request.inputs` already carries the initial file set, because real schemas have transitive references (`.proto` files `import` other `.proto` files, GraphQL SDL has `extend type`, WIT has `use` statements). The generator calls `read-file` for transitive pickups; every such call is logged and contributes to the cache key.
+- `read-file` exists even though `request.primary` and `request.inputs` already carry the declared file set, because real schemas have transitive references (`.proto` files `import` other `.proto` files, GraphQL SDL has `extend type`, WIT has `use` statements). The generator calls `read-file` for transitive pickups; every such call is logged and contributes to the cache key.
 - `source-span` is `(path, byte-start, byte-end)`. The compiler renders the snippet by re-reading the file via `CompilerHost`. This is a small extension to Wado's existing diagnostic system — today spans reference internal file ids, and Kiln needs spans to point at files the compiler itself did not load directly. See "Diagnostics" below.
 - `options` is typed per-generator, not a generic JSON blob. See the next section.
 
@@ -198,13 +182,11 @@ export fn generate(req: Request<Options>) -> Result<Response, Error> {
 }
 ```
 
-Several useful consequences fall out:
+Because `Options` is a real Wado record, typos and type mismatches are reported at manifest parse time (before the generator runs), and the LSP can offer completions for both `wado.toml` and inline `with { generator: { options: { ... } } }` blocks.
 
-- Typos in options (`stile = "rpc"`, `style = "rcp"`) are reported at manifest parse time, not after the generator has run and failed cryptically.
-- The LSP can offer completions for option fields inside `wado.toml` and inside `use ... with { generator: { options: { ... } } }`, because the expected type is a real Wado record.
-- When a generator evolves its `Options` incompatibly, consuming projects fail to parse their `wado.toml` with a precise error naming the missing or renamed field. No silent degradation.
+Default-value semantics follow the struct-defaults design (see [`wep-2026-03-04-default-trait.md`](./wep-2026-03-04-default-trait.md)): omitting the entire `options` block is equivalent to `Options::default()`, and any field that declares a default may be omitted individually. Fields without a default must be supplied.
 
-Until the Wado → WIT mapping is implemented, generators may declare their `Options` type in Wado source as above, and the compiler may extract it directly from the Wado IR of the generator module. The end state is to route through the WIT mapping so that generators written in other languages (if that ever becomes useful) can participate without a special case.
+Until the Wado → WIT mapping ships, the compiler extracts `Options` directly from the generator module's Wado IR; once the mapping is available, extraction routes through the component's WIT `record`, at which point generators written outside Wado can participate without a special case.
 
 ### Anatomy of a generator module
 
@@ -224,13 +206,13 @@ pub struct Options {
 }
 
 export fn generate(req: Request<Options>) -> Result<Response, Error> {
-    let proto = req.inputs[0];
-    let text = String::from_utf8(proto.content)?;
+    let text = String::from_utf8(req.primary.content)?;
     // ... parse text, produce Wado source ...
     return Result::Ok(Response {
         files: [OutputFile {
             path: `{req.options.namespace}.wado`,
             content: generated_source,
+            is_entry: true,
         }],
     });
 }
@@ -238,52 +220,49 @@ export fn generate(req: Request<Options>) -> Result<Response, Error> {
 
 The generator is compiled to a component targeting the `wasm32-wasip*` family at the moment the compiler first needs to invoke it (see "Build pipeline integration"). It runs inside wasmtime with the `host` interface linked to compiler-provided host functions; all other world imports are refused at link time.
 
+### Generator output layout
+
+Every invocation must emit exactly one **entry module** (`is_entry: true`) and zero or more **supplementary modules** (`is_entry: false`). The entry is the Wado module that a `use { ... } from "<from>"` binds to. Supplementary modules are ordinary Wado source files alongside the entry; the entry uses them via normal `use "./helper.wado"` statements, and all of Wado's usual visibility and import rules apply between them. Kiln does not define a virtual cross-file namespace — once files are on disk, they are just Wado.
+
+A generator that emits zero entries, two entries, or a supplementary module with no entry is a compile error reported against the generator's `response`.
+
 ### Manifest schema: `[build.generators]`
 
-A new top-level section in `wado.toml` declares generator invocations. The section key is an arbitrary identifier that names the invocation; it is not tied to a file extension, so a project may have multiple invocations of the same generator module, or different generators that consume the same file extension.
+A new top-level section in `wado.toml` declares generator invocations. The section key names the invocation; it is not tied to a file extension.
 
 ```toml
 [build-dependencies]
 proto-codegen = { registry = "example", package = "proto-codegen", version = "1.2" }
-my-graphql = { path = "../my-graphql-gen" }
+gale = { registry = "wado", package = "gale", version = "0.1" }
 
-[build.generators.proto-rpc]
+[build.generators.user-proto]
 module = "example:proto-codegen@1.2"
-inputs = [
-    "schemas/user.proto",
-    "schemas/billing.proto",
-]
-output-dir = "src/generated/proto-rpc"
+from = "schemas/user.proto"
 options = { style = "rpc", emit_comments = true }
 
-[build.generators.proto-grpc]
-module = "example:proto-codegen@1.2"
-inputs = ["schemas/service.proto"]
-output-dir = "src/generated/proto-grpc"
-options = { style = "grpc" }
-
-[build.generators.graphql]
-module = { path = "../my-graphql-gen" }
-inputs = ["schema.graphql"]
-output-dir = "src/generated/graphql"
+[build.generators.rust-grammar]
+module = "wado:gale@0.1"
+from = "grammars/Rust.g4"
+inputs = ["grammars/RustLexer.g4"]   # supplementary schemas
 ```
 
 Fields of a `[build.generators.<name>]` table:
 
 - `module` (required) — a reference to the Wado module that exports the `wado:kiln/generator` world. Accepts the same shapes as an entry in `[dependencies]` / `[build-dependencies]`: either a string of the form `"namespace:name@version"` that must match an entry in `[build-dependencies]`, or an inline dependency record (`{ path = "..." }`, `{ git = "..." }`, etc.). A module path inside a multi-module package may be appended (for example `"example:proto-codegen@1.2/generator"`); the default is the package's root module.
-- `inputs` (required) — a list of literal paths relative to the manifest directory. Globs are not accepted. Every schema the generator will directly consume must appear here. Transitive files pulled in via `read-file` need not appear in this list but contribute to the cache key as they are read.
-- `output-dir` (required) — the directory where generated `.wado` files are written, relative to the manifest directory. The compiler creates it if missing. Every file in the directory with a `#![generated]` attribute belongs to this generator and may be overwritten or deleted by subsequent runs; files without that attribute are left alone and produce an error if they collide with a generator output path.
-- `options` (optional) — a TOML table whose shape must match the generator's exported `Options` type. Missing required fields and type mismatches are reported at manifest parse time.
+- `from` (required) — the primary schema file, as a literal path relative to the manifest directory. Exactly one `from` per invocation. This is the path that a `use { ... } from "<from>"` statement elsewhere in the project binds to; see "Inline syntax at `use` sites" below.
+- `inputs` (optional, default `[]`) — literal paths to supplementary schemas that the primary implicitly depends on (for example a matching lexer grammar, or a shared OpenAPI components file). Globs are not accepted. Transitive files picked up via `host.read-file` need not appear here but still contribute to the cache key.
+- `output-dir` (optional, default `build/kiln/<name>`) — the directory where generated `.wado` files are written, relative to the manifest directory. The compiler creates it if missing. Every file in the directory with a `#![generated]` attribute belongs to this invocation and may be overwritten or deleted by subsequent runs; files without that attribute are left alone and produce an error if they collide with a generator output path.
+- `options` (optional) — a TOML table whose shape must match the generator's exported `Options` type (see "Options schema"). Omitting the whole table is equivalent to `Options::default()`; partial tables must still satisfy every field that lacks a default.
 
-Multiple `[build.generators.<name>]` sections may reference the same `module`. They are independent invocations with independent caches.
+Multiple `[build.generators.<name>]` sections may reference the same `module`. They are independent invocations with independent caches, as long as each uses a distinct `from`.
 
 #### New section: `[build-dependencies]`
 
-Generators are delivered as normal Wado packages, but they are built for a different target (`wasm32-wasip*`) and must not appear in the consuming project's runtime dependency graph. This WEP introduces `[build-dependencies]` in `wado.toml`, mirroring Cargo's `[build-dependencies]`. Entries use the same `Dependency` source shapes as `[dependencies]` — `Git`, `Registry`, `Path`, `Workspace`. They are resolved independently from runtime dependencies and are locked in a separate section of `wado.lock`.
+Generators are normal Wado packages but built for `wasm32-wasip*` and must not appear in the consuming project's runtime dependency graph. `[build-dependencies]` (mirroring Cargo's) accepts the same `Git`, `Registry`, `Path`, `Workspace` source shapes as `[dependencies]`, resolves in a separate build-only graph, and is locked in its own section of `wado.lock`.
 
 ### Inline syntax at `use` sites
 
-The manifest form above is convenient for projects with many schemas, but Wado is designed so that a single `.wado` file with a shebang can be a useful program. To keep that property, any generator configuration that can be written in `wado.toml` can also be written inline at the `use` site, with the same schema.
+Any generator configuration expressible in `wado.toml` can also be written inline at a `use` site, with the same schema and the same runtime behavior. This keeps Wado's single-file-with-shebang programs first-class.
 
 ```wado
 #!/usr/bin/env wado run
@@ -294,72 +273,59 @@ use { User, Billing } from "./user.proto" with {
         options: { style: "rpc", emit_comments: true },
     },
 };
-
-export fn run() with Stdout {
-    let u = User { id: 1, name: "Ada" };
-    println(`{u:?}`);
-}
 ```
 
-For schema families with implicit cross-file dependencies — Gale's parser grammar referencing an unimported lexer grammar, OpenAPI's main spec referencing a shared components file, and so on — the secondary files are declared via the `inputs` key:
+When the primary schema implicitly depends on sibling files the generator cannot discover from the primary alone (a parser grammar assuming a matching lexer grammar, an OpenAPI spec with an external components file, …), list them under `inputs`:
 
 ```wado
 use { RustParser } from "./Rust.g4" with {
     generator: {
         module: "wado:gale@0.1",
         inputs: ["./RustLexer.g4"],
-        options: { },
     },
 };
 ```
 
 Semantics of `use ... from "<schema>" with { generator: { ... } }`:
 
-- The `from` target is the **primary IDL file** the generator consumes. It is a path to the source schema (`.proto`, `.g4`, `.graphql`, `.wit`, …), not a path to a generated `.wado` file. Paths are resolved relative to the source file containing the `use` statement, and the compiler passes this file to the generator as the first entry of `request.inputs`.
-- The `inputs` key (optional) is a list of **supplementary IDL files** that the primary input implicitly depends on but does not explicitly import. It exists because real grammar and schema ecosystems have conventional split-file patterns without language-level `import` statements: a parser grammar `Rust.g4` assumes a matching lexer grammar `RustLexer.g4` by naming convention; an OpenAPI spec uses `$ref` into a shared components file. Paths are resolved relative to the source file containing the `use` statement. A generator that reaches further (for example, a `.proto` that `import`s another `.proto`) still picks transitive files up via `host.read-file`; `inputs` is only for files that the generator cannot discover from the primary input alone.
-- The `module` and `options` keys have the same meaning as in `[build.generators.<name>]`.
-- Symbol scope: the `use` statement draws its symbols from the union of all `.wado` files the generator emits for this invocation. Kiln does not require the user to know which emitted file defines which symbol — a single invocation is treated as one logical module, even when it materializes as several files on disk (Gale, for instance, typically emits a lexer, a parser, and a token table as separate `.wado` files).
-- Output location: for inline invocations the compiler chooses a deterministic path under its target directory (`target/kiln/<cache-key>/...`, exact layout deferred to the `target/` layout WEP) and materializes the generated files there. Users who need an explicit, repo-committed output directory declare the invocation in `wado.toml` instead.
+- `from` is the **primary schema**; `inputs` (optional) lists **supplementary schemas**. Paths are resolved relative to the source file. Transitive files beyond these — e.g. a `.proto` that `import`s another `.proto` — are picked up via `host.read-file` at generation time.
+- `module` and `options` have the same meaning as in `[build.generators.<name>]`. `output-dir` may be given to redirect output off the default `build/kiln/<id>/`; omit it to accept the default.
+- The `use` statement resolves against the invocation's **entry module** (see "Generator output layout" below). The imported symbols must be `pub` in that entry. The entry may re-export or `use` supplementary generated modules; the consuming project does not need to know about those files.
 - LSP navigation:
-  - **Go to definition** on an imported symbol jumps to the **generated `.wado`** file that defines it. The file is an ordinary Wado source file that the LSP can index, even though it lives under the target directory.
-  - **Go to schema** on the `from` literal jumps to the primary IDL file; on an entry in `inputs` it jumps to that supplementary IDL file.
-- When the compiler sees this `use` statement, it synthesizes an anonymous `[build.generators.<anonymous>]` entry whose `inputs` is `[<from>, ...<with.inputs>]` and whose `output-dir` is the compiler-managed directory described above. The generator runs, every file it emits is written into that directory, and everything from there on is identical to the manifest form.
+  - **Go to definition** on an imported symbol jumps to the generated `.wado` that defines it — ordinarily the entry module, but a symbol re-exported through the entry resolves to its true definition file as usual.
+  - **Go to schema** on the `from` literal jumps to the primary IDL; on an entry in `inputs` it jumps to that supplementary IDL.
+- The compiler synthesizes an anonymous `[build.generators.<id>]` entry from this clause (`id` is derived from `from`). From this point on the invocation is indistinguishable from a manifest-declared one.
 
-De-duplication and sibling imports:
+De-duplication:
 
-- If two or more `use ... with` clauses in the compilation unit specify the same `module`, the same ordered list of inputs (primary + supplementary), and the same `options`, they are merged into a single invocation. This lets a project split its imports across files — `use { Lexer } from "./Rust.g4" with {...}` in one file and `use { Parser } from "./Rust.g4" with {...}` in another — without duplicating the generator run.
-- A subsequent `use { ExtraSym } from "./Rust.g4"` without a `with` clause is permitted once any `use ... with` clause has pinned the generator configuration for that primary input; it resolves against the same invocation's emitted symbol set. If no `with` clause has been declared for the primary input anywhere in the compilation unit, a bare `use from "./Rust.g4"` is an error.
-- If the `(module, inputs, options)` triples of two clauses for the same primary input differ at all, it is a duplicate-generator error listing both declarations.
+- Two `use ... with` clauses with the same `(module, from, inputs, options)` tuple are merged into one invocation. This lets a project split imports across multiple files — `use { Lexer } from "./Rust.g4" with {...}` and `use { Parser } from "./Rust.g4" with {...}` — without running the generator twice.
+- A bare `use { X } from "./Rust.g4"` (no `with`) is allowed iff some `use ... with` clause, or some `[build.generators.*]`, has already registered an invocation whose `from` is `./Rust.g4` in the same compilation unit. Order within the compilation unit does not matter; the compiler collects all `with` clauses before resolving any bare `use`.
+- If two clauses share a `from` but disagree on any of `module`, `inputs`, or `options`, it is a duplicate-generator error listing both declarations.
 
-Rules around mixing the two forms:
-
-- A given primary-input schema path may appear in at most one generator invocation in the whole compilation unit. If a path appears in a manifest `[build.generators.*].inputs` list as the primary input, it may not also appear as the `from` target of a `use ... with`; the compiler reports this as a duplicate-generator error, listing both declarations. (A supplementary `inputs` entry of one invocation may, however, be the primary input of another — that is how one manifest can register both a lexer invocation and a parser invocation that reference each other.)
-- A `with { generator: { ... } }` block must include at least `module`. The `inputs` key is optional and defaults to the empty list; the `options` key is optional and defaults to the `Options` type's default value.
-
-Both surfaces parse to the same internal representation (an `Invocation { module, inputs, output-dir, options }`, where `inputs[0]` is the primary input), so downstream logic — caching, scheduling, diagnostics — does not need to care which form the user wrote.
+Both surfaces parse to the same internal `Invocation { module, from, inputs, output-dir, options }`, so downstream logic — caching, scheduling, diagnostics — is oblivious to which form the user wrote.
 
 ### Build pipeline integration
 
-Kiln sits between parsing and name resolution in the compiler pipeline described by [`wep-2026-01-14-compiler-pipeline-refactoring.md`](./wep-2026-01-14-compiler-pipeline-refactoring.md). The sequence for a `wado compile` run is:
+Kiln sits between parsing and name resolution in the pipeline described by [`wep-2026-01-14-compiler-pipeline-refactoring.md`](./wep-2026-01-14-compiler-pipeline-refactoring.md). The sequence for a `wado compile` run is:
 
-1. Read `wado.toml`, resolve `[build-dependencies]`, and fetch generator packages into the build-dependency graph. Individual generator modules are not compiled yet; compilation is deferred until the first invocation that needs them, so that inline `use ... with` clauses can pull in additional modules not named in the manifest.
-2. Parse every `.wado` source file in the project. Resolution of `use` statements is deferred until after generators have run (step 6), so missing `from` targets are not an error at this point — a plain `use` may legitimately point at a generated sibling of some other file's `use ... with` clause. Genuine typos are caught at resolution.
-3. Walk parsed ASTs and collect all inline `use ... with` generator invocations. De-duplicate inline invocations whose `(module, inputs, options)` triples are identical, then merge them with the manifest invocations into a single invocation list. Detect duplicate schema targets (the same path appearing in `inputs` of two different invocations) and error out.
-4. Build the **generator dependency graph**: an edge from invocation A to invocation B exists if any of A's `inputs`, or any `read-file` target recorded from a previous run of A, lies inside B's `output-dir`. Run a topological sort. A cycle is a compile error.
+1. Read `wado.toml` and resolve `[build-dependencies]` into the build-dependency graph. Generator modules themselves are compiled lazily, so inline `use ... with` clauses may pull in additional modules not named in the manifest.
+2. Parse every `.wado` source file in the project. Record each `use ... with` clause and its `from` target. `use` resolution is deferred to step 6.
+3. Merge the manifest's `[build.generators.*]` entries with the inline clauses into a single invocation list, keyed by `from`. Clauses sharing a `from` are deduplicated when identical and rejected when conflicting. Any `from` path that also appears as a supplementary `inputs` entry of another invocation is permitted (e.g. a lexer grammar that is also its own invocation); any `from` used by two different invocations is a duplicate-generator error.
+4. Build the generator dependency graph: an edge from invocation A to invocation B exists if any of A's inputs (primary or supplementary), or any `read-file` target recorded on a previous run of A, lies inside B's `output-dir`. Topologically sort. Cycles are a compile error.
 5. For each invocation in topological order:
    a. Compute the cache key.
-   b. If `wado.lock` has an entry matching the cache key, and every output file exists on disk with the recorded hash, skip to 5(e).
-   c. Compile the generator module to a `wasm32-wasip*` component if a cached binary is not already available, then instantiate the component in wasmtime. Link `host.read-file` and `host.emit-diagnostic` to compiler-provided closures. All other imports are unlinked and will trap on first use.
-   d. Call `generate(request)` with the initial `inputs` pre-loaded from `CompilerHost`. Every `read-file` made by the generator is forwarded to `CompilerHost` and appended to a per-invocation dependency list.
-   e. Persist each `output-file` in `response` to `<output-dir>/<path>`, stamping the header described below. Delete any existing file in `output-dir` that carries a `#![generated]` attribute and was not produced by this run (garbage collection of outputs that the generator used to emit but no longer does).
+   b. If `wado.lock` has a matching entry and every output file exists on disk with the recorded hash, skip to 5(e).
+   c. Compile the generator module to a `wasm32-wasip*` component if not already cached, instantiate it in wasmtime, and link `host.read-file` and `host.emit-diagnostic`. All other imports are unlinked and trap on first use.
+   d. Call `generate(request)` with `primary` and `inputs` pre-loaded from `CompilerHost`. Forward every `read-file` to `CompilerHost` and append the path to the invocation's dependency list.
+   e. Persist each `output-file` to `<output-dir>/<path>`, stamping the `#![generated(...)]` header. Delete any existing `#![generated]` file in `output-dir` that was not produced by this run.
    f. Record the cache entry in `wado.lock`.
-6. Parse the newly materialized `.wado` files and resolve every `use` statement whose target now exists — both the `use ... with { generator: { ... } }` clause that declared an invocation and any plain sibling `use` statements pointing at files the same invocation emitted. Proceed with name resolution, type checking, and the rest of the normal compile. A `use` whose target is still missing at this point is a real error.
+6. Resolve every `use` statement. A `use { ... } from "<schema>"` with a registered invocation binds to that invocation's entry module; all other `use` statements resolve normally. A `use` whose target is a schema with no registered invocation, or whose imported symbols are not `pub` in the resolved entry, is a real error.
 
-The design deliberately re-parses generated files through the same parser path as user-authored Wado, rather than accepting a pre-parsed AST from the generator. This is important because it means a generator that emits syntactically invalid Wado fails with a normal parse error over the generator's own output, and the user can inspect the file on disk to see what went wrong.
+Generated files go through the same parser and resolver as user-authored Wado, so a generator emitting syntactically invalid Wado fails with a normal parse error against the on-disk file.
 
 ### Generated file header
 
-Every file a generator produces is rewritten by the compiler to begin with a structured `#![generated(...)]` attribute:
+The compiler prefixes every generated file with a `#![generated(...)]` attribute:
 
 ```wado
 #![generated(
@@ -368,31 +334,24 @@ Every file a generator produces is rewritten by the compiler to begin with a str
 )]
 ```
 
-`#![generated]` is extended (in a separate, small compiler change, not via a dedicated WEP) to accept named arguments. Kiln uses the following keys:
+- `by` — the generator package identity (`namespace:name@version`).
+- `sources` — the list of IDL input paths that produced this file, relative to the project root. Every contributing input is listed on every output file the generator emits from those inputs.
 
-- `by` — the generator package identity, in the same `namespace:name@version` form used in the manifest.
-- `sources` — the list of IDL input paths that produced this file, relative to the project root. A generator that fans a single output out of multiple inputs lists every contributing input in the array. A generator that emits more than one file from the same IDL input stamps every output with that same `sources` list.
+`#![generated]` is extended to accept named arguments in a separate, small compiler change. Unknown keys are tolerated, so future additions (`world = "..."`, `schema-hash = "..."`, …) are backward compatible.
 
-Unknown arguments to `#![generated]` are tolerated, so extending the attribute with further keys (for example `world = "..."` or `schema-hash = "..."`) in a future release is backward compatible.
-
-The attribute serves four purposes:
-
-- `wado format` and linters recognize the presence of `#![generated]` and refuse to rewrite the file's contents.
-- The LSP reads the `sources` argument to offer "go to schema" as a secondary navigation target, independently of whether the user wrote `with { generator: { ... } }` at the use site.
-- A human browsing the repository sees immediately that the file is derived and can jump to the IDL from the first line of the file.
-- The cache uses the presence of `#![generated]` to distinguish generated files from hand-written ones when cleaning up stale outputs in an `output-dir`.
+The attribute lets `wado format` and linters skip the file, lets the LSP offer "go to schema" independently of any `with` clause, flags the file as derived for human readers, and gates stale-output garbage collection inside `output-dir`.
 
 ### Caching and `wado.lock`
 
 Each invocation's cache key is the SHA-256 of a canonical concatenation of:
 
-- the resolved generator package identity (`namespace:name@version` + content hash of its source distribution);
-- the content of each initial `input-file`;
-- the content of each file the generator retrieved via `read-file` during the previous successful run;
-- the canonical serialization of the `options` value;
-- the `kiln` world protocol version (see "Versioning" below).
+- the resolved generator package identity (`namespace:name@version` + source-distribution content hash);
+- the content of `primary` and every `inputs` entry;
+- every file the generator retrieved via `read-file` on the previous successful run;
+- the canonical serialization of `options`;
+- the `kiln` world protocol version.
 
-Crucially, the **compiled generator `.wasm` binary is not part of the cache key**. Its content is determined by the generator source plus the Wado compiler version, both of which are already part of the lock file. Including the `.wasm` hash would mean every upgrade of `wado-compiler` forces every generator to re-run, which is undesirable and unnecessary: if the source hash matches, the rebuilt `.wasm` is deterministic enough for caching purposes.
+The compiled generator `.wasm` is not part of the cache key: its content is determined by the generator source and the compiler version, both already captured in the lock file. Hashing the `.wasm` would force every generator to re-run on a compiler upgrade for no added safety.
 
 `wado.lock` gains two new sections:
 
@@ -407,98 +366,83 @@ source-hash = "sha256:abcd1234..."
 dependencies = ["wado:prelude@0.1", "example:wit-parser@0.4"]
 
 [[generator-cache]]
-invocation = "proto-rpc"          # the manifest key, or a stable synthesized id for inline invocations
+invocation = "user-proto"          # manifest key, or a stable synthesized id for inline
 generator = "example:proto-codegen@1.2.3"
+primary = { path = "schemas/user.proto", hash = "sha256:..." }
 inputs = [
-    { path = "schemas/user.proto",    hash = "sha256:..." },
-    { path = "schemas/billing.proto", hash = "sha256:..." },
-    { path = "schemas/common.proto",  hash = "sha256:..." },  # transitive via read-file
+    { path = "schemas/common.proto", hash = "sha256:..." },    # supplementary
+    { path = "schemas/shared.proto", hash = "sha256:..." },    # transitive via read-file
 ]
 options-hash = "sha256:..."
 outputs = [
-    { path = "src/generated/proto-rpc/user.wado",    hash = "sha256:..." },
-    { path = "src/generated/proto-rpc/billing.wado", hash = "sha256:..." },
+    { path = "build/kiln/user-proto/user.wado",   hash = "sha256:...", entry = true },
+    { path = "build/kiln/user-proto/types.wado",  hash = "sha256:..." },
 ]
 ```
 
-On every build, the compiler recomputes the cache key and compares the expected output hashes against the files actually on disk. If either the key or any output file is out of date, the generator is re-run. If every file matches, the generator is skipped and parsing proceeds against the existing files.
-
-Because all outputs are committed to the repository, this is also the mechanism that makes the framework CI-friendly: a `wado compile --check-clean` mode can run every relevant generator, refuse to overwrite, and fail if the on-disk files differ from what the generator would have produced. This is the same discipline that `cargo fmt --check` enforces for formatting.
-
-### Determinism as a guarantee
-
-Because Wado already targets Wasm, deterministic generator execution is essentially free. The `kiln` world does not import `wasi:clocks`, `wasi:random`, `wasi:http`, `wasi:sockets`, or `wasi:cli/environment`. Wasmtime enforces this at link time: a generator that tries to import anything outside of `wado:kiln/host` fails to instantiate, with a compile error naming the offending import. The consequence is that a generator is, by construction, a pure function of its request plus the files it reads through `host.read-file`. This is the property that makes content-addressed caching sound and that makes CI reproducibility trivial.
-
-This is one place where Wado's choice of Wasm as the language substrate pays off. In-compiler macro systems for non-Wasm languages (Rust, Nim, Scala 3) have to fight determinism via convention; Wado gets it by construction.
+On every build, the compiler recomputes the cache key and compares the expected output hashes against the files on disk. If either is out of date, the generator re-runs; otherwise parsing proceeds against the existing files. A `wado compile --check-clean` mode runs every invocation, refuses to overwrite, and fails if on-disk files differ — the analogue of `cargo fmt --check` for commit-tracked generator output.
 
 ### Diagnostics: extending spans to external files
 
 Today, `wado-compiler` spans reference an internal `FileId` assigned when a source file is loaded into a `SourceMap`. Kiln needs spans to point at IDL files that the compiler itself did not originally parse — it only read them on behalf of a generator via `host.read-file`. Two small extensions handle this:
 
-1. `SourceMap` is taught to register any file that comes in via `CompilerHost::load_source`, including files read on behalf of a generator. Once a file has been read, it has a stable `FileId` for the rest of the compilation and can back span-based diagnostics.
-2. The generator-facing `source-span` WIT record carries `(path, byte-start, byte-end)` instead of a raw `FileId`. When the compiler materializes a diagnostic produced via `host.emit-diagnostic`, it looks up (or registers) the `FileId` for `path` and emits the diagnostic in its normal format. If `path` refers to a file that was never read by this generator run, the compiler still displays the diagnostic but omits the source excerpt and adds a note that the span is unverified.
+1. `SourceMap` registers any file that comes in via `CompilerHost::load_source`, including files read on behalf of a generator. Once a file has been read, it has a stable `FileId` for the rest of the compilation.
+2. The generator-facing `source-span` carries `(path, byte-start, byte-end)`. When the compiler materializes a diagnostic from `host.emit-diagnostic`, it looks up (or registers) the `FileId` for `path` and renders in its normal format. If `path` was never read by this run, the diagnostic is displayed without a source excerpt and marked unverified.
 
-This is a small, targeted extension. No new span kind is required for user code, and the behavior of existing Wado diagnostics is unchanged. The detailed implementation lives in follow-up patches rather than a separate WEP.
+Existing user-facing diagnostics are unaffected.
 
 ### Relationship to existing pipelines
 
-`wado-from-idl` remains a Tier 0 bootstrap tool. It generates the `wasi:*` standard library that Wado itself depends on, so it cannot be authored in Wado without a chicken-and-egg problem. It continues to run from `mise run update-stdlib-wasi`, and its output remains committed. This WEP does not propose migrating `wado-from-idl` to the new framework.
+`wado-from-idl` stays a Tier 0 bootstrap tool: it generates the `wasi:*` standard library that Wado itself depends on, so authoring it in Wado would be a chicken-and-egg. It continues to run from `mise run update-stdlib-wasi` with committed output and is not migrated to Kiln.
 
-Gale is a Tier 1 user-space tool and migrates to Kiln. A `.g4`-consuming invocation registered in `wado.toml` or inline at a `use` site replaces the current `mise run update-gale-golden` dance. Gale's generator module exports the `wado:kiln/generator` world and accepts an `Options` type that matches the options Gale currently consumes on its command line.
+Gale is Tier 1 and migrates: a `.g4` invocation in `wado.toml` or inline at a `use` site replaces the `mise run update-gale-golden` dance. Gale's module exports `wado:kiln/generator` with an `Options` matching its current CLI flags.
 
 ### Versioning
 
-The `kiln` world is versioned as an ordinary WIT interface. The initial version is `wado:kiln@0.1`. A generator declares the exact version it targets in its own `wado.toml`; the compiler refuses to instantiate a generator whose targeted version does not match the compiler's supported set, with an error that names both sides. Until Kiln stabilizes, compatibility across `0.x` versions is not guaranteed. Post-1.0 versions follow the usual component-model versioning rules.
-
-The world version is part of the cache key, so a compiler upgrade that bumps the world version invalidates every cached generator output automatically.
+The `kiln` world is versioned as an ordinary WIT interface, starting at `wado:kiln@0.1`. A generator declares the exact version it targets in its own `wado.toml`; a mismatch against the compiler's supported set is a hard error naming both sides. `0.x` compatibility is not guaranteed; post-1.0 follows ordinary component-model versioning. The world version is part of the cache key, so bumping it invalidates every cached output automatically.
 
 ## Alternatives considered
 
 ### In-compiler macro system
 
-Running generator code directly inside `wado-compiler` — the Rust proc-macro model — would be faster and require no wasmtime dependency. It was rejected for three reasons. First, it would expose the full Rust host environment to every generator, forfeiting determinism. Second, generators written in Wado could not be used this way, so the natural bootstrap story (Gale, `wado-from-idl`) would be a different, second mechanism. Third, Wasm sandboxing is already integral to Wado's story; using it for the compiler's own plugin surface is consistent with the rest of the language.
+Running generator code directly inside `wado-compiler` (the Rust proc-macro model) would be faster and drop the wasmtime dependency, but it exposes the full host environment to every generator (forfeiting determinism), and generators written in Wado could not participate without a second, separate mechanism. Reusing Wasm sandboxing — already integral to Wado — keeps the plugin surface consistent with the rest of the language.
 
 ### Pre-build arbitrary program (`build.rs` equivalent)
 
-Allowing `wado.toml` to declare an arbitrary command line that runs before compile would be maximally flexible. It was rejected because the goal is specifically to introduce a _supervised_ mechanism. Users who need an arbitrary pre-build step can run their own shell and then call `wado compile` — that path already exists and does not need language blessing.
+Declaring an arbitrary pre-compile command in `wado.toml` is maximally flexible but unsupervised. Users who need this can run their own shell before `wado compile`; no language support is required.
 
-### Glob-based input discovery
+### Static enumeration: no globs, no `list-dir`
 
-An earlier draft allowed `inputs = ["schemas/**/*.proto"]`. It was rejected because globs make the input set of a generator invisible to the LSP and to static tooling in general. With an explicit list, `wado` and the LSP can point at every file that feeds every generator, and there is no ambient "the file appeared in the directory" failure mode. The ergonomic cost — listing files — is paid exactly once per schema file per project.
-
-### `list-dir` host import
-
-For the same reason as globs, the host interface does not expose directory enumeration. A generator that wants to process several files reads them through the initial `request.inputs` list (which is statically enumerable) plus transitive `read-file` calls (which are logged).
+Both `inputs = ["schemas/**/*.proto"]` globs and a `host.list-dir` import were rejected for the same reason: they hide the generator's input set from the LSP and from static tooling, and introduce an ambient "a file appeared in the directory" failure mode. The explicit list of paths costs one line per schema and is paid once per project.
 
 ### Inline-only configuration
 
-Dropping `[build.generators]` entirely and requiring every generator invocation to be declared at a `use` site would make the framework uniform. It was rejected because a large project with many schemas would spread generator configuration across many files, making global changes (e.g., bumping the generator version) a tedious search-and-replace. The two forms coexist with the rule that a given schema file belongs to exactly one invocation.
+Requiring every invocation at a `use` site would be uniform but forces projects with many schemas to spread generator configuration across many files, making global changes (version bumps, option edits) a search-and-replace. Manifest and inline forms coexist and share the same `Invocation` representation.
 
-### JSON/TOML options instead of typed `Options`
+### Opaque JSON/TOML options
 
-A simpler v1 could have accepted `options` as an opaque JSON/TOML value and left validation to the generator. It was rejected because it defers all feedback to generator runtime, where error messages are necessarily worse than the compiler's own. Typed options also let the LSP offer completions for `wado.toml` and `use ... with { generator: { options: { ... } } }`, which matters for discoverability.
+Accepting `options` as an untyped blob would defer validation to generator runtime, where errors are necessarily worse than the compiler's. A typed `Options` record also enables LSP completions at manifest and `use` sites.
 
 ## Open questions
 
-The following are deliberately unresolved in this WEP and will be decided during implementation or in follow-up WEPs.
+The following are deliberately unresolved here; they will be decided during implementation or in follow-up WEPs.
 
-- [ ] **Watch mode.** `wado compile --watch` is natural for iterative development (edit `.proto`, see `.wado` regenerate). The v1 of this WEP does not specify watch mode; the caching design is already correct for one.
-- [ ] **Parallel execution of independent generator invocations.** The framework is structured so that independent invocations may run in parallel. Whether v1 exploits this is an implementation choice.
-- [ ] **Fine-grained error shape in `response.error`.** The `error` variant is currently `invalid-schema | unsupported | other`. Real generators may want richer structured errors, but we can extend the variant backward-compatibly in a `0.x` bump.
-- [ ] **Target directory for locally compiled generators.** Project-local generators (a `.wado` file inside the consuming project) are compiled to a component on demand. Where the compiled artifact lives — `target/wado-gen/`, a package-global cache, or both — is deferred to the WEP that formally defines a Wado `target/` layout.
-- [ ] **`host.read-file` access scope.** A generator can, in principle, attempt to read any path the compiler host is willing to serve. The v1 behavior is "any path `CompilerHost` accepts", which in practice means any path inside the project directory and the build-dependency cache. A stricter policy (e.g., explicit allow-list per invocation) may be revisited if it turns out to matter.
-- [ ] **Exact `wado.lock` layout.** The sketch in this WEP is indicative. The final layout is decided as part of implementation in `wado-manifest/`.
-- [ ] **Inline-use `source` resolution relative to project root vs. source file.** The WEP specifies resolution relative to the source file containing the `use` statement. If we later want project-root-relative paths for some reason, a new `with { generator: { root: "workspace" } }` key can be added without breaking existing uses.
+- [ ] Watch mode (`wado compile --watch`). The caching design already supports it; v1 leaves the command surface unspecified.
+- [ ] Parallel execution of independent invocations — an implementation choice.
+- [ ] Richer shape for `response.error`. The current `invalid-schema | unsupported | other` variant is extendable in a `0.x` bump.
+- [ ] On-disk location of the compiled generator `.wasm` (package-global cache vs. per-project `target/`). Deferred to the Wado `target/` layout WEP.
+- [ ] `host.read-file` access scope. V1 serves any path `CompilerHost` accepts; a stricter per-invocation allow-list may be revisited if needed.
+- [ ] Final `wado.lock` layout. The sketch here is indicative.
+- [ ] `root: "workspace"` escape hatch for project-root-relative paths at `use` sites. Not needed in v1.
 
 ## Consequences
 
-- Users gain a first-class way to consume any schema language that has (or can acquire) a Wado generator package. The ergonomic bar is close to Dart's `build_runner` and the operational model is close to Swift macros: sandboxed, deterministic, cacheable, automatic.
-- `wado.toml` grows a `[build-dependencies]` section and a `[build.generators]` section. `wado.lock` grows `[[build-dependency]]` and `[[generator-cache]]` entries.
-- `wado-compiler` grows a new phase between parsing and name resolution that runs generators and materializes their output. It gains a wasmtime dependency scoped to the generator-execution path. The core compiler remains I/O-free; all filesystem access still routes through `CompilerHost`.
-- The `CompilerHost` trait gains responsibility for serving generator file reads, in addition to its existing responsibility for user source files. Implementations in `wado-cli` and in the test harness must be updated accordingly.
-- Wado's `SourceMap` and diagnostic renderer are extended to handle spans in files that were read on behalf of a generator. This is a small change; existing diagnostics are unaffected.
-- Gale migrates from `mise run update-gale-golden` to a registered `[build.generators]` invocation. The update task is retired once migration completes. `wado-from-idl` is unchanged.
-- Adding a new schema language to Wado's ecosystem becomes a matter of publishing a package that exports the `wado:kiln/generator` world. No compiler changes are required.
+- Users gain a first-class way to consume any schema language that has (or can acquire) a Wado generator package. Operationally close to Swift macros: sandboxed, deterministic, cacheable, automatic.
+- `wado.toml` grows `[build-dependencies]` and `[build.generators]`; `wado.lock` grows `[[build-dependency]]` and `[[generator-cache]]`.
+- `wado-compiler` gains a phase between parsing and name resolution that runs generators via wasmtime and materializes their output. The core compiler remains I/O-free; `CompilerHost` serves generator reads on top of user-source reads. Implementations in `wado-cli` and the test harness are updated accordingly.
+- `SourceMap` and the diagnostic renderer extend to spans in generator-read files; existing user diagnostics are unaffected.
+- Gale migrates from `mise run update-gale-golden` to a `[build.generators]` invocation; the update task is retired. `wado-from-idl` is unchanged.
+- Adding a new schema language becomes a matter of publishing a package that exports `wado:kiln/generator`; no compiler changes are required.
 
 ## References
 

--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -1,4 +1,4 @@
-# Kiln — Code Generation Framework
+# Kiln — Keyed IDL Lowering Notation
 
 ## Context
 
@@ -9,7 +9,12 @@ Wado is a language that is frequently expected to talk to schema-defined externa
 
 Each pipeline is wired up by hand in `mise.toml`, runs out-of-band, and produces output that is committed to the repository. There is no shared contract, no cache, no first-class story for users who want to do the same thing in their own projects. A user who wants to generate Wado from their own `.proto` files today has no better option than writing an external script and calling `wado compile` afterwards.
 
-This WEP introduces **Kiln**, a first-class mechanism for **schema-driven code generation** — the Wado equivalent of Java annotation processors (APT/KSP), Roslyn source generators, Swift macros, or Dart's `build_runner`, narrowed to a single use case: **IDL → Wado source**. The name joins Wado's existing element-themed tools (Tide for WebIDL, Gale for grammars) as the "fire" in which raw schemas are fired into Wado source.
+This WEP introduces **Kiln** (**K**eyed **I**DL **L**owering **N**otation), a first-class mechanism for **schema-driven code generation** — the Wado equivalent of Java annotation processors (APT/KSP), Roslyn source generators, Swift macros, or Dart's `build_runner`, narrowed to a single use case: **IDL → Wado source**. The name joins Wado's existing element-themed tools (Tide for WebIDL, Gale for grammars) as the "fire" in which raw schemas are fired into Wado source, and the expansion captures the four defining properties of the design:
+
+- **K**eyed — every invocation is content-addressed by a cache key covering schemas, options, and the generator's own source hash (see "Caching and `wado.lock`").
+- **I**DL — the sole accepted input shape is an interface description language; Kiln is deliberately narrower than a general build system.
+- **L**owering — Kiln lowers high-level schema files into plain Wado source that the ordinary compiler pipeline then handles with no further specialization.
+- **N**otation — the user-facing surface is a declarative notation (`[build.generators]` and `use ... from "<schema>" with { ... }`), not an imperative build script.
 
 ### Scope
 
@@ -283,10 +288,9 @@ The manifest form above is convenient for projects with many schemas, but Wado i
 ```wado
 #!/usr/bin/env wado run
 
-use { User, Billing } from "./user.wado" with {
+use { User, Billing } from "./user.proto" with {
     generator: {
         module: "example:proto-codegen@1.2",
-        inputs: ["./user.proto"],
         options: { style: "rpc", emit_comments: true },
     },
 };
@@ -297,24 +301,42 @@ export fn run() with Stdout {
 }
 ```
 
-Semantics of `use ... with { generator: { ... } }`:
+For schema families with implicit cross-file dependencies — Gale's parser grammar referencing an unimported lexer grammar, OpenAPI's main spec referencing a shared components file, and so on — the secondary files are declared via the `inputs` key:
 
-- The `from` target is one of the **generated `.wado`** files that the invocation will emit, exactly as it would be if the generator had been declared in `wado.toml`. A single invocation may produce many files (Gale, for instance, typically emits a lexer, a parser, and a token table as separate `.wado` files); the `from` target points at whichever file this particular `use` statement needs symbols from. The LSP treats it as the primary jump target.
-- The `inputs` key is the list of IDL input files the generator consumes. It is a list — not a single string — because real generators frequently take several inputs at once (Gale's lexer grammar + parser grammar, OpenAPI's spec + shared components file, etc.). Paths are resolved relative to the source file containing the `use` statement. The LSP treats the `inputs` files as secondary jump targets for "go to schema".
+```wado
+use { RustParser } from "./Rust.g4" with {
+    generator: {
+        module: "wado:gale@0.1",
+        inputs: ["./RustLexer.g4"],
+        options: { },
+    },
+};
+```
+
+Semantics of `use ... from "<schema>" with { generator: { ... } }`:
+
+- The `from` target is the **primary IDL file** the generator consumes. It is a path to the source schema (`.proto`, `.g4`, `.graphql`, `.wit`, …), not a path to a generated `.wado` file. Paths are resolved relative to the source file containing the `use` statement, and the compiler passes this file to the generator as the first entry of `request.inputs`.
+- The `inputs` key (optional) is a list of **supplementary IDL files** that the primary input implicitly depends on but does not explicitly import. It exists because real grammar and schema ecosystems have conventional split-file patterns without language-level `import` statements: a parser grammar `Rust.g4` assumes a matching lexer grammar `RustLexer.g4` by naming convention; an OpenAPI spec uses `$ref` into a shared components file. Paths are resolved relative to the source file containing the `use` statement. A generator that reaches further (for example, a `.proto` that `import`s another `.proto`) still picks transitive files up via `host.read-file`; `inputs` is only for files that the generator cannot discover from the primary input alone.
 - The `module` and `options` keys have the same meaning as in `[build.generators.<name>]`.
-- When the compiler sees this `use` statement, it synthesizes an anonymous `[build.generators.<anonymous>]` entry whose `inputs` is the literal list above and whose `output-dir` is the directory of the `from` target. The generator runs, every file it emits is written into that directory, and everything from there on is identical to the manifest form.
+- Symbol scope: the `use` statement draws its symbols from the union of all `.wado` files the generator emits for this invocation. Kiln does not require the user to know which emitted file defines which symbol — a single invocation is treated as one logical module, even when it materializes as several files on disk (Gale, for instance, typically emits a lexer, a parser, and a token table as separate `.wado` files).
+- Output location: for inline invocations the compiler chooses a deterministic path under its target directory (`target/kiln/<cache-key>/...`, exact layout deferred to the `target/` layout WEP) and materializes the generated files there. Users who need an explicit, repo-committed output directory declare the invocation in `wado.toml` instead.
+- LSP navigation:
+  - **Go to definition** on an imported symbol jumps to the **generated `.wado`** file that defines it. The file is an ordinary Wado source file that the LSP can index, even though it lives under the target directory.
+  - **Go to schema** on the `from` literal jumps to the primary IDL file; on an entry in `inputs` it jumps to that supplementary IDL file.
+- When the compiler sees this `use` statement, it synthesizes an anonymous `[build.generators.<anonymous>]` entry whose `inputs` is `[<from>, ...<with.inputs>]` and whose `output-dir` is the compiler-managed directory described above. The generator runs, every file it emits is written into that directory, and everything from there on is identical to the manifest form.
 
-Sibling imports and de-duplication:
+De-duplication and sibling imports:
 
-- Because a single invocation may emit several output files, a project may contain several `use` statements that point into the same output directory. Only one of them needs to carry the `with { generator: { ... } }` clause — the others may be plain `use` statements. The compiler parses the entire project before running generators (see the build pipeline below), so the plain `use` statements are resolved after their targets have been materialized.
-- If two or more `use ... with` clauses in the compilation unit specify the same `module`, the same `inputs`, and the same `options`, they are merged into a single invocation. This lets a project spread related imports across multiple files without duplicating the generator run. If the triples differ at all (different `module`, a different `inputs` list, different `options`), they are treated as separate invocations.
+- If two or more `use ... with` clauses in the compilation unit specify the same `module`, the same ordered list of inputs (primary + supplementary), and the same `options`, they are merged into a single invocation. This lets a project split its imports across files — `use { Lexer } from "./Rust.g4" with {...}` in one file and `use { Parser } from "./Rust.g4" with {...}` in another — without duplicating the generator run.
+- A subsequent `use { ExtraSym } from "./Rust.g4"` without a `with` clause is permitted once any `use ... with` clause has pinned the generator configuration for that primary input; it resolves against the same invocation's emitted symbol set. If no `with` clause has been declared for the primary input anywhere in the compilation unit, a bare `use from "./Rust.g4"` is an error.
+- If the `(module, inputs, options)` triples of two clauses for the same primary input differ at all, it is a duplicate-generator error listing both declarations.
 
 Rules around mixing the two forms:
 
-- A given schema file may be targeted by at most one generator invocation in the whole compilation unit. If a path appears in a manifest `[build.generators.*].inputs` list, it may not also appear in the `inputs` of a `use ... with`. The compiler reports this as a duplicate-generator error, listing both declarations.
-- A `with { generator: { ... } }` block must include at least `module` and `inputs`. Partial forms that only override `options` are not supported in v1; manifest and inline are full equivalents, not a cascade.
+- A given primary-input schema path may appear in at most one generator invocation in the whole compilation unit. If a path appears in a manifest `[build.generators.*].inputs` list as the primary input, it may not also appear as the `from` target of a `use ... with`; the compiler reports this as a duplicate-generator error, listing both declarations. (A supplementary `inputs` entry of one invocation may, however, be the primary input of another — that is how one manifest can register both a lexer invocation and a parser invocation that reference each other.)
+- A `with { generator: { ... } }` block must include at least `module`. The `inputs` key is optional and defaults to the empty list; the `options` key is optional and defaults to the `Options` type's default value.
 
-Both surfaces parse to the same internal representation (an `Invocation { module, inputs, output-dir, options }`), so downstream logic — caching, scheduling, diagnostics — does not need to care which form the user wrote.
+Both surfaces parse to the same internal representation (an `Invocation { module, inputs, output-dir, options }`, where `inputs[0]` is the primary input), so downstream logic — caching, scheduling, diagnostics — does not need to care which form the user wrote.
 
 ### Build pipeline integration
 


### PR DESCRIPTION
## Summary

- `use { ... } from "./schema.idl"` now points at the IDL source; LSP go-to-definition jumps to the generated `.wado` entry module.
- Added `with { generator: { ..., inputs: [...] } }` for schemas (e.g. G4 grammars) that implicitly depend on multiple IDL files.
- Unified manifest and inline invocations around one shape (`from` + optional `inputs`, default output `build/kiln/<id>/`), and mandated one entry module plus optional supplementary modules wired via ordinary Wado `use`.
- Expanded the name: Kiln — Keyed IDL Lowering Notation. Trimmed duplicated determinism/pipeline/alternatives sections.

## Test plan

- [ ] Docs-only change — verify rendering of `docs/wep-2026-04-12-kiln.md` on GitHub
- [ ] `mise run format` leaves the tree clean

https://claude.ai/code/session_01Fm6nWGj7CDbGiLHn9uCeyK