### PR TITLE
wado-lsp: implement textDocument/references and textDocument/documentHighlight

### DIFF
--- a/wado-cli/Cargo.toml
+++ b/wado-cli/Cargo.toml
@@ -27,6 +27,7 @@ http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
 lexopt = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true, features = ["net"] }

--- a/wado-cli/src/lib.rs
+++ b/wado-cli/src/lib.rs
@@ -21,7 +21,7 @@ pub mod format;
 pub mod init;
 pub mod lsp;
 pub mod lsp_adapter;
-pub mod lsp_type;
+pub mod lsp_rpc;
 pub mod manifest;
 pub mod query;
 pub mod query_adapter;

--- a/wado-cli/src/lib.rs
+++ b/wado-cli/src/lib.rs
@@ -21,6 +21,7 @@ pub mod format;
 pub mod init;
 pub mod lsp;
 pub mod lsp_adapter;
+pub mod lsp_type;
 pub mod manifest;
 pub mod query;
 pub mod query_adapter;

--- a/wado-cli/src/lsp.rs
+++ b/wado-cli/src/lsp.rs
@@ -35,6 +35,8 @@ pub async fn run() {
                             },
                             "definitionProvider": true,
                             "hoverProvider": true,
+                            "referencesProvider": true,
+                            "documentHighlightProvider": true,
                             "semanticTokensProvider": {
                                 "legend": {
                                     "tokenTypes": wado_lsp::semantic_tokens::TOKEN_TYPES,
@@ -188,6 +190,104 @@ pub async fn run() {
                         }),
                         None => Value::Null,
                     };
+                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
+                        eprintln!("wado-lsp: {e}");
+                        break;
+                    }
+                }
+            }
+            "textDocument/references" => {
+                if let Some(id) = id {
+                    let uri = params
+                        .get("textDocument")
+                        .and_then(|td| td.get("uri"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    let line = params
+                        .get("position")
+                        .and_then(|p| p.get("line"))
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0) as u32;
+                    let character = params
+                        .get("position")
+                        .and_then(|p| p.get("character"))
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0) as u32;
+                    let include_declaration = params
+                        .get("context")
+                        .and_then(|c| c.get("includeDeclaration"))
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false);
+                    let position = wado_lsp::Position { line, character };
+                    let host = lsp_adapter::host_for_uri(uri);
+                    let refs = engine
+                        .references(uri, position, include_declaration, &host)
+                        .await;
+                    let result = Value::Array(
+                        refs.into_iter()
+                            .map(|r| {
+                                json!({
+                                    "uri": r.uri,
+                                    "range": {
+                                        "start": {
+                                            "line": r.range.start.line,
+                                            "character": r.range.start.character,
+                                        },
+                                        "end": {
+                                            "line": r.range.end.line,
+                                            "character": r.range.end.character,
+                                        },
+                                    },
+                                })
+                            })
+                            .collect(),
+                    );
+                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
+                        eprintln!("wado-lsp: {e}");
+                        break;
+                    }
+                }
+            }
+            "textDocument/documentHighlight" => {
+                if let Some(id) = id {
+                    let uri = params
+                        .get("textDocument")
+                        .and_then(|td| td.get("uri"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    let line = params
+                        .get("position")
+                        .and_then(|p| p.get("line"))
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0) as u32;
+                    let character = params
+                        .get("position")
+                        .and_then(|p| p.get("character"))
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0) as u32;
+                    let position = wado_lsp::Position { line, character };
+                    let host = lsp_adapter::host_for_uri(uri);
+                    let highlights = engine.document_highlight(uri, position, &host).await;
+                    let result = Value::Array(
+                        highlights
+                            .into_iter()
+                            .map(|h| {
+                                json!({
+                                    "range": {
+                                        "start": {
+                                            "line": h.range.start.line,
+                                            "character": h.range.start.character,
+                                        },
+                                        "end": {
+                                            "line": h.range.end.line,
+                                            "character": h.range.end.character,
+                                        },
+                                    },
+                                    "kind": h.kind as u32,
+                                })
+                            })
+                            .collect(),
+                    );
                     if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
                         eprintln!("wado-lsp: {e}");
                         break;

--- a/wado-cli/src/lsp.rs
+++ b/wado-cli/src/lsp.rs
@@ -2,12 +2,12 @@ use serde_json::Value;
 use tokio::io::BufReader;
 
 use crate::lsp_adapter;
-use crate::lsp_type::{
-    self, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    DocumentHighlight, Hover, InitializeResult, Location, MarkupContent, MarkupKind, Position,
-    PublishDiagnosticsParams, Range, ReferenceParams, SemanticTokens, SemanticTokensLegend,
-    SemanticTokensOptions, SemanticTokensParams, ServerCapabilities, ServerInfo,
-    TextDocumentPositionParams, TextDocumentSyncOptions, error_codes, text_document_sync_kind,
+use crate::lsp_rpc::{
+    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    InitializeResult, PublishDiagnosticsParams, ReferenceParams, SemanticTokens,
+    SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams, ServerCapabilities,
+    ServerInfo, TextDocumentPositionParams, TextDocumentSyncOptions, error_codes,
+    text_document_sync_kind,
 };
 
 /// Run the LSP server over stdio.
@@ -81,7 +81,7 @@ pub async fn run() {
                     continue;
                 };
                 let uri = &p.text_document.uri;
-                engine.open_document(uri, p.text_document.text.clone());
+                engine.open_document(uri, p.text_document.text);
                 if let Err(e) = lsp_adapter::publish_diagnostics(&engine, uri, &mut writer).await {
                     eprintln!("wado-lsp: {e}");
                 }
@@ -102,42 +102,15 @@ pub async fn run() {
             }
             "textDocument/definition" => {
                 if let Some(id) = id {
-                    let p: TextDocumentPositionParams =
-                        serde_json::from_value(params).unwrap_or_else(|_| {
-                            TextDocumentPositionParams {
-                                text_document: lsp_type::TextDocumentIdentifier {
-                                    uri: String::new(),
-                                },
-                                position: Position {
-                                    line: 0,
-                                    character: 0,
-                                },
-                            }
-                        });
-                    let uri = &p.text_document.uri;
-                    let position = wado_lsp::Position {
-                        line: p.position.line,
-                        character: p.position.character,
+                    let Ok(p) = serde_json::from_value::<TextDocumentPositionParams>(params) else {
+                        continue;
                     };
-                    let host = lsp_adapter::host_for_uri(uri);
-                    let result = match engine.definition(uri, position, &host).await {
-                        Some(def) => serde_json::to_value(Location {
-                            uri: def.uri,
-                            range: Range {
-                                start: Position {
-                                    line: def.range.start.line,
-                                    character: def.range.start.character,
-                                },
-                                end: Position {
-                                    line: def.range.end.line,
-                                    character: def.range.end.character,
-                                },
-                            },
-                        })
-                        .unwrap_or(Value::Null),
-                        None => Value::Null,
-                    };
-                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
+                    let host = lsp_adapter::host_for_uri(&p.text_document.uri);
+                    let result = engine
+                        .definition(&p.text_document.uri, p.position, &host)
+                        .await;
+                    let body = serde_json::to_value(result).unwrap_or(Value::Null);
+                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, body).await {
                         eprintln!("wado-lsp: {e}");
                         break;
                     }
@@ -145,45 +118,13 @@ pub async fn run() {
             }
             "textDocument/hover" => {
                 if let Some(id) = id {
-                    let p: TextDocumentPositionParams =
-                        serde_json::from_value(params).unwrap_or_else(|_| {
-                            TextDocumentPositionParams {
-                                text_document: lsp_type::TextDocumentIdentifier {
-                                    uri: String::new(),
-                                },
-                                position: Position {
-                                    line: 0,
-                                    character: 0,
-                                },
-                            }
-                        });
-                    let uri = &p.text_document.uri;
-                    let position = wado_lsp::Position {
-                        line: p.position.line,
-                        character: p.position.character,
+                    let Ok(p) = serde_json::from_value::<TextDocumentPositionParams>(params) else {
+                        continue;
                     };
-                    let host = lsp_adapter::host_for_uri(uri);
-                    let result = match engine.hover(uri, position, &host).await {
-                        Some(hover) => serde_json::to_value(Hover {
-                            contents: MarkupContent {
-                                kind: MarkupKind::Markdown,
-                                value: hover.contents,
-                            },
-                            range: Some(Range {
-                                start: Position {
-                                    line: hover.range.start.line,
-                                    character: hover.range.start.character,
-                                },
-                                end: Position {
-                                    line: hover.range.end.line,
-                                    character: hover.range.end.character,
-                                },
-                            }),
-                        })
-                        .unwrap_or(Value::Null),
-                        None => Value::Null,
-                    };
-                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
+                    let host = lsp_adapter::host_for_uri(&p.text_document.uri);
+                    let result = engine.hover(&p.text_document.uri, p.position, &host).await;
+                    let body = serde_json::to_value(result).unwrap_or(Value::Null);
+                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, body).await {
                         eprintln!("wado-lsp: {e}");
                         break;
                     }
@@ -191,44 +132,19 @@ pub async fn run() {
             }
             "textDocument/references" => {
                 if let Some(id) = id {
-                    let p: ReferenceParams = serde_json::from_value(params).unwrap_or_else(|_| {
-                        ReferenceParams {
-                            text_document: lsp_type::TextDocumentIdentifier {
-                                uri: String::new(),
-                            },
-                            position: Position {
-                                line: 0,
-                                character: 0,
-                            },
-                            context: lsp_type::ReferenceContext::default(),
-                        }
-                    });
-                    let uri = &p.text_document.uri;
-                    let position = wado_lsp::Position {
-                        line: p.position.line,
-                        character: p.position.character,
+                    let Ok(p) = serde_json::from_value::<ReferenceParams>(params) else {
+                        continue;
                     };
-                    let host = lsp_adapter::host_for_uri(uri);
+                    let host = lsp_adapter::host_for_uri(&p.text_document.uri);
                     let refs = engine
-                        .references(uri, position, p.context.include_declaration, &host)
+                        .references(
+                            &p.text_document.uri,
+                            p.position,
+                            p.context.include_declaration,
+                            &host,
+                        )
                         .await;
-                    let locations: Vec<Location> = refs
-                        .into_iter()
-                        .map(|r| Location {
-                            uri: r.uri,
-                            range: Range {
-                                start: Position {
-                                    line: r.range.start.line,
-                                    character: r.range.start.character,
-                                },
-                                end: Position {
-                                    line: r.range.end.line,
-                                    character: r.range.end.character,
-                                },
-                            },
-                        })
-                        .collect();
-                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, locations).await {
+                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, refs).await {
                         eprintln!("wado-lsp: {e}");
                         break;
                     }
@@ -236,42 +152,14 @@ pub async fn run() {
             }
             "textDocument/documentHighlight" => {
                 if let Some(id) = id {
-                    let p: TextDocumentPositionParams =
-                        serde_json::from_value(params).unwrap_or_else(|_| {
-                            TextDocumentPositionParams {
-                                text_document: lsp_type::TextDocumentIdentifier {
-                                    uri: String::new(),
-                                },
-                                position: Position {
-                                    line: 0,
-                                    character: 0,
-                                },
-                            }
-                        });
-                    let uri = &p.text_document.uri;
-                    let position = wado_lsp::Position {
-                        line: p.position.line,
-                        character: p.position.character,
+                    let Ok(p) = serde_json::from_value::<TextDocumentPositionParams>(params) else {
+                        continue;
                     };
-                    let host = lsp_adapter::host_for_uri(uri);
-                    let highlights = engine.document_highlight(uri, position, &host).await;
-                    let result: Vec<DocumentHighlight> = highlights
-                        .into_iter()
-                        .map(|h| DocumentHighlight {
-                            range: Range {
-                                start: Position {
-                                    line: h.range.start.line,
-                                    character: h.range.start.character,
-                                },
-                                end: Position {
-                                    line: h.range.end.line,
-                                    character: h.range.end.character,
-                                },
-                            },
-                            kind: h.kind as u32,
-                        })
-                        .collect();
-                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
+                    let host = lsp_adapter::host_for_uri(&p.text_document.uri);
+                    let highlights = engine
+                        .document_highlight(&p.text_document.uri, p.position, &host)
+                        .await;
+                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, highlights).await {
                         eprintln!("wado-lsp: {e}");
                         break;
                     }
@@ -279,12 +167,9 @@ pub async fn run() {
             }
             "textDocument/semanticTokens/full" => {
                 if let Some(id) = id {
-                    let p: SemanticTokensParams =
-                        serde_json::from_value(params).unwrap_or_else(|_| SemanticTokensParams {
-                            text_document: lsp_type::TextDocumentIdentifier {
-                                uri: String::new(),
-                            },
-                        });
+                    let Ok(p) = serde_json::from_value::<SemanticTokensParams>(params) else {
+                        continue;
+                    };
                     let data = engine.semantic_tokens(&p.text_document.uri);
                     let result = SemanticTokens { data };
                     if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {

--- a/wado-cli/src/lsp.rs
+++ b/wado-cli/src/lsp.rs
@@ -1,7 +1,14 @@
-use serde_json::{Value, json};
+use serde_json::Value;
 use tokio::io::BufReader;
 
 use crate::lsp_adapter;
+use crate::lsp_type::{
+    self, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    DocumentHighlight, Hover, InitializeResult, Location, MarkupContent, MarkupKind, Position,
+    PublishDiagnosticsParams, Range, ReferenceParams, SemanticTokens, SemanticTokensLegend,
+    SemanticTokensOptions, SemanticTokensParams, ServerCapabilities, ServerInfo,
+    TextDocumentPositionParams, TextDocumentSyncOptions, error_codes, text_document_sync_kind,
+};
 
 /// Run the LSP server over stdio.
 pub async fn run() {
@@ -11,7 +18,7 @@ pub async fn run() {
     let mut shutdown_requested = false;
 
     loop {
-        let msg = match lsp_adapter::read_message(&mut reader).await {
+        let request = match lsp_adapter::read_message(&mut reader).await {
             Ok(Some(msg)) => msg,
             Ok(None) => break, // EOF
             Err(e) => {
@@ -20,36 +27,36 @@ pub async fn run() {
             }
         };
 
-        let method = msg.get("method").and_then(Value::as_str).unwrap_or("");
-        let id = msg.get("id");
-        let params = msg.get("params").cloned().unwrap_or(Value::Null);
+        let method = request.method.as_str();
+        let id = request.id.as_ref();
+        let params = request.params;
 
         match method {
             "initialize" => {
                 if let Some(id) = id {
-                    let result = json!({
-                        "capabilities": {
-                            "textDocumentSync": {
-                                "openClose": true,
-                                "change": 1, // Full sync
-                            },
-                            "definitionProvider": true,
-                            "hoverProvider": true,
-                            "referencesProvider": true,
-                            "documentHighlightProvider": true,
-                            "semanticTokensProvider": {
-                                "legend": {
-                                    "tokenTypes": wado_lsp::semantic_tokens::TOKEN_TYPES,
-                                    "tokenModifiers": wado_lsp::semantic_tokens::TOKEN_MODIFIERS,
+                    let result = InitializeResult {
+                        capabilities: ServerCapabilities {
+                            text_document_sync: Some(TextDocumentSyncOptions {
+                                open_close: true,
+                                change: text_document_sync_kind::FULL,
+                            }),
+                            definition_provider: Some(true),
+                            hover_provider: Some(true),
+                            references_provider: Some(true),
+                            document_highlight_provider: Some(true),
+                            semantic_tokens_provider: Some(SemanticTokensOptions {
+                                legend: SemanticTokensLegend {
+                                    token_types: wado_lsp::semantic_tokens::TOKEN_TYPES,
+                                    token_modifiers: wado_lsp::semantic_tokens::TOKEN_MODIFIERS,
                                 },
-                                "full": true,
-                            },
+                                full: true,
+                            }),
                         },
-                        "serverInfo": {
-                            "name": "wado-lsp",
-                            "version": env!("CARGO_PKG_VERSION"),
-                        },
-                    });
+                        server_info: Some(ServerInfo {
+                            name: "wado-lsp",
+                            version: Some(env!("CARGO_PKG_VERSION")),
+                        }),
+                    };
                     if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
                         eprintln!("wado-lsp: {e}");
                         break;
@@ -70,17 +77,22 @@ pub async fn run() {
                 std::process::exit(i32::from(!shutdown_requested));
             }
             "textDocument/didOpen" => {
-                if let (Some(uri), Some(text)) = (
-                    params
-                        .get("textDocument")
-                        .and_then(|td| td.get("uri"))
-                        .and_then(Value::as_str),
-                    params
-                        .get("textDocument")
-                        .and_then(|td| td.get("text"))
-                        .and_then(Value::as_str),
-                ) {
-                    engine.open_document(uri, text.to_string());
+                let Ok(p) = serde_json::from_value::<DidOpenTextDocumentParams>(params) else {
+                    continue;
+                };
+                let uri = &p.text_document.uri;
+                engine.open_document(uri, p.text_document.text.clone());
+                if let Err(e) = lsp_adapter::publish_diagnostics(&engine, uri, &mut writer).await {
+                    eprintln!("wado-lsp: {e}");
+                }
+            }
+            "textDocument/didChange" => {
+                let Ok(p) = serde_json::from_value::<DidChangeTextDocumentParams>(params) else {
+                    continue;
+                };
+                let uri = &p.text_document.uri;
+                if let Some(change) = p.content_changes.into_iter().last() {
+                    engine.update_document(uri, change.text);
                     if let Err(e) =
                         lsp_adapter::publish_diagnostics(&engine, uri, &mut writer).await
                     {
@@ -88,62 +100,41 @@ pub async fn run() {
                     }
                 }
             }
-            "textDocument/didChange" => {
-                if let Some(uri) = params
-                    .get("textDocument")
-                    .and_then(|td| td.get("uri"))
-                    .and_then(Value::as_str)
-                {
-                    // Full sync: take the last content change
-                    if let Some(text) = params
-                        .get("contentChanges")
-                        .and_then(Value::as_array)
-                        .and_then(|changes| changes.last())
-                        .and_then(|change| change.get("text"))
-                        .and_then(Value::as_str)
-                    {
-                        engine.update_document(uri, text.to_string());
-                        if let Err(e) =
-                            lsp_adapter::publish_diagnostics(&engine, uri, &mut writer).await
-                        {
-                            eprintln!("wado-lsp: {e}");
-                        }
-                    }
-                }
-            }
             "textDocument/definition" => {
                 if let Some(id) = id {
-                    let uri = params
-                        .get("textDocument")
-                        .and_then(|td| td.get("uri"))
-                        .and_then(Value::as_str)
-                        .unwrap_or("");
-                    let line = params
-                        .get("position")
-                        .and_then(|p| p.get("line"))
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0) as u32;
-                    let character = params
-                        .get("position")
-                        .and_then(|p| p.get("character"))
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0) as u32;
-                    let position = wado_lsp::Position { line, character };
+                    let p: TextDocumentPositionParams =
+                        serde_json::from_value(params).unwrap_or_else(|_| {
+                            TextDocumentPositionParams {
+                                text_document: lsp_type::TextDocumentIdentifier {
+                                    uri: String::new(),
+                                },
+                                position: Position {
+                                    line: 0,
+                                    character: 0,
+                                },
+                            }
+                        });
+                    let uri = &p.text_document.uri;
+                    let position = wado_lsp::Position {
+                        line: p.position.line,
+                        character: p.position.character,
+                    };
                     let host = lsp_adapter::host_for_uri(uri);
                     let result = match engine.definition(uri, position, &host).await {
-                        Some(def) => json!({
-                            "uri": def.uri,
-                            "range": {
-                                "start": {
-                                    "line": def.range.start.line,
-                                    "character": def.range.start.character,
+                        Some(def) => serde_json::to_value(Location {
+                            uri: def.uri,
+                            range: Range {
+                                start: Position {
+                                    line: def.range.start.line,
+                                    character: def.range.start.character,
                                 },
-                                "end": {
-                                    "line": def.range.end.line,
-                                    "character": def.range.end.character,
+                                end: Position {
+                                    line: def.range.end.line,
+                                    character: def.range.end.character,
                                 },
                             },
-                        }),
+                        })
+                        .unwrap_or(Value::Null),
                         None => Value::Null,
                     };
                     if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
@@ -154,40 +145,42 @@ pub async fn run() {
             }
             "textDocument/hover" => {
                 if let Some(id) = id {
-                    let uri = params
-                        .get("textDocument")
-                        .and_then(|td| td.get("uri"))
-                        .and_then(Value::as_str)
-                        .unwrap_or("");
-                    let line = params
-                        .get("position")
-                        .and_then(|p| p.get("line"))
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0) as u32;
-                    let character = params
-                        .get("position")
-                        .and_then(|p| p.get("character"))
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0) as u32;
-                    let position = wado_lsp::Position { line, character };
+                    let p: TextDocumentPositionParams =
+                        serde_json::from_value(params).unwrap_or_else(|_| {
+                            TextDocumentPositionParams {
+                                text_document: lsp_type::TextDocumentIdentifier {
+                                    uri: String::new(),
+                                },
+                                position: Position {
+                                    line: 0,
+                                    character: 0,
+                                },
+                            }
+                        });
+                    let uri = &p.text_document.uri;
+                    let position = wado_lsp::Position {
+                        line: p.position.line,
+                        character: p.position.character,
+                    };
                     let host = lsp_adapter::host_for_uri(uri);
                     let result = match engine.hover(uri, position, &host).await {
-                        Some(hover) => json!({
-                            "contents": {
-                                "kind": "markdown",
-                                "value": hover.contents,
+                        Some(hover) => serde_json::to_value(Hover {
+                            contents: MarkupContent {
+                                kind: MarkupKind::Markdown,
+                                value: hover.contents,
                             },
-                            "range": {
-                                "start": {
-                                    "line": hover.range.start.line,
-                                    "character": hover.range.start.character,
+                            range: Some(Range {
+                                start: Position {
+                                    line: hover.range.start.line,
+                                    character: hover.range.start.character,
                                 },
-                                "end": {
-                                    "line": hover.range.end.line,
-                                    "character": hover.range.end.character,
+                                end: Position {
+                                    line: hover.range.end.line,
+                                    character: hover.range.end.character,
                                 },
-                            },
-                        }),
+                            }),
+                        })
+                        .unwrap_or(Value::Null),
                         None => Value::Null,
                     };
                     if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
@@ -198,51 +191,44 @@ pub async fn run() {
             }
             "textDocument/references" => {
                 if let Some(id) = id {
-                    let uri = params
-                        .get("textDocument")
-                        .and_then(|td| td.get("uri"))
-                        .and_then(Value::as_str)
-                        .unwrap_or("");
-                    let line = params
-                        .get("position")
-                        .and_then(|p| p.get("line"))
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0) as u32;
-                    let character = params
-                        .get("position")
-                        .and_then(|p| p.get("character"))
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0) as u32;
-                    let include_declaration = params
-                        .get("context")
-                        .and_then(|c| c.get("includeDeclaration"))
-                        .and_then(Value::as_bool)
-                        .unwrap_or(false);
-                    let position = wado_lsp::Position { line, character };
+                    let p: ReferenceParams = serde_json::from_value(params).unwrap_or_else(|_| {
+                        ReferenceParams {
+                            text_document: lsp_type::TextDocumentIdentifier {
+                                uri: String::new(),
+                            },
+                            position: Position {
+                                line: 0,
+                                character: 0,
+                            },
+                            context: lsp_type::ReferenceContext::default(),
+                        }
+                    });
+                    let uri = &p.text_document.uri;
+                    let position = wado_lsp::Position {
+                        line: p.position.line,
+                        character: p.position.character,
+                    };
                     let host = lsp_adapter::host_for_uri(uri);
                     let refs = engine
-                        .references(uri, position, include_declaration, &host)
+                        .references(uri, position, p.context.include_declaration, &host)
                         .await;
-                    let result = Value::Array(
-                        refs.into_iter()
-                            .map(|r| {
-                                json!({
-                                    "uri": r.uri,
-                                    "range": {
-                                        "start": {
-                                            "line": r.range.start.line,
-                                            "character": r.range.start.character,
-                                        },
-                                        "end": {
-                                            "line": r.range.end.line,
-                                            "character": r.range.end.character,
-                                        },
-                                    },
-                                })
-                            })
-                            .collect(),
-                    );
-                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
+                    let locations: Vec<Location> = refs
+                        .into_iter()
+                        .map(|r| Location {
+                            uri: r.uri,
+                            range: Range {
+                                start: Position {
+                                    line: r.range.start.line,
+                                    character: r.range.start.character,
+                                },
+                                end: Position {
+                                    line: r.range.end.line,
+                                    character: r.range.end.character,
+                                },
+                            },
+                        })
+                        .collect();
+                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, locations).await {
                         eprintln!("wado-lsp: {e}");
                         break;
                     }
@@ -250,44 +236,41 @@ pub async fn run() {
             }
             "textDocument/documentHighlight" => {
                 if let Some(id) = id {
-                    let uri = params
-                        .get("textDocument")
-                        .and_then(|td| td.get("uri"))
-                        .and_then(Value::as_str)
-                        .unwrap_or("");
-                    let line = params
-                        .get("position")
-                        .and_then(|p| p.get("line"))
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0) as u32;
-                    let character = params
-                        .get("position")
-                        .and_then(|p| p.get("character"))
-                        .and_then(Value::as_u64)
-                        .unwrap_or(0) as u32;
-                    let position = wado_lsp::Position { line, character };
+                    let p: TextDocumentPositionParams =
+                        serde_json::from_value(params).unwrap_or_else(|_| {
+                            TextDocumentPositionParams {
+                                text_document: lsp_type::TextDocumentIdentifier {
+                                    uri: String::new(),
+                                },
+                                position: Position {
+                                    line: 0,
+                                    character: 0,
+                                },
+                            }
+                        });
+                    let uri = &p.text_document.uri;
+                    let position = wado_lsp::Position {
+                        line: p.position.line,
+                        character: p.position.character,
+                    };
                     let host = lsp_adapter::host_for_uri(uri);
                     let highlights = engine.document_highlight(uri, position, &host).await;
-                    let result = Value::Array(
-                        highlights
-                            .into_iter()
-                            .map(|h| {
-                                json!({
-                                    "range": {
-                                        "start": {
-                                            "line": h.range.start.line,
-                                            "character": h.range.start.character,
-                                        },
-                                        "end": {
-                                            "line": h.range.end.line,
-                                            "character": h.range.end.character,
-                                        },
-                                    },
-                                    "kind": h.kind as u32,
-                                })
-                            })
-                            .collect(),
-                    );
+                    let result: Vec<DocumentHighlight> = highlights
+                        .into_iter()
+                        .map(|h| DocumentHighlight {
+                            range: Range {
+                                start: Position {
+                                    line: h.range.start.line,
+                                    character: h.range.start.character,
+                                },
+                                end: Position {
+                                    line: h.range.end.line,
+                                    character: h.range.end.character,
+                                },
+                            },
+                            kind: h.kind as u32,
+                        })
+                        .collect();
                     if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
                         eprintln!("wado-lsp: {e}");
                         break;
@@ -296,13 +279,14 @@ pub async fn run() {
             }
             "textDocument/semanticTokens/full" => {
                 if let Some(id) = id {
-                    let uri = params
-                        .get("textDocument")
-                        .and_then(|td| td.get("uri"))
-                        .and_then(Value::as_str)
-                        .unwrap_or("");
-                    let data = engine.semantic_tokens(uri);
-                    let result = json!({ "data": data });
+                    let p: SemanticTokensParams =
+                        serde_json::from_value(params).unwrap_or_else(|_| SemanticTokensParams {
+                            text_document: lsp_type::TextDocumentIdentifier {
+                                uri: String::new(),
+                            },
+                        });
+                    let data = engine.semantic_tokens(&p.text_document.uri);
+                    let result = SemanticTokens { data };
                     if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
                         eprintln!("wado-lsp: {e}");
                         break;
@@ -310,34 +294,31 @@ pub async fn run() {
                 }
             }
             "textDocument/didClose" => {
-                if let Some(uri) = params
-                    .get("textDocument")
-                    .and_then(|td| td.get("uri"))
-                    .and_then(Value::as_str)
+                let Ok(p) = serde_json::from_value::<DidCloseTextDocumentParams>(params) else {
+                    continue;
+                };
+                let uri = &p.text_document.uri;
+                engine.close_document(uri);
+                let params = PublishDiagnosticsParams {
+                    uri: uri.clone(),
+                    diagnostics: Vec::new(),
+                };
+                if let Err(e) = lsp_adapter::send_notification(
+                    &mut writer,
+                    "textDocument/publishDiagnostics",
+                    params,
+                )
+                .await
                 {
-                    engine.close_document(uri);
-                    // Clear diagnostics for closed document
-                    if let Err(e) = lsp_adapter::send_notification(
-                        &mut writer,
-                        "textDocument/publishDiagnostics",
-                        json!({
-                            "uri": uri,
-                            "diagnostics": [],
-                        }),
-                    )
-                    .await
-                    {
-                        eprintln!("wado-lsp: {e}");
-                    }
+                    eprintln!("wado-lsp: {e}");
                 }
             }
             _ => {
-                // Unknown method — send MethodNotFound error for requests (with id)
                 if let Some(id) = id
                     && let Err(e) = lsp_adapter::send_error(
                         &mut writer,
                         id,
-                        -32601,
+                        error_codes::METHOD_NOT_FOUND,
                         format!("method not found: {method}"),
                     )
                     .await
@@ -345,7 +326,6 @@ pub async fn run() {
                     eprintln!("wado-lsp: {e}");
                     break;
                 }
-                // Notifications for unknown methods are silently ignored
             }
         }
     }

--- a/wado-cli/src/lsp.rs
+++ b/wado-cli/src/lsp.rs
@@ -1,10 +1,10 @@
 use serde_json::Value;
-use tokio::io::BufReader;
+use tokio::io::{AsyncWrite, BufReader};
 
 use crate::lsp_adapter;
 use crate::lsp_rpc::{
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    InitializeResult, PublishDiagnosticsParams, ReferenceParams, SemanticTokens,
+    InitializeResult, JsonRpcRequest, PublishDiagnosticsParams, ReferenceParams, SemanticTokens,
     SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams, ServerCapabilities,
     ServerInfo, TextDocumentPositionParams, TextDocumentSyncOptions, error_codes,
     text_document_sync_kind,
@@ -27,191 +27,182 @@ pub async fn run() {
             }
         };
 
-        let method = request.method.as_str();
-        let id = request.id.as_ref();
-        let params = request.params;
+        if let Err(e) = dispatch(&mut engine, &mut writer, &mut shutdown_requested, request).await {
+            eprintln!("wado-lsp: {e}");
+            break;
+        }
+    }
+}
 
-        match method {
-            "initialize" => {
-                if let Some(id) = id {
-                    let result = InitializeResult {
-                        capabilities: ServerCapabilities {
-                            text_document_sync: Some(TextDocumentSyncOptions {
-                                open_close: true,
-                                change: text_document_sync_kind::FULL,
-                            }),
-                            definition_provider: Some(true),
-                            hover_provider: Some(true),
-                            references_provider: Some(true),
-                            document_highlight_provider: Some(true),
-                            semantic_tokens_provider: Some(SemanticTokensOptions {
-                                legend: SemanticTokensLegend {
-                                    token_types: wado_lsp::semantic_tokens::TOKEN_TYPES,
-                                    token_modifiers: wado_lsp::semantic_tokens::TOKEN_MODIFIERS,
-                                },
-                                full: true,
-                            }),
-                        },
-                        server_info: Some(ServerInfo {
-                            name: "wado-lsp",
-                            version: Some(env!("CARGO_PKG_VERSION")),
+async fn dispatch<W: AsyncWrite + Unpin>(
+    engine: &mut wado_lsp::Engine,
+    writer: &mut W,
+    shutdown_requested: &mut bool,
+    request: JsonRpcRequest,
+) -> Result<(), String> {
+    let method = request.method.as_str();
+    let id = request.id.as_ref();
+    let params = request.params;
+
+    match method {
+        "initialize" => {
+            if let Some(id) = id {
+                let result = InitializeResult {
+                    capabilities: ServerCapabilities {
+                        text_document_sync: Some(TextDocumentSyncOptions {
+                            open_close: true,
+                            change: text_document_sync_kind::FULL,
                         }),
-                    };
-                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
-                        eprintln!("wado-lsp: {e}");
-                        break;
-                    }
-                }
-            }
-            "initialized" => {} // no-op
-            "shutdown" => {
-                shutdown_requested = true;
-                if let Some(id) = id
-                    && let Err(e) = lsp_adapter::send_response(&mut writer, id, Value::Null).await
-                {
-                    eprintln!("wado-lsp: {e}");
-                    break;
-                }
-            }
-            "exit" => {
-                std::process::exit(i32::from(!shutdown_requested));
-            }
-            "textDocument/didOpen" => {
-                let Ok(p) = serde_json::from_value::<DidOpenTextDocumentParams>(params) else {
-                    continue;
+                        definition_provider: Some(true),
+                        hover_provider: Some(true),
+                        references_provider: Some(true),
+                        document_highlight_provider: Some(true),
+                        semantic_tokens_provider: Some(SemanticTokensOptions {
+                            legend: SemanticTokensLegend {
+                                token_types: wado_lsp::semantic_tokens::TOKEN_TYPES,
+                                token_modifiers: wado_lsp::semantic_tokens::TOKEN_MODIFIERS,
+                            },
+                            full: true,
+                        }),
+                    },
+                    server_info: Some(ServerInfo {
+                        name: "wado-lsp",
+                        version: Some(env!("CARGO_PKG_VERSION")),
+                    }),
                 };
-                let uri = &p.text_document.uri;
-                engine.open_document(uri, p.text_document.text);
-                if let Err(e) = lsp_adapter::publish_diagnostics(&engine, uri, &mut writer).await {
-                    eprintln!("wado-lsp: {e}");
-                }
+                lsp_adapter::send_response(writer, id, result).await?;
             }
-            "textDocument/didChange" => {
-                let Ok(p) = serde_json::from_value::<DidChangeTextDocumentParams>(params) else {
-                    continue;
-                };
-                let uri = &p.text_document.uri;
-                if let Some(change) = p.content_changes.into_iter().last() {
-                    engine.update_document(uri, change.text);
-                    if let Err(e) =
-                        lsp_adapter::publish_diagnostics(&engine, uri, &mut writer).await
-                    {
-                        eprintln!("wado-lsp: {e}");
-                    }
-                }
+        }
+        "initialized" => {} // no-op
+        "shutdown" => {
+            *shutdown_requested = true;
+            if let Some(id) = id {
+                lsp_adapter::send_response(writer, id, Value::Null).await?;
             }
-            "textDocument/definition" => {
-                if let Some(id) = id {
-                    let Ok(p) = serde_json::from_value::<TextDocumentPositionParams>(params) else {
-                        continue;
-                    };
-                    let host = lsp_adapter::host_for_uri(&p.text_document.uri);
-                    let result = engine
-                        .definition(&p.text_document.uri, p.position, &host)
-                        .await;
-                    let body = serde_json::to_value(result).unwrap_or(Value::Null);
-                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, body).await {
-                        eprintln!("wado-lsp: {e}");
-                        break;
-                    }
-                }
+        }
+        "exit" => {
+            std::process::exit(i32::from(!*shutdown_requested));
+        }
+        "textDocument/didOpen" => {
+            let Ok(p) = serde_json::from_value::<DidOpenTextDocumentParams>(params) else {
+                return Ok(());
+            };
+            let uri = &p.text_document.uri;
+            engine.open_document(uri, p.text_document.text);
+            lsp_adapter::publish_diagnostics(engine, uri, writer).await?;
+        }
+        "textDocument/didChange" => {
+            let Ok(p) = serde_json::from_value::<DidChangeTextDocumentParams>(params) else {
+                return Ok(());
+            };
+            let uri = &p.text_document.uri;
+            if let Some(change) = p.content_changes.into_iter().last() {
+                engine.update_document(uri, change.text);
+                lsp_adapter::publish_diagnostics(engine, uri, writer).await?;
             }
-            "textDocument/hover" => {
-                if let Some(id) = id {
-                    let Ok(p) = serde_json::from_value::<TextDocumentPositionParams>(params) else {
-                        continue;
-                    };
-                    let host = lsp_adapter::host_for_uri(&p.text_document.uri);
-                    let result = engine.hover(&p.text_document.uri, p.position, &host).await;
-                    let body = serde_json::to_value(result).unwrap_or(Value::Null);
-                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, body).await {
-                        eprintln!("wado-lsp: {e}");
-                        break;
-                    }
-                }
-            }
-            "textDocument/references" => {
-                if let Some(id) = id {
-                    let Ok(p) = serde_json::from_value::<ReferenceParams>(params) else {
-                        continue;
-                    };
-                    let host = lsp_adapter::host_for_uri(&p.text_document.uri);
-                    let refs = engine
-                        .references(
-                            &p.text_document.uri,
-                            p.position,
-                            p.context.include_declaration,
-                            &host,
-                        )
-                        .await;
-                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, refs).await {
-                        eprintln!("wado-lsp: {e}");
-                        break;
-                    }
-                }
-            }
-            "textDocument/documentHighlight" => {
-                if let Some(id) = id {
-                    let Ok(p) = serde_json::from_value::<TextDocumentPositionParams>(params) else {
-                        continue;
-                    };
-                    let host = lsp_adapter::host_for_uri(&p.text_document.uri);
-                    let highlights = engine
-                        .document_highlight(&p.text_document.uri, p.position, &host)
-                        .await;
-                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, highlights).await {
-                        eprintln!("wado-lsp: {e}");
-                        break;
-                    }
-                }
-            }
-            "textDocument/semanticTokens/full" => {
-                if let Some(id) = id {
-                    let Ok(p) = serde_json::from_value::<SemanticTokensParams>(params) else {
-                        continue;
-                    };
-                    let data = engine.semantic_tokens(&p.text_document.uri);
-                    let result = SemanticTokens { data };
-                    if let Err(e) = lsp_adapter::send_response(&mut writer, id, result).await {
-                        eprintln!("wado-lsp: {e}");
-                        break;
-                    }
-                }
-            }
-            "textDocument/didClose" => {
-                let Ok(p) = serde_json::from_value::<DidCloseTextDocumentParams>(params) else {
-                    continue;
-                };
-                let uri = &p.text_document.uri;
-                engine.close_document(uri);
-                let params = PublishDiagnosticsParams {
-                    uri: uri.clone(),
-                    diagnostics: Vec::new(),
-                };
-                if let Err(e) = lsp_adapter::send_notification(
-                    &mut writer,
-                    "textDocument/publishDiagnostics",
-                    params,
+        }
+        "textDocument/definition" => {
+            if let Some(id) = id {
+                let Some(p) = lsp_adapter::decode_or_error::<TextDocumentPositionParams, _>(
+                    writer, id, params,
                 )
-                .await
-                {
-                    eprintln!("wado-lsp: {e}");
-                }
+                .await?
+                else {
+                    return Ok(());
+                };
+                let host = lsp_adapter::host_for_uri(&p.text_document.uri);
+                let result = engine
+                    .definition(&p.text_document.uri, p.position, &host)
+                    .await;
+                lsp_adapter::send_response(writer, id, result).await?;
             }
-            _ => {
-                if let Some(id) = id
-                    && let Err(e) = lsp_adapter::send_error(
-                        &mut writer,
-                        id,
-                        error_codes::METHOD_NOT_FOUND,
-                        format!("method not found: {method}"),
+        }
+        "textDocument/hover" => {
+            if let Some(id) = id {
+                let Some(p) = lsp_adapter::decode_or_error::<TextDocumentPositionParams, _>(
+                    writer, id, params,
+                )
+                .await?
+                else {
+                    return Ok(());
+                };
+                let host = lsp_adapter::host_for_uri(&p.text_document.uri);
+                let result = engine.hover(&p.text_document.uri, p.position, &host).await;
+                lsp_adapter::send_response(writer, id, result).await?;
+            }
+        }
+        "textDocument/references" => {
+            if let Some(id) = id {
+                let Some(p) =
+                    lsp_adapter::decode_or_error::<ReferenceParams, _>(writer, id, params).await?
+                else {
+                    return Ok(());
+                };
+                let host = lsp_adapter::host_for_uri(&p.text_document.uri);
+                let refs = engine
+                    .references(
+                        &p.text_document.uri,
+                        p.position,
+                        p.context.include_declaration,
+                        &host,
                     )
-                    .await
-                {
-                    eprintln!("wado-lsp: {e}");
-                    break;
-                }
+                    .await;
+                lsp_adapter::send_response(writer, id, refs).await?;
+            }
+        }
+        "textDocument/documentHighlight" => {
+            if let Some(id) = id {
+                let Some(p) = lsp_adapter::decode_or_error::<TextDocumentPositionParams, _>(
+                    writer, id, params,
+                )
+                .await?
+                else {
+                    return Ok(());
+                };
+                let host = lsp_adapter::host_for_uri(&p.text_document.uri);
+                let highlights = engine
+                    .document_highlight(&p.text_document.uri, p.position, &host)
+                    .await;
+                lsp_adapter::send_response(writer, id, highlights).await?;
+            }
+        }
+        "textDocument/semanticTokens/full" => {
+            if let Some(id) = id {
+                let Some(p) =
+                    lsp_adapter::decode_or_error::<SemanticTokensParams, _>(writer, id, params)
+                        .await?
+                else {
+                    return Ok(());
+                };
+                let data = engine.semantic_tokens(&p.text_document.uri);
+                let result = SemanticTokens { data };
+                lsp_adapter::send_response(writer, id, result).await?;
+            }
+        }
+        "textDocument/didClose" => {
+            let Ok(p) = serde_json::from_value::<DidCloseTextDocumentParams>(params) else {
+                return Ok(());
+            };
+            let uri = &p.text_document.uri;
+            engine.close_document(uri);
+            let params = PublishDiagnosticsParams {
+                uri: uri.clone(),
+                diagnostics: Vec::new(),
+            };
+            lsp_adapter::send_notification(writer, "textDocument/publishDiagnostics", params)
+                .await?;
+        }
+        _ => {
+            if let Some(id) = id {
+                lsp_adapter::send_error(
+                    writer,
+                    id,
+                    error_codes::METHOD_NOT_FOUND,
+                    format!("method not found: {method}"),
+                )
+                .await?;
             }
         }
     }
+    Ok(())
 }

--- a/wado-cli/src/lsp_adapter.rs
+++ b/wado-cli/src/lsp_adapter.rs
@@ -1,13 +1,13 @@
 use std::path::PathBuf;
 
-use serde::Serialize;
+use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 
 use crate::compiler_host::FilesystemCompilerHost;
 use crate::lsp_rpc::{
     JsonRpcError, JsonRpcErrorResponse, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
-    PublishDiagnosticsParams,
+    PublishDiagnosticsParams, error_codes,
 };
 
 const JSONRPC_VERSION: &str = "2.0";
@@ -115,6 +115,33 @@ pub async fn send_error<W: AsyncWrite + Unpin>(
     };
     let body = serde_json::to_string(&msg).map_err(|e| format!("serialize error: {e}"))?;
     write_serialized(writer, body).await
+}
+
+/// Decode request params. On failure, send an `InvalidParams` error response
+/// to the client and return `Ok(None)` so the caller can skip the request.
+/// Returns `Err` only if the error response itself fails to write.
+pub async fn decode_or_error<P, W>(
+    writer: &mut W,
+    id: &Value,
+    params: Value,
+) -> Result<Option<P>, String>
+where
+    P: DeserializeOwned,
+    W: AsyncWrite + Unpin,
+{
+    match serde_json::from_value(params) {
+        Ok(p) => Ok(Some(p)),
+        Err(e) => {
+            send_error(
+                writer,
+                id,
+                error_codes::INVALID_PARAMS,
+                format!("invalid params: {e}"),
+            )
+            .await?;
+            Ok(None)
+        }
+    }
 }
 
 /// Build a silent filesystem host rooted at the directory containing `uri`.

--- a/wado-cli/src/lsp_adapter.rs
+++ b/wado-cli/src/lsp_adapter.rs
@@ -1,15 +1,21 @@
 use std::path::PathBuf;
 
-use serde_json::{Value, json};
+use serde::Serialize;
+use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
-use wado_lsp::Diagnostic;
 
 use crate::compiler_host::FilesystemCompilerHost;
+use crate::lsp_type::{
+    self, JsonRpcError, JsonRpcErrorResponse, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
+    PublishDiagnosticsParams,
+};
+
+const JSONRPC_VERSION: &str = "2.0";
 
 /// Read one JSON-RPC message (Content-Length framed).
 pub async fn read_message<R: tokio::io::AsyncRead + Unpin>(
     reader: &mut BufReader<R>,
-) -> Result<Option<Value>, String> {
+) -> Result<Option<JsonRpcRequest>, String> {
     let mut content_length: Option<usize> = None;
     loop {
         let mut header = String::new();
@@ -45,12 +51,7 @@ pub async fn read_message<R: tokio::io::AsyncRead + Unpin>(
         .map_err(|e| format!("invalid JSON: {e}"))
 }
 
-/// Write one JSON-RPC message (Content-Length framed).
-pub async fn write_message<W: AsyncWrite + Unpin>(
-    writer: &mut W,
-    msg: &Value,
-) -> Result<(), String> {
-    let body = serde_json::to_string(msg).map_err(|e| format!("serialize error: {e}"))?;
+async fn write_serialized<W: AsyncWrite + Unpin>(writer: &mut W, body: String) -> Result<(), String> {
     let header = format!("Content-Length: {}\r\n\r\n", body.len());
     writer
         .write_all(header.as_bytes())
@@ -67,38 +68,34 @@ pub async fn write_message<W: AsyncWrite + Unpin>(
     Ok(())
 }
 
-/// Send a JSON-RPC response.
-pub async fn send_response<W: AsyncWrite + Unpin>(
+/// Send a typed JSON-RPC response.
+pub async fn send_response<W: AsyncWrite + Unpin, T: Serialize>(
     writer: &mut W,
     id: &Value,
-    result: Value,
+    result: T,
 ) -> Result<(), String> {
-    write_message(
-        writer,
-        &json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "result": result,
-        }),
-    )
-    .await
+    let msg = JsonRpcResponse {
+        jsonrpc: JSONRPC_VERSION,
+        id,
+        result,
+    };
+    let body = serde_json::to_string(&msg).map_err(|e| format!("serialize error: {e}"))?;
+    write_serialized(writer, body).await
 }
 
-/// Send a JSON-RPC notification (no id).
-pub async fn send_notification<W: AsyncWrite + Unpin>(
+/// Send a typed JSON-RPC notification.
+pub async fn send_notification<W: AsyncWrite + Unpin, T: Serialize>(
     writer: &mut W,
-    method: &str,
-    params: Value,
+    method: &'static str,
+    params: T,
 ) -> Result<(), String> {
-    write_message(
-        writer,
-        &json!({
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": params,
-        }),
-    )
-    .await
+    let msg = JsonRpcNotification {
+        jsonrpc: JSONRPC_VERSION,
+        method,
+        params,
+    };
+    let body = serde_json::to_string(&msg).map_err(|e| format!("serialize error: {e}"))?;
+    write_serialized(writer, body).await
 }
 
 /// Send a JSON-RPC error response.
@@ -108,42 +105,36 @@ pub async fn send_error<W: AsyncWrite + Unpin>(
     code: i32,
     message: String,
 ) -> Result<(), String> {
-    write_message(
-        writer,
-        &json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "error": { "code": code, "message": message },
-        }),
-    )
-    .await
+    let msg = JsonRpcErrorResponse {
+        jsonrpc: JSONRPC_VERSION,
+        id,
+        error: JsonRpcError { code, message },
+    };
+    let body = serde_json::to_string(&msg).map_err(|e| format!("serialize error: {e}"))?;
+    write_serialized(writer, body).await
 }
 
-/// Convert engine diagnostics to LSP JSON format.
-pub fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> Value {
-    Value::Array(
-        diagnostics
-            .iter()
-            .map(|d| {
-                json!({
-                    "range": {
-                        "start": {
-                            "line": d.range.start.line,
-                            "character": d.range.start.character,
-                        },
-                        "end": {
-                            "line": d.range.end.line,
-                            "character": d.range.end.character,
-                        },
-                    },
-                    "severity": d.severity as u32,
-                    "code": d.code,
-                    "source": "wado",
-                    "message": d.message,
-                })
-            })
-            .collect(),
-    )
+/// Convert engine diagnostics to LSP diagnostics.
+pub fn diagnostics_to_lsp(diagnostics: &[wado_lsp::Diagnostic]) -> Vec<lsp_type::Diagnostic> {
+    diagnostics
+        .iter()
+        .map(|d| lsp_type::Diagnostic {
+            range: lsp_type::Range {
+                start: lsp_type::Position {
+                    line: d.range.start.line,
+                    character: d.range.start.character,
+                },
+                end: lsp_type::Position {
+                    line: d.range.end.line,
+                    character: d.range.end.character,
+                },
+            },
+            severity: Some(d.severity as u32),
+            code: Some(d.code.clone()),
+            source: Some("wado".to_string()),
+            message: d.message.clone(),
+        })
+        .collect()
 }
 
 /// Build a silent filesystem host rooted at the directory containing `uri`.
@@ -163,16 +154,10 @@ pub async fn publish_diagnostics<W: AsyncWrite + Unpin>(
     writer: &mut W,
 ) -> Result<(), String> {
     let host = host_for_uri(uri);
-
     let diagnostics = engine.diagnostics(uri, &host).await;
-
-    send_notification(
-        writer,
-        "textDocument/publishDiagnostics",
-        json!({
-            "uri": uri,
-            "diagnostics": diagnostics_to_json(&diagnostics),
-        }),
-    )
-    .await
+    let params = PublishDiagnosticsParams {
+        uri: uri.to_string(),
+        diagnostics: diagnostics_to_lsp(&diagnostics),
+    };
+    send_notification(writer, "textDocument/publishDiagnostics", params).await
 }

--- a/wado-cli/src/lsp_adapter.rs
+++ b/wado-cli/src/lsp_adapter.rs
@@ -5,8 +5,8 @@ use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 
 use crate::compiler_host::FilesystemCompilerHost;
-use crate::lsp_type::{
-    self, JsonRpcError, JsonRpcErrorResponse, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
+use crate::lsp_rpc::{
+    JsonRpcError, JsonRpcErrorResponse, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
     PublishDiagnosticsParams,
 };
 
@@ -51,7 +51,10 @@ pub async fn read_message<R: tokio::io::AsyncRead + Unpin>(
         .map_err(|e| format!("invalid JSON: {e}"))
 }
 
-async fn write_serialized<W: AsyncWrite + Unpin>(writer: &mut W, body: String) -> Result<(), String> {
+async fn write_serialized<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    body: String,
+) -> Result<(), String> {
     let header = format!("Content-Length: {}\r\n\r\n", body.len());
     writer
         .write_all(header.as_bytes())
@@ -114,29 +117,6 @@ pub async fn send_error<W: AsyncWrite + Unpin>(
     write_serialized(writer, body).await
 }
 
-/// Convert engine diagnostics to LSP diagnostics.
-pub fn diagnostics_to_lsp(diagnostics: &[wado_lsp::Diagnostic]) -> Vec<lsp_type::Diagnostic> {
-    diagnostics
-        .iter()
-        .map(|d| lsp_type::Diagnostic {
-            range: lsp_type::Range {
-                start: lsp_type::Position {
-                    line: d.range.start.line,
-                    character: d.range.start.character,
-                },
-                end: lsp_type::Position {
-                    line: d.range.end.line,
-                    character: d.range.end.character,
-                },
-            },
-            severity: Some(d.severity as u32),
-            code: Some(d.code.clone()),
-            source: Some("wado".to_string()),
-            message: d.message.clone(),
-        })
-        .collect()
-}
-
 /// Build a silent filesystem host rooted at the directory containing `uri`.
 pub fn host_for_uri(uri: &str) -> FilesystemCompilerHost {
     let filename = uri.strip_prefix("file://").unwrap_or(uri);
@@ -157,7 +137,7 @@ pub async fn publish_diagnostics<W: AsyncWrite + Unpin>(
     let diagnostics = engine.diagnostics(uri, &host).await;
     let params = PublishDiagnosticsParams {
         uri: uri.to_string(),
-        diagnostics: diagnostics_to_lsp(&diagnostics),
+        diagnostics,
     };
     send_notification(writer, "textDocument/publishDiagnostics", params).await
 }

--- a/wado-cli/src/lsp_rpc.rs
+++ b/wado-cli/src/lsp_rpc.rs
@@ -1,34 +1,16 @@
-//! LSP and JSON-RPC type definitions used by `wado lsp`.
+//! LSP JSON-RPC envelope and request/response param types used by `wado lsp`.
 //!
-//! Only what we actually emit or accept is defined here. Spec reference:
+//! Semantic LSP types (Position, Range, Diagnostic, ...) live in `wado-lsp`
+//! and are reused here. This module only defines the protocol-handling
+//! layer: JSON-RPC framing, request param shapes, server capabilities.
+//!
+//! Spec reference:
 //! <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/>.
-//!
-//! Conventions:
-//! - All structs use `serde(rename_all = "camelCase")` to match LSP wire format.
-//! - Optional fields default-skip on serialization to keep payloads compact.
-//! - Numeric enums (severity, highlight kind, sync kind) are kept as `u32` to
-//!   avoid pulling in `serde_repr`; named constants live in submodules below.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct Position {
-    pub line: u32,
-    pub character: u32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct Range {
-    pub start: Position,
-    pub end: Position,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Location {
-    pub uri: String,
-    pub range: Range,
-}
+use wado_lsp::Position;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TextDocumentIdentifier {
@@ -105,61 +87,10 @@ pub struct SemanticTokens {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Hover {
-    pub contents: MarkupContent,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub range: Option<Range>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MarkupContent {
-    pub kind: MarkupKind,
-    pub value: String,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum MarkupKind {
-    Plaintext,
-    Markdown,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DocumentHighlight {
-    pub range: Range,
-    pub kind: u32,
-}
-
-pub mod document_highlight_kind {
-    pub const TEXT: u32 = 1;
-    pub const READ: u32 = 2;
-    pub const WRITE: u32 = 3;
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PublishDiagnosticsParams {
     pub uri: String,
-    pub diagnostics: Vec<Diagnostic>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Diagnostic {
-    pub range: Range,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub severity: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub code: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source: Option<String>,
-    pub message: String,
-}
-
-pub mod diagnostic_severity {
-    pub const ERROR: u32 = 1;
-    pub const WARNING: u32 = 2;
-    pub const INFORMATION: u32 = 3;
-    pub const HINT: u32 = 4;
+    pub diagnostics: Vec<wado_lsp::Diagnostic>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/wado-cli/src/lsp_rpc.rs
+++ b/wado-cli/src/lsp_rpc.rs
@@ -190,4 +190,5 @@ pub struct JsonRpcNotification<T: Serialize> {
 
 pub mod error_codes {
     pub const METHOD_NOT_FOUND: i32 = -32601;
+    pub const INVALID_PARAMS: i32 = -32602;
 }

--- a/wado-cli/src/lsp_type.rs
+++ b/wado-cli/src/lsp_type.rs
@@ -1,0 +1,262 @@
+//! LSP and JSON-RPC type definitions used by `wado lsp`.
+//!
+//! Only what we actually emit or accept is defined here. Spec reference:
+//! <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/>.
+//!
+//! Conventions:
+//! - All structs use `serde(rename_all = "camelCase")` to match LSP wire format.
+//! - Optional fields default-skip on serialization to keep payloads compact.
+//! - Numeric enums (severity, highlight kind, sync kind) are kept as `u32` to
+//!   avoid pulling in `serde_repr`; named constants live in submodules below.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Position {
+    pub line: u32,
+    pub character: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Range {
+    pub start: Position,
+    pub end: Position,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Location {
+    pub uri: String,
+    pub range: Range,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextDocumentIdentifier {
+    pub uri: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextDocumentItem {
+    pub uri: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub language_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<i32>,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DidOpenTextDocumentParams {
+    pub text_document: TextDocumentItem,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DidChangeTextDocumentParams {
+    pub text_document: TextDocumentIdentifier,
+    pub content_changes: Vec<TextDocumentContentChangeEvent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextDocumentContentChangeEvent {
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DidCloseTextDocumentParams {
+    pub text_document: TextDocumentIdentifier,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextDocumentPositionParams {
+    pub text_document: TextDocumentIdentifier,
+    pub position: Position,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReferenceParams {
+    pub text_document: TextDocumentIdentifier,
+    pub position: Position,
+    #[serde(default)]
+    pub context: ReferenceContext,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReferenceContext {
+    #[serde(default)]
+    pub include_declaration: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SemanticTokensParams {
+    pub text_document: TextDocumentIdentifier,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SemanticTokens {
+    pub data: Vec<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Hover {
+    pub contents: MarkupContent,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub range: Option<Range>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarkupContent {
+    pub kind: MarkupKind,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MarkupKind {
+    Plaintext,
+    Markdown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocumentHighlight {
+    pub range: Range,
+    pub kind: u32,
+}
+
+pub mod document_highlight_kind {
+    pub const TEXT: u32 = 1;
+    pub const READ: u32 = 2;
+    pub const WRITE: u32 = 3;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PublishDiagnosticsParams {
+    pub uri: String,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Diagnostic {
+    pub range: Range,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub severity: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    pub message: String,
+}
+
+pub mod diagnostic_severity {
+    pub const ERROR: u32 = 1;
+    pub const WARNING: u32 = 2;
+    pub const INFORMATION: u32 = 3;
+    pub const HINT: u32 = 4;
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitializeResult {
+    pub capabilities: ServerCapabilities,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_info: Option<ServerInfo>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ServerInfo {
+    pub name: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<&'static str>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_document_sync: Option<TextDocumentSyncOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub definition_provider: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hover_provider: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub references_provider: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub document_highlight_provider: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub semantic_tokens_provider: Option<SemanticTokensOptions>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextDocumentSyncOptions {
+    pub open_close: bool,
+    pub change: u32,
+}
+
+pub mod text_document_sync_kind {
+    pub const NONE: u32 = 0;
+    pub const FULL: u32 = 1;
+    pub const INCREMENTAL: u32 = 2;
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SemanticTokensOptions {
+    pub legend: SemanticTokensLegend,
+    pub full: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SemanticTokensLegend {
+    pub token_types: &'static [&'static str],
+    pub token_modifiers: &'static [&'static str],
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<Value>,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonRpcResponse<'a, T: Serialize> {
+    pub jsonrpc: &'static str,
+    pub id: &'a Value,
+    pub result: T,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonRpcErrorResponse<'a> {
+    pub jsonrpc: &'static str,
+    pub id: &'a Value,
+    pub error: JsonRpcError,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonRpcNotification<T: Serialize> {
+    pub jsonrpc: &'static str,
+    pub method: &'static str,
+    pub params: T,
+}
+
+pub mod error_codes {
+    pub const METHOD_NOT_FOUND: i32 = -32601;
+}

--- a/wado-cli/src/query.rs
+++ b/wado-cli/src/query.rs
@@ -5,25 +5,39 @@ use lexopt::Arg::Value;
 use crate::args::{self, CliExit};
 use crate::query_adapter;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum QueryKind {
     Diagnostics,
+    References,
+    DocumentHighlight,
 }
 
 pub struct QueryOptions {
     kind: QueryKind,
     input: String,
     json: bool,
+    line: Option<u32>,
+    column: Option<u32>,
+    include_declaration: bool,
 }
 
 #[derive(Clone, Copy)]
 enum Opt {
     Json,
+    Line,
+    Column,
+    IncludeDeclaration,
     Help,
 }
 
 impl Opt {
-    const ALL: &[Self] = &[Self::Json, Self::Help];
+    const ALL: &[Self] = &[
+        Self::Json,
+        Self::Line,
+        Self::Column,
+        Self::IncludeDeclaration,
+        Self::Help,
+    ];
 
     const fn spec(self) -> args::OptSpec {
         match self {
@@ -32,6 +46,24 @@ impl Opt {
                 short: None,
                 value: None,
                 desc: "Output as JSON",
+            },
+            Self::Line => args::OptSpec {
+                long: Some("line"),
+                short: None,
+                value: Some("<n>"),
+                desc: "1-based line number for position-based queries",
+            },
+            Self::Column => args::OptSpec {
+                long: Some("column"),
+                short: None,
+                value: Some("<n>"),
+                desc: "1-based column number for position-based queries",
+            },
+            Self::IncludeDeclaration => args::OptSpec {
+                long: Some("include-declaration"),
+                short: None,
+                value: None,
+                desc: "Include the declaration in `references` results",
             },
             Self::Help => args::HELP_SPEC,
         }
@@ -45,7 +77,17 @@ fn format_usage() -> String {
     writeln!(buf, "Query compiler information about a source file.").unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Kinds:").unwrap();
-    writeln!(buf, "  diagnostics    Show errors and warnings").unwrap();
+    writeln!(buf, "  diagnostics          Show errors and warnings").unwrap();
+    writeln!(
+        buf,
+        "  references           Find references to the symbol at --line/--column"
+    )
+    .unwrap();
+    writeln!(
+        buf,
+        "  document-highlight   Highlight occurrences of the symbol at --line/--column"
+    )
+    .unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Options:").unwrap();
     write!(buf, "{}", args::format_opts_help(Opt::ALL, |o| o.spec())).unwrap();
@@ -54,6 +96,14 @@ fn format_usage() -> String {
 
 pub fn print_usage() {
     eprint!("{}", format_usage());
+}
+
+fn parse_position_value(opt_name: &str, val: String) -> Result<u32, CliExit> {
+    val.parse::<u32>().map_err(|_| {
+        CliExit::error(format!(
+            "{opt_name} requires a positive integer, got '{val}'"
+        ))
+    })
 }
 
 /// Parse command-line arguments for the `query` subcommand.
@@ -66,11 +116,23 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<QueryOptions, CliExit> {
     let mut kind: Option<QueryKind> = None;
     let mut input: Option<String> = None;
     let mut json = false;
+    let mut line: Option<u32> = None;
+    let mut column: Option<u32> = None;
+    let mut include_declaration = false;
 
     while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
             match opt {
                 Opt::Json => json = true,
+                Opt::Line => {
+                    let val = args::require_string(&mut parser)?;
+                    line = Some(parse_position_value("--line", val)?);
+                }
+                Opt::Column => {
+                    let val = args::require_string(&mut parser)?;
+                    column = Some(parse_position_value("--column", val)?);
+                }
+                Opt::IncludeDeclaration => include_declaration = true,
                 Opt::Help => return Err(CliExit::help(usage)),
             }
         } else if let Value(val) = arg {
@@ -78,9 +140,11 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<QueryOptions, CliExit> {
             if kind.is_none() {
                 kind = Some(match val_str.as_ref() {
                     "diagnostics" => QueryKind::Diagnostics,
+                    "references" => QueryKind::References,
+                    "document-highlight" => QueryKind::DocumentHighlight,
                     other => {
                         return Err(CliExit::error(format!(
-                            "unknown query kind '{other}'. Available: diagnostics"
+                            "unknown query kind '{other}'. Available: diagnostics, references, document-highlight"
                         )));
                     }
                 });
@@ -96,11 +160,52 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<QueryOptions, CliExit> {
     let kind = kind.ok_or_else(|| CliExit::error_with_usage("missing query kind", &usage))?;
     let input = input.ok_or_else(|| CliExit::error_with_usage("missing input file", &usage))?;
 
-    Ok(QueryOptions { kind, input, json })
+    if matches!(kind, QueryKind::References | QueryKind::DocumentHighlight) {
+        if line.is_none() {
+            return Err(CliExit::error_with_usage(
+                "--line is required for this query kind",
+                &usage,
+            ));
+        }
+        if column.is_none() {
+            return Err(CliExit::error_with_usage(
+                "--column is required for this query kind",
+                &usage,
+            ));
+        }
+    }
+
+    Ok(QueryOptions {
+        kind,
+        input,
+        json,
+        line,
+        column,
+        include_declaration,
+    })
 }
 
 pub async fn run(opts: QueryOptions) {
     match opts.kind {
         QueryKind::Diagnostics => query_adapter::run_diagnostics(&opts.input, opts.json).await,
+        QueryKind::References => {
+            query_adapter::run_references(
+                &opts.input,
+                opts.line.unwrap(),
+                opts.column.unwrap(),
+                opts.include_declaration,
+                opts.json,
+            )
+            .await;
+        }
+        QueryKind::DocumentHighlight => {
+            query_adapter::run_document_highlight(
+                &opts.input,
+                opts.line.unwrap(),
+                opts.column.unwrap(),
+                opts.json,
+            )
+            .await;
+        }
     }
 }

--- a/wado-cli/src/query_adapter.rs
+++ b/wado-cli/src/query_adapter.rs
@@ -3,11 +3,17 @@ use std::path::Path;
 use std::process;
 
 use serde_json::json;
+use wado_lsp::{DocumentHighlight, HighlightKind, Position, ReferenceLocation};
 
 use crate::compiler_host::FilesystemCompilerHost;
 
-/// Run diagnostics query and print results.
-pub async fn run_diagnostics(filename: &str, json_output: bool) {
+struct PreparedQuery {
+    uri: String,
+    engine: wado_lsp::Engine,
+    host: FilesystemCompilerHost,
+}
+
+fn prepare_query(filename: &str) -> PreparedQuery {
     let path = Path::new(filename);
     let source = match fs::read_to_string(path) {
         Ok(s) => s,
@@ -32,7 +38,20 @@ pub async fn run_diagnostics(filename: &str, json_output: bool) {
     let mut engine = wado_lsp::Engine::new();
     engine.open_document(&uri, source);
 
-    let diagnostics = engine.diagnostics(&uri, &host).await;
+    PreparedQuery { uri, engine, host }
+}
+
+fn position_from_one_based(line: u32, column: u32) -> Position {
+    Position {
+        line: line.saturating_sub(1),
+        character: column.saturating_sub(1),
+    }
+}
+
+/// Run diagnostics query and print results.
+pub async fn run_diagnostics(filename: &str, json_output: bool) {
+    let prepared = prepare_query(filename);
+    let diagnostics = prepared.engine.diagnostics(&prepared.uri, &prepared.host).await;
 
     if json_output {
         print_diagnostics_json(filename, &diagnostics);
@@ -45,6 +64,44 @@ pub async fn run_diagnostics(filename: &str, json_output: bool) {
         .any(|d| matches!(d.severity, wado_lsp::Severity::Error))
     {
         process::exit(1);
+    }
+}
+
+/// Run references query and print results.
+pub async fn run_references(
+    filename: &str,
+    line: u32,
+    column: u32,
+    include_declaration: bool,
+    json_output: bool,
+) {
+    let prepared = prepare_query(filename);
+    let position = position_from_one_based(line, column);
+    let refs = prepared
+        .engine
+        .references(&prepared.uri, position, include_declaration, &prepared.host)
+        .await;
+
+    if json_output {
+        print_references_json(&refs);
+    } else {
+        print_references_text(&refs);
+    }
+}
+
+/// Run document-highlight query and print results.
+pub async fn run_document_highlight(filename: &str, line: u32, column: u32, json_output: bool) {
+    let prepared = prepare_query(filename);
+    let position = position_from_one_based(line, column);
+    let highlights = prepared
+        .engine
+        .document_highlight(&prepared.uri, position, &prepared.host)
+        .await;
+
+    if json_output {
+        print_highlights_json(&highlights);
+    } else {
+        print_highlights_text(filename, &highlights);
     }
 }
 
@@ -88,7 +145,6 @@ fn print_diagnostics_text(filename: &str, diagnostics: &[wado_lsp::Diagnostic]) 
             wado_lsp::Severity::Information => "info",
             wado_lsp::Severity::Hint => "hint",
         };
-        // Display as 1-based line/column for human readability
         println!(
             "{}:{}:{}: {}: {} [{}]",
             filename,
@@ -97,6 +153,81 @@ fn print_diagnostics_text(filename: &str, diagnostics: &[wado_lsp::Diagnostic]) 
             severity,
             d.message,
             d.code,
+        );
+    }
+}
+
+fn uri_to_display(uri: &str) -> &str {
+    uri.strip_prefix("file://").unwrap_or(uri)
+}
+
+fn print_references_json(refs: &[ReferenceLocation]) {
+    let json_refs: Vec<serde_json::Value> = refs
+        .iter()
+        .map(|r| {
+            json!({
+                "uri": r.uri,
+                "range": {
+                    "start": { "line": r.range.start.line, "character": r.range.start.character },
+                    "end": { "line": r.range.end.line, "character": r.range.end.character },
+                },
+            })
+        })
+        .collect();
+    println!("{}", serde_json::to_string_pretty(&json_refs).unwrap());
+}
+
+fn print_references_text(refs: &[ReferenceLocation]) {
+    if refs.is_empty() {
+        println!("No references.");
+        return;
+    }
+    for r in refs {
+        println!(
+            "{}:{}:{}",
+            uri_to_display(&r.uri),
+            r.range.start.line + 1,
+            r.range.start.character + 1,
+        );
+    }
+}
+
+fn highlight_kind_str(kind: HighlightKind) -> &'static str {
+    match kind {
+        HighlightKind::Text => "text",
+        HighlightKind::Read => "read",
+        HighlightKind::Write => "write",
+    }
+}
+
+fn print_highlights_json(highlights: &[DocumentHighlight]) {
+    let json_hl: Vec<serde_json::Value> = highlights
+        .iter()
+        .map(|h| {
+            json!({
+                "range": {
+                    "start": { "line": h.range.start.line, "character": h.range.start.character },
+                    "end": { "line": h.range.end.line, "character": h.range.end.character },
+                },
+                "kind": highlight_kind_str(h.kind),
+            })
+        })
+        .collect();
+    println!("{}", serde_json::to_string_pretty(&json_hl).unwrap());
+}
+
+fn print_highlights_text(filename: &str, highlights: &[DocumentHighlight]) {
+    if highlights.is_empty() {
+        println!("No highlights.");
+        return;
+    }
+    for h in highlights {
+        println!(
+            "{}:{}:{}: {}",
+            filename,
+            h.range.start.line + 1,
+            h.range.start.character + 1,
+            highlight_kind_str(h.kind),
         );
     }
 }

--- a/wado-cli/src/query_adapter.rs
+++ b/wado-cli/src/query_adapter.rs
@@ -51,7 +51,10 @@ fn position_from_one_based(line: u32, column: u32) -> Position {
 /// Run diagnostics query and print results.
 pub async fn run_diagnostics(filename: &str, json_output: bool) {
     let prepared = prepare_query(filename);
-    let diagnostics = prepared.engine.diagnostics(&prepared.uri, &prepared.host).await;
+    let diagnostics = prepared
+        .engine
+        .diagnostics(&prepared.uri, &prepared.host)
+        .await;
 
     if json_output {
         print_diagnostics_json(filename, &diagnostics);

--- a/wado-cli/tests/lsp.rs
+++ b/wado-cli/tests/lsp.rs
@@ -580,6 +580,23 @@ fn lsp_unknown_method_returns_error() {
 }
 
 #[test]
+fn lsp_invalid_params_returns_error() {
+    let mut session = LspSession::start();
+
+    session.send_request("initialize", json!({ "capabilities": {} }));
+    let _init_resp = session.read_message();
+
+    // Send a well-formed request with malformed params (missing required fields).
+    let id = session.send_request("textDocument/hover", json!({ "bogus": true }));
+
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    assert_eq!(resp["error"]["code"], -32602); // InvalidParams
+
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
 fn lsp_exit_without_shutdown_returns_nonzero() {
     let mut child = Command::new(wado_bin())
         .args(["lsp"])

--- a/wado-cli/tests/lsp.rs
+++ b/wado-cli/tests/lsp.rs
@@ -464,6 +464,100 @@ fn lsp_hover_function_signature() {
 }
 
 #[test]
+fn lsp_references_includes_call_sites() {
+    let mut session = LspSession::start();
+
+    session.send_request("initialize", json!({ "capabilities": {} }));
+    let _init_resp = session.read_message();
+    session.send_notification("initialized", json!({}));
+
+    let source = "fn helper() -> i32 {\n    return 1;\n}\n\nexport fn run() {\n    let _ = helper();\n    let _ = helper();\n}\n";
+    session.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": "file:///tmp/lsp_refs.wado",
+                "languageId": "wado",
+                "version": 1,
+                "text": source,
+            }
+        }),
+    );
+    let _diag = session.read_message();
+
+    let id = session.send_request(
+        "textDocument/references",
+        json!({
+            "textDocument": { "uri": "file:///tmp/lsp_refs.wado" },
+            "position": { "line": 0, "character": 4 },
+            "context": { "includeDeclaration": true }
+        }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+
+    let arr = resp["result"].as_array().unwrap();
+    assert_eq!(arr.len(), 3, "decl + 2 calls, got: {arr:?}");
+    for r in arr {
+        assert_eq!(r["uri"], "file:///tmp/lsp_refs.wado");
+    }
+    // Declaration at line 0, character 3..9 (helper)
+    assert_eq!(arr[0]["range"]["start"]["line"], 0);
+    assert_eq!(arr[0]["range"]["start"]["character"], 3);
+    // Call sites at lines 5 and 6
+    assert_eq!(arr[1]["range"]["start"]["line"], 5);
+    assert_eq!(arr[2]["range"]["start"]["line"], 6);
+
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_document_highlight_classifies_read_write() {
+    let mut session = LspSession::start();
+
+    session.send_request("initialize", json!({ "capabilities": {} }));
+    let _init_resp = session.read_message();
+    session.send_notification("initialized", json!({}));
+
+    let source = "fn f() -> i32 {\n    let mut x = 0;\n    x = 1;\n    return x;\n}\n";
+    session.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": "file:///tmp/lsp_highlight.wado",
+                "languageId": "wado",
+                "version": 1,
+                "text": source,
+            }
+        }),
+    );
+    let _diag = session.read_message();
+
+    let id = session.send_request(
+        "textDocument/documentHighlight",
+        json!({
+            "textDocument": { "uri": "file:///tmp/lsp_highlight.wado" },
+            "position": { "line": 1, "character": 12 }
+        }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+
+    let arr = resp["result"].as_array().unwrap();
+    assert_eq!(arr.len(), 3, "decl + write + read, got: {arr:?}");
+    // Declaration: write
+    assert_eq!(arr[0]["kind"], 3);
+    // x = 1: write
+    assert_eq!(arr[1]["range"]["start"]["line"], 2);
+    assert_eq!(arr[1]["kind"], 3);
+    // return x: read
+    assert_eq!(arr[2]["range"]["start"]["line"], 3);
+    assert_eq!(arr[2]["kind"], 2);
+
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
 fn lsp_unknown_method_returns_error() {
     let mut session = LspSession::start();
 
@@ -658,5 +752,186 @@ fn query_help() {
         .assert()
         .success()
         .stderr(predicate::str::contains("diagnostics"))
-        .stderr(predicate::str::contains("--json"));
+        .stderr(predicate::str::contains("references"))
+        .stderr(predicate::str::contains("document-highlight"))
+        .stderr(predicate::str::contains("--json"))
+        .stderr(predicate::str::contains("--line"))
+        .stderr(predicate::str::contains("--column"))
+        .stderr(predicate::str::contains("--include-declaration"));
+}
+
+#[test]
+fn query_references_text_output() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".wado").unwrap();
+    std::fs::write(
+        tmp.path(),
+        "fn helper() -> i32 {\n    return 1;\n}\n\nexport fn run() {\n    let _ = helper();\n    let _ = helper();\n}\n",
+    )
+    .unwrap();
+
+    let path_str = tmp.path().to_str().unwrap();
+    let output = wado()
+        .args([
+            "query",
+            "references",
+            "--line",
+            "1",
+            "--column",
+            "4",
+            path_str,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    let lines: Vec<&str> = text.lines().collect();
+    assert_eq!(lines.len(), 2, "expected 2 call sites, got: {text}");
+    assert!(lines[0].ends_with(":6:13"), "got: {}", lines[0]);
+    assert!(lines[1].ends_with(":7:13"), "got: {}", lines[1]);
+}
+
+#[test]
+fn query_references_include_declaration() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".wado").unwrap();
+    std::fs::write(
+        tmp.path(),
+        "fn helper() -> i32 {\n    return 1;\n}\n\nexport fn run() {\n    let _ = helper();\n}\n",
+    )
+    .unwrap();
+
+    let output = wado()
+        .args([
+            "query",
+            "references",
+            "--include-declaration",
+            "--line",
+            "1",
+            "--column",
+            "4",
+            tmp.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    let lines: Vec<&str> = text.lines().collect();
+    assert_eq!(lines.len(), 2, "expected decl + 1 call, got: {text}");
+    assert!(lines[0].ends_with(":1:4"), "decl, got: {}", lines[0]);
+    assert!(lines[1].ends_with(":6:13"), "call, got: {}", lines[1]);
+}
+
+#[test]
+fn query_references_json_output() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".wado").unwrap();
+    std::fs::write(
+        tmp.path(),
+        "fn helper() -> i32 {\n    return 1;\n}\n\nexport fn run() {\n    let _ = helper();\n}\n",
+    )
+    .unwrap();
+
+    let output = wado()
+        .args([
+            "query",
+            "references",
+            "--json",
+            "--line",
+            "1",
+            "--column",
+            "4",
+            tmp.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let parsed: Vec<Value> = serde_json::from_slice(&output).unwrap();
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0]["range"]["start"]["line"], 5);
+    assert_eq!(parsed[0]["range"]["start"]["character"], 12);
+    assert!(parsed[0]["uri"].as_str().unwrap().starts_with("file://"));
+}
+
+#[test]
+fn query_document_highlight_text_output() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".wado").unwrap();
+    std::fs::write(
+        tmp.path(),
+        "fn f() -> i32 {\n    let mut x = 0;\n    x = 1;\n    return x;\n}\n",
+    )
+    .unwrap();
+
+    let output = wado()
+        .args([
+            "query",
+            "document-highlight",
+            "--line",
+            "2",
+            "--column",
+            "13",
+            tmp.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.contains(":2:13: write"), "decl write, got: {text}");
+    assert!(text.contains(":3:5: write"), "x = 1, got: {text}");
+    assert!(text.contains(":4:12: read"), "return x, got: {text}");
+}
+
+#[test]
+fn query_document_highlight_json_output() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".wado").unwrap();
+    std::fs::write(
+        tmp.path(),
+        "fn f() -> i32 {\n    let x = 1;\n    return x;\n}\n",
+    )
+    .unwrap();
+
+    let output = wado()
+        .args([
+            "query",
+            "document-highlight",
+            "--json",
+            "--line",
+            "2",
+            "--column",
+            "9",
+            tmp.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let parsed: Vec<Value> = serde_json::from_slice(&output).unwrap();
+    assert_eq!(parsed.len(), 2);
+    assert_eq!(parsed[0]["kind"], "write");
+    assert_eq!(parsed[1]["kind"], "read");
+}
+
+#[test]
+fn query_references_requires_line_and_column() {
+    wado()
+        .args(["query", "references", "example/hello.wado"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--line is required"));
+}
+
+#[test]
+fn query_unknown_kind_lists_new_kinds() {
+    wado()
+        .args(["query", "hover"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("references"))
+        .stderr(predicate::str::contains("document-highlight"));
 }

--- a/wado-compiler/src/annotate.rs
+++ b/wado-compiler/src/annotate.rs
@@ -93,6 +93,29 @@ impl Annotated {
         self.references.get(key).cloned()
     }
 
+    /// Iterate every recorded use-site `(use_key, def_key)` edge.
+    ///
+    /// Each `use_key` is typically an [`IdentExpr`] id; `def_key` is the
+    /// binding's defining [`SymbolKey`]. Use sites of locals, parameters,
+    /// item-level definitions (functions, types, globals) and imported items
+    /// are all recorded here.
+    pub fn iter_references(&self) -> impl Iterator<Item = (&SymbolKey, &SymbolKey)> {
+        self.references.iter()
+    }
+
+    /// Find every use-site `SymbolKey` whose definition is `def_key`.
+    ///
+    /// Walks [`Self::iter_references`] and collects matches. The returned keys
+    /// can be passed to [`Self::span_of_key`] for source ranges. The defining
+    /// occurrence itself is **not** included — callers that want it should add
+    /// it via [`Self::name_span_of`] / [`Self::span_of_key`].
+    #[must_use]
+    pub fn references_to(&self, def_key: &SymbolKey) -> Vec<SymbolKey> {
+        self.iter_references()
+            .filter_map(|(use_key, target)| (target == def_key).then(|| use_key.clone()))
+            .collect()
+    }
+
     /// Resolved type for the declaring symbol at `key`, if `key` refers to a
     /// type-declaring AST node (struct, enum, variant, flags, newtype,
     /// resource).

--- a/wado-compiler/src/annotate.rs
+++ b/wado-compiler/src/annotate.rs
@@ -112,7 +112,8 @@ impl Annotated {
     #[must_use]
     pub fn references_to(&self, def_key: &SymbolKey) -> Vec<SymbolKey> {
         self.iter_references()
-            .filter_map(|(use_key, target)| (target == def_key).then(|| use_key.clone()))
+            .filter(|&(_use_key, target)| target == def_key)
+            .map(|(use_key, _target)| use_key.clone())
             .collect()
     }
 

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -11,16 +11,16 @@ Language service engine for the Wado compiler toolchain.
 
 ## Architecture
 
-| File                     | Role                                                                                             |
-| ------------------------ | ------------------------------------------------------------------------------------------------ |
-| `src/lib.rs`             | `Engine` struct: document management + query dispatch                                            |
-| `src/diagnostics.rs`     | Compiler `Diagnostic` to LSP-compatible `Diagnostic` conversion                                  |
-| `src/semantic_tokens.rs` | Semantic token computation (lexer + AST classification)                                          |
-| `src/definition.rs`      | Go-to-definition via `Annotated::{ast_id_at, referenced_symbol, symbol_at}`                      |
-| `src/hover.rs`           | Hover info; locals render from the resolved AST node, items delegate to `wado_compiler::unparse` |
-| `src/references.rs`      | Find-references, walks `Annotated::iter_references` and collects matching use-sites              |
-| `src/document_highlight.rs` | Document highlight; classifies each occurrence as Read or Write via AST walk                  |
-| `src/location.rs`        | Shared cursor→`SymbolKey` resolution and span/URI helpers                                        |
+| File                        | Role                                                                                             |
+| --------------------------- | ------------------------------------------------------------------------------------------------ |
+| `src/lib.rs`                | `Engine` struct: document management + query dispatch                                            |
+| `src/diagnostics.rs`        | Compiler `Diagnostic` to LSP-compatible `Diagnostic` conversion                                  |
+| `src/semantic_tokens.rs`    | Semantic token computation (lexer + AST classification)                                          |
+| `src/definition.rs`         | Go-to-definition via `Annotated::{ast_id_at, referenced_symbol, symbol_at}`                      |
+| `src/hover.rs`              | Hover info; locals render from the resolved AST node, items delegate to `wado_compiler::unparse` |
+| `src/references.rs`         | Find-references, walks `Annotated::iter_references` and collects matching use-sites              |
+| `src/document_highlight.rs` | Document highlight; classifies each occurrence as Read or Write via AST walk                     |
+| `src/location.rs`           | Shared cursor→`SymbolKey` resolution and span/URI helpers                                        |
 
 ### Engine
 

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -18,6 +18,9 @@ Language service engine for the Wado compiler toolchain.
 | `src/semantic_tokens.rs` | Semantic token computation (lexer + AST classification)                                          |
 | `src/definition.rs`      | Go-to-definition via `Annotated::{ast_id_at, referenced_symbol, symbol_at}`                      |
 | `src/hover.rs`           | Hover info; locals render from the resolved AST node, items delegate to `wado_compiler::unparse` |
+| `src/references.rs`      | Find-references, walks `Annotated::iter_references` and collects matching use-sites              |
+| `src/document_highlight.rs` | Document highlight; classifies each occurrence as Read or Write via AST walk                  |
+| `src/location.rs`        | Shared cursor→`SymbolKey` resolution and span/URI helpers                                        |
 
 ### Engine
 
@@ -69,14 +72,12 @@ Progress tracker for LSP 3.18 feature kinds. Each item represents a protocol kin
 - [ ] `textDocument/declaration`
 - [ ] `textDocument/typeDefinition`
 - [ ] `textDocument/implementation`
-- [ ] `textDocument/references`
 - [ ] `textDocument/callHierarchy` (prepare / incomingCalls / outgoingCalls)
 - [ ] `textDocument/typeHierarchy` (prepare / supertypes / subtypes)
 
 ### Language Features — Comprehension
 
 - [ ] `textDocument/signatureHelp`
-- [ ] `textDocument/documentHighlight`
 - [ ] `textDocument/documentLink`
 - [ ] `textDocument/codeLens`
 - [ ] `textDocument/inlayHint`

--- a/wado-lsp/src/definition.rs
+++ b/wado-lsp/src/definition.rs
@@ -8,6 +8,7 @@
 //! 4. Otherwise the cursor AST id itself points at a declared symbol.
 //! 5. Translate the resulting [`SymbolKey`] into a [`DefinitionResult`].
 
+use serde::{Deserialize, Serialize};
 use wado_compiler::CompilerHost;
 use wado_compiler::annotate::annotate;
 use wado_compiler::ast::{self, AstId, Item, Module};
@@ -16,7 +17,7 @@ use wado_compiler::token::Span;
 use crate::diagnostics::{Position, Range};
 use crate::location::{resolve_def_key, span_to_range, symbol_uri, uri_to_filename};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DefinitionResult {
     pub uri: String,
     pub range: Range,

--- a/wado-lsp/src/definition.rs
+++ b/wado-lsp/src/definition.rs
@@ -9,13 +9,12 @@
 //! 5. Translate the resulting [`SymbolKey`] into a [`DefinitionResult`].
 
 use wado_compiler::CompilerHost;
-use wado_compiler::annotate::{Annotated, annotate};
+use wado_compiler::annotate::annotate;
 use wado_compiler::ast::{self, AstId, Item, Module};
-use wado_compiler::name::ModuleSource;
-use wado_compiler::symbol::{Symbol, SymbolKey};
 use wado_compiler::token::Span;
 
 use crate::diagnostics::{Position, Range};
+use crate::location::{resolve_def_key, span_to_range, symbol_uri, uri_to_filename};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DefinitionResult {
@@ -54,30 +53,6 @@ pub async fn find_definition<H: CompilerHost>(
     })
 }
 
-/// Resolve the defining [`SymbolKey`] for the identifier at the cursor.
-///
-/// Tries in order:
-/// 1. `ast_id_at` → `referenced_symbol` (use-site → definition: local, param,
-///    imported item, etc.)
-/// 2. `ast_id_at` → key points directly to a declared symbol (cursor on the
-///    defining occurrence itself).
-fn resolve_def_key(
-    annotated: &Annotated,
-    module: &ModuleSource,
-    line: usize,
-    col: usize,
-) -> Option<SymbolKey> {
-    let ast_id = annotated.ast_id_at(module, line, col)?;
-    let cursor_key = SymbolKey::new(module.clone(), ast_id);
-    if let Some(def) = annotated.referenced_symbol(&cursor_key) {
-        return Some(def);
-    }
-    if annotated.symbol_at(&cursor_key).is_some() {
-        return Some(cursor_key);
-    }
-    None
-}
-
 /// Best-effort span for an arbitrary [`AstId`] — walks module items looking for
 /// a matching id. Used only when `name_span_of` has no name-span and the
 /// symbol has no declared span (rare).
@@ -101,67 +76,6 @@ fn item_span_if_match(item: &Item, target: AstId) -> Option<Span> {
         Item::Newtype(n) if n.id == target => Some(n.span),
         Item::Global(g) if g.id == target => Some(g.span),
         _ => None,
-    }
-}
-
-/// Derive the URI for a symbol's defining module.
-fn symbol_uri(annotated: &Annotated, symbol: &Symbol, request_uri: &str) -> Option<String> {
-    let module = &symbol.defined_at.module;
-    if module == &annotated.entry_module_source {
-        return Some(request_uri.to_string());
-    }
-    match module {
-        ModuleSource::EntryPoint { filename } => Some(filename_to_uri(filename)),
-        ModuleSource::Local { path } => Some(resolve_local_uri(path, request_uri)),
-        _ => None,
-    }
-}
-
-fn uri_to_filename(uri: &str) -> String {
-    if let Some(path) = uri.strip_prefix("file://") {
-        path.to_string()
-    } else {
-        uri.to_string()
-    }
-}
-
-fn filename_to_uri(filename: &str) -> String {
-    if filename.starts_with("file://") {
-        filename.to_string()
-    } else if filename.starts_with('/') {
-        format!("file://{filename}")
-    } else {
-        filename.to_string()
-    }
-}
-
-fn resolve_local_uri(module_path: &str, request_uri: &str) -> String {
-    if module_path.starts_with('/') || module_path.starts_with("file://") {
-        return filename_to_uri(module_path);
-    }
-    let request_path = uri_to_filename(request_uri);
-    let base_dir = request_path
-        .rsplit_once('/')
-        .map(|(dir, _)| dir)
-        .unwrap_or("");
-    let normalized = module_path.strip_prefix("./").unwrap_or(module_path);
-    if base_dir.is_empty() {
-        filename_to_uri(normalized)
-    } else {
-        filename_to_uri(&format!("{base_dir}/{normalized}"))
-    }
-}
-
-fn span_to_range(span: &Span) -> Range {
-    Range {
-        start: Position {
-            line: span.line.saturating_sub(1) as u32,
-            character: span.column.saturating_sub(1) as u32,
-        },
-        end: Position {
-            line: span.end_line.saturating_sub(1) as u32,
-            character: span.end_column.saturating_sub(1) as u32,
-        },
     }
 }
 

--- a/wado-lsp/src/diagnostics.rs
+++ b/wado-lsp/src/diagnostics.rs
@@ -1,7 +1,10 @@
+use serde::{Deserialize, Serialize};
 use wado_compiler::{Code, Diagnostic as CompilerDiagnostic, Severity as CompilerSeverity};
 
-/// LSP-compatible diagnostic severity.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// LSP-compatible diagnostic severity. Serializes as the 1..=4 integer
+/// defined by the LSP wire format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(into = "u32", try_from = "u32")]
 pub enum Severity {
     Error = 1,
     Warning = 2,
@@ -9,26 +12,48 @@ pub enum Severity {
     Hint = 4,
 }
 
+impl From<Severity> for u32 {
+    fn from(s: Severity) -> Self {
+        s as Self
+    }
+}
+
+impl TryFrom<u32> for Severity {
+    type Error = String;
+
+    fn try_from(n: u32) -> Result<Self, <Self as TryFrom<u32>>::Error> {
+        match n {
+            1 => Ok(Self::Error),
+            2 => Ok(Self::Warning),
+            3 => Ok(Self::Information),
+            4 => Ok(Self::Hint),
+            _ => Err(format!("invalid Severity: {n}")),
+        }
+    }
+}
+
 /// Zero-based line/column position in a text document.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Position {
     pub line: u32,
     pub character: u32,
 }
 
 /// A range in a text document (start inclusive, end exclusive).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Range {
     pub start: Position,
     pub end: Position,
 }
 
 /// A diagnostic message (error, warning, etc.) for a text document.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Diagnostic {
     pub range: Range,
     pub severity: Severity,
     pub code: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
     pub message: String,
 }
 
@@ -79,6 +104,7 @@ pub fn from_compiler_diagnostic(diag: &CompilerDiagnostic, _uri: &str) -> Option
         },
         severity,
         code: format!("{}", diag.code),
+        source: Some("wado".to_string()),
         message: diag.message.clone(),
     })
 }

--- a/wado-lsp/src/document_highlight.rs
+++ b/wado-lsp/src/document_highlight.rs
@@ -1,0 +1,429 @@
+//! Document highlight, powered by `wado_compiler::annotate`.
+//!
+//! Returns every occurrence of the symbol named at the cursor that lives
+//! inside the requested document. References to the same symbol from other
+//! files are filtered out — that's `textDocument/references`' job.
+//!
+//! Each occurrence is classified:
+//! - `Write` for the declaration and for use-sites that are direct targets of
+//!   `=`, `+=`, etc.
+//! - `Read` for every other use-site.
+
+use wado_compiler::CompilerHost;
+use wado_compiler::annotate::{Annotated, annotate};
+use wado_compiler::ast::{
+    self, AssignExpr, AstId, Block, CompoundAssignExpr, Condition, ConditionElement, Expr, Item,
+    MatchExpr, Module, Stmt,
+};
+use wado_compiler::name::ModuleSource;
+
+use crate::diagnostics::{Position, Range};
+use crate::location::{resolve_def_key, span_to_range, uri_to_filename};
+
+/// LSP `DocumentHighlightKind` values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HighlightKind {
+    Text = 1,
+    Read = 2,
+    Write = 3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentHighlight {
+    pub range: Range,
+    pub kind: HighlightKind,
+}
+
+pub async fn document_highlight<H: CompilerHost>(
+    source: &str,
+    position: Position,
+    uri: &str,
+    host: &H,
+) -> Vec<DocumentHighlight> {
+    let filename = uri_to_filename(uri);
+    let Ok(annotated) = annotate(source, host, Some(&filename)).await else {
+        return Vec::new();
+    };
+
+    let module = annotated.entry_module_source.clone();
+    let line = position.line as usize + 1;
+    let col = position.character as usize + 1;
+
+    let Some(def_key) = resolve_def_key(&annotated, &module, line, col) else {
+        return Vec::new();
+    };
+
+    let write_targets = collect_write_target_ids(&annotated, &module);
+    let mut out = Vec::new();
+
+    if def_key.module == module
+        && let Some(span) = annotated
+            .name_span_of(&def_key)
+            .or_else(|| annotated.symbol_at(&def_key).and_then(|s| s.span))
+    {
+        out.push(DocumentHighlight {
+            range: span_to_range(&span),
+            kind: HighlightKind::Write,
+        });
+    }
+
+    for use_key in annotated.references_to(&def_key) {
+        if use_key.module != module {
+            continue;
+        }
+        let Some(span) = annotated.span_of_key(&use_key) else {
+            continue;
+        };
+        let kind = if write_targets.contains(&use_key.ast_id) {
+            HighlightKind::Write
+        } else {
+            HighlightKind::Read
+        };
+        out.push(DocumentHighlight {
+            range: span_to_range(&span),
+            kind,
+        });
+    }
+
+    out.sort_by_key(|h| (h.range.start.line, h.range.start.character));
+    out.dedup();
+    out
+}
+
+/// Collect every `IdentExpr.id` that appears as the direct target of
+/// `Expr::Assign` / `Expr::CompoundAssign` in the given module.
+fn collect_write_target_ids(annotated: &Annotated, module: &ModuleSource) -> Vec<AstId> {
+    let mut writes = Vec::new();
+    let Some(module) = annotated.modules.get(module) else {
+        return writes;
+    };
+    visit_module(module, &mut writes);
+    writes
+}
+
+fn visit_module(module: &Module, writes: &mut Vec<AstId>) {
+    for item in &module.items {
+        visit_item(item, writes);
+    }
+}
+
+fn visit_item(item: &Item, writes: &mut Vec<AstId>) {
+    match item {
+        Item::Function(f) => {
+            if let Some(body) = &f.body {
+                visit_block(body, writes);
+            }
+        }
+        Item::Impl(imp) => {
+            for m in &imp.methods {
+                if let Some(body) = &m.body {
+                    visit_block(body, writes);
+                }
+            }
+        }
+        Item::Trait(t) => {
+            for m in &t.methods {
+                if let Some(body) = &m.body {
+                    visit_block(body, writes);
+                }
+            }
+        }
+        Item::Test(t) => visit_block(&t.body, writes),
+        Item::Global(g) => visit_expr(&g.initializer, writes),
+        _ => {}
+    }
+}
+
+fn visit_block(block: &Block, writes: &mut Vec<AstId>) {
+    for stmt in &block.stmts {
+        visit_stmt(stmt, writes);
+    }
+}
+
+fn visit_stmt(stmt: &Stmt, writes: &mut Vec<AstId>) {
+    match stmt {
+        Stmt::Let(s) => {
+            if let Some(v) = &s.value {
+                visit_expr(v, writes);
+            }
+        }
+        Stmt::Expr(s) => visit_expr(&s.expr, writes),
+        Stmt::Return(s) => {
+            if let Some(v) = &s.value {
+                visit_expr(v, writes);
+            }
+        }
+        Stmt::TaskReturn(s) => visit_expr(&s.value, writes),
+        Stmt::If(s) => {
+            visit_condition(&s.condition, writes);
+            visit_block(&s.then_block, writes);
+            if let Some(eb) = &s.else_block {
+                visit_block(eb, writes);
+            }
+        }
+        Stmt::While(s) => {
+            visit_condition(&s.condition, writes);
+            visit_block(&s.body, writes);
+        }
+        Stmt::For(s) => {
+            if let Some(init) = &s.init {
+                visit_stmt(init, writes);
+            }
+            if let Some(cond) = &s.condition {
+                visit_condition(cond, writes);
+            }
+            if let Some(u) = &s.update {
+                visit_expr(u, writes);
+            }
+            visit_block(&s.body, writes);
+        }
+        Stmt::ForOf(s) => {
+            visit_expr(&s.iterable, writes);
+            visit_block(&s.body, writes);
+        }
+        Stmt::Loop(s) => visit_block(&s.body, writes),
+        Stmt::Match(m) => visit_match(m, writes),
+        Stmt::Break(s) => {
+            if let Some(v) = &s.value {
+                visit_expr(v, writes);
+            }
+        }
+        Stmt::Continue(_) => {}
+        Stmt::Assert(s) => {
+            visit_expr(&s.condition, writes);
+            if let Some(msg) = &s.message {
+                visit_expr(msg, writes);
+            }
+        }
+        Stmt::LabeledBlock(s) => visit_block(&s.block, writes),
+    }
+}
+
+fn visit_condition(cond: &Condition, writes: &mut Vec<AstId>) {
+    match cond {
+        Condition::Expr(e) => visit_expr(e, writes),
+        Condition::LetChain { elements, .. } => {
+            for el in elements {
+                match el {
+                    ConditionElement::Let { expr, .. } => visit_expr(expr, writes),
+                    ConditionElement::Expr(e) => visit_expr(e, writes),
+                }
+            }
+        }
+    }
+}
+
+fn visit_match(m: &MatchExpr, writes: &mut Vec<AstId>) {
+    visit_expr(&m.expr, writes);
+    for arm in &m.arms {
+        if let Some(g) = &arm.guard {
+            visit_expr(g, writes);
+        }
+        visit_expr(&arm.body, writes);
+    }
+}
+
+fn visit_expr(expr: &Expr, writes: &mut Vec<AstId>) {
+    match expr {
+        Expr::Assign(e) => visit_assign(e, writes),
+        Expr::CompoundAssign(e) => visit_compound_assign(e, writes),
+        Expr::Ident(_) | Expr::Literal(_) => {}
+        Expr::Binary(e) => {
+            visit_expr(&e.left, writes);
+            visit_expr(&e.right, writes);
+        }
+        Expr::Unary(e) => visit_expr(&e.expr, writes),
+        Expr::ComparisonChain(e) => {
+            visit_expr(&e.first, writes);
+            for c in &e.comparisons {
+                visit_expr(&c.right, writes);
+            }
+        }
+        Expr::Call(e) => {
+            visit_expr(&e.callee, writes);
+            for a in &e.args {
+                visit_expr(a, writes);
+            }
+        }
+        Expr::MethodCall(e) => {
+            visit_expr(&e.receiver, writes);
+            for a in &e.args {
+                visit_expr(a, writes);
+            }
+        }
+        Expr::StaticMethodCall(e) => {
+            for a in &e.args {
+                visit_expr(a, writes);
+            }
+        }
+        Expr::FieldAccess(e) => visit_expr(&e.expr, writes),
+        Expr::Index(e) => {
+            visit_expr(&e.expr, writes);
+            visit_expr(&e.index, writes);
+        }
+        Expr::Block(b) => visit_block(b, writes),
+        Expr::If(e) => {
+            visit_condition(&e.condition, writes);
+            visit_block(&e.then_block, writes);
+            if let Some(eb) = &e.else_block {
+                visit_block(eb, writes);
+            }
+        }
+        Expr::Match(m) => visit_match(m, writes),
+        Expr::Matches(m) => {
+            visit_expr(&m.expr, writes);
+            if let Some(g) = &m.guard {
+                visit_expr(g, writes);
+            }
+        }
+        Expr::Closure(c) => visit_expr(&c.body, writes),
+        Expr::TemplateString(t) => {
+            for part in &t.parts {
+                if let ast::TemplatePart::Interpolation { expr, .. } = part {
+                    visit_expr(expr, writes);
+                }
+            }
+        }
+        Expr::Cast(c) => visit_expr(&c.expr, writes),
+        Expr::StructLiteral(s) => {
+            for f in &s.fields {
+                visit_expr(&f.value, writes);
+            }
+        }
+        Expr::TupleLiteral(t) => {
+            for el in &t.elements {
+                visit_expr(el, writes);
+            }
+        }
+        Expr::LabeledBlock(lb) => visit_block(&lb.block, writes),
+        Expr::TryOp(t) => visit_expr(&t.expr, writes),
+        Expr::Spread(inner, _) => visit_expr(inner, writes),
+        Expr::Range(r) => {
+            visit_expr(&r.start, writes);
+            visit_expr(&r.end, writes);
+        }
+    }
+}
+
+fn visit_assign(e: &AssignExpr, writes: &mut Vec<AstId>) {
+    record_target(&e.target, writes);
+    visit_expr(&e.target, writes);
+    visit_expr(&e.value, writes);
+}
+
+fn visit_compound_assign(e: &CompoundAssignExpr, writes: &mut Vec<AstId>) {
+    record_target(&e.target, writes);
+    visit_expr(&e.target, writes);
+    visit_expr(&e.value, writes);
+}
+
+/// Record an `IdentExpr` target as a write site. Only direct identifier
+/// targets count — for `obj.field = v`, the write is on `field`, not `obj`,
+/// so the `IdentExpr` for `obj` remains a Read.
+fn record_target(target: &Expr, writes: &mut Vec<AstId>) {
+    if let Expr::Ident(id) = target {
+        writes.push(id.id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+    use wado_compiler::{Diagnostic as CompilerDiagnostic, SourceError};
+
+    struct TestHost {
+        sources: IndexMap<String, Vec<u8>>,
+    }
+
+    impl TestHost {
+        fn single(path: &str, source: &str) -> Self {
+            let mut sources = IndexMap::new();
+            sources.insert(path.to_string(), source.as_bytes().to_vec());
+            Self { sources }
+        }
+    }
+
+    impl CompilerHost for TestHost {
+        async fn load_source(&self, path: &str) -> Result<Vec<u8>, SourceError> {
+            self.sources
+                .get(path)
+                .cloned()
+                .ok_or_else(|| SourceError::NotFound {
+                    path: path.to_string(),
+                })
+        }
+
+        fn emit_diagnostic(&self, _diagnostic: CompilerDiagnostic) {}
+    }
+
+    async fn highlights_at(source: &str, line: u32, character: u32) -> Vec<DocumentHighlight> {
+        let path = "/test.wado";
+        let uri = format!("file://{path}");
+        let host = TestHost::single(path, source);
+        document_highlight(source, Position { line, character }, &uri, &host).await
+    }
+
+    fn summarize(refs: &[DocumentHighlight]) -> Vec<(u32, u32, HighlightKind)> {
+        refs.iter()
+            .map(|h| (h.range.start.line, h.range.start.character, h.kind))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn read_only_uses() {
+        let source = "fn f() -> i32 {\n    let x: i32 = 1;\n    return x + x;\n}\n";
+        let hl = highlights_at(source, 1, 8).await;
+        assert_eq!(
+            summarize(&hl),
+            vec![
+                (1, 8, HighlightKind::Write),
+                (2, 11, HighlightKind::Read),
+                (2, 15, HighlightKind::Read),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn assignment_marks_target_as_write() {
+        let source = "fn f() {\n    let mut x: i32 = 0;\n    x = 1;\n    x += 2;\n    let y = x;\n}\n";
+        let hl = highlights_at(source, 1, 12).await;
+        assert_eq!(
+            summarize(&hl),
+            vec![
+                (1, 12, HighlightKind::Write),
+                (2, 4, HighlightKind::Write),
+                (3, 4, HighlightKind::Write),
+                (4, 12, HighlightKind::Read),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn cursor_on_use_site_works() {
+        let source = "fn f() -> i32 {\n    let x: i32 = 1;\n    return x + x;\n}\n";
+        let hl = highlights_at(source, 2, 11).await;
+        assert_eq!(
+            summarize(&hl),
+            vec![
+                (1, 8, HighlightKind::Write),
+                (2, 11, HighlightKind::Read),
+                (2, 15, HighlightKind::Read),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn function_highlights_within_file() {
+        let source = "fn helper() -> i32 {\n    return 1;\n}\nfn run() -> i32 {\n    return helper() + helper();\n}\n";
+        let hl = highlights_at(source, 0, 4).await;
+        assert_eq!(
+            summarize(&hl),
+            vec![
+                (0, 3, HighlightKind::Write),
+                (4, 11, HighlightKind::Read),
+                (4, 22, HighlightKind::Read),
+            ]
+        );
+    }
+}

--- a/wado-lsp/src/document_highlight.rs
+++ b/wado-lsp/src/document_highlight.rs
@@ -9,6 +9,7 @@
 //!   `=`, `+=`, etc.
 //! - `Read` for every other use-site.
 
+use serde::{Deserialize, Serialize};
 use wado_compiler::CompilerHost;
 use wado_compiler::annotate::{Annotated, annotate};
 use wado_compiler::ast::{
@@ -20,15 +21,36 @@ use wado_compiler::name::ModuleSource;
 use crate::diagnostics::{Position, Range};
 use crate::location::{resolve_def_key, span_to_range, uri_to_filename};
 
-/// LSP `DocumentHighlightKind` values.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// LSP `DocumentHighlightKind` values. Serializes as the 1..=3 integer
+/// defined by the LSP wire format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(into = "u32", try_from = "u32")]
 pub enum HighlightKind {
     Text = 1,
     Read = 2,
     Write = 3,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+impl From<HighlightKind> for u32 {
+    fn from(k: HighlightKind) -> Self {
+        k as Self
+    }
+}
+
+impl TryFrom<u32> for HighlightKind {
+    type Error = String;
+
+    fn try_from(n: u32) -> Result<Self, <Self as TryFrom<u32>>::Error> {
+        match n {
+            1 => Ok(Self::Text),
+            2 => Ok(Self::Read),
+            3 => Ok(Self::Write),
+            _ => Err(format!("invalid HighlightKind: {n}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DocumentHighlight {
     pub range: Range,
     pub kind: HighlightKind,

--- a/wado-lsp/src/document_highlight.rs
+++ b/wado-lsp/src/document_highlight.rs
@@ -386,7 +386,8 @@ mod tests {
 
     #[tokio::test]
     async fn assignment_marks_target_as_write() {
-        let source = "fn f() {\n    let mut x: i32 = 0;\n    x = 1;\n    x += 2;\n    let y = x;\n}\n";
+        let source =
+            "fn f() {\n    let mut x: i32 = 0;\n    x = 1;\n    x += 2;\n    let y = x;\n}\n";
         let hl = highlights_at(source, 1, 12).await;
         assert_eq!(
             summarize(&hl),

--- a/wado-lsp/src/hover.rs
+++ b/wado-lsp/src/hover.rs
@@ -7,6 +7,7 @@
 //! symbol. Locals render as `let`/param signatures (computed from the
 //! defining AST node); items delegate to `wado_compiler::unparse`.
 
+use serde::{Deserialize, Serialize};
 use wado_compiler::CompilerHost;
 use wado_compiler::annotate::{Annotated, annotate};
 use wado_compiler::ast::{self, AstId, Expr, Item, Module, Stmt};
@@ -16,10 +17,24 @@ use wado_compiler::unparse;
 use crate::diagnostics::{Position, Range};
 use crate::location::{span_to_range, uri_to_filename};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HoverResult {
-    pub contents: String,
-    pub range: Range,
+    pub contents: MarkupContent,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub range: Option<Range>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MarkupContent {
+    pub kind: MarkupKind,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MarkupKind {
+    Plaintext,
+    Markdown,
 }
 
 pub async fn find_hover<H: CompilerHost>(
@@ -49,8 +64,11 @@ pub async fn find_hover<H: CompilerHost>(
 
     let cursor_span = annotated.span_of_key(&cursor_key)?;
     Some(HoverResult {
-        contents: format!("```wado\n{signature}\n```"),
-        range: span_to_range(&cursor_span),
+        contents: MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: format!("```wado\n{signature}\n```"),
+        },
+        range: Some(span_to_range(&cursor_span)),
     })
 }
 
@@ -397,14 +415,14 @@ mod tests {
     async fn local_var_hover() {
         let source = "fn f() -> i32 {\n    let x: i32 = 1;\n    return x;\n}\n";
         let result = hover_at(source, 2, 11).await.expect("hover on x");
-        assert_eq!(result.contents, "```wado\nlet x: i32\n```");
+        assert_eq!(result.contents.value, "```wado\nlet x: i32\n```");
     }
 
     #[tokio::test]
     async fn param_hover() {
         let source = "fn add(a: i32, b: i32) -> i32 {\n    return a + b;\n}\n";
         let result = hover_at(source, 1, 11).await.expect("hover on a");
-        assert_eq!(result.contents, "```wado\na: i32\n```");
+        assert_eq!(result.contents.value, "```wado\na: i32\n```");
     }
 
     #[tokio::test]
@@ -412,9 +430,12 @@ mod tests {
         let source = "fn add(a: i32, b: i32) -> i32 {\n    return a + b;\n}\nfn run() -> i32 {\n    return add(1, 2);\n}\n";
         let result = hover_at(source, 4, 12).await.expect("hover on add call");
         assert!(
-            result.contents.contains("fn add(a: i32, b: i32) -> i32"),
+            result
+                .contents
+                .value
+                .contains("fn add(a: i32, b: i32) -> i32"),
             "got: {}",
-            result.contents
+            result.contents.value
         );
     }
 
@@ -422,7 +443,7 @@ mod tests {
     async fn let_mut_hover() {
         let source = "fn f() -> i32 {\n    let mut x: i32 = 1;\n    return x;\n}\n";
         let result = hover_at(source, 2, 11).await.expect("hover on x");
-        assert_eq!(result.contents, "```wado\nlet mut x: i32\n```");
+        assert_eq!(result.contents.value, "```wado\nlet mut x: i32\n```");
     }
 
     #[tokio::test]
@@ -435,7 +456,7 @@ mod tests {
             "}\n",
         );
         let result = hover_at(source, 3, 11).await.expect("hover on x");
-        assert_eq!(result.contents, "```wado\nlet x\n```");
+        assert_eq!(result.contents.value, "```wado\nlet x\n```");
     }
 
     #[tokio::test]
@@ -447,7 +468,7 @@ mod tests {
             "}\n",
         );
         let result = hover_at(source, 1, 21).await.expect("hover on x");
-        assert_eq!(result.contents, "```wado\n|x: i32|\n```");
+        assert_eq!(result.contents.value, "```wado\n|x: i32|\n```");
     }
 
     #[tokio::test]
@@ -461,7 +482,7 @@ mod tests {
             "}\n",
         );
         let result = hover_at(source, 2, 15).await.expect("hover on v");
-        assert_eq!(result.contents, "```wado\nlet v\n```");
+        assert_eq!(result.contents.value, "```wado\nlet v\n```");
     }
 
     #[tokio::test]
@@ -475,6 +496,6 @@ mod tests {
             "}\n",
         );
         let result = hover_at(source, 2, 19).await.expect("hover on v");
-        assert_eq!(result.contents, "```wado\nlet v\n```");
+        assert_eq!(result.contents.value, "```wado\nlet v\n```");
     }
 }

--- a/wado-lsp/src/hover.rs
+++ b/wado-lsp/src/hover.rs
@@ -11,10 +11,10 @@ use wado_compiler::CompilerHost;
 use wado_compiler::annotate::{Annotated, annotate};
 use wado_compiler::ast::{self, AstId, Expr, Item, Module, Stmt};
 use wado_compiler::symbol::{Symbol, SymbolKey, SymbolKind};
-use wado_compiler::token::Span;
 use wado_compiler::unparse;
 
 use crate::diagnostics::{Position, Range};
+use crate::location::{span_to_range, uri_to_filename};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HoverResult {
@@ -52,19 +52,6 @@ pub async fn find_hover<H: CompilerHost>(
         contents: format!("```wado\n{signature}\n```"),
         range: span_to_range(&cursor_span),
     })
-}
-
-fn span_to_range(span: &Span) -> Range {
-    Range {
-        start: Position {
-            line: span.line.saturating_sub(1) as u32,
-            character: span.column.saturating_sub(1) as u32,
-        },
-        end: Position {
-            line: span.end_line.saturating_sub(1) as u32,
-            character: span.end_column.saturating_sub(1) as u32,
-        },
-    }
 }
 
 /// Render a signature for the given item-level symbol.
@@ -365,14 +352,6 @@ fn item_info(item: &Item, name: &str) -> Option<String> {
             None
         }
         _ => None,
-    }
-}
-
-fn uri_to_filename(uri: &str) -> String {
-    if let Some(path) = uri.strip_prefix("file://") {
-        path.to_string()
-    } else {
-        uri.to_string()
     }
 }
 

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -12,7 +12,7 @@ use wado_compiler::{CompilerHost, CompilerOptions, Diagnostic as CompilerDiagnos
 pub use definition::DefinitionResult;
 pub use diagnostics::{Diagnostic, Position, Range, Severity};
 pub use document_highlight::{DocumentHighlight, HighlightKind};
-pub use hover::HoverResult;
+pub use hover::{HoverResult, MarkupContent, MarkupKind};
 pub use references::ReferenceLocation;
 
 /// Protocol-agnostic language service engine.

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -1,6 +1,9 @@
 mod definition;
 mod diagnostics;
+mod document_highlight;
 mod hover;
+mod location;
+mod references;
 pub mod semantic_tokens;
 
 use indexmap::IndexMap;
@@ -8,7 +11,9 @@ use wado_compiler::{CompilerHost, CompilerOptions, Diagnostic as CompilerDiagnos
 
 pub use definition::DefinitionResult;
 pub use diagnostics::{Diagnostic, Position, Range, Severity};
+pub use document_highlight::{DocumentHighlight, HighlightKind};
 pub use hover::HoverResult;
+pub use references::ReferenceLocation;
 
 /// Protocol-agnostic language service engine.
 ///
@@ -72,6 +77,39 @@ impl Engine {
     ) -> Option<HoverResult> {
         let source = self.documents.get(uri)?;
         hover::find_hover(source, position, uri, host).await
+    }
+
+    /// Find every reference to the symbol named at the given position.
+    ///
+    /// When `include_declaration` is true, the defining occurrence is included
+    /// in the result. Returns an empty vector when the cursor is not on a
+    /// known symbol or when the document is not open.
+    pub async fn references<H: CompilerHost>(
+        &self,
+        uri: &str,
+        position: Position,
+        include_declaration: bool,
+        host: &H,
+    ) -> Vec<ReferenceLocation> {
+        let Some(source) = self.documents.get(uri) else {
+            return Vec::new();
+        };
+        references::find_references(source, position, uri, include_declaration, host).await
+    }
+
+    /// Find every occurrence of the symbol named at the given position
+    /// **inside the requested document**. References from other files are
+    /// filtered out — see [`Engine::references`] for the cross-file lookup.
+    pub async fn document_highlight<H: CompilerHost>(
+        &self,
+        uri: &str,
+        position: Position,
+        host: &H,
+    ) -> Vec<DocumentHighlight> {
+        let Some(source) = self.documents.get(uri) else {
+            return Vec::new();
+        };
+        document_highlight::document_highlight(source, position, uri, host).await
     }
 
     /// Compute semantic tokens for the given document.

--- a/wado-lsp/src/location.rs
+++ b/wado-lsp/src/location.rs
@@ -1,0 +1,107 @@
+//! Shared helpers for translating between compiler positions/symbols and LSP
+//! types. Used by go-to-definition, find-references, and document highlight.
+
+use wado_compiler::annotate::Annotated;
+use wado_compiler::name::ModuleSource;
+use wado_compiler::symbol::{Symbol, SymbolKey};
+use wado_compiler::token::Span;
+
+use crate::diagnostics::{Position, Range};
+
+pub(crate) fn uri_to_filename(uri: &str) -> String {
+    if let Some(path) = uri.strip_prefix("file://") {
+        path.to_string()
+    } else {
+        uri.to_string()
+    }
+}
+
+pub(crate) fn filename_to_uri(filename: &str) -> String {
+    if filename.starts_with("file://") {
+        filename.to_string()
+    } else if filename.starts_with('/') {
+        format!("file://{filename}")
+    } else {
+        filename.to_string()
+    }
+}
+
+/// Resolve the URI of a module relative to the requesting document's URI.
+///
+/// `request_uri` provides the base directory used to anchor `./relative.wado`
+/// imports. Returns the request URI itself when the module is the entry point.
+pub(crate) fn module_uri(
+    annotated: &Annotated,
+    module: &ModuleSource,
+    request_uri: &str,
+) -> Option<String> {
+    if module == &annotated.entry_module_source {
+        return Some(request_uri.to_string());
+    }
+    match module {
+        ModuleSource::EntryPoint { filename } => Some(filename_to_uri(filename)),
+        ModuleSource::Local { path } => Some(resolve_local_uri(path, request_uri)),
+        _ => None,
+    }
+}
+
+fn resolve_local_uri(module_path: &str, request_uri: &str) -> String {
+    if module_path.starts_with('/') || module_path.starts_with("file://") {
+        return filename_to_uri(module_path);
+    }
+    let request_path = uri_to_filename(request_uri);
+    let base_dir = request_path
+        .rsplit_once('/')
+        .map(|(dir, _)| dir)
+        .unwrap_or("");
+    let normalized = module_path.strip_prefix("./").unwrap_or(module_path);
+    if base_dir.is_empty() {
+        filename_to_uri(normalized)
+    } else {
+        filename_to_uri(&format!("{base_dir}/{normalized}"))
+    }
+}
+
+/// URI of the module defining `symbol`, relative to the requesting document.
+pub(crate) fn symbol_uri(
+    annotated: &Annotated,
+    symbol: &Symbol,
+    request_uri: &str,
+) -> Option<String> {
+    module_uri(annotated, &symbol.defined_at.module, request_uri)
+}
+
+pub(crate) fn span_to_range(span: &Span) -> Range {
+    Range {
+        start: Position {
+            line: span.line.saturating_sub(1) as u32,
+            character: span.column.saturating_sub(1) as u32,
+        },
+        end: Position {
+            line: span.end_line.saturating_sub(1) as u32,
+            character: span.end_column.saturating_sub(1) as u32,
+        },
+    }
+}
+
+/// Resolve the cursor at `(line, col)` to the [`SymbolKey`] of the binding it
+/// names — either via use→def lookup or because the cursor lands directly on a
+/// declared symbol. Returns `None` when the cursor is not on a name.
+///
+/// `line` and `col` are 1-based to match compiler conventions.
+pub(crate) fn resolve_def_key(
+    annotated: &Annotated,
+    module: &ModuleSource,
+    line: usize,
+    col: usize,
+) -> Option<SymbolKey> {
+    let ast_id = annotated.ast_id_at(module, line, col)?;
+    let cursor_key = SymbolKey::new(module.clone(), ast_id);
+    if let Some(def) = annotated.referenced_symbol(&cursor_key) {
+        return Some(def);
+    }
+    if annotated.symbol_at(&cursor_key).is_some() {
+        return Some(cursor_key);
+    }
+    None
+}

--- a/wado-lsp/src/references.rs
+++ b/wado-lsp/src/references.rs
@@ -47,9 +47,7 @@ pub async fn find_references<H: CompilerHost>(
     };
 
     let mut out = Vec::new();
-    if include_declaration
-        && let Some(loc) = declaration_location(&annotated, &def_key, uri)
-    {
+    if include_declaration && let Some(loc) = declaration_location(&annotated, &def_key, uri) {
         out.push(loc);
     }
     for use_key in annotated.references_to(&def_key) {
@@ -160,7 +158,8 @@ mod tests {
 
     #[tokio::test]
     async fn local_var_uses() {
-        let source = "fn f() -> i32 {\n    let x: i32 = 1;\n    let y = x + x;\n    return y + x;\n}\n";
+        let source =
+            "fn f() -> i32 {\n    let x: i32 = 1;\n    let y = x + x;\n    return y + x;\n}\n";
         let refs = refs_at(source, 1, 8, false).await;
         assert_eq!(
             ranges(&refs),

--- a/wado-lsp/src/references.rs
+++ b/wado-lsp/src/references.rs
@@ -1,0 +1,207 @@
+//! Find-references, powered by `wado_compiler::annotate`.
+//!
+//! Resolution flow mirrors `definition.rs`:
+//! 1. Run `annotate` to produce a fully-resolved snapshot.
+//! 2. Resolve the cursor to a defining [`SymbolKey`].
+//! 3. Walk `Annotated::iter_references` and collect every use-site whose
+//!    target equals the def key.
+//! 4. Translate each use-site into a [`ReferenceLocation`].
+//! 5. Optionally prepend the defining occurrence itself.
+
+use wado_compiler::CompilerHost;
+use wado_compiler::annotate::{Annotated, annotate};
+use wado_compiler::symbol::SymbolKey;
+
+use crate::diagnostics::{Position, Range};
+use crate::location::{module_uri, resolve_def_key, span_to_range, symbol_uri, uri_to_filename};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReferenceLocation {
+    pub uri: String,
+    pub range: Range,
+}
+
+/// Find every reference to the symbol named at `position` in `source`.
+///
+/// When `include_declaration` is true, the defining occurrence (the
+/// identifier at the symbol's declaration site) is included in the result.
+/// The result is deduplicated and sorted by `(uri, range.start)`.
+pub async fn find_references<H: CompilerHost>(
+    source: &str,
+    position: Position,
+    uri: &str,
+    include_declaration: bool,
+    host: &H,
+) -> Vec<ReferenceLocation> {
+    let filename = uri_to_filename(uri);
+    let Ok(annotated) = annotate(source, host, Some(&filename)).await else {
+        return Vec::new();
+    };
+
+    let module = annotated.entry_module_source.clone();
+    let line = position.line as usize + 1;
+    let col = position.character as usize + 1;
+
+    let Some(def_key) = resolve_def_key(&annotated, &module, line, col) else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    if include_declaration
+        && let Some(loc) = declaration_location(&annotated, &def_key, uri)
+    {
+        out.push(loc);
+    }
+    for use_key in annotated.references_to(&def_key) {
+        if let Some(loc) = use_site_location(&annotated, &use_key, uri) {
+            out.push(loc);
+        }
+    }
+
+    out.sort_by(|a, b| {
+        a.uri.cmp(&b.uri).then_with(|| {
+            (a.range.start.line, a.range.start.character)
+                .cmp(&(b.range.start.line, b.range.start.character))
+        })
+    });
+    out.dedup();
+    out
+}
+
+pub(crate) fn declaration_location(
+    annotated: &Annotated,
+    def_key: &SymbolKey,
+    request_uri: &str,
+) -> Option<ReferenceLocation> {
+    let symbol = annotated.symbol_at(def_key)?;
+    let span = annotated.name_span_of(def_key).or(symbol.span)?;
+    let uri = symbol_uri(annotated, symbol, request_uri)?;
+    Some(ReferenceLocation {
+        uri,
+        range: span_to_range(&span),
+    })
+}
+
+pub(crate) fn use_site_location(
+    annotated: &Annotated,
+    use_key: &SymbolKey,
+    request_uri: &str,
+) -> Option<ReferenceLocation> {
+    let span = annotated.span_of_key(use_key)?;
+    let uri = module_uri(annotated, &use_key.module, request_uri)?;
+    Some(ReferenceLocation {
+        uri,
+        range: span_to_range(&span),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+    use wado_compiler::{Diagnostic as CompilerDiagnostic, SourceError};
+
+    struct TestHost {
+        sources: IndexMap<String, Vec<u8>>,
+    }
+
+    impl TestHost {
+        fn single(path: &str, source: &str) -> Self {
+            let mut sources = IndexMap::new();
+            sources.insert(path.to_string(), source.as_bytes().to_vec());
+            Self { sources }
+        }
+    }
+
+    impl CompilerHost for TestHost {
+        async fn load_source(&self, path: &str) -> Result<Vec<u8>, SourceError> {
+            self.sources
+                .get(path)
+                .cloned()
+                .ok_or_else(|| SourceError::NotFound {
+                    path: path.to_string(),
+                })
+        }
+
+        fn emit_diagnostic(&self, _diagnostic: CompilerDiagnostic) {}
+    }
+
+    async fn refs_at(
+        source: &str,
+        line: u32,
+        character: u32,
+        include_declaration: bool,
+    ) -> Vec<ReferenceLocation> {
+        let path = "/test.wado";
+        let uri = format!("file://{path}");
+        let host = TestHost::single(path, source);
+        find_references(
+            source,
+            Position { line, character },
+            &uri,
+            include_declaration,
+            &host,
+        )
+        .await
+    }
+
+    fn ranges(refs: &[ReferenceLocation]) -> Vec<(u32, u32, u32, u32)> {
+        refs.iter()
+            .map(|r| {
+                (
+                    r.range.start.line,
+                    r.range.start.character,
+                    r.range.end.line,
+                    r.range.end.character,
+                )
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn local_var_uses() {
+        let source = "fn f() -> i32 {\n    let x: i32 = 1;\n    let y = x + x;\n    return y + x;\n}\n";
+        let refs = refs_at(source, 1, 8, false).await;
+        assert_eq!(
+            ranges(&refs),
+            vec![(2, 12, 2, 13), (2, 16, 2, 17), (3, 15, 3, 16),]
+        );
+    }
+
+    #[tokio::test]
+    async fn includes_declaration_when_requested() {
+        let source = "fn f() -> i32 {\n    let x: i32 = 1;\n    return x;\n}\n";
+        let refs = refs_at(source, 1, 8, true).await;
+        assert_eq!(ranges(&refs), vec![(1, 8, 1, 9), (2, 11, 2, 12),]);
+    }
+
+    #[tokio::test]
+    async fn function_references_from_call_site() {
+        let source = "fn helper() -> i32 {\n    return 1;\n}\nfn run() -> i32 {\n    let a = helper();\n    let b = helper();\n    return a + b;\n}\n";
+        // cursor on the declaration of `helper`
+        let refs = refs_at(source, 0, 4, false).await;
+        assert_eq!(ranges(&refs), vec![(4, 12, 4, 18), (5, 12, 5, 18),]);
+    }
+
+    #[tokio::test]
+    async fn cursor_on_use_site_finds_all_uses() {
+        let source = "fn helper() -> i32 {\n    return 1;\n}\nfn run() -> i32 {\n    let a = helper();\n    let b = helper();\n    return a + b;\n}\n";
+        // cursor on the first call to `helper`
+        let refs = refs_at(source, 4, 13, false).await;
+        assert_eq!(ranges(&refs), vec![(4, 12, 4, 18), (5, 12, 5, 18),]);
+    }
+
+    #[tokio::test]
+    async fn param_references() {
+        let source = "fn add(a: i32, b: i32) -> i32 {\n    return a + b;\n}\n";
+        let refs = refs_at(source, 0, 7, false).await;
+        assert_eq!(ranges(&refs), vec![(1, 11, 1, 12)]);
+    }
+
+    #[tokio::test]
+    async fn no_match_outside_identifier() {
+        let source = "fn f() -> i32 {\n    let x: i32 = 1;\n    return x;\n}\n";
+        let refs = refs_at(source, 0, 0, false).await;
+        assert!(refs.is_empty(), "got: {refs:?}");
+    }
+}

--- a/wado-lsp/src/references.rs
+++ b/wado-lsp/src/references.rs
@@ -8,6 +8,7 @@
 //! 4. Translate each use-site into a [`ReferenceLocation`].
 //! 5. Optionally prepend the defining occurrence itself.
 
+use serde::{Deserialize, Serialize};
 use wado_compiler::CompilerHost;
 use wado_compiler::annotate::{Annotated, annotate};
 use wado_compiler::symbol::SymbolKey;
@@ -15,7 +16,7 @@ use wado_compiler::symbol::SymbolKey;
 use crate::diagnostics::{Position, Range};
 use crate::location::{module_uri, resolve_def_key, span_to_range, symbol_uri, uri_to_filename};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReferenceLocation {
     pub uri: String,
     pub range: Range,


### PR DESCRIPTION
## Summary

Implements two LSP language features end-to-end on top of `wado_compiler::annotate`, and exposes both via `wado lsp` and `wado query` so they can be tried from the command line. Also consolidates the LSP wire-format types and tightens the JSON-RPC dispatch loop.

### `wado-lsp`

- `src/references.rs` — find-references. Resolves the cursor to a defining `SymbolKey`, walks `Annotated::iter_references` for matching use-sites, and returns dedup'd, sorted `ReferenceLocation`s. Supports `includeDeclaration`.
- `src/document_highlight.rs` — document highlight (current file only). Classifies each occurrence as `Write` (declaration or direct target of `=` / `+=` / etc.) or `Read` via a single AST walk.
- `src/location.rs` — shared helpers (`resolve_def_key`, `span_to_range`, `module_uri`, `symbol_uri`, …) factored out from `definition.rs` / `hover.rs`.
- `wado_compiler::Annotated` exposes `iter_references` and `references_to(def_key)` so external crates can walk use→def edges.
- LSP semantic types (`Position`, `Range`, `Diagnostic`, `Severity`, `DefinitionResult`, `HoverResult`, `MarkupContent`, `DocumentHighlight`, `HighlightKind`, `ReferenceLocation`) now carry serde derives with LSP wire-format camelCase naming so they can be reused directly by protocol code. `Severity` / `HighlightKind` use `#[serde(into/try_from = "u32")]` to stay as typed enums on the wire. `HoverResult.contents` switched from `String` to `MarkupContent` to match LSP 3.18.

### `wado-cli`

- `wado lsp` advertises `referencesProvider` and `documentHighlightProvider`, and handles both requests.
- JSON-RPC envelope, request-param shapes, and server capabilities split into `lsp_rpc.rs` (protocol layer); `lsp_adapter.rs` keeps framing/I/O helpers. Both reuse the serde-annotated types from `wado-lsp` instead of redeclaring them.
- The `run()` loop was split into an outer I/O loop and a `dispatch()` function, so each method arm uses `?` and write-error handling lives in one place. `Option<T: Serialize>` (from `definition` / `hover`) is passed straight to `send_response`, removing a `serde_json::to_value(...).unwrap_or(Value::Null)` round-trip that also swallowed serialization errors.
- Request handlers respond with JSON-RPC `InvalidParams` (-32602) when params fail to decode instead of silently dropping the request (which previously left the client waiting forever).
- `wado query` gained two new kinds, taking 1-based `--line`/`--column` for ergonomics:
  - `wado query references --line N --column N [--include-declaration] [--json] file.wado`
  - `wado query document-highlight --line N --column N [--json] file.wado`

### Tests

- 41 `wado-lsp` unit tests (including 10 new ones for references/document-highlight covering uses, declarations, params, function call sites, write/read classification, etc.).
- 28 `wado-cli` LSP integration tests covering JSON-RPC handlers, the `wado query` subcommands, JSON output, required-flag validation, and `InvalidParams` error responses.
- Full `mise run on-task-done` suite passes (5160 e2e tests, ~22 min).

## Test plan

- [x] `cargo test -p wado-lsp`
- [x] `cargo test -p wado-cli --test lsp`
- [x] `mise run on-task-done`
- [x] Smoke test: `wado query references --line 1 --column 4 --include-declaration` returns declaration + call sites
- [x] Smoke test: `wado query document-highlight ...` reports `write` for declarations and assignment targets, `read` otherwise

https://claude.ai/code/session_01FmqfR6VCNLFYayFmYy1pGW