### PR TITLE
docs(kiln): delegate generator execution to CompilerHost

### DIFF
--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -22,7 +22,7 @@ In scope:
 
 - Users register code generators in `wado.toml` or inline at a `use` site.
 - Generators read schema files (`.proto`, `.graphql`, `.g4`, `.wit`, `.json`, custom IDLs, …) and emit `.wado` source files.
-- Generators are compiled to WebAssembly components and executed by the compiler via wasmtime.
+- Generators are compiled to WebAssembly components by `wado-compiler` and executed by the host via a new `CompilerHost::run_generator` capability. The native host (`wado-cli`) uses wasmtime; `wasm32`-bundled clients either forward to a Wasm runtime available to them or fall back to the consume-only mode described in "Transitional consume-only mode".
 - Generated `.wado` files are written to `build/kiln/` by default and may be redirected to any directory. Committing them is recommended but not required; `build/kiln/` is commonly `.gitignore`-d.
 - Invocation is automatic: the compiler runs the relevant generators during `wado compile`, with content-addressed caching so unchanged inputs skip the generator.
 
@@ -48,15 +48,16 @@ Languages with a serious IDL story have landed on one of four designs: in-compil
 
 ### Design principles
 
-Three principles drive every detail in this WEP:
+Four principles drive every detail in this WEP:
 
 1. **Determinism by construction.** The `kiln` world provides no access to clocks, randomness, the network, environment variables, or ambient filesystems. A generator is a pure function `(inputs, options) → outputs + diagnostics`. Violating this requires rebuilding the compiler; it is not a runtime flag. This is the one thing in-compiler macro systems (Rust, Roslyn) cannot cleanly guarantee.
 2. **Every input is statically enumerable.** No `list-dir` host function, no globs in the manifest. Every file that feeds a generator appears as a literal path in `wado.toml` or at a `use ... with` site. This lets the LSP jump to both the IDL and the generated `.wado`, and lets the compiler precompute the full dependency graph before any generator runs.
 3. **Single-file scripts are first-class.** Any generator configuration expressible in `wado.toml` works inline at a `use` site with the same schema and the same behavior, so a single `.wado` file with a shebang never needs a `wado.toml` just to consume a `.proto`.
+4. **Runtime-free compiler core.** `wado-compiler` never links a Wasm runtime. Generator component execution is a `CompilerHost` capability, on the same I/O boundary as source loading ([`wep-2026-01-16-source-provider-abstraction.md`](./wep-2026-01-16-source-provider-abstraction.md)). Native hosts (`wado-cli`) execute generators via wasmtime; `wasm32`-bundled hosts (`wado-lsp` embedded in VS Code Wasm or the browser playground — see [`wep-2026-04-18-lsp-architecture.md`](./wep-2026-04-18-lsp-architecture.md)) either forward execution through their own Wasm host or fall back to consume-only mode. The `cargo check -p wado-compiler --target wasm32-unknown-unknown` CI gate is therefore not at risk.
 
 ### Overview
 
-A **generator** is a Wado module that exports the `wado:kiln/generator` world. The compiler compiles it to a `wasm32-wasip*` component, caches it, runs it inside wasmtime, and persists its `response` record — a set of `.wado` files and optional diagnostics — to disk. Content-addressed caching keyed on schemas, options, and the generator's source hash ensures unchanged inputs skip the run. Invocations form a DAG (one generator may consume another's output); cycles are a compile error. The full sequence is specified in "Build pipeline integration" below.
+A **generator** is a Wado module that exports the `wado:kiln/generator` world. `wado-compiler` compiles it to a `wasm32-wasip*` component (using its ordinary codegen path — no Wasm runtime involved) and hands the component bytes to the host via a new `CompilerHost::run_generator` capability. The host instantiates and invokes the component; `wado-compiler` persists the returned `response` record — a set of `.wado` files and optional diagnostics — through the same `CompilerHost`. Content-addressed caching keyed on schemas, options, and the generator's source hash ensures unchanged inputs skip the run. Invocations form a DAG (one generator may consume another's output); cycles are a compile error. The responsibility split is spelled out in "Host-delegated execution" and the full sequence is specified in "Build pipeline integration" below.
 
 ### The `kiln` world
 
@@ -188,6 +189,74 @@ Default-value semantics follow the struct-defaults design (see [`wep-2026-03-04-
 
 Until the Wado → WIT mapping ships, the compiler extracts `Options` directly from the generator module's Wado IR; once the mapping is available, extraction routes through the component's WIT `record`, at which point generators written outside Wado can participate without a special case.
 
+### Host-delegated execution
+
+`wado-compiler` must compile for `wasm32-unknown-unknown`: `wado-lsp` embeds it as a `wasm32-wasip2` component for VS Code's Wasm host and the browser playground ([`wep-2026-04-18-lsp-architecture.md`](./wep-2026-04-18-lsp-architecture.md)), and the compiler's Cargo manifest lists wasmtime only under `[dev-dependencies]`. Linking a Wasm runtime into the compiler core would break both constraints. Kiln therefore reuses the I/O boundary established by [`wep-2026-01-16-source-provider-abstraction.md`](./wep-2026-01-16-source-provider-abstraction.md) and adds one method to `CompilerHost`:
+
+```rust
+pub trait CompilerHost {
+    // existing methods: load_source, emit_diagnostic, ...
+
+    /// Execute a generator component and return its response.
+    ///
+    /// `component_wasm` is the component the compiler produced from the
+    /// generator module's Wado source. `request` mirrors the
+    /// `wado:kiln/types` records one-to-one. The host is responsible for
+    /// instantiating the component, linking `wado:kiln/host` so that
+    /// `read-file` and `emit-diagnostic` forward back into this same
+    /// `CompilerHost`, refusing every other import, and lifting/lowering
+    /// Component Model values at the boundary.
+    async fn run_generator(
+        &mut self,
+        component_wasm: &[u8],
+        request: GeneratorRequest,
+    ) -> Result<GeneratorResponse, GeneratorRunnerError>;
+}
+
+pub enum GeneratorRunnerError {
+    /// This host does not implement generator execution.
+    /// The compiler falls back to consume-only mode (see below).
+    Unsupported,
+    /// The generator ran and returned its typed `error` variant.
+    Generator(GeneratorError),
+    /// The generator trapped, timed out, exhausted fuel, etc.
+    Host(String),
+}
+```
+
+`GeneratorRequest` and `GeneratorResponse` are plain Rust types in `wado-compiler` that correspond 1:1 to the `wado:kiln/types` records. They do not reference wasmtime; a host implementation that happens to use wasmtime lifts/lowers them at its own boundary via `wasmtime::component::bindgen!`.
+
+Responsibility split:
+
+| Step                                                                         | Owner                         | Notes                                                        |
+| ---------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------ |
+| Parse `[build-dependencies]` and `[build.generators.*]` in `wado.toml`       | `wado-manifest`               | Already `wasm32-unknown-unknown`-ready.                      |
+| Read and write `[[build-dependency]]` / `[[generator-cache]]` in `wado.lock` | `wado-manifest`               | Pure parsing + serialization.                                |
+| Deduplicate invocations, build the DAG, topologically sort                   | `wado-compiler`               | Pure logic.                                                  |
+| Compile each generator's Wado source to a `wasm32-wasip*` component          | `wado-compiler`               | Ordinary codegen; no Wasm runtime required.                  |
+| Compute cache keys                                                           | `wado-compiler`               | Pure logic.                                                  |
+| Instantiate the component, run `generate`, lift/lower CM values              | `CompilerHost::run_generator` | Native host uses wasmtime; web hosts see below.              |
+| Persist `output-file` entries under `<output-dir>`                           | `CompilerHost`                | Same filesystem view as `load_source`.                       |
+| Re-parse generated `.wado` via the ordinary `load_source` path               | `wado-compiler`               | Generated files are indistinguishable from user source here. |
+
+The default native host (`CliCompilerHost` in `wado-cli`) wires `run_generator` to a `wasmtime::component::Linker` generated from the `wado:kiln/generator` world. `wado-compiler` never sees a wasmtime type.
+
+### Transitional consume-only mode
+
+In principle, any host that can run `wado-compiler` as Wasm can also run a generator component — it already has a Wasm runtime. In practice, today's non-wasmtime hosts (`@vscode/wasm-wasi-core`, browser polyfills for the playground) target WASI preview 1/2 and do not support nested Component Model instances, async, or WASI p3 — precisely the shape Wado generators require. Until those hosts catch up, the `wasm32`-bundled LSP and playground run in **consume-only mode**.
+
+Consume-only semantics:
+
+- `run_generator` returns `Unsupported`.
+- For each invocation the compiler still recomputes the cache key and compares it against `wado.lock` and `<output-dir>`:
+  - Cache hit: the generated `.wado` files are loaded through the ordinary `load_source` path; compilation proceeds as if the user had authored those files by hand.
+  - Cache miss or hash mismatch: the compiler emits a `warning` diagnostic (`stale kiln cache: <invocation>; re-run 'wado compile' natively to refresh`) and treats the invocation's entry module as present-but-unresolved. `use` statements targeting its symbols surface as ordinary resolution errors; the rest of the compilation unit still proceeds.
+- No writes occur: neither `wado.lock` nor `<output-dir>` is modified in consume-only mode.
+
+Consume-only is a compatibility bridge, not part of the steady-state design. Once a web host gains CM + WASI p3 support, the same `CompilerHost` implementation can route `run_generator` through that host's runtime and consume-only never kicks in. Nothing user-visible changes at that point.
+
+Because `wado-lsp` running in web editors depends on this mode, projects that want a full web LSP experience commit `build/kiln/` and `wado.lock` to the repository. A `.gitignore`-d `build/kiln/` is still supported for projects that only care about native `wado compile` / `wado lsp`.
+
 ### Anatomy of a generator module
 
 A generator is a normal Wado module. It may be:
@@ -218,7 +287,7 @@ export fn generate(req: Request<Options>) -> Result<Response, Error> {
 }
 ```
 
-The generator is compiled to a component targeting the `wasm32-wasip*` family at the moment the compiler first needs to invoke it (see "Build pipeline integration"). It runs inside wasmtime with the `host` interface linked to compiler-provided host functions; all other world imports are refused at link time.
+The generator is compiled to a component targeting the `wasm32-wasip*` family at the moment the compiler first needs to invoke it (see "Build pipeline integration"). `wado-compiler` hands the component bytes to `CompilerHost::run_generator`, which instantiates the component inside its own runtime (wasmtime on native hosts), links `wado:kiln/host` so that `read-file` and `emit-diagnostic` forward back through the same `CompilerHost`, and refuses every other import at link time.
 
 ### Generator output layout
 
@@ -314,11 +383,11 @@ Kiln sits between parsing and name resolution in the pipeline described by [`wep
 4. Build the generator dependency graph: an edge from invocation A to invocation B exists if any of A's inputs (primary or supplementary), or any `read-file` target recorded on a previous run of A, lies inside B's `output-dir`. Topologically sort. Cycles are a compile error.
 5. For each invocation in topological order:
    a. Compute the cache key.
-   b. If `wado.lock` has a matching entry and every output file exists on disk with the recorded hash, skip to 5(e).
-   c. Compile the generator module to a `wasm32-wasip*` component if not already cached, instantiate it in wasmtime, and link `host.read-file` and `host.emit-diagnostic`. All other imports are unlinked and trap on first use.
-   d. Call `generate(request)` with `primary` and `inputs` pre-loaded from `CompilerHost`. Forward every `read-file` to `CompilerHost` and append the path to the invocation's dependency list.
-   e. Persist each `output-file` to `<output-dir>/<path>`, stamping the `#![generated(...)]` header. Delete any existing `#![generated]` file in `output-dir` that was not produced by this run.
-   f. Record the cache entry in `wado.lock`.
+   b. If `wado.lock` has a matching entry and every output file exists on disk with the recorded hash, skip to 5(f).
+   c. Compile the generator module to a `wasm32-wasip*` component if not already cached. This step runs entirely inside `wado-compiler` and reuses the ordinary codegen pipeline; no Wasm runtime is involved.
+   d. Build a `GeneratorRequest` (primary + inputs + options) and call `CompilerHost::run_generator(component_bytes, request)`. The host instantiates the component, links `wado:kiln/host` so that `read-file` and `emit-diagnostic` forward back through `CompilerHost`, refuses every other import, and invokes `generate`. Each `read-file` the host relays is appended to the invocation's dependency list.
+   e. Persist each `output-file` to `<output-dir>/<path>`, stamping the `#![generated(...)]` header. Delete any existing `#![generated]` file in `output-dir` that was not produced by this run. Record the cache entry in `wado.lock`.
+   f. If `run_generator` returned `Unsupported`, the consume-only path in "Transitional consume-only mode" runs instead: 5(c)–5(e) are skipped, a stale-cache diagnostic is emitted if the on-disk outputs do not match the cache key, and compilation continues against whatever is on disk.
 6. Resolve every `use` statement. A `use { ... } from "<schema>"` with a registered invocation binds to that invocation's entry module; all other `use` statements resolve normally. A `use` whose target is a schema with no registered invocation, or whose imported symbols are not `pub` in the resolved entry, is a real error.
 
 Generated files go through the same parser and resolver as user-authored Wado, so a generator emitting syntactically invalid Wado fails with a normal parse error against the on-disk file.
@@ -382,6 +451,8 @@ outputs = [
 
 On every build, the compiler recomputes the cache key and compares the expected output hashes against the files on disk. If either is out of date, the generator re-runs; otherwise parsing proceeds against the existing files. A `wado compile --check-clean` mode runs every invocation, refuses to overwrite, and fails if on-disk files differ — the analogue of `cargo fmt --check` for commit-tracked generator output.
 
+In consume-only mode (see "Transitional consume-only mode"), the cache check still runs: the compiler recomputes the cache key and compares expected output hashes against files on disk. A mismatch produces a `warning` diagnostic, not an error; compilation proceeds against whatever is on disk and `wado.lock` is not written.
+
 ### Diagnostics: extending spans to external files
 
 Today, `wado-compiler` spans reference an internal `FileId` assigned when a source file is loaded into a `SourceMap`. Kiln needs spans to point at IDL files that the compiler itself did not originally parse — it only read them on behalf of a generator via `host.read-file`. Two small extensions handle this:
@@ -406,6 +477,23 @@ The `kiln` world is versioned as an ordinary WIT interface, starting at `wado:ki
 ### In-compiler macro system
 
 Running generator code directly inside `wado-compiler` (the Rust proc-macro model) would be faster and drop the wasmtime dependency, but it exposes the full host environment to every generator (forfeiting determinism), and generators written in Wado could not participate without a second, separate mechanism. Reusing Wasm sandboxing — already integral to Wado — keeps the plugin surface consistent with the rest of the language.
+
+### Link wasmtime into `wado-compiler`
+
+The shortest path to a working Kiln prototype is to add `wasmtime` to `wado-compiler`'s main dependencies and drive it from inside the pipeline. This was rejected on two independent grounds that Wado's existing architecture makes non-negotiable:
+
+1. `wado-compiler` must build for `wasm32-unknown-unknown` — enforced by CI (`.github/workflows/ci.yml: check-wasm32`) and required because `wado-lsp` bundles the compiler as a `wasm32-wasip2` component for VS Code Wasm and the browser playground ([`wep-2026-04-18-lsp-architecture.md`](./wep-2026-04-18-lsp-architecture.md)). wasmtime does not build for `wasm32-unknown-unknown`.
+2. The same I/O boundary that already keeps source loading out of `wado-compiler` ([`wep-2026-01-16-source-provider-abstraction.md`](./wep-2026-01-16-source-provider-abstraction.md)) applies equally to generator execution; a one-off escape hatch for Kiln would be out of family.
+
+Delegating execution to `CompilerHost::run_generator` gives the native build the same wasmtime-backed behavior at no cost, while letting `wasm32` clients degrade to consume-only until their hosts can run the generator themselves.
+
+### Pure-Rust Wasm interpreter in the compiler
+
+Embedding `wasmi` or `tinywasm` would keep the compiler self-contained on `wasm32-unknown-unknown`, but neither currently supports the Component Model, async, or WASI p3 — the full shape Wado generators expect. This alternative only becomes viable if a suitable pure-Rust CM + p3 host appears. Until then, consume-only mode is the cheaper transitional answer.
+
+### Out-of-band generation before `wado compile`
+
+Exposing Kiln as a separate `wado kiln generate` step that users must run before compiling would remove every runtime concern from `wado-compiler`, but it breaks principle 1 of the Overview ("Invocation is automatic") and kills the single-file-with-shebang path. Host delegation preserves automatic invocation without pulling a Wasm runtime into the compiler core.
 
 ### Pre-build arbitrary program (`build.rs` equivalent)
 
@@ -434,13 +522,18 @@ The following are deliberately unresolved here; they will be decided during impl
 - [ ] `host.read-file` access scope. V1 serves any path `CompilerHost` accepts; a stricter per-invocation allow-list may be revisited if needed.
 - [ ] Final `wado.lock` layout. The sketch here is indicative.
 - [ ] `root: "workspace"` escape hatch for project-root-relative paths at `use` sites. Not needed in v1.
+- [ ] Web-host routing for `run_generator`. When VS Code Wasm or the browser playground gains CM + WASI p3, the host-hosts-host arrangement (`wado-lsp`-in-Wasm asks its embedder to run the generator-in-Wasm) needs a concrete transport. Consume-only mode is the v1 stopgap.
+- [ ] Streaming / progress reporting through `CompilerHost::run_generator`. V1 is blocking; long-running generators block the compile.
+- [ ] Fuel or timeout budget for `run_generator`. Native hosts can enforce one via wasmtime; spec leaves the limit as host policy in v1.
 
 ## Consequences
 
 - Users gain a first-class way to consume any schema language that has (or can acquire) a Wado generator package. Operationally close to Swift macros: sandboxed, deterministic, cacheable, automatic.
-- `wado.toml` grows `[build-dependencies]` and `[build.generators]`; `wado.lock` grows `[[build-dependency]]` and `[[generator-cache]]`.
-- `wado-compiler` gains a phase between parsing and name resolution that runs generators via wasmtime and materializes their output. The core compiler remains I/O-free; `CompilerHost` serves generator reads on top of user-source reads. Implementations in `wado-cli` and the test harness are updated accordingly.
+- `wado.toml` grows `[build-dependencies]` and `[build.generators]`; `wado.lock` grows `[[build-dependency]]` and `[[generator-cache]]`. Both changes land in `wado-manifest`, which is already `wasm32-unknown-unknown`-ready.
+- `wado-compiler` gains a phase between parsing and name resolution that plans generator invocations, compiles generator modules to components, hands them to `CompilerHost::run_generator`, and materializes the returned output. The core compiler remains I/O-free and runtime-free; wasmtime is never linked into it, and `cargo check -p wado-compiler --target wasm32-unknown-unknown` continues to pass.
+- `CompilerHost` grows one method (`run_generator`). `CliCompilerHost` (in `wado-cli`) implements it via wasmtime; hosts that cannot run generators today return `Unsupported` and the compiler degrades to consume-only mode. `CompilerHost` serves generator-relayed `read-file` calls on top of user-source reads.
 - `SourceMap` and the diagnostic renderer extend to spans in generator-read files; existing user diagnostics are unaffected.
+- `wado-lsp` (wasm32 build) and the browser playground initially run in consume-only mode. Projects that want a full LSP experience in web editors commit `build/kiln/` and `wado.lock`; projects that compile only natively can keep `build/kiln/` in `.gitignore`.
 - Gale migrates from `mise run update-gale-golden` to a `[build.generators]` invocation; the update task is retired. `wado-from-idl` is unchanged.
 - Adding a new schema language becomes a matter of publishing a package that exports `wado:kiln/generator`; no compiler changes are required.
 

--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -23,7 +23,7 @@ In scope:
 - Users register code generators in `wado.toml` or inline at a `use` site.
 - Generators read schema files (`.proto`, `.graphql`, `.g4`, `.wit`, `.json`, custom IDLs, …) and emit `.wado` source files.
 - Generators are compiled to WebAssembly components by `wado-compiler` and executed by the host via a new `CompilerHost::run_generator` capability. The native host (`wado-cli`) uses wasmtime; `wasm32`-bundled clients either forward to a Wasm runtime available to them or fall back to the consume-only mode described in "Transitional consume-only mode".
-- Generated `.wado` files are written to `build/kiln/` by default and may be redirected to any directory. Committing them is recommended but not required; `build/kiln/` is commonly `.gitignore`-d.
+- Generated `.wado` files are written to `build/kiln/` by default and may be redirected to any directory. Committing `build/kiln/` and `wado.lock` is recommended for projects that want the LSP to work in web editors (VS Code Wasm, browser playground); native-only projects may keep `build/kiln/` in `.gitignore`. See "Transitional consume-only mode" for why.
 - Invocation is automatic: the compiler runs the relevant generators during `wado compile`, with content-addressed caching so unchanged inputs skip the generator.
 
 Out of scope:
@@ -53,11 +53,11 @@ Four principles drive every detail in this WEP:
 1. **Determinism by construction.** The `kiln` world provides no access to clocks, randomness, the network, environment variables, or ambient filesystems. A generator is a pure function `(inputs, options) → outputs + diagnostics`. Violating this requires rebuilding the compiler; it is not a runtime flag. This is the one thing in-compiler macro systems (Rust, Roslyn) cannot cleanly guarantee.
 2. **Every input is statically enumerable.** No `list-dir` host function, no globs in the manifest. Every file that feeds a generator appears as a literal path in `wado.toml` or at a `use ... with` site. This lets the LSP jump to both the IDL and the generated `.wado`, and lets the compiler precompute the full dependency graph before any generator runs.
 3. **Single-file scripts are first-class.** Any generator configuration expressible in `wado.toml` works inline at a `use` site with the same schema and the same behavior, so a single `.wado` file with a shebang never needs a `wado.toml` just to consume a `.proto`.
-4. **Runtime-free compiler core.** `wado-compiler` never links a Wasm runtime. Generator component execution is a `CompilerHost` capability, on the same I/O boundary as source loading ([`wep-2026-01-16-source-provider-abstraction.md`](./wep-2026-01-16-source-provider-abstraction.md)). Native hosts (`wado-cli`) execute generators via wasmtime; `wasm32`-bundled hosts (`wado-lsp` embedded in VS Code Wasm or the browser playground — see [`wep-2026-04-18-lsp-architecture.md`](./wep-2026-04-18-lsp-architecture.md)) either forward execution through their own Wasm host or fall back to consume-only mode. The `cargo check -p wado-compiler --target wasm32-unknown-unknown` CI gate is therefore not at risk.
+4. **Runtime-free compiler core.** `wado-compiler` never links a Wasm runtime. Generator component execution is a `CompilerHost` capability, on the same I/O boundary as source loading ([`wep-2026-01-16-source-provider-abstraction.md`](./wep-2026-01-16-source-provider-abstraction.md)). Native hosts (`wado-cli`) execute generators via wasmtime; `wasm32`-bundled hosts (`wado-lsp` embedded in VS Code Wasm or the browser playground — see [`wep-2026-04-18-lsp-architecture.md`](./wep-2026-04-18-lsp-architecture.md)) either forward execution through their own Wasm host or fall back to consume-only mode.
 
 ### Overview
 
-A **generator** is a Wado module that exports the `wado:kiln/generator` world. `wado-compiler` compiles it to a `wasm32-wasip*` component (using its ordinary codegen path — no Wasm runtime involved) and hands the component bytes to the host via a new `CompilerHost::run_generator` capability. The host instantiates and invokes the component; `wado-compiler` persists the returned `response` record — a set of `.wado` files and optional diagnostics — through the same `CompilerHost`. Content-addressed caching keyed on schemas, options, and the generator's source hash ensures unchanged inputs skip the run. Invocations form a DAG (one generator may consume another's output); cycles are a compile error. The responsibility split is spelled out in "Host-delegated execution" and the full sequence is specified in "Build pipeline integration" below.
+A **generator** is a Wado module that exports the `wado:kiln/generator` world. `wado-compiler` compiles it to a `wasm32-wasip*` component and hands the component bytes to the host via a new `CompilerHost::run_generator` capability; the host instantiates and invokes the component, and `wado-compiler` persists the returned `response` record — a set of `.wado` files and optional diagnostics — through the same `CompilerHost`. Content-addressed caching keyed on schemas, options, and the generator's source hash ensures unchanged inputs skip the run. Invocations form a DAG (one generator may consume another's output); cycles are a compile error. The responsibility split is spelled out in "Host-delegated execution" and the full sequence is specified in "Build pipeline integration" below.
 
 ### The `kiln` world
 
@@ -233,7 +233,7 @@ Responsibility split:
 | Parse `[build-dependencies]` and `[build.generators.*]` in `wado.toml`       | `wado-manifest`               | Already `wasm32-unknown-unknown`-ready.                      |
 | Read and write `[[build-dependency]]` / `[[generator-cache]]` in `wado.lock` | `wado-manifest`               | Pure parsing + serialization.                                |
 | Deduplicate invocations, build the DAG, topologically sort                   | `wado-compiler`               | Pure logic.                                                  |
-| Compile each generator's Wado source to a `wasm32-wasip*` component          | `wado-compiler`               | Ordinary codegen; no Wasm runtime required.                  |
+| Compile each generator's Wado source to a `wasm32-wasip*` component          | `wado-compiler`               | Ordinary codegen path.                                       |
 | Compute cache keys                                                           | `wado-compiler`               | Pure logic.                                                  |
 | Instantiate the component, run `generate`, lift/lower CM values              | `CompilerHost::run_generator` | Native host uses wasmtime; web hosts see below.              |
 | Persist `output-file` entries under `<output-dir>`                           | `CompilerHost`                | Same filesystem view as `load_source`.                       |
@@ -287,7 +287,7 @@ export fn generate(req: Request<Options>) -> Result<Response, Error> {
 }
 ```
 
-The generator is compiled to a component targeting the `wasm32-wasip*` family at the moment the compiler first needs to invoke it (see "Build pipeline integration"). `wado-compiler` hands the component bytes to `CompilerHost::run_generator`, which instantiates the component inside its own runtime (wasmtime on native hosts), links `wado:kiln/host` so that `read-file` and `emit-diagnostic` forward back through the same `CompilerHost`, and refuses every other import at link time.
+The generator is compiled to a component targeting the `wasm32-wasip*` family at the moment the compiler first needs to invoke it (see "Build pipeline integration"). Execution goes through `CompilerHost::run_generator`; the host contract (instantiation, import linking, import refusal) is described in "Host-delegated execution".
 
 ### Generator output layout
 
@@ -383,11 +383,10 @@ Kiln sits between parsing and name resolution in the pipeline described by [`wep
 4. Build the generator dependency graph: an edge from invocation A to invocation B exists if any of A's inputs (primary or supplementary), or any `read-file` target recorded on a previous run of A, lies inside B's `output-dir`. Topologically sort. Cycles are a compile error.
 5. For each invocation in topological order:
    a. Compute the cache key.
-   b. If `wado.lock` has a matching entry and every output file exists on disk with the recorded hash, skip to 5(f).
-   c. Compile the generator module to a `wasm32-wasip*` component if not already cached. This step runs entirely inside `wado-compiler` and reuses the ordinary codegen pipeline; no Wasm runtime is involved.
-   d. Build a `GeneratorRequest` (primary + inputs + options) and call `CompilerHost::run_generator(component_bytes, request)`. The host instantiates the component, links `wado:kiln/host` so that `read-file` and `emit-diagnostic` forward back through `CompilerHost`, refuses every other import, and invokes `generate`. Each `read-file` the host relays is appended to the invocation's dependency list.
+   b. If `wado.lock` has a matching entry and every output file exists on disk with the recorded hash, the invocation is up-to-date; continue to the next invocation.
+   c. Otherwise, compile the generator module to a `wasm32-wasip*` component if not already cached. This step reuses `wado-compiler`'s ordinary codegen pipeline.
+   d. Build a `GeneratorRequest` (primary + inputs + options) and call `CompilerHost::run_generator` (see "Host-delegated execution" for its contract). Each `read-file` the host relays back is appended to the invocation's dependency list for future cache-key computation. On `Ok(response)` continue with 5(e). On `Err(Unsupported)` the consume-only path in "Transitional consume-only mode" runs instead: 5(e) is skipped, a stale-cache warning is emitted if the on-disk outputs do not match the cache key, and compilation continues against whatever is in `<output-dir>`. On any other `Err(...)` the invocation fails with a hard compile error reported against its declaration.
    e. Persist each `output-file` to `<output-dir>/<path>`, stamping the `#![generated(...)]` header. Delete any existing `#![generated]` file in `output-dir` that was not produced by this run. Record the cache entry in `wado.lock`.
-   f. If `run_generator` returned `Unsupported`, the consume-only path in "Transitional consume-only mode" runs instead: 5(c)–5(e) are skipped, a stale-cache diagnostic is emitted if the on-disk outputs do not match the cache key, and compilation continues against whatever is on disk.
 6. Resolve every `use` statement. A `use { ... } from "<schema>"` with a registered invocation binds to that invocation's entry module; all other `use` statements resolve normally. A `use` whose target is a schema with no registered invocation, or whose imported symbols are not `pub` in the resolved entry, is a real error.
 
 Generated files go through the same parser and resolver as user-authored Wado, so a generator emitting syntactically invalid Wado fails with a normal parse error against the on-disk file.


### PR DESCRIPTION
## Summary

`wado-compiler` must compile for `wasm32-unknown-unknown` (CI-enforced), but the original Kiln WEP proposed embedding `wasmtime` to execute generator components — which breaks the wasm32 build. This PR revises the Kiln spec so the compiler never links a Wasm runtime.

- Add a new `CompilerHost::run_generator` capability (same I/O boundary as `load_source` in [wep-2026-01-16-source-provider-abstraction](./docs/wep-2026-01-16-source-provider-abstraction.md)). The compiler produces component bytes; the host instantiates, links `wado:kiln/host` imports, refuses all others, and invokes `generate`.
- Native host (`wado-cli`) uses wasmtime. `wasm32`-bundled hosts (`wado-lsp` in VS Code Wasm / browser playground) either forward to their own Wasm runtime or return `Err(Unsupported)` to trigger the transitional **consume-only mode** (reads committed `build/kiln/` outputs verbatim; stale-cache → warning).
- Manifest parsing stays in `wado-manifest` (already wasm32-ready); orchestration, DAG, cache-key logic stay in `wado-compiler`.
- Pipeline step 5 is rewritten with proper `Ok` / `Err(Unsupported)` / `Err(_)` branches. Scope bullet reconciled: committing `build/kiln/` and `wado.lock` is recommended for web-LSP users; native-only projects may keep them `.gitignore`-d.
- Prose de-duplication pass: "no Wasm runtime", the `run_generator` contract, and the wasm32 CI gate now each live in one canonical section with cross-references elsewhere.

## Test plan

- [ ] Spec-only change — no code impact yet.
- [ ] Confirm downstream implementation tasks reference the updated pipeline/Host-delegated execution sections.

https://claude.ai/code/session_0192CnovetfdwnzvUYq6bbwL