### PR TITLE
wado-cli: LSP 3.18 spec review — conformance tests + lifecycle/parse-error recovery

### DIFF
--- a/wado-cli/src/lsp.rs
+++ b/wado-cli/src/lsp.rs
@@ -39,14 +39,9 @@ pub async fn run() {
                 // Per JSON-RPC 2.0 §5.1: respond with ParseError (id: null)
                 // and keep the loop running so a well-formed follow-up can
                 // still be processed.
-                if lsp_adapter::send_error(
-                    &mut writer,
-                    &Value::Null,
-                    error_codes::PARSE_ERROR,
-                    msg,
-                )
-                .await
-                .is_err()
+                if lsp_adapter::send_error(&mut writer, &Value::Null, error_codes::PARSE_ERROR, msg)
+                    .await
+                    .is_err()
                 {
                     break;
                 }

--- a/wado-cli/src/lsp.rs
+++ b/wado-cli/src/lsp.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 use tokio::io::{AsyncWrite, BufReader};
 
-use crate::lsp_adapter;
+use crate::lsp_adapter::{self, ReadError};
 use crate::lsp_rpc::{
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     InitializeResult, JsonRpcRequest, PublishDiagnosticsParams, ReferenceParams, SemanticTokens,
@@ -10,24 +10,55 @@ use crate::lsp_rpc::{
     text_document_sync_kind,
 };
 
+/// Tracks server lifecycle per LSP 3.18 §Server lifecycle.
+///
+/// - `initialized` flips to `true` once the server has *responded* to
+///   `initialize`. Before that, requests must be rejected with
+///   `ServerNotInitialized` and notifications (except `exit`) must be dropped.
+/// - `shutdown_requested` flips to `true` once the server has responded to
+///   `shutdown`. After that, every request except `exit` must fail with
+///   `InvalidRequest` and every notification except `exit` must be dropped.
+#[derive(Default)]
+struct Lifecycle {
+    initialized: bool,
+    shutdown_requested: bool,
+}
+
 /// Run the LSP server over stdio.
 pub async fn run() {
     let mut reader = BufReader::new(tokio::io::stdin());
     let mut writer = tokio::io::stdout();
     let mut engine = wado_lsp::Engine::new();
-    let mut shutdown_requested = false;
+    let mut lifecycle = Lifecycle::default();
 
     loop {
         let request = match lsp_adapter::read_message(&mut reader).await {
             Ok(Some(msg)) => msg,
             Ok(None) => break, // EOF
-            Err(e) => {
-                eprintln!("wado-lsp: {e}");
+            Err(ReadError::Parse(msg)) => {
+                // Per JSON-RPC 2.0 §5.1: respond with ParseError (id: null)
+                // and keep the loop running so a well-formed follow-up can
+                // still be processed.
+                if lsp_adapter::send_error(
+                    &mut writer,
+                    &Value::Null,
+                    error_codes::PARSE_ERROR,
+                    msg,
+                )
+                .await
+                .is_err()
+                {
+                    break;
+                }
+                continue;
+            }
+            Err(ReadError::Io(msg)) => {
+                eprintln!("wado-lsp: {msg}");
                 break;
             }
         };
 
-        if let Err(e) = dispatch(&mut engine, &mut writer, &mut shutdown_requested, request).await {
+        if let Err(e) = dispatch(&mut engine, &mut writer, &mut lifecycle, request).await {
             eprintln!("wado-lsp: {e}");
             break;
         }
@@ -37,16 +68,64 @@ pub async fn run() {
 async fn dispatch<W: AsyncWrite + Unpin>(
     engine: &mut wado_lsp::Engine,
     writer: &mut W,
-    shutdown_requested: &mut bool,
+    lifecycle: &mut Lifecycle,
     request: JsonRpcRequest,
 ) -> Result<(), String> {
     let method = request.method.as_str();
     let id = request.id.as_ref();
     let params = request.params;
 
+    // `exit` is always processed, regardless of lifecycle state.
+    if method == "exit" {
+        std::process::exit(i32::from(!lifecycle.shutdown_requested));
+    }
+
+    // Pre-initialize: only `initialize` is allowed. Other requests get
+    // -32002 ServerNotInitialized; notifications are dropped silently.
+    if !lifecycle.initialized && method != "initialize" {
+        if let Some(id) = id {
+            lsp_adapter::send_error(
+                writer,
+                id,
+                error_codes::SERVER_NOT_INITIALIZED,
+                format!("server not initialized: received {method} before initialize"),
+            )
+            .await?;
+        }
+        return Ok(());
+    }
+
+    // Post-shutdown: only `exit` is allowed (handled above). Requests get
+    // -32600 InvalidRequest; notifications are dropped silently.
+    if lifecycle.shutdown_requested {
+        if let Some(id) = id {
+            lsp_adapter::send_error(
+                writer,
+                id,
+                error_codes::INVALID_REQUEST,
+                format!("server is shutting down: rejected {method}"),
+            )
+            .await?;
+        }
+        return Ok(());
+    }
+
     match method {
         "initialize" => {
             if let Some(id) = id {
+                if lifecycle.initialized {
+                    // LSP 3.18 §initialize: the `initialize` request is sent
+                    // as the first request from the client. A second one is
+                    // a protocol error.
+                    lsp_adapter::send_error(
+                        writer,
+                        id,
+                        error_codes::INVALID_REQUEST,
+                        "server already initialized".to_string(),
+                    )
+                    .await?;
+                    return Ok(());
+                }
                 let result = InitializeResult {
                     capabilities: ServerCapabilities {
                         text_document_sync: Some(TextDocumentSyncOptions {
@@ -71,17 +150,15 @@ async fn dispatch<W: AsyncWrite + Unpin>(
                     }),
                 };
                 lsp_adapter::send_response(writer, id, result).await?;
+                lifecycle.initialized = true;
             }
         }
         "initialized" => {} // no-op
         "shutdown" => {
-            *shutdown_requested = true;
+            lifecycle.shutdown_requested = true;
             if let Some(id) = id {
                 lsp_adapter::send_response(writer, id, Value::Null).await?;
             }
-        }
-        "exit" => {
-            std::process::exit(i32::from(!*shutdown_requested));
         }
         "textDocument/didOpen" => {
             let Ok(p) = serde_json::from_value::<DidOpenTextDocumentParams>(params) else {

--- a/wado-cli/src/lsp_adapter.rs
+++ b/wado-cli/src/lsp_adapter.rs
@@ -12,17 +12,31 @@ use crate::lsp_rpc::{
 
 const JSONRPC_VERSION: &str = "2.0";
 
+/// Failure mode of [`read_message`].
+///
+/// `Parse` errors are recoverable: per LSP 3.18 (JSON-RPC 2.0 §5.1), the
+/// server should respond with `-32700 ParseError` and keep processing. `Io`
+/// errors are unrecoverable — the transport is broken.
+#[derive(Debug)]
+pub enum ReadError {
+    Parse(String),
+    Io(String),
+}
+
 /// Read one JSON-RPC message (Content-Length framed).
+///
+/// Returns `Ok(None)` on clean EOF, `Err(ReadError::Parse)` for malformed
+/// framing or JSON bodies, and `Err(ReadError::Io)` for transport failures.
 pub async fn read_message<R: tokio::io::AsyncRead + Unpin>(
     reader: &mut BufReader<R>,
-) -> Result<Option<JsonRpcRequest>, String> {
+) -> Result<Option<JsonRpcRequest>, ReadError> {
     let mut content_length: Option<usize> = None;
     loop {
         let mut header = String::new();
         let n: usize = reader
             .read_line(&mut header)
             .await
-            .map_err(|e| format!("read error: {e}"))?;
+            .map_err(|e| ReadError::Io(format!("read error: {e}")))?;
         if n == 0 {
             return Ok(None); // EOF
         }
@@ -31,24 +45,23 @@ pub async fn read_message<R: tokio::io::AsyncRead + Unpin>(
             break;
         }
         if let Some(len_str) = trimmed.strip_prefix("Content-Length: ") {
-            content_length = Some(
-                len_str
-                    .parse()
-                    .map_err(|_| format!("invalid Content-Length: {len_str}"))?,
-            );
+            content_length = Some(len_str.parse().map_err(|_| {
+                ReadError::Parse(format!("invalid Content-Length: {len_str}"))
+            })?);
         }
     }
 
-    let length = content_length.ok_or("missing Content-Length header")?;
+    let length = content_length
+        .ok_or_else(|| ReadError::Parse("missing Content-Length header".to_string()))?;
     let mut body = vec![0u8; length];
     reader
         .read_exact(&mut body)
         .await
-        .map_err(|e| format!("read body error: {e}"))?;
+        .map_err(|e| ReadError::Io(format!("read body error: {e}")))?;
 
     serde_json::from_slice(&body)
         .map(Some)
-        .map_err(|e| format!("invalid JSON: {e}"))
+        .map_err(|e| ReadError::Parse(format!("invalid JSON: {e}")))
 }
 
 async fn write_serialized<W: AsyncWrite + Unpin>(

--- a/wado-cli/src/lsp_adapter.rs
+++ b/wado-cli/src/lsp_adapter.rs
@@ -45,9 +45,11 @@ pub async fn read_message<R: tokio::io::AsyncRead + Unpin>(
             break;
         }
         if let Some(len_str) = trimmed.strip_prefix("Content-Length: ") {
-            content_length = Some(len_str.parse().map_err(|_| {
-                ReadError::Parse(format!("invalid Content-Length: {len_str}"))
-            })?);
+            content_length = Some(
+                len_str
+                    .parse()
+                    .map_err(|_| ReadError::Parse(format!("invalid Content-Length: {len_str}")))?,
+            );
         }
     }
 

--- a/wado-cli/src/lsp_rpc.rs
+++ b/wado-cli/src/lsp_rpc.rs
@@ -189,6 +189,11 @@ pub struct JsonRpcNotification<T: Serialize> {
 }
 
 pub mod error_codes {
+    pub const PARSE_ERROR: i32 = -32700;
+    pub const INVALID_REQUEST: i32 = -32600;
     pub const METHOD_NOT_FOUND: i32 = -32601;
     pub const INVALID_PARAMS: i32 = -32602;
+    /// Server received a request/notification before `initialize`.
+    /// LSP 3.18 §initialize.
+    pub const SERVER_NOT_INITIALIZED: i32 = -32002;
 }

--- a/wado-cli/tests/lsp.rs
+++ b/wado-cli/tests/lsp.rs
@@ -60,6 +60,13 @@ impl LspSession {
         stdin.flush().unwrap();
     }
 
+    /// Write a raw byte sequence to the server (for malformed-input tests).
+    fn send_raw(&mut self, bytes: &[u8]) {
+        let stdin = self.child.stdin.as_mut().unwrap();
+        stdin.write_all(bytes).unwrap();
+        stdin.flush().unwrap();
+    }
+
     fn send_request(&mut self, method: &str, params: Value) -> i64 {
         let id = self.next_id;
         self.next_id += 1;
@@ -70,6 +77,43 @@ impl LspSession {
             "params": params,
         }));
         id
+    }
+
+    /// Send a request with a caller-provided id (e.g. a string id).
+    fn send_request_with_id(&mut self, id: Value, method: &str, params: Value) {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }));
+    }
+
+    /// Initialize boilerplate — sends `initialize` + reads response + sends
+    /// `initialized`. Returns the `initialize` response for callers that want
+    /// to inspect the advertised capabilities.
+    fn initialize(&mut self) -> Value {
+        self.send_request("initialize", json!({ "capabilities": {} }));
+        let resp = self.read_message();
+        self.send_notification("initialized", json!({}));
+        resp
+    }
+
+    /// Open a document and read+return the initial `publishDiagnostics`
+    /// notification that the server emits in response.
+    fn open_doc(&mut self, uri: &str, text: &str) -> Value {
+        self.send_notification(
+            "textDocument/didOpen",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "wado",
+                    "version": 1,
+                    "text": text,
+                }
+            }),
+        );
+        self.read_message()
     }
 
     fn send_notification(&mut self, method: &str, params: Value) {
@@ -653,6 +697,601 @@ fn lsp_exit_without_shutdown_returns_nonzero() {
         1,
         "exit without shutdown should return 1"
     );
+}
+
+// ===========================================================================
+// LSP spec conformance tests — base protocol
+//
+// These tests pin down behaviour described by LSP 3.18 (see wado-lsp/lsp.md):
+// JSON-RPC 2.0 framing, id echoing, `$/`-prefixed requests, the default
+// pattern for notifications vs. requests, and lifecycle messages.
+// ===========================================================================
+
+#[test]
+fn lsp_response_includes_jsonrpc_version_field() {
+    let mut session = LspSession::start();
+    let id = session.send_request("initialize", json!({ "capabilities": {} }));
+    let resp = session.read_message();
+    assert_eq!(resp["jsonrpc"], "2.0", "response must carry jsonrpc: 2.0");
+    assert_eq!(resp["id"], id);
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_request_with_string_id_is_echoed() {
+    let mut session = LspSession::start();
+    session.send_request_with_id(
+        json!("init-string-id"),
+        "initialize",
+        json!({ "capabilities": {} }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["jsonrpc"], "2.0");
+    assert_eq!(resp["id"], "init-string-id");
+    assert!(resp["result"].is_object(), "got: {resp}");
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_initialize_advertises_all_providers() {
+    let mut session = LspSession::start();
+    let resp = session.initialize();
+    let caps = &resp["result"]["capabilities"];
+    assert_eq!(caps["textDocumentSync"]["openClose"], true);
+    assert_eq!(caps["textDocumentSync"]["change"], 1);
+    assert_eq!(caps["definitionProvider"], true);
+    assert_eq!(caps["hoverProvider"], true);
+    assert_eq!(caps["referencesProvider"], true);
+    assert_eq!(caps["documentHighlightProvider"], true);
+    let st = &caps["semanticTokensProvider"];
+    assert_eq!(st["full"], true);
+    let types = st["legend"]["tokenTypes"].as_array().unwrap();
+    assert!(
+        types.contains(&json!("keyword")) && types.contains(&json!("function")),
+        "token types missing core entries: {types:?}"
+    );
+    let mods = st["legend"]["tokenModifiers"].as_array().unwrap();
+    assert!(mods.contains(&json!("declaration")), "got: {mods:?}");
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_initialized_notification_is_accepted() {
+    // `initialized` is a notification — it must not yield a response and must
+    // not crash the server. We verify by issuing a known request afterwards
+    // and confirming the server still responds.
+    let mut session = LspSession::start();
+    session.send_request("initialize", json!({ "capabilities": {} }));
+    let _ = session.read_message();
+    session.send_notification("initialized", json!({}));
+    // Next request must still succeed.
+    let id = session.send_request("shutdown", Value::Null);
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    assert_eq!(resp["result"], Value::Null);
+    session.send_notification("exit", Value::Null);
+    drop(session.child.stdin.take());
+    assert_eq!(session.child.wait().unwrap().code().unwrap(), 0);
+}
+
+#[test]
+fn lsp_dollar_notification_is_silently_ignored() {
+    // Per spec §$-notifications: "If a server or client receives notifications
+    // starting with '$/' it is free to ignore the notification." We confirm
+    // the server keeps running by issuing a normal request afterwards.
+    let mut session = LspSession::start();
+    session.initialize();
+    session.send_notification("$/cancelRequest", json!({ "id": 99 }));
+    session.send_notification("$/setTrace", json!({ "value": "off" }));
+    let id = session.send_request("shutdown", Value::Null);
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    assert_eq!(resp["result"], Value::Null);
+    session.send_notification("exit", Value::Null);
+    drop(session.child.stdin.take());
+    assert_eq!(session.child.wait().unwrap().code().unwrap(), 0);
+}
+
+#[test]
+fn lsp_dollar_request_returns_method_not_found() {
+    // Per spec §$-notifications: "If a server or client receives a request
+    // starting with '$/' it must error the request with error code
+    // MethodNotFound (e.g. -32601)."
+    let mut session = LspSession::start();
+    session.initialize();
+    let id = session.send_request("$/unknownDollar", json!({}));
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    assert_eq!(resp["error"]["code"], -32601);
+    assert!(resp["error"]["message"].is_string());
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_unknown_notification_is_silently_ignored() {
+    // Unknown notifications (no id) must not elicit any response. We confirm
+    // by issuing a normal request afterwards and expecting exactly one reply.
+    let mut session = LspSession::start();
+    session.initialize();
+    session.send_notification("workspace/didChangeSomethingBogus", json!({}));
+    let id = session.send_request("shutdown", Value::Null);
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    session.send_notification("exit", Value::Null);
+    drop(session.child.stdin.take());
+    assert_eq!(session.child.wait().unwrap().code().unwrap(), 0);
+}
+
+#[test]
+fn lsp_multiple_sequential_requests_all_get_responses() {
+    let mut session = LspSession::start();
+    session.initialize();
+    session.open_doc(
+        "file:///tmp/lsp_seq.wado",
+        "fn helper() -> i32 {\n    return 1;\n}\n\nexport fn run() {\n    let _ = helper();\n}\n",
+    );
+
+    let id1 = session.send_request(
+        "textDocument/definition",
+        json!({
+            "textDocument": { "uri": "file:///tmp/lsp_seq.wado" },
+            "position": { "line": 4, "character": 13 }
+        }),
+    );
+    let id2 = session.send_request(
+        "textDocument/hover",
+        json!({
+            "textDocument": { "uri": "file:///tmp/lsp_seq.wado" },
+            "position": { "line": 4, "character": 13 }
+        }),
+    );
+    let id3 = session.send_request(
+        "textDocument/references",
+        json!({
+            "textDocument": { "uri": "file:///tmp/lsp_seq.wado" },
+            "position": { "line": 0, "character": 4 },
+            "context": { "includeDeclaration": false }
+        }),
+    );
+
+    let r1 = session.read_message();
+    let r2 = session.read_message();
+    let r3 = session.read_message();
+    assert_eq!(r1["id"], id1);
+    assert_eq!(r2["id"], id2);
+    assert_eq!(r3["id"], id3);
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_content_type_header_is_accepted() {
+    // Per spec §header: `Content-Type` is optional and defaults to
+    // application/vscode-jsonrpc; charset=utf-8. The server must accept
+    // messages carrying an explicit Content-Type header.
+    let mut session = LspSession::start();
+    let body = serde_json::to_string(&json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "initialize",
+        "params": { "capabilities": {} }
+    }))
+    .unwrap();
+    let raw = format!(
+        "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n\
+         Content-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    session.send_raw(raw.as_bytes());
+    let resp = session.read_message();
+    assert_eq!(resp["id"], 7);
+    assert!(resp["result"]["capabilities"].is_object());
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+// ===========================================================================
+// LSP spec conformance tests — lifecycle
+// ===========================================================================
+
+#[test]
+fn lsp_shutdown_returns_null_result() {
+    let mut session = LspSession::start();
+    session.initialize();
+    let id = session.send_request("shutdown", Value::Null);
+    let resp = session.read_message();
+    assert_eq!(resp["jsonrpc"], "2.0");
+    assert_eq!(resp["id"], id);
+    // Spec §shutdown: the response result is `null`.
+    assert_eq!(resp["result"], Value::Null);
+    // Exit with shutdown flag set → exit code 0.
+    session.send_notification("exit", Value::Null);
+    drop(session.child.stdin.take());
+    assert_eq!(session.child.wait().unwrap().code().unwrap(), 0);
+}
+
+#[test]
+fn lsp_exit_after_shutdown_returns_zero() {
+    let mut session = LspSession::start();
+    session.initialize();
+    // `shutdown_and_exit` already asserts id echo and null result; we assert
+    // the exit-code = 0 contract explicitly here.
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+// ===========================================================================
+// LSP spec conformance tests — text document synchronization
+// ===========================================================================
+
+#[test]
+fn lsp_did_change_full_sync_last_change_wins() {
+    // Server advertises Full sync (change: 1). Per spec, the content change
+    // array contains the full document text and the last entry is the final
+    // document state.
+    let mut session = LspSession::start();
+    session.initialize();
+    session.open_doc(
+        "file:///tmp/lsp_full_sync.wado",
+        "export fn run() {\n    let x: i32 = \"oops\";\n}\n",
+    );
+    session.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": "file:///tmp/lsp_full_sync.wado", "version": 2 },
+            "contentChanges": [
+                { "text": "still broken \"nope\"" },
+                { "text": "use { println, Stdout } from \"core:cli\";\n\nexport fn run() with Stdout {\n    println(\"ok\");\n}\n" }
+            ]
+        }),
+    );
+    let notif = session.read_message();
+    assert_eq!(notif["method"], "textDocument/publishDiagnostics");
+    let diags = notif["params"]["diagnostics"].as_array().unwrap();
+    assert!(
+        diags.is_empty(),
+        "last change should win and clear errors, got: {diags:?}"
+    );
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_did_change_empty_content_changes_is_noop() {
+    let mut session = LspSession::start();
+    session.initialize();
+    session.open_doc(
+        "file:///tmp/lsp_empty_change.wado",
+        "export fn run() {\n    let x: i32 = \"oops\";\n}\n",
+    );
+    session.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": "file:///tmp/lsp_empty_change.wado", "version": 2 },
+            "contentChanges": []
+        }),
+    );
+    // With no content changes, the server should not re-publish diagnostics.
+    // Confirm by issuing a request and expecting exactly that request's
+    // response (not a stray publishDiagnostics notification).
+    let id = session.send_request("shutdown", Value::Null);
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    session.send_notification("exit", Value::Null);
+    drop(session.child.stdin.take());
+    assert_eq!(session.child.wait().unwrap().code().unwrap(), 0);
+}
+
+#[test]
+fn lsp_did_open_on_empty_text_produces_no_errors() {
+    let mut session = LspSession::start();
+    session.initialize();
+    let notif = session.open_doc("file:///tmp/lsp_empty.wado", "");
+    assert_eq!(notif["method"], "textDocument/publishDiagnostics");
+    // An empty file has no top-level items — compiler may warn or stay silent,
+    // but it must not crash the server.
+    assert!(notif["params"]["diagnostics"].is_array());
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+// ===========================================================================
+// LSP spec conformance tests — language features (empty / null results)
+// ===========================================================================
+
+#[test]
+fn lsp_definition_returns_null_for_whitespace_position() {
+    let mut session = LspSession::start();
+    session.initialize();
+    session.open_doc(
+        "file:///tmp/lsp_def_null.wado",
+        "fn f() -> i32 {\n    return 1;\n}\n",
+    );
+    let id = session.send_request(
+        "textDocument/definition",
+        json!({
+            "textDocument": { "uri": "file:///tmp/lsp_def_null.wado" },
+            // Column 0 on the blank `return` line: no identifier at this spot.
+            "position": { "line": 1, "character": 0 }
+        }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    // Spec §definition allows `Location | Location[] | LocationLink[] | null`.
+    assert!(
+        resp["result"].is_null(),
+        "definition on whitespace should be null, got: {}",
+        resp["result"]
+    );
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_hover_returns_null_for_whitespace_position() {
+    let mut session = LspSession::start();
+    session.initialize();
+    session.open_doc(
+        "file:///tmp/lsp_hover_null.wado",
+        "fn f() -> i32 {\n    return 1;\n}\n",
+    );
+    let id = session.send_request(
+        "textDocument/hover",
+        json!({
+            "textDocument": { "uri": "file:///tmp/lsp_hover_null.wado" },
+            "position": { "line": 1, "character": 0 }
+        }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    assert!(
+        resp["result"].is_null(),
+        "hover on whitespace should be null, got: {}",
+        resp["result"]
+    );
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_references_returns_empty_array_for_whitespace_position() {
+    let mut session = LspSession::start();
+    session.initialize();
+    session.open_doc(
+        "file:///tmp/lsp_refs_empty.wado",
+        "fn f() -> i32 {\n    return 1;\n}\n",
+    );
+    let id = session.send_request(
+        "textDocument/references",
+        json!({
+            "textDocument": { "uri": "file:///tmp/lsp_refs_empty.wado" },
+            "position": { "line": 1, "character": 0 },
+            "context": { "includeDeclaration": true }
+        }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    let arr = resp["result"].as_array().expect("references returns array");
+    assert!(arr.is_empty(), "got: {arr:?}");
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_document_highlight_returns_empty_array_for_whitespace_position() {
+    let mut session = LspSession::start();
+    session.initialize();
+    session.open_doc(
+        "file:///tmp/lsp_hl_empty.wado",
+        "fn f() -> i32 {\n    return 1;\n}\n",
+    );
+    let id = session.send_request(
+        "textDocument/documentHighlight",
+        json!({
+            "textDocument": { "uri": "file:///tmp/lsp_hl_empty.wado" },
+            "position": { "line": 1, "character": 0 }
+        }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    let arr = resp["result"]
+        .as_array()
+        .expect("documentHighlight returns array");
+    assert!(arr.is_empty(), "got: {arr:?}");
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_references_without_context_defaults_to_exclude_declaration() {
+    // `ReferenceContext` is optional in our RPC shape (`#[serde(default)]`),
+    // which means an omitted `context` implies `includeDeclaration: false`.
+    let mut session = LspSession::start();
+    session.initialize();
+    session.open_doc(
+        "file:///tmp/lsp_refs_no_context.wado",
+        "fn helper() -> i32 {\n    return 1;\n}\n\nexport fn run() {\n    let _ = helper();\n}\n",
+    );
+    let id = session.send_request(
+        "textDocument/references",
+        json!({
+            "textDocument": { "uri": "file:///tmp/lsp_refs_no_context.wado" },
+            "position": { "line": 0, "character": 4 }
+        }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    let arr = resp["result"].as_array().unwrap();
+    // Only the single call-site (line 5 `    let _ = helper();`), no declaration.
+    assert_eq!(arr.len(), 1, "got: {arr:?}");
+    assert_eq!(arr[0]["range"]["start"]["line"], 5);
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+// ===========================================================================
+// LSP spec conformance tests — semantic tokens
+// ===========================================================================
+
+#[test]
+fn lsp_semantic_tokens_full_returns_data_array() {
+    let mut session = LspSession::start();
+    session.initialize();
+    session.open_doc(
+        "file:///tmp/lsp_semtoks.wado",
+        "fn run() -> i32 {\n    return 42;\n}\n",
+    );
+    let id = session.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": "file:///tmp/lsp_semtoks.wado" } }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    let data = resp["result"]["data"].as_array().expect("data must be array");
+    // Delta-encoded tokens come in 5-tuples. Must be a non-empty multiple of 5.
+    assert!(!data.is_empty(), "expected semantic tokens, got none");
+    assert_eq!(
+        data.len() % 5,
+        0,
+        "semantic tokens data length must be a multiple of 5: {}",
+        data.len()
+    );
+    for v in data {
+        assert!(v.is_number(), "data must contain only integers: {v}");
+    }
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_semantic_tokens_unopened_document_returns_empty() {
+    let mut session = LspSession::start();
+    session.initialize();
+    let id = session.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": "file:///tmp/lsp_never_opened.wado" } }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    let data = resp["result"]["data"].as_array().unwrap();
+    assert!(data.is_empty(), "got: {data:?}");
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+// ===========================================================================
+// LSP spec conformance tests — InvalidParams across all request methods
+// ===========================================================================
+
+#[test]
+fn lsp_invalid_params_on_definition() {
+    let mut session = LspSession::start();
+    session.initialize();
+    let id = session.send_request("textDocument/definition", json!({ "nope": true }));
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    assert_eq!(resp["error"]["code"], -32602);
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_invalid_params_on_references() {
+    let mut session = LspSession::start();
+    session.initialize();
+    let id = session.send_request("textDocument/references", json!({ "nope": true }));
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    assert_eq!(resp["error"]["code"], -32602);
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_invalid_params_on_document_highlight() {
+    let mut session = LspSession::start();
+    session.initialize();
+    let id = session.send_request("textDocument/documentHighlight", json!({ "nope": true }));
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    assert_eq!(resp["error"]["code"], -32602);
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_invalid_params_on_semantic_tokens() {
+    let mut session = LspSession::start();
+    session.initialize();
+    let id = session.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "wrong": "shape" }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    assert_eq!(resp["error"]["code"], -32602);
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+// ===========================================================================
+// Documented spec gaps — tests are `#[ignore]`'d until the behaviour is added.
+//
+// These tests encode LSP 3.18 requirements that the current dispatcher in
+// `wado-cli/src/lsp.rs` does not yet enforce. Run with
+// `cargo test -p wado-cli --test lsp -- --ignored` to see the current
+// observable behaviour.
+// ===========================================================================
+
+#[test]
+#[ignore = "spec gap: request before `initialize` should return -32002 ServerNotInitialized"]
+fn lsp_request_before_initialize_returns_server_not_initialized() {
+    let mut session = LspSession::start();
+    let id = session.send_request(
+        "textDocument/hover",
+        json!({
+            "textDocument": { "uri": "file:///tmp/x.wado" },
+            "position": { "line": 0, "character": 0 }
+        }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    assert_eq!(resp["error"]["code"], -32002);
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+#[ignore = "spec gap: duplicate `initialize` should return -32600 InvalidRequest"]
+fn lsp_duplicate_initialize_returns_invalid_request() {
+    let mut session = LspSession::start();
+    session.initialize();
+    let id = session.send_request("initialize", json!({ "capabilities": {} }));
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    assert_eq!(resp["error"]["code"], -32600);
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+#[ignore = "spec gap: requests after `shutdown` should return -32600 InvalidRequest"]
+fn lsp_request_after_shutdown_returns_invalid_request() {
+    let mut session = LspSession::start();
+    session.initialize();
+    let id = session.send_request("shutdown", Value::Null);
+    let _ = session.read_message();
+    let id2 = session.send_request(
+        "textDocument/hover",
+        json!({
+            "textDocument": { "uri": "file:///tmp/x.wado" },
+            "position": { "line": 0, "character": 0 }
+        }),
+    );
+    let resp = session.read_message();
+    let _ = id;
+    assert_eq!(resp["id"], id2);
+    assert_eq!(resp["error"]["code"], -32600);
+    session.send_notification("exit", Value::Null);
+    drop(session.child.stdin.take());
+    assert_eq!(session.child.wait().unwrap().code().unwrap(), 0);
+}
+
+#[test]
+#[ignore = "spec gap: malformed JSON should elicit a -32700 ParseError response rather than kill the server loop"]
+fn lsp_malformed_json_returns_parse_error() {
+    let mut session = LspSession::start();
+    session.initialize();
+    let bogus = b"not valid json at all";
+    let raw = format!("Content-Length: {}\r\n\r\n", bogus.len());
+    session.send_raw(raw.as_bytes());
+    session.send_raw(bogus);
+    let resp = session.read_message();
+    assert_eq!(resp["error"]["code"], -32700);
+    assert_eq!(session.shutdown_and_exit(), 0);
 }
 
 // ===========================================================================

--- a/wado-cli/tests/lsp.rs
+++ b/wado-cli/tests/lsp.rs
@@ -1220,16 +1220,13 @@ fn lsp_invalid_params_on_semantic_tokens() {
 }
 
 // ===========================================================================
-// Documented spec gaps — tests are `#[ignore]`'d until the behaviour is added.
+// LSP spec conformance tests — lifecycle enforcement
 //
-// These tests encode LSP 3.18 requirements that the current dispatcher in
-// `wado-cli/src/lsp.rs` does not yet enforce. Run with
-// `cargo test -p wado-cli --test lsp -- --ignored` to see the current
-// observable behaviour.
+// Covers the "only `initialize` first" and "no work after `shutdown`" rules
+// (LSP 3.18 §Server lifecycle) plus JSON-RPC 2.0 §5.1 parse-error recovery.
 // ===========================================================================
 
 #[test]
-#[ignore = "spec gap: request before `initialize` should return -32002 ServerNotInitialized"]
 fn lsp_request_before_initialize_returns_server_not_initialized() {
     let mut session = LspSession::start();
     let id = session.send_request(
@@ -1242,11 +1239,40 @@ fn lsp_request_before_initialize_returns_server_not_initialized() {
     let resp = session.read_message();
     assert_eq!(resp["id"], id);
     assert_eq!(resp["error"]["code"], -32002);
+    assert!(resp["error"]["message"].is_string());
+    // Cannot `shutdown` gracefully here — that would also be rejected with
+    // ServerNotInitialized. Send `exit` directly; per spec this is allowed
+    // before `initialize` and must exit non-zero when no shutdown was seen.
+    session.send_notification("exit", Value::Null);
+    drop(session.child.stdin.take());
+    assert_eq!(session.child.wait().unwrap().code().unwrap(), 1);
+}
+
+#[test]
+fn lsp_notification_before_initialize_is_silently_dropped() {
+    // Notifications before `initialize` must be dropped (spec §initialize).
+    // We confirm by initializing afterwards and seeing a normal response.
+    let mut session = LspSession::start();
+    session.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": "file:///tmp/lsp_pre_init.wado",
+                "languageId": "wado",
+                "version": 1,
+                "text": "fn f() {}\n"
+            }
+        }),
+    );
+    // No publishDiagnostics should have been emitted for that didOpen.
+    let id = session.send_request("initialize", json!({ "capabilities": {} }));
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    assert!(resp["result"]["capabilities"].is_object());
     assert_eq!(session.shutdown_and_exit(), 0);
 }
 
 #[test]
-#[ignore = "spec gap: duplicate `initialize` should return -32600 InvalidRequest"]
 fn lsp_duplicate_initialize_returns_invalid_request() {
     let mut session = LspSession::start();
     session.initialize();
@@ -1258,13 +1284,15 @@ fn lsp_duplicate_initialize_returns_invalid_request() {
 }
 
 #[test]
-#[ignore = "spec gap: requests after `shutdown` should return -32600 InvalidRequest"]
 fn lsp_request_after_shutdown_returns_invalid_request() {
     let mut session = LspSession::start();
     session.initialize();
-    let id = session.send_request("shutdown", Value::Null);
-    let _ = session.read_message();
-    let id2 = session.send_request(
+    let id_shut = session.send_request("shutdown", Value::Null);
+    let shut_resp = session.read_message();
+    assert_eq!(shut_resp["id"], id_shut);
+    assert_eq!(shut_resp["result"], Value::Null);
+
+    let id_req = session.send_request(
         "textDocument/hover",
         json!({
             "textDocument": { "uri": "file:///tmp/x.wado" },
@@ -1272,25 +1300,86 @@ fn lsp_request_after_shutdown_returns_invalid_request() {
         }),
     );
     let resp = session.read_message();
-    let _ = id;
-    assert_eq!(resp["id"], id2);
+    assert_eq!(resp["id"], id_req);
     assert_eq!(resp["error"]["code"], -32600);
+
+    session.send_notification("exit", Value::Null);
+    drop(session.child.stdin.take());
+    // Exit after shutdown → code 0.
+    assert_eq!(session.child.wait().unwrap().code().unwrap(), 0);
+}
+
+#[test]
+fn lsp_notification_after_shutdown_is_silently_dropped() {
+    let mut session = LspSession::start();
+    session.initialize();
+    let id_shut = session.send_request("shutdown", Value::Null);
+    let _ = session.read_message();
+    // This didOpen must not be processed and must not produce a
+    // publishDiagnostics notification.
+    session.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": "file:///tmp/lsp_post_shutdown.wado",
+                "languageId": "wado",
+                "version": 1,
+                "text": "fn f() {}\n"
+            }
+        }),
+    );
+    // Follow with a request we expect to fail with InvalidRequest — its
+    // response is the *next* message the client sees, proving the stray
+    // didOpen did not emit anything.
+    let id = session.send_request(
+        "textDocument/hover",
+        json!({
+            "textDocument": { "uri": "file:///tmp/lsp_post_shutdown.wado" },
+            "position": { "line": 0, "character": 0 }
+        }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    assert_eq!(resp["error"]["code"], -32600);
+    let _ = id_shut;
+
     session.send_notification("exit", Value::Null);
     drop(session.child.stdin.take());
     assert_eq!(session.child.wait().unwrap().code().unwrap(), 0);
 }
 
 #[test]
-#[ignore = "spec gap: malformed JSON should elicit a -32700 ParseError response rather than kill the server loop"]
-fn lsp_malformed_json_returns_parse_error() {
+fn lsp_malformed_json_returns_parse_error_and_keeps_server_alive() {
     let mut session = LspSession::start();
     session.initialize();
+
     let bogus = b"not valid json at all";
-    let raw = format!("Content-Length: {}\r\n\r\n", bogus.len());
-    session.send_raw(raw.as_bytes());
+    let header = format!("Content-Length: {}\r\n\r\n", bogus.len());
+    session.send_raw(header.as_bytes());
     session.send_raw(bogus);
+
+    let resp = session.read_message();
+    assert_eq!(resp["jsonrpc"], "2.0");
+    assert_eq!(resp["error"]["code"], -32700);
+    // JSON-RPC 2.0: when the id cannot be determined, response id is null.
+    assert!(resp["id"].is_null(), "got: {}", resp["id"]);
+
+    // Server must still be alive — follow-up requests are processed.
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_missing_content_length_returns_parse_error() {
+    let mut session = LspSession::start();
+    session.initialize();
+
+    // A terminated header block with no Content-Length: header.
+    session.send_raw(b"NoLengthHeader: hello\r\n\r\n");
+
     let resp = session.read_message();
     assert_eq!(resp["error"]["code"], -32700);
+    assert!(resp["id"].is_null());
+
     assert_eq!(session.shutdown_and_exit(), 0);
 }
 

--- a/wado-cli/tests/lsp.rs
+++ b/wado-cli/tests/lsp.rs
@@ -1138,7 +1138,9 @@ fn lsp_semantic_tokens_full_returns_data_array() {
     );
     let resp = session.read_message();
     assert_eq!(resp["id"], id);
-    let data = resp["result"]["data"].as_array().expect("data must be array");
+    let data = resp["result"]["data"]
+        .as_array()
+        .expect("data must be array");
     // Delta-encoded tokens come in 5-tuples. Must be a non-empty multiple of 5.
     assert!(!data.is_empty(), "expected semantic tokens, got none");
     assert_eq!(

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -2171,8 +2171,8 @@ fn import_http_client(
         // Emit each function from registry metadata.
         // Client functions use the same param/result types as the HTTP handler
         // (own<request> → result<own<response>, error-code>).
-        let mut local_type_idx: u32 = 2; // 0=request alias, 1=result alias
-        for func in &client_funcs {
+        // local_type_idx starts at 2: 0=request alias, 1=result alias
+        for (func_type_idx, func) in (2_u32..).zip(client_funcs.iter()) {
             let mut func_encoder = instance_type.ty().function();
             if func.is_async {
                 func_encoder
@@ -2184,8 +2184,6 @@ fn import_http_client(
                     .params([("request", ComponentValType::Type(0))])
                     .result(Some(ComponentValType::Type(1)));
             }
-            let func_type_idx = local_type_idx;
-            local_type_idx += 1;
 
             instance_type.export(
                 &func.wasi_func_name,

--- a/wado-compiler/src/codegen/emit.rs
+++ b/wado-compiler/src/codegen/emit.rs
@@ -613,8 +613,8 @@ impl<'a> WirEmitter<'a> {
         }
         // Defined functions use DEFINED_FUNC_BASE + list_position as WirFuncId,
         // mapped to actual Wasm indices starting after imports.
-        for (wasm_idx, (i, _func)) in (self.func_index_offset..)
-            .zip(self.wir.functions.iter().enumerate())
+        for (wasm_idx, (i, _func)) in
+            (self.func_index_offset..).zip(self.wir.functions.iter().enumerate())
         {
             let wir_func_idx = DEFINED_FUNC_BASE + u32::try_from(i).unwrap();
             self.func_index_map.insert(wir_func_idx, wasm_idx);

--- a/wado-compiler/src/codegen/emit.rs
+++ b/wado-compiler/src/codegen/emit.rs
@@ -613,11 +613,11 @@ impl<'a> WirEmitter<'a> {
         }
         // Defined functions use DEFINED_FUNC_BASE + list_position as WirFuncId,
         // mapped to actual Wasm indices starting after imports.
-        let mut wasm_idx = self.func_index_offset;
-        for (i, _func) in self.wir.functions.iter().enumerate() {
+        for (wasm_idx, (i, _func)) in (self.func_index_offset..)
+            .zip(self.wir.functions.iter().enumerate())
+        {
             let wir_func_idx = DEFINED_FUNC_BASE + u32::try_from(i).unwrap();
             self.func_index_map.insert(wir_func_idx, wasm_idx);
-            wasm_idx += 1;
         }
     }
 

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -4182,9 +4182,9 @@ fn generate_struct_ord_fn(
 
     let mut stmts = Vec::new();
     let mut local_types = vec![ref_struct_type, ref_struct_type];
-    let mut next_local: u32 = 2;
 
-    for (field_name, field_type, field_index) in fields {
+    // Local indices start at 2 (0 = self, 1 = other).
+    for (local_idx, (field_name, field_type, field_index)) in (2_u32..).zip(fields.iter()) {
         let self_field = TirExpr::new(
             TirExprKind::FieldAccess {
                 expr: Box::new(self_ref(span)),
@@ -4213,8 +4213,6 @@ fn generate_struct_ord_fn(
             span,
         );
 
-        let local_idx = next_local;
-        next_local += 1;
         local_types.push(ordering_type);
 
         // let c = self.field.cmp(&other.field);
@@ -4855,9 +4853,9 @@ fn generate_generic_struct_ord_fn(
 
     let mut stmts = Vec::new();
     let mut local_types = vec![ref_struct_type, ref_struct_type];
-    let mut next_local: u32 = 2;
 
-    for (field_name, field_type, field_index) in fields {
+    // Local indices start at 2 (0 = self, 1 = other).
+    for (local_idx, (field_name, field_type, field_index)) in (2_u32..).zip(fields.iter()) {
         let self_field = TirExpr::new(
             TirExprKind::FieldAccess {
                 expr: Box::new(self_ref(span)),
@@ -4886,8 +4884,6 @@ fn generate_generic_struct_ord_fn(
             span,
         );
 
-        let local_idx = next_local;
-        next_local += 1;
         local_types.push(ordering_type);
 
         stmts.push(TirStmt::new(


### PR DESCRIPTION
## Summary

Review the current `wado-cli` LSP implementation against the LSP 3.18 specification (`wado-lsp/lsp.md`), add conformance tests, and implement missing spec behavior.

- **LSP 3.18 conformance tests** (60 tests) for the `wado lsp` subcommand, covering lifecycle (`initialize` / `initialized` / `shutdown` / `exit`), request/notification dispatch, error codes, and capability negotiation.
- **Lifecycle enforcement + parse-error recovery**: requests before `initialize` → `ServerNotInitialized`; requests after `shutdown` → `InvalidRequest`; malformed JSON-RPC frames respond with `ParseError` (id: `null`) per JSON-RPC 2.0 §5.1 and keep the server loop running so well-formed follow-ups are still processed.
- **Clippy cleanup**: fix four pre-existing `explicit_counter_loop` warnings in `wado-compiler` (`codegen/emit.rs`, `codegen/component.rs`, `synthesis/traits.rs`) by rewriting manually-incremented loop counters to `(start..).zip(iter)`.

## Commits

- `9b4dd6a` wado-cli: add LSP 3.18 spec conformance tests for lsp subcommand
- `088048e` wado-cli: enforce LSP 3.18 lifecycle and parse-error recovery
- `6c5a1aa` wado-compiler: fix explicit_counter_loop clippy warnings
- `6ba0c3c` style: apply rustfmt formatting

## Test plan

- [x] `cargo test -p wado-cli --test lsp` — 60 tests pass
- [x] `cargo test -p wado-compiler --lib` — 342 tests pass
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `mise run on-task-done` — all phases pass end-to-end (build, clippy-fix, update-golden-fixtures, update-golden-format-fixtures, update-gale-golden, doc-stdlib, format, test, test-wado)
- [x] `mise run test-wado` — 1776 passed, 0 failed
- [x] Benchmark suite — 10/10 pass (count_prime, fts, json_canada, json_catalog, json_twitter, mandelbrot, sieve, sqlite_parse, syntax_highlight, zlib)

https://claude.ai/code/session_012nvXnkbqPMtMrrAnGHSiJt