### PR TITLE
Gale: tag virtual tokens and gate emission on `is_virtual`

### DIFF
--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -47,9 +47,6 @@ most of the new fields. "Parsed and stored" is not "used":
   ANTLR4 itself ignores these at codegen, so matching ANTLR4's behavior
   is fine, but a lint or doc comment in the generated output would make
   the information observable.
-- `LexerRule.is_virtual` — stored but not emitted differently from real
-  lexer rules. Generated lexers happily produce try_<name> functions for
-  virtual tokens that should never match. Should be gated.
 
 ## C. Representation quality of stored options
 

--- a/package-gale/src/generator.wado
+++ b/package-gale/src/generator.wado
@@ -31,7 +31,7 @@ use { gen_parser } from "./parser_gen.wado";
 use { gen_visitor } from "./visitor_gen.wado";
 use { gen_highlight } from "./highlight_gen.wado";
 use { GenContext } from "./gen_context.wado";
-use { CodeWriter, StructSpec, VariantSpec, EnumSpec } from "./wadopoet.wado";
+use { CodeWriter, StructSpec, VariantSpec } from "./wadopoet.wado";
 
 pub struct GenerateOptions {
     pub highlight: bool,
@@ -89,16 +89,19 @@ fn gen_runtime(w: &mut CodeWriter) {
 }
 
 fn gen_token_kind(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>) {
-    let mut e = EnumSpec::new("TokenKind");
-    e.set_pub();
+    w.begin("pub enum TokenKind");
     for let rule of lexer_rules {
         if !rule.is_fragment {
-            e.add_member(&rule.name);
+            if rule.is_virtual {
+                w.line(`{rule.name},  // virtual`);
+            } else {
+                w.line(`{rule.name},`);
+            }
         }
     }
-    e.add_member("Eof");
-    e.add_member("Error");
-    e.emit(w);
+    w.line("Eof,");
+    w.line("Error,");
+    w.end();
     w.blank();
 }
 

--- a/package-gale/src/generator.wado
+++ b/package-gale/src/generator.wado
@@ -31,7 +31,7 @@ use { gen_parser } from "./parser_gen.wado";
 use { gen_visitor } from "./visitor_gen.wado";
 use { gen_highlight } from "./highlight_gen.wado";
 use { GenContext } from "./gen_context.wado";
-use { CodeWriter, StructSpec, VariantSpec } from "./wadopoet.wado";
+use { CodeWriter, StructSpec, VariantSpec, EnumSpec } from "./wadopoet.wado";
 
 pub struct GenerateOptions {
     pub highlight: bool,
@@ -89,19 +89,20 @@ fn gen_runtime(w: &mut CodeWriter) {
 }
 
 fn gen_token_kind(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>) {
-    w.begin("pub enum TokenKind");
+    let mut e = EnumSpec::new("TokenKind");
+    e.set_pub();
     for let rule of lexer_rules {
         if !rule.is_fragment {
             if rule.is_virtual {
-                w.line(`{rule.name},  // virtual`);
+                e.add_member_with_comment(&rule.name, &"virtual");
             } else {
-                w.line(`{rule.name},`);
+                e.add_member(&rule.name);
             }
         }
     }
-    w.line("Eof,");
-    w.line("Error,");
-    w.end();
+    e.add_member("Eof");
+    e.add_member("Error");
+    e.emit(w);
     w.blank();
 }
 

--- a/package-gale/src/generator_test.wado
+++ b/package-gale/src/generator_test.wado
@@ -770,6 +770,31 @@ ID : [a-z]+ ;";
         `ID has no CI; [a-z] must not be mirrored to [A-Z]:\n{output}`;
 }
 
+test "virtual tokens are marked and not match-generated" {
+    // Virtual tokens (declared in `tokens { }` without a real lexer rule) must
+    // still appear in the TokenKind enum, the TK_<name> constant table, and
+    // the token_kind_name dispatch — but they must not get a try_<name>
+    // matcher (the tokenizer cannot produce them directly), and the emitted
+    // entries should be tagged `// virtual` so downstream tooling can see the
+    // distinction.
+    let input = "grammar Test;
+tokens { VIRTUAL_TOK }
+rule : ID ;
+ID : [a-z]+ ;
+WS : [ \\t]+ -> skip ;";
+    let grammar = parse_grammar(input, "test.g4");
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    assert str_contains(&output, "    VIRTUAL_TOK,  // virtual"),
+        `TokenKind member must be marked virtual:\n{output}`;
+    assert str_contains(&output, "global TK_VIRTUAL_TOK: i32 = ") &&
+        str_contains(&output, ";  // virtual"),
+        `TK_VIRTUAL_TOK constant must be marked virtual:\n{output}`;
+    assert str_contains(&output, "TK_VIRTUAL_TOK => \"VIRTUAL_TOK\",  // virtual"),
+        `token_kind_name arm must be marked virtual:\n{output}`;
+    assert !str_contains(&output, "fn try_virtual_tok("),
+        `virtual token must not get a matcher fn:\n{output}`;
+}
+
 test "caseInsensitive does not fold non-letters" {
     let input = "lexer grammar Test;
 options { caseInsensitive = true; }

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -16,7 +16,7 @@ use {
     LabelElement,
 } from "./ir.wado";
 use { to_lower, escape_char, literal_const_name } from "./gen_util.wado";
-use { CodeWriter, StructSpec, ImplSpec, FnSpec } from "./wadopoet.wado";
+use { CodeWriter, StructSpec, ImplSpec, FnSpec, GlobalSpec } from "./wadopoet.wado";
 
 pub struct LitToken {
     pub text: String,
@@ -124,17 +124,25 @@ pub fn gen_token_constants(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, l
     let mut idx = 0;
     for let rule of lexer_rules {
         if !rule.is_fragment {
-            let trailer = if rule.is_virtual { "  // virtual" } else { "" };
-            w.line(`global TK_{rule.name}: i32 = {idx};{trailer}`);
+            let name = `TK_{rule.name}`;
+            let init = `{idx}`;
+            let mut g = GlobalSpec::new(&name, "i32", &init);
+            if rule.is_virtual {
+                g.set_trailing_comment(&"virtual");
+            }
+            g.emit(w);
             idx += 1;
         }
     }
-    w.line(`global TK_EOF: i32 = {idx};`);
+    let eof_init = `{idx}`;
+    GlobalSpec::new("TK_EOF", "i32", &eof_init).emit(w);
     idx += 1;
-    w.line(`global TK_ERROR: i32 = {idx};`);
+    let err_init = `{idx}`;
+    GlobalSpec::new("TK_ERROR", "i32", &err_init).emit(w);
     idx += 1;
     for let lit of lit_tokens {
-        w.line(`global {lit.const_name}: i32 = {idx};`);
+        let init = `{idx}`;
+        GlobalSpec::new(&lit.const_name, "i32", &init).emit(w);
         idx += 1;
     }
     w.blank();

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -16,7 +16,7 @@ use {
     LabelElement,
 } from "./ir.wado";
 use { to_lower, escape_char, literal_const_name } from "./gen_util.wado";
-use { CodeWriter, StructSpec, ImplSpec, FnSpec, GlobalSpec } from "./wadopoet.wado";
+use { CodeWriter, StructSpec, ImplSpec, FnSpec } from "./wadopoet.wado";
 
 pub struct LitToken {
     pub text: String,
@@ -124,21 +124,17 @@ pub fn gen_token_constants(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, l
     let mut idx = 0;
     for let rule of lexer_rules {
         if !rule.is_fragment {
-            let name = `TK_{rule.name}`;
-            let init = `{idx}`;
-            GlobalSpec::new(&name, "i32", &init).emit(w);
+            let trailer = if rule.is_virtual { "  // virtual" } else { "" };
+            w.line(`global TK_{rule.name}: i32 = {idx};{trailer}`);
             idx += 1;
         }
     }
-    let eof_init = `{idx}`;
-    GlobalSpec::new("TK_EOF", "i32", &eof_init).emit(w);
+    w.line(`global TK_EOF: i32 = {idx};`);
     idx += 1;
-    let err_init = `{idx}`;
-    GlobalSpec::new("TK_ERROR", "i32", &err_init).emit(w);
+    w.line(`global TK_ERROR: i32 = {idx};`);
     idx += 1;
     for let lit of lit_tokens {
-        let init = `{idx}`;
-        GlobalSpec::new(&lit.const_name, "i32", &init).emit(w);
+        w.line(`global {lit.const_name}: i32 = {idx};`);
         idx += 1;
     }
     w.blank();
@@ -204,8 +200,10 @@ fn gen_lexer_match_fns(
     let empty_opts: Array<GrammarOption> = [];
     let grammar_ci = resolve_ci(grammar_opts, &empty_opts);
     for let rule of lexer_rules {
-        if rule.body.is_empty() {
-            // Virtual token (from `tokens { }` block): no match function needed
+        if rule.is_virtual {
+            // Virtual token (from `tokens { }` block): no match function
+            // needed — the tokenizer can never produce it directly. Only
+            // `type(X)` rewrites or actions can emit one.
         } else if !rule.is_fragment {
             if !is_keyword_rule_name(&rule.name, keywords)
                 && !is_literal_duplicate(rule, lit_tokens, grammar_opts, grammar_ci) {
@@ -699,7 +697,7 @@ pub fn collect_keyword_rules(
 ) -> Array<KeywordInfo> {
     let mut result: Array<KeywordInfo> = [];
     for let rule of lexer_rules {
-        if rule.is_fragment || rule.body.is_empty() {
+        if rule.is_fragment || rule.is_virtual {
             continue;
         }
         let info = try_extract_keyword_info(rule, lexer_rules, grammar_opts);
@@ -1484,7 +1482,7 @@ fn gen_tokenize_fn(
             }
             for let rule of lexer_rules {
                 if !rule.is_fragment
-                    && !rule.body.is_empty()
+                    && !rule.is_virtual
                     && rule.mode == mi
                     && !is_keyword_rule_name(&rule.name, keywords)
                     && !is_literal_duplicate(rule, lit_tokens, grammar_opts, grammar_ci) {
@@ -1561,7 +1559,7 @@ fn gen_tokenize_fn(
         }
         for let rule of lexer_rules {
             if !rule.is_fragment
-                && !rule.body.is_empty()
+                && !rule.is_virtual
                 && !is_keyword_rule_name(&rule.name, keywords)
                 && !is_literal_duplicate(rule, lit_tokens, grammar_opts, grammar_ci) {
                 all_calls.push(compute_first_chars(
@@ -1710,7 +1708,8 @@ fn gen_token_kind_name_fn(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>, li
     w.indent();
     for let rule of lexer_rules {
         if !rule.is_fragment {
-            w.line(`TK_{rule.name} => "{rule.name}",`);
+            let trailer = if rule.is_virtual { "  // virtual" } else { "" };
+            w.line(`TK_{rule.name} => "{rule.name}",{trailer}`);
         }
     }
     w.line("TK_EOF => \"Eof\",");

--- a/package-gale/src/wadopoet.wado
+++ b/package-gale/src/wadopoet.wado
@@ -237,9 +237,14 @@ impl VariantSpec {
     }
 }
 
+pub struct EnumMember {
+    pub name: String,
+    pub trailing_comment: Option<String>,
+}
+
 pub struct EnumSpec {
     pub name: String,
-    members: Array<String>,
+    members: Array<EnumMember>,
     is_pub: bool,
 }
 
@@ -254,7 +259,19 @@ impl EnumSpec {
     }
 
     pub fn add_member(&mut self, name: &String) -> &mut EnumSpec with stores[self] {
-        self.members.push(*name);
+        self.members.push(EnumMember { name: *name, trailing_comment: null });
+        return self;
+    }
+
+    pub fn add_member_with_comment(
+        &mut self,
+        name: &String,
+        comment: &String,
+    ) -> &mut EnumSpec with stores[self] {
+        self.members.push(EnumMember {
+            name: *name,
+            trailing_comment: Option::<String>::Some(*comment),
+        });
         return self;
     }
 
@@ -262,7 +279,11 @@ impl EnumSpec {
         let prefix = if self.is_pub { "pub " } else { "" };
         w.begin(`{prefix}enum {self.name}`);
         for let member of &self.members {
-            w.line(`{*member},`);
+            if let Some(c) = &member.trailing_comment {
+                w.line(`{member.name},  // {*c}`);
+            } else {
+                w.line(`{member.name},`);
+            }
         }
         w.end();
     }
@@ -406,6 +427,7 @@ pub struct GlobalSpec {
     initializer: String,
     is_pub: bool,
     is_mut: bool,
+    trailing_comment: Option<String>,
 }
 
 impl GlobalSpec {
@@ -416,6 +438,7 @@ impl GlobalSpec {
             initializer: *initializer,
             is_pub: false,
             is_mut: false,
+            trailing_comment: null,
         };
     }
 
@@ -429,10 +452,20 @@ impl GlobalSpec {
         return self;
     }
 
+    pub fn set_trailing_comment(&mut self, comment: &String) -> &mut GlobalSpec with stores[self] {
+        self.trailing_comment = Option::<String>::Some(*comment);
+        return self;
+    }
+
     pub fn emit(&self, w: &mut CodeWriter) {
         let vis = if self.is_pub { "pub " } else { "" };
         let mutability = if self.is_mut { "mut " } else { "" };
-        w.line(`{vis}global {mutability}{self.name}: {self.type_str} = {self.initializer};`);
+        let trailer = if let Some(c) = &self.trailing_comment {
+            `  // {*c}`;
+        } else {
+            "";
+        };
+        w.line(`{vis}global {mutability}{self.name}: {self.type_str} = {self.initializer};{trailer}`);
     }
 }
 

--- a/package-gale/tests/golden/antlr4.wado
+++ b/package-gale/tests/golden/antlr4.wado
@@ -528,27 +528,27 @@ pub enum TokenKind {
     LEXER_CHAR_SET_BODY,
     LEXER_CHAR_SET,
     UNTERMINATED_CHAR_SET,
-    ARG_ACTION,
-    ARG_OR_CHARSET,
-    RULE_REF,
-    SEMPRED,
-    TOKEN_REF,
-    UNICODE_ESC,
-    UNICODE_EXTENDED_ESC,
-    ALT,
-    BLOCK,
-    CLOSURE,
-    ELEMENT_OPTIONS,
-    EPSILON,
-    LEXER_ACTION_CALL,
-    LEXER_ALT_ACTION,
-    OPTIONAL,
-    POSITIVE_CLOSURE,
-    RULE,
-    RULEMODIFIERS,
-    RULES,
-    SET,
-    WILDCARD,
+    ARG_ACTION,  // virtual
+    ARG_OR_CHARSET,  // virtual
+    RULE_REF,  // virtual
+    SEMPRED,  // virtual
+    TOKEN_REF,  // virtual
+    UNICODE_ESC,  // virtual
+    UNICODE_EXTENDED_ESC,  // virtual
+    ALT,  // virtual
+    BLOCK,  // virtual
+    CLOSURE,  // virtual
+    ELEMENT_OPTIONS,  // virtual
+    EPSILON,  // virtual
+    LEXER_ACTION_CALL,  // virtual
+    LEXER_ALT_ACTION,  // virtual
+    OPTIONAL,  // virtual
+    POSITIVE_CLOSURE,  // virtual
+    RULE,  // virtual
+    RULEMODIFIERS,  // virtual
+    RULES,  // virtual
+    SET,  // virtual
+    WILDCARD,  // virtual
     Eof,
     Error,
 }
@@ -1566,27 +1566,27 @@ global TK_ARGUMENT_CONTENT: i32 = 55;
 global TK_LEXER_CHAR_SET_BODY: i32 = 56;
 global TK_LEXER_CHAR_SET: i32 = 57;
 global TK_UNTERMINATED_CHAR_SET: i32 = 58;
-global TK_ARG_ACTION: i32 = 59;
-global TK_ARG_OR_CHARSET: i32 = 60;
-global TK_RULE_REF: i32 = 61;
-global TK_SEMPRED: i32 = 62;
-global TK_TOKEN_REF: i32 = 63;
-global TK_UNICODE_ESC: i32 = 64;
-global TK_UNICODE_EXTENDED_ESC: i32 = 65;
-global TK_ALT: i32 = 66;
-global TK_BLOCK: i32 = 67;
-global TK_CLOSURE: i32 = 68;
-global TK_ELEMENT_OPTIONS: i32 = 69;
-global TK_EPSILON: i32 = 70;
-global TK_LEXER_ACTION_CALL: i32 = 71;
-global TK_LEXER_ALT_ACTION: i32 = 72;
-global TK_OPTIONAL: i32 = 73;
-global TK_POSITIVE_CLOSURE: i32 = 74;
-global TK_RULE: i32 = 75;
-global TK_RULEMODIFIERS: i32 = 76;
-global TK_RULES: i32 = 77;
-global TK_SET: i32 = 78;
-global TK_WILDCARD: i32 = 79;
+global TK_ARG_ACTION: i32 = 59;  // virtual
+global TK_ARG_OR_CHARSET: i32 = 60;  // virtual
+global TK_RULE_REF: i32 = 61;  // virtual
+global TK_SEMPRED: i32 = 62;  // virtual
+global TK_TOKEN_REF: i32 = 63;  // virtual
+global TK_UNICODE_ESC: i32 = 64;  // virtual
+global TK_UNICODE_EXTENDED_ESC: i32 = 65;  // virtual
+global TK_ALT: i32 = 66;  // virtual
+global TK_BLOCK: i32 = 67;  // virtual
+global TK_CLOSURE: i32 = 68;  // virtual
+global TK_ELEMENT_OPTIONS: i32 = 69;  // virtual
+global TK_EPSILON: i32 = 70;  // virtual
+global TK_LEXER_ACTION_CALL: i32 = 71;  // virtual
+global TK_LEXER_ALT_ACTION: i32 = 72;  // virtual
+global TK_OPTIONAL: i32 = 73;  // virtual
+global TK_POSITIVE_CLOSURE: i32 = 74;  // virtual
+global TK_RULE: i32 = 75;  // virtual
+global TK_RULEMODIFIERS: i32 = 76;  // virtual
+global TK_RULES: i32 = 77;  // virtual
+global TK_SET: i32 = 78;  // virtual
+global TK_WILDCARD: i32 = 79;  // virtual
 global TK_EOF: i32 = 80;
 global TK_ERROR: i32 = 81;
 
@@ -3698,27 +3698,27 @@ pub fn token_kind_name(kind: i32) -> String {
         TK_LEXER_CHAR_SET_BODY => "LEXER_CHAR_SET_BODY",
         TK_LEXER_CHAR_SET => "LEXER_CHAR_SET",
         TK_UNTERMINATED_CHAR_SET => "UNTERMINATED_CHAR_SET",
-        TK_ARG_ACTION => "ARG_ACTION",
-        TK_ARG_OR_CHARSET => "ARG_OR_CHARSET",
-        TK_RULE_REF => "RULE_REF",
-        TK_SEMPRED => "SEMPRED",
-        TK_TOKEN_REF => "TOKEN_REF",
-        TK_UNICODE_ESC => "UNICODE_ESC",
-        TK_UNICODE_EXTENDED_ESC => "UNICODE_EXTENDED_ESC",
-        TK_ALT => "ALT",
-        TK_BLOCK => "BLOCK",
-        TK_CLOSURE => "CLOSURE",
-        TK_ELEMENT_OPTIONS => "ELEMENT_OPTIONS",
-        TK_EPSILON => "EPSILON",
-        TK_LEXER_ACTION_CALL => "LEXER_ACTION_CALL",
-        TK_LEXER_ALT_ACTION => "LEXER_ALT_ACTION",
-        TK_OPTIONAL => "OPTIONAL",
-        TK_POSITIVE_CLOSURE => "POSITIVE_CLOSURE",
-        TK_RULE => "RULE",
-        TK_RULEMODIFIERS => "RULEMODIFIERS",
-        TK_RULES => "RULES",
-        TK_SET => "SET",
-        TK_WILDCARD => "WILDCARD",
+        TK_ARG_ACTION => "ARG_ACTION",  // virtual
+        TK_ARG_OR_CHARSET => "ARG_OR_CHARSET",  // virtual
+        TK_RULE_REF => "RULE_REF",  // virtual
+        TK_SEMPRED => "SEMPRED",  // virtual
+        TK_TOKEN_REF => "TOKEN_REF",  // virtual
+        TK_UNICODE_ESC => "UNICODE_ESC",  // virtual
+        TK_UNICODE_EXTENDED_ESC => "UNICODE_EXTENDED_ESC",  // virtual
+        TK_ALT => "ALT",  // virtual
+        TK_BLOCK => "BLOCK",  // virtual
+        TK_CLOSURE => "CLOSURE",  // virtual
+        TK_ELEMENT_OPTIONS => "ELEMENT_OPTIONS",  // virtual
+        TK_EPSILON => "EPSILON",  // virtual
+        TK_LEXER_ACTION_CALL => "LEXER_ACTION_CALL",  // virtual
+        TK_LEXER_ALT_ACTION => "LEXER_ALT_ACTION",  // virtual
+        TK_OPTIONAL => "OPTIONAL",  // virtual
+        TK_POSITIVE_CLOSURE => "POSITIVE_CLOSURE",  // virtual
+        TK_RULE => "RULE",  // virtual
+        TK_RULEMODIFIERS => "RULEMODIFIERS",  // virtual
+        TK_RULES => "RULES",  // virtual
+        TK_SET => "SET",  // virtual
+        TK_WILDCARD => "WILDCARD",  // virtual
         TK_EOF => "Eof",
         TK_ERROR => "Error",
         _ => "Unknown",


### PR DESCRIPTION
## Summary

Closes the `LexerRule.is_virtual` follow-up from `package-gale/TODO.md` §B.

- Switch every code path that decides whether to emit a `try_<name>` matcher from the structural `body.is_empty()` proxy to the explicit `is_virtual` flag (`gen_lexer_match_fns`, `collect_keyword_rules`, both tokenizer dispatch loops in `gen_tokenize_fn`).
- Tag the surviving emissions with a `// virtual` trailer so downstream tooling can distinguish virtual tokens from real lexer rules: `TokenKind` members (`gen_token_kind`), `TK_<name>` constants (`gen_token_constants`), and `token_kind_name` arms (`gen_token_kind_name_fn`).
- Virtual ≠ unused: the constants / enum / name lookup are still emitted because virtual tokens may be referenced from parser rules, produced via `type(X)` lexer rewrites, or emitted by external tooling — only the direct matcher is omitted.

## Test plan

- [x] New unit test `virtual tokens are marked and not match-generated` in `package-gale/src/generator_test.wado` (red → green).
- [x] `mise run update-gale-golden` regenerates `tests/golden/antlr4.wado` with the new `// virtual` trailers (the only golden whose grammar uses `tokens { }`-only entries).
- [x] `time mise run on-task-done` — 1776 Wado tests + 10 benchmark tests, all green (19m34s).

https://claude.ai/code/session_01MG8iAk3s7f1QT4Soi6LtPB