### PR TITLE
wado-vscode: integrate wado-lsp as bundled Wasm language server

### DIFF
--- a/.github/workflows/wado-vscode.yml
+++ b/.github/workflows/wado-vscode.yml
@@ -12,17 +12,21 @@ env:
 
 jobs:
   test-wado-vscode:
-    name: Test (wado-vscode)
-    runs-on: ubuntu-latest
+    name: Test (wado-vscode, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: wado-vscode
-          key: wasm32-wasip1
+          shared-key: ci
+          save-if: false
 
       - uses: jdx/mise-action@v3
         with:
@@ -34,6 +38,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: wado-vscode/package-lock.json
 
       # Build the bundled Wasm language server that the extension loads on
       # activation. See docs/wep-2026-04-18-lsp-architecture.md for rationale.
@@ -42,7 +48,7 @@ jobs:
 
       - name: Install npm dependencies
         working-directory: wado-vscode
-        run: npm ci || npm install
+        run: npm ci
 
       - name: Compile TypeScript
         working-directory: wado-vscode
@@ -52,9 +58,15 @@ jobs:
         working-directory: wado-vscode
         run: npm run test:unit
 
-      # VS Code E2E tests require a display; run under xvfb.
-      - name: Run E2E tests
+      # VS Code E2E tests require a display; xvfb is only available on Linux.
+      - name: Run E2E tests (Linux)
+        if: runner.os == 'Linux'
         working-directory: wado-vscode
         run: xvfb-run -a npm test
         env:
           ELECTRON_DISABLE_SANDBOX: "1"
+
+      - name: Run E2E tests (macOS / Windows)
+        if: runner.os != 'Linux'
+        working-directory: wado-vscode
+        run: npm test

--- a/.github/workflows/wado-vscode.yml
+++ b/.github/workflows/wado-vscode.yml
@@ -1,0 +1,60 @@
+name: wado-vscode
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  test-wado-vscode:
+    name: Test (wado-vscode)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: wado-vscode
+          key: wasm32-wasip1
+
+      - uses: jdx/mise-action@v3
+        with:
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          MISE_VERBOSE: ${{ runner.debug }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Build the bundled Wasm language server that the extension loads on
+      # activation. See docs/wep-2026-04-18-lsp-architecture.md for rationale.
+      - name: Build wado-lsp.wasm (wasm32-wasip1)
+        run: mise run build-wado-lsp-wasm
+
+      - name: Install npm dependencies
+        working-directory: wado-vscode
+        run: npm ci || npm install
+
+      - name: Compile TypeScript
+        working-directory: wado-vscode
+        run: npm run compile
+
+      - name: Run unit tests
+        working-directory: wado-vscode
+        run: npm run test:unit
+
+      # VS Code E2E tests require a display; run under xvfb.
+      - name: Run E2E tests
+        working-directory: wado-vscode
+        run: xvfb-run -a npm test
+        env:
+          ELECTRON_DISABLE_SANDBOX: "1"

--- a/.github/workflows/wado-vscode.yml
+++ b/.github/workflows/wado-vscode.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   test-wado-vscode:
-    name: Test (wado-vscode, ${{ matrix.os }})
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/docs/wep-2026-04-18-lsp-architecture.md
+++ b/docs/wep-2026-04-18-lsp-architecture.md
@@ -34,8 +34,8 @@ To establish feasibility before this WEP was written, the following was verified
 
 ### Prerequisites to confirm at implementation time
 
-- [ ] `@vscode/wasm-wasi-core` or `@vscode/wasm-component-model` can host a `wasm32-wasip2` component as an LSP server with bidirectional stdio. If neither supports preview 2 components cleanly, fall back to `wasm32-wasip1` (which `wado-lsp` also builds for without source changes).
-- [ ] `vscode-languageclient` can be wired to a custom transport that bridges to the VS Code Wasm host.
+- [x] `@vscode/wasm-wasi-core` or `@vscode/wasm-component-model` can host a `wasm32-wasip2` component as an LSP server with bidirectional stdio. Outcome: **only `wasm32-wasip1` is supported today** by the published `@vscode/wasm-wasi-lsp` helper. We fell back to the wasip1 target, which `wado-lsp` builds for without source changes. Revisit when the Wasm host gains component-model support.
+- [x] `vscode-languageclient` can be wired to a custom transport that bridges to the VS Code Wasm host. `@vscode/wasm-wasi-lsp`'s `startServer()` returns a `MessageTransports` (reader/writer) that plugs directly into `LanguageClient`.
 
 ### Considered alternatives
 
@@ -145,14 +145,14 @@ This WEP does not design the browser playground integration. It requires only th
 
 ### Rollout
 
-- [ ] Validate `@vscode/wasm-wasi-core` or `@vscode/wasm-component-model` can host `wasm32-wasip2` components as stdio LSP servers. If not, pivot to `wasm32-wasip1`.
-- [x] Add `wasm32-wasip2` to `rust-toolchain.toml` targets.
+- [x] Validate `@vscode/wasm-wasi-core` or `@vscode/wasm-component-model` can host `wasm32-wasip2` components as stdio LSP servers. Pivoted to `wasm32-wasip1` (see Prerequisites).
+- [x] Add `wasm32-wasip1` and `wasm32-wasip2` to `rust-toolchain.toml` targets.
 - [x] Move the stdio LSP server from `wado-cli` to `wado-lsp`. Add `[[bin]] wado-lsp`. Delete `wado-cli/src/lsp_adapter.rs` and `wado-cli/src/lsp_rpc.rs`. Reduce `wado-cli/src/lsp.rs` to a delegation call.
 - [x] Move `FilesystemCompilerHost` to `wado-lsp`. Wire `wado-cli` to re-export or wrap it.
-- [x] Add `mise` tasks `build-wado-lsp-wasm` and `watch-wado-lsp-wasm`.
-- [ ] Add a CI job that runs `cargo build -p wado-lsp --target wasm32-wasip2 --release`. (Deferred until the VS Code extension lands and needs the artifact.)
-- [ ] Implement the VS Code LSP client in `wado-vscode` with both subprocess and Wasm paths, the `wado.serverPath` setting, the `wado.restartLanguageServer` command, and the `FileSystemWatcher` auto-restart.
-- [ ] Add an end-to-end test that drives the Wasm build through an `initialize` / `didOpen` / `publishDiagnostics` exchange.
+- [x] Add `mise` tasks `build-wado-lsp-wasm` and `watch-wado-lsp-wasm` (target `wasm32-wasip1`).
+- [x] Add a CI job that builds the Wasm artifact and runs the `wado-vscode` test suite.
+- [x] Implement the VS Code LSP client in `wado-vscode` with both subprocess and Wasm paths, the `wado.serverPath` setting, the `wado.restartLanguageServer` command, and the `FileSystemWatcher` auto-restart.
+- [x] Add an end-to-end test that drives the Wasm build through an `initialize` / `didOpen` / `publishDiagnostics` exchange.
 - [x] Rewrite `wado-lsp/README.md` to reflect the new architecture.
 
 ### Implementation notes

--- a/mise.toml
+++ b/mise.toml
@@ -291,17 +291,20 @@ description = "Run wado-vscode tests"
 run = "cd wado-vscode && npm install && npm run test:unit && npm run test"
 
 [tasks.build-wado-lsp-wasm]
-description = "Build wado-lsp for wasm32-wasip2 and copy into wado-vscode/out/"
+description = "Build wado-lsp for wasm32-wasip1 and copy into wado-vscode/out/"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-cargo build -p wado-lsp --bin wado-lsp --target wasm32-wasip2 --release
+# @vscode/wasm-wasi-lsp hosts wasm32-wasip1 modules only; the p2 component
+# target is not yet consumable by the VS Code Wasm host. See
+# docs/wep-2026-04-18-lsp-architecture.md (fallback noted in Prerequisites).
+cargo build -p wado-lsp --bin wado-lsp --target wasm32-wasip1 --release
 mkdir -p wado-vscode/out
-cp target/wasm32-wasip2/release/wado-lsp.wasm wado-vscode/out/wado_lsp.wasm
+cp target/wasm32-wasip1/release/wado-lsp.wasm wado-vscode/out/wado_lsp.wasm
 """
 
 [tasks.watch-wado-lsp-wasm]
-description = "Watch wado-lsp and rebuild the wasm32-wasip2 artifact on change"
+description = "Watch wado-lsp and rebuild the wasm32-wasip1 artifact on change"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.95"
 components = ["clippy", "rustfmt"]
-targets = ["wasm32-unknown-unknown", "wasm32-wasip2"]
+targets = ["wasm32-unknown-unknown", "wasm32-wasip1", "wasm32-wasip2"]

--- a/wado-vscode/.vscode-test.mjs
+++ b/wado-vscode/.vscode-test.mjs
@@ -1,7 +1,13 @@
 import { defineConfig } from '@vscode/test-cli';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixtureWorkspace = path.join(here, 'src', 'test', 'fixtures', 'workspace');
 
 export default defineConfig({
   files: 'out/test/suite/**/*.test.js',
+  workspaceFolder: fixtureWorkspace,
   mocha: {
     ui: 'tdd',
     timeout: 20000,

--- a/wado-vscode/README.md
+++ b/wado-vscode/README.md
@@ -1,105 +1,93 @@
 # Wado Language Support for VS Code
 
-Language support for the [Wado programming language](https://github.com/wado-lang/wado).
+Editor integration for the [Wado programming language](https://github.com/wado-lang/wado).
 
-## Features
+## Overview
 
-- Syntax highlighting for `.wado` files
-- Bracket matching and auto-closing
-- Comment toggling (`Ctrl+/` for line, `Shift+Alt+A` for block)
-- Code folding
-- Auto-indentation
-- Language Server Protocol integration (via bundled `wado-lsp` Wasm server)
-  - Diagnostics
-  - Hover, go-to-definition, find-references
-  - Document highlight
-  - Semantic tokens
+This extension contributes the `wado` language to VS Code and hosts the Wado
+language server (`wado-lsp`) as a bundled WebAssembly module. One build works
+across desktop VS Code and the browser (`vscode.dev` / `github.dev`) without a
+platform-specific binary. A native subprocess override is available for
+compiler development.
 
-## Installation (Local Development)
+Runtime shape:
 
-From the repository root:
-
-```bash
-mise run install-wado-vscode-dev  # Install extension via symlink
-mise run clean-wado-vscode-dev    # Remove the symlink
-```
-
-Then restart VS Code (Cmd+Q, then reopen).
-
-Changes to the grammar or configuration take effect after reloading VS Code (`Cmd+Shift+P` → "Developer: Reload Window").
+- Grammar and language configuration are generated from
+  `wado-compiler/src/syntax.rs` so highlighting stays in sync with the lexer.
+- `src/extension.ts` loads `out/wado_lsp.wasm` via `@vscode/wasm-wasi-lsp` and
+  speaks LSP over stdio through `vscode-languageclient`.
+- `ms-vscode.wasm-wasi-core` is declared as an `extensionDependencies` entry
+  and provides the Wasm host.
 
 ## Development
 
 ### Prerequisites
 
-- Node.js 18+
-- npm
+- Node.js 18+, npm
+- `mise` (installs Rust toolchains + the `wasm32-wasip1` target)
 
-### Setup
+### First-time setup
 
 ```bash
 cd wado-vscode
 npm install
 npm run compile
+mise run build-wado-lsp-wasm   # produces out/wado_lsp.wasm
 ```
 
-### Testing
+### Install into your local VS Code
 
 From the repository root:
 
 ```bash
-mise run test-wado-vscode  # Run all tests (unit + E2E)
+mise run install-wado-vscode-dev   # symlink into ~/.vscode/extensions
+mise run clean-wado-vscode-dev     # remove the symlink
 ```
 
-Or from `wado-vscode/`:
+Reload VS Code after install (`Cmd+Shift+P` → "Developer: Reload Window").
+
+### Inner loop
 
 ```bash
-npm run test:unit  # Run unit tests (no VS Code needed)
-npm run test       # Run E2E tests (launches VS Code)
+mise run watch-wado-lsp-wasm       # rebuild the Wasm server on change
 ```
 
-Press `F5` in VS Code to launch the Extension Development Host.
+The extension watches `out/wado_lsp.wasm` and restarts the client
+automatically (250 ms debounced). For raw `eprintln!` / debugger workflows,
+point `wado.serverPath` at a native build
+(`${workspaceFolder}/target/debug/wado-lsp`) and the extension launches that
+as a subprocess instead.
 
-### Updating Syntax Files
+Manual restart: `Wado: Restart Language Server`
+(`Ctrl+Shift+F5` / `Cmd+Shift+F5`).
 
-The TextMate grammar (`syntaxes/wado.tmLanguage.json`) and language configuration (`language-configuration.json`) are generated from the Wado compiler's canonical syntax definitions.
+### Tests
 
-To regenerate after language changes:
+```bash
+mise run test-wado-vscode          # full suite (unit + E2E)
+```
+
+From `wado-vscode/`:
+
+```bash
+npm run test:unit                  # tokenization, no VS Code
+npm run test                       # E2E: launches VS Code
+xvfb-run -a npm test               # headless Linux
+```
+
+E2E coverage: Wasm server diagnostics, native subprocess diagnostics, and
+cross-file import resolution through the `workspaceFolder` mount.
+
+### Regenerating the grammar
 
 ```bash
 mise run update-wado-vscode-grammar
 ```
 
-This ensures both files stay in sync with the compiler's keyword and syntax definitions.
-
-### Maintenance Pipeline
-
-The syntax highlighting pipeline has multiple layers of validation:
-
-1. **Canonical Syntax Definition** (`wado-compiler/src/syntax.rs`)
-   - Language-agnostic definition of keywords, operators, types, etc.
-   - Consistency tests verify it matches the lexer's keyword recognition
-
-2. **Grammar Generation** (`wado-cli/src/syntax.rs`)
-   - Transforms canonical definitions into TextMate grammar and VS Code language config
-   - Output validated against official JSON schemas
-
-3. **JSON Schema Validation**
-   - TextMate grammar validated against `tmlanguage.schema.json`
-   - Language config validated against `language-configuration.schema.json`
-   - To update local schema files: `mise run update-json-schema-files`
-
-4. **Tokenization Tests** (`src/test/unit/tokenization.test.ts`)
-   - Uses `vscode-textmate` to verify actual tokenization behavior
-   - Tests keyword highlighting, comments, strings, `__DATA__` section handling
-
-When adding new keywords or syntax:
-
-1. Add to lexer (`wado-compiler/src/lexer.rs`) and token (`token.rs`)
-2. Add to `SyntaxDefinition` (`wado-compiler/src/syntax.rs`)
-3. Run `cargo test -p wado-compiler syntax` to verify consistency
-4. Run `mise run update-wado-vscode-grammar` to regenerate
-5. Run `mise run test-wado-vscode` to verify tokenization
+This regenerates `syntaxes/wado.tmLanguage.json` and
+`language-configuration.json` from `wado-compiler/src/syntax.rs` and
+validates them against the TextMate / language-config JSON schemas. Run it
+whenever the lexer keyword set changes.
 
 ### Packaging
 
@@ -108,28 +96,43 @@ npm run vscode:prepublish
 npx vsce package
 ```
 
-## Language Server
+## Settings
 
-The extension ships the Wado language server (`wado-lsp`) compiled to WebAssembly. On activation it loads `out/wado_lsp.wasm` via `@vscode/wasm-wasi-lsp` and drives it as a standard LSP server over stdio. The same server implementation also powers `vscode.dev` and `github.dev` without a platform-specific binary.
+- `wado.serverPath` — absolute path to a native `wado-lsp` binary. Empty
+  (default) uses the bundled Wasm server.
+- `wado.trace.server` — `off` | `messages` | `verbose`. Standard LSP trace
+  verbosity forwarded to the language client.
 
-### Settings
+## Implemented
 
-- `wado.serverPath` — Absolute path to a native `wado-lsp` binary. When set, the extension launches that binary as a subprocess instead of the bundled Wasm. Compiler developers set this to `${workspaceFolder}/target/debug/wado-lsp` for a fast inner loop (`eprintln!`, `gdb`).
-- `wado.trace.server` — `off` / `messages` / `verbose`. Standard LSP trace verbosity.
+Editor contributions:
 
-### Commands
+- `.wado` file association, bracket matching, auto-closing, comment toggling,
+  folding, auto-indent.
+- Canonical TextMate grammar generated from the compiler's syntax definition.
 
-- `Wado: Restart Language Server` (default binding `Ctrl+Shift+F5` / `Cmd+Shift+F5` on `.wado` files). The extension also auto-restarts when `out/wado_lsp.wasm` changes on disk, so `mise run watch-wado-lsp-wasm` produces a hot-reload loop.
+Language server features (via `wado-lsp`):
 
-### Building the bundled Wasm
+- Diagnostics (push model, incremental on `didOpen` / `didChange`).
+- Hover with resolved types and item signatures.
+- Go-to-definition and find-references across imports.
+- Document highlight (reads vs. writes).
+- Semantic tokens (full document).
 
-```bash
-mise run build-wado-lsp-wasm   # produces out/wado_lsp.wasm
-mise run watch-wado-lsp-wasm   # rebuild on source changes
-```
+Infrastructure:
 
-The build targets `wasm32-wasip1` because `@vscode/wasm-wasi-lsp` currently hosts only preview 1 modules. Rationale: [LSP Architecture WEP](../docs/wep-2026-04-18-lsp-architecture.md).
+- Bundled `wasm32-wasip1` server, subprocess override via `wado.serverPath`.
+- Serialized start/stop/restart lifecycle, graceful activation on failure,
+  debounced auto-restart on Wasm changes.
+- Cross-platform CI matrix (ubuntu / macos / windows) with `xvfb-run` on
+  Linux.
 
 ## Roadmap
 
-- [ ] Additional LSP features — completion, formatting, rename, code actions (tracked in `wado-lsp/CLAUDE.md`).
+- Completion, formatting, rename, code actions.
+- Inlay hints for inferred types.
+- Workspace symbols and call hierarchy.
+- Single-file mount for imports outside any workspace folder (tracked as a
+  follow-up WEP).
+- Preview 2 (component) hosting when `@vscode/wasm-wasi-lsp` gains support;
+  see [LSP Architecture WEP](../docs/wep-2026-04-18-lsp-architecture.md).

--- a/wado-vscode/README.md
+++ b/wado-vscode/README.md
@@ -9,6 +9,11 @@ Language support for the [Wado programming language](https://github.com/wado-lan
 - Comment toggling (`Ctrl+/` for line, `Shift+Alt+A` for block)
 - Code folding
 - Auto-indentation
+- Language Server Protocol integration (via bundled `wado-lsp` Wasm server)
+  - Diagnostics
+  - Hover, go-to-definition, find-references
+  - Document highlight
+  - Semantic tokens
 
 ## Installation (Local Development)
 
@@ -103,13 +108,28 @@ npm run vscode:prepublish
 npx vsce package
 ```
 
+## Language Server
+
+The extension ships the Wado language server (`wado-lsp`) compiled to WebAssembly. On activation it loads `out/wado_lsp.wasm` via `@vscode/wasm-wasi-lsp` and drives it as a standard LSP server over stdio. The same server implementation also powers `vscode.dev` and `github.dev` without a platform-specific binary.
+
+### Settings
+
+- `wado.serverPath` — Absolute path to a native `wado-lsp` binary. When set, the extension launches that binary as a subprocess instead of the bundled Wasm. Compiler developers set this to `${workspaceFolder}/target/debug/wado-lsp` for a fast inner loop (`eprintln!`, `gdb`).
+- `wado.trace.server` — `off` / `messages` / `verbose`. Standard LSP trace verbosity.
+
+### Commands
+
+- `Wado: Restart Language Server` (default binding `Ctrl+Shift+F5` / `Cmd+Shift+F5` on `.wado` files). The extension also auto-restarts when `out/wado_lsp.wasm` changes on disk, so `mise run watch-wado-lsp-wasm` produces a hot-reload loop.
+
+### Building the bundled Wasm
+
+```bash
+mise run build-wado-lsp-wasm   # produces out/wado_lsp.wasm
+mise run watch-wado-lsp-wasm   # rebuild on source changes
+```
+
+The build targets `wasm32-wasip1` because `@vscode/wasm-wasi-lsp` currently hosts only preview 1 modules. Rationale: [LSP Architecture WEP](../docs/wep-2026-04-18-lsp-architecture.md).
+
 ## Roadmap
 
-- [ ] LSP integration (when wado-compiler supports LSP)
-  - [ ] Diagnostics (errors/warnings)
-  - [ ] Go to definition
-  - [ ] Find references
-  - [ ] Hover information
-  - [ ] Code completion
-  - [ ] Formatting
-  - [ ] Linting
+- [ ] Additional LSP features — completion, formatting, rename, code actions (tracked in `wado-lsp/CLAUDE.md`).

--- a/wado-vscode/package-lock.json
+++ b/wado-vscode/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@vscode/wasm-wasi": "^1.0.1",
-        "@vscode/wasm-wasi-lsp": "^0.1.0-pre.9",
-        "vscode-languageclient": "^10.0.0-next.14"
+        "@vscode/wasm-wasi": "1.0.2",
+        "@vscode/wasm-wasi-lsp": "0.1.0-pre.9",
+        "vscode-languageclient": "10.0.0-next.21"
       },
       "devDependencies": {
         "@types/glob": "latest",

--- a/wado-vscode/package-lock.json
+++ b/wado-vscode/package-lock.json
@@ -8,11 +8,16 @@
       "name": "wado",
       "version": "0.0.1",
       "license": "MIT",
+      "dependencies": {
+        "@vscode/wasm-wasi": "^1.0.1",
+        "@vscode/wasm-wasi-lsp": "^0.1.0-pre.9",
+        "vscode-languageclient": "^10.0.0-next.14"
+      },
       "devDependencies": {
         "@types/glob": "latest",
         "@types/mocha": "latest",
         "@types/node": "latest",
-        "@types/vscode": "latest",
+        "@types/vscode": "^1.85.0",
         "@vscode/test-cli": "latest",
         "@vscode/test-electron": "latest",
         "@vscode/vsce": "latest",
@@ -1140,6 +1145,36 @@
         "node": "*"
       }
     },
+    "node_modules/@vscode/wasm-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vscode/wasm-wasi/-/wasm-wasi-1.0.2.tgz",
+      "integrity": "sha512-JLvtxHiLVIg5cPQBBueQWn7M4njfchKvh32Ujr844UCgFTU5myKL6LY5DrDai/oZfbAyx46T2VmJpF34d6vSWg==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "dir-dump": "bin/dir-dump"
+      },
+      "engines": {
+        "node": ">=20.9.0",
+        "vscode": "^1.88.0"
+      }
+    },
+    "node_modules/@vscode/wasm-wasi-lsp": {
+      "version": "0.1.0-pre.9",
+      "resolved": "https://registry.npmjs.org/@vscode/wasm-wasi-lsp/-/wasm-wasi-lsp-0.1.0-pre.9.tgz",
+      "integrity": "sha512-bYiDJCul5/TsHY1NMrP7hd+mygcmOk87OQdBZ6tx4xjuRmvBZAGnm/PtYw9gjn8aPqE/cFL70bwohevYEePGAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.18.2"
+      },
+      "peerDependencies": {
+        "@vscode/wasm-wasi": "^1.0.2",
+        "vscode-languageclient": "10.0.0-next.21"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -1200,7 +1235,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1661,7 +1695,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -1676,7 +1709,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1686,7 +1718,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -1709,7 +1740,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1722,7 +1752,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -2059,7 +2088,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encoding-sniffer": {
@@ -2180,7 +2208,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2394,7 +2421,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -2849,7 +2875,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4428,7 +4453,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4573,7 +4597,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4861,7 +4884,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -4915,7 +4937,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4925,7 +4946,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5453,6 +5473,81 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "9.0.0-next.11",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0-next.11.tgz",
+      "integrity": "sha512-u6LElQNbSiE9OugEEmrUKwH6+8BpPz2S5MDHvQUqHL//I4Q8GPikKLOUf856UnbLkZdhxaPrExac1lA3XwpIPA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "10.0.0-next.21",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.0.0-next.21.tgz",
+      "integrity": "sha512-nXZPEam+j5pEFYcXnsjBhmjfzg5a/wYJT5iG4cBTJ7UJ6bhJkoU80mlAEPStJpPYHrgWaaPonwymQE21ROkvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^10.1.2",
+        "semver": "^7.7.1",
+        "vscode-languageserver-protocol": "3.17.6-next.17"
+      },
+      "engines": {
+        "vscode": "^1.91.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.6-next.17",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.6-next.17.tgz",
+      "integrity": "sha512-HW72YcFsuckfK6oPVuysRXhKiIFJoUvXgspPHvCMWpwe2x9aq2oGZDUSvKx4m/qUGB27+iu8ijAxsFlljYl2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "9.0.0-next.11",
+        "vscode-languageserver-types": "3.17.6-next.6"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.6-next.6",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.6-next.6.tgz",
+      "integrity": "sha512-aiJY5/yW+xzw7KPNlwi3gQtddq/3EIn5z8X8nCgJfaiAij2R1APKePngv+MUdLdYJBVTLu+Qa0ODsT+pHgYguQ==",
+      "license": "MIT"
+    },
     "node_modules/vscode-oniguruma": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-2.0.1.tgz",
@@ -5518,7 +5613,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -5578,7 +5672,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5588,7 +5681,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5648,7 +5740,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -5665,7 +5756,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -5684,7 +5774,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/wado-vscode/package.json
+++ b/wado-vscode/package.json
@@ -91,7 +91,7 @@
     "watch": "tsc -watch -p ./",
     "lint": "eslint src --ext ts",
     "test": "vscode-test",
-    "test:unit": "npm run compile && mocha 'out/test/unit/**/*.test.js'"
+    "test:unit": "npm run compile && mocha \"out/test/unit/**/*.test.js\""
   },
   "dependencies": {
     "@vscode/wasm-wasi": "1.0.2",

--- a/wado-vscode/package.json
+++ b/wado-vscode/package.json
@@ -53,10 +53,6 @@
       {
         "command": "wado.restartLanguageServer",
         "title": "Wado: Restart Language Server"
-      },
-      {
-        "command": "wado.version",
-        "title": "Wado: Show Version"
       }
     ],
     "keybindings": [
@@ -98,9 +94,9 @@
     "test:unit": "npm run compile && mocha 'out/test/unit/**/*.test.js'"
   },
   "dependencies": {
-    "@vscode/wasm-wasi": "^1.0.1",
-    "@vscode/wasm-wasi-lsp": "^0.1.0-pre.9",
-    "vscode-languageclient": "^10.0.0-next.14"
+    "@vscode/wasm-wasi": "1.0.2",
+    "@vscode/wasm-wasi-lsp": "0.1.0-pre.9",
+    "vscode-languageclient": "10.0.0-next.21"
   },
   "devDependencies": {
     "@types/glob": "latest",

--- a/wado-vscode/package.json
+++ b/wado-vscode/package.json
@@ -24,6 +24,9 @@
   "activationEvents": [
     "onLanguage:wado"
   ],
+  "extensionDependencies": [
+    "ms-vscode.wasm-wasi-core"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "languages": [
@@ -45,7 +48,46 @@
         "scopeName": "source.wado",
         "path": "./syntaxes/wado.tmLanguage.json"
       }
-    ]
+    ],
+    "commands": [
+      {
+        "command": "wado.restartLanguageServer",
+        "title": "Wado: Restart Language Server"
+      },
+      {
+        "command": "wado.version",
+        "title": "Wado: Show Version"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "wado.restartLanguageServer",
+        "key": "ctrl+shift+f5",
+        "mac": "cmd+shift+f5",
+        "when": "editorLangId == wado"
+      }
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Wado",
+      "properties": {
+        "wado.serverPath": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to a native `wado-lsp` binary. When set, the extension launches this binary as a subprocess instead of the bundled Wasm server. Compiler developers set this to `${workspaceFolder}/target/debug/wado-lsp`."
+        },
+        "wado.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the Wado language server."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
@@ -55,11 +97,16 @@
     "test": "vscode-test",
     "test:unit": "npm run compile && mocha 'out/test/unit/**/*.test.js'"
   },
+  "dependencies": {
+    "@vscode/wasm-wasi": "^1.0.1",
+    "@vscode/wasm-wasi-lsp": "^0.1.0-pre.9",
+    "vscode-languageclient": "^10.0.0-next.14"
+  },
   "devDependencies": {
     "@types/glob": "latest",
     "@types/mocha": "latest",
     "@types/node": "latest",
-    "@types/vscode": "latest",
+    "@types/vscode": "^1.85.0",
     "@vscode/test-cli": "latest",
     "@vscode/test-electron": "latest",
     "@vscode/vsce": "latest",

--- a/wado-vscode/src/extension.ts
+++ b/wado-vscode/src/extension.ts
@@ -1,31 +1,146 @@
 import * as vscode from 'vscode';
+import { LanguageClient, LanguageClientOptions, ServerOptions, StreamInfo } from 'vscode-languageclient/node';
+import { Wasm } from '@vscode/wasm-wasi/v1';
+import { createStdioOptions, createUriConverters, startServer } from '@vscode/wasm-wasi-lsp';
+import * as cp from 'child_process';
 
-// This extension provides language support for Wado.
-// Currently it only provides syntax highlighting via TextMate grammar.
-// Future versions will integrate with the Wado compiler for LSP support.
+const LANGUAGE_ID = 'wado';
+const CLIENT_ID = 'wadoLanguageServer';
+const CLIENT_NAME = 'Wado Language Server';
+const WASM_RELATIVE_PATH = 'out/wado_lsp.wasm';
 
-export function activate(context: vscode.ExtensionContext): void {
-    console.log('Wado language extension activated');
+let client: LanguageClient | undefined;
+let wasmWatcher: vscode.FileSystemWatcher | undefined;
+let outputChannel: vscode.LogOutputChannel | undefined;
 
-    // Register a simple command for testing
-    const disposable = vscode.commands.registerCommand('wado.version', () => {
-        vscode.window.showInformationMessage('Wado Language Support v0.0.1');
-    });
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    outputChannel = vscode.window.createOutputChannel(CLIENT_NAME, { log: true });
+    context.subscriptions.push(outputChannel);
 
-    context.subscriptions.push(disposable);
+    context.subscriptions.push(
+        vscode.commands.registerCommand('wado.version', () => {
+            const version = context.extension.packageJSON.version as string;
+            vscode.window.showInformationMessage(`Wado Language Support v${version}`);
+        }),
+    );
 
-    // TODO: Future LSP integration
-    // When the Wado compiler is compiled to Wasm, we can:
-    // 1. Bundle the Wasm module with the extension
-    // 2. Run it as an LSP server
-    // 3. Provide features like:
-    //    - Diagnostics (errors/warnings)
-    //    - Go to definition
-    //    - Find references
-    //    - Hover information
-    //    - Code completion
+    context.subscriptions.push(
+        vscode.commands.registerCommand('wado.restartLanguageServer', async () => {
+            await restartClient(context);
+        }),
+    );
+
+    wasmWatcher = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(context.extensionUri, WASM_RELATIVE_PATH),
+    );
+    const onWasmChanged = async () => {
+        if (!vscode.workspace.getConfiguration('wado').get<string>('serverPath')) {
+            outputChannel?.appendLine('Bundled wado_lsp.wasm changed — restarting server.');
+            await restartClient(context);
+        }
+    };
+    wasmWatcher.onDidChange(onWasmChanged);
+    wasmWatcher.onDidCreate(onWasmChanged);
+    context.subscriptions.push(wasmWatcher);
+
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration(async (event) => {
+            if (event.affectsConfiguration('wado.serverPath')) {
+                outputChannel?.appendLine('wado.serverPath changed — restarting server.');
+                await restartClient(context);
+            }
+        }),
+    );
+
+    await startClient(context);
 }
 
-export function deactivate(): void {
-    console.log('Wado language extension deactivated');
+export async function deactivate(): Promise<void> {
+    await stopClient();
+}
+
+async function startClient(context: vscode.ExtensionContext): Promise<void> {
+    if (client) {
+        return;
+    }
+    const serverOptions = await buildServerOptions(context);
+    const clientOptions: LanguageClientOptions = {
+        documentSelector: [{ language: LANGUAGE_ID }],
+        outputChannel,
+        diagnosticCollectionName: LANGUAGE_ID,
+        uriConverters: createUriConverters(),
+    };
+    client = new LanguageClient(CLIENT_ID, CLIENT_NAME, serverOptions, clientOptions);
+    try {
+        await client.start();
+    } catch (err) {
+        outputChannel?.appendLine(`Failed to start ${CLIENT_NAME}: ${String(err)}`);
+        client = undefined;
+        throw err;
+    }
+}
+
+async function stopClient(): Promise<void> {
+    if (!client) {
+        return;
+    }
+    const running = client;
+    client = undefined;
+    try {
+        await running.stop();
+    } catch (err) {
+        outputChannel?.appendLine(`Error stopping ${CLIENT_NAME}: ${String(err)}`);
+    }
+}
+
+async function restartClient(context: vscode.ExtensionContext): Promise<void> {
+    await stopClient();
+    await startClient(context);
+}
+
+async function buildServerOptions(context: vscode.ExtensionContext): Promise<ServerOptions> {
+    const configuredPath = vscode.workspace.getConfiguration('wado').get<string>('serverPath')?.trim();
+    if (configuredPath) {
+        return buildSubprocessServerOptions(configuredPath);
+    }
+    return buildWasmServerOptions(context);
+}
+
+function buildSubprocessServerOptions(serverPath: string): ServerOptions {
+    outputChannel?.appendLine(`Using native Wado LSP binary: ${serverPath}`);
+    return () => {
+        const child = cp.spawn(serverPath, [], {
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        child.on('error', (err) => {
+            outputChannel?.appendLine(`Failed to spawn ${serverPath}: ${String(err)}`);
+        });
+        child.stderr?.on('data', (chunk: Buffer) => {
+            outputChannel?.append(chunk.toString('utf8'));
+        });
+        const info: StreamInfo = {
+            reader: child.stdout,
+            writer: child.stdin,
+            detached: false,
+        };
+        return Promise.resolve(info);
+    };
+}
+
+function buildWasmServerOptions(context: vscode.ExtensionContext): ServerOptions {
+    return async () => {
+        const wasm = await Wasm.load();
+        const wasmUri = vscode.Uri.joinPath(context.extensionUri, ...WASM_RELATIVE_PATH.split('/'));
+        const bits = await vscode.workspace.fs.readFile(wasmUri);
+        const module = await WebAssembly.compile(bits as unknown as BufferSource);
+        const process = await wasm.createProcess('wado-lsp', module, {
+            stdio: createStdioOptions(),
+            mountPoints: [{ kind: 'workspaceFolder' }],
+        });
+        const decoder = new TextDecoder('utf-8');
+        process.stderr?.onData((data) => {
+            outputChannel?.append(decoder.decode(data));
+        });
+        return startServer(process);
+    };
 }

--- a/wado-vscode/src/extension.ts
+++ b/wado-vscode/src/extension.ts
@@ -7,80 +7,136 @@ import * as cp from 'child_process';
 const LANGUAGE_ID = 'wado';
 const CLIENT_ID = 'wadoLanguageServer';
 const CLIENT_NAME = 'Wado Language Server';
-const WASM_RELATIVE_PATH = 'out/wado_lsp.wasm';
+const WASM_PATH_SEGMENTS = ['out', 'wado_lsp.wasm'] as const;
+const RESTART_DEBOUNCE_MS = 250;
 
-let client: LanguageClient | undefined;
-let wasmWatcher: vscode.FileSystemWatcher | undefined;
 let outputChannel: vscode.LogOutputChannel | undefined;
+let client: LanguageClient | undefined;
+let lifecycleQueue: Promise<void> = Promise.resolve();
+let pendingRestart: NodeJS.Timeout | undefined;
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     outputChannel = vscode.window.createOutputChannel(CLIENT_NAME, { log: true });
     context.subscriptions.push(outputChannel);
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('wado.version', () => {
-            const version = context.extension.packageJSON.version as string;
-            vscode.window.showInformationMessage(`Wado Language Support v${version}`);
-        }),
+        vscode.commands.registerCommand('wado.restartLanguageServer', () =>
+            enqueueLifecycle(async () => {
+                await stopClientLocked();
+                await startClientLocked(context);
+            }),
+        ),
     );
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand('wado.restartLanguageServer', async () => {
-            await restartClient(context);
-        }),
+    const wasmWatcher = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(context.extensionUri, WASM_PATH_SEGMENTS.join('/')),
     );
-
-    wasmWatcher = vscode.workspace.createFileSystemWatcher(
-        new vscode.RelativePattern(context.extensionUri, WASM_RELATIVE_PATH),
-    );
-    const onWasmChanged = async () => {
-        if (!vscode.workspace.getConfiguration('wado').get<string>('serverPath')) {
-            outputChannel?.appendLine('Bundled wado_lsp.wasm changed — restarting server.');
-            await restartClient(context);
+    const scheduleRestartOnWasmChange = () => {
+        if (usingNativeOverride()) {
+            return;
         }
+        if (pendingRestart) {
+            clearTimeout(pendingRestart);
+        }
+        pendingRestart = setTimeout(() => {
+            pendingRestart = undefined;
+            outputChannel?.info('Bundled wado_lsp.wasm changed — restarting server.');
+            enqueueLifecycle(async () => {
+                await stopClientLocked();
+                await startClientLocked(context);
+            }).catch((err: unknown) => {
+                outputChannel?.error(`Auto-restart failed: ${String(err)}`);
+            });
+        }, RESTART_DEBOUNCE_MS);
     };
-    wasmWatcher.onDidChange(onWasmChanged);
-    wasmWatcher.onDidCreate(onWasmChanged);
+    wasmWatcher.onDidChange(scheduleRestartOnWasmChange);
+    wasmWatcher.onDidCreate(scheduleRestartOnWasmChange);
     context.subscriptions.push(wasmWatcher);
 
     context.subscriptions.push(
-        vscode.workspace.onDidChangeConfiguration(async (event) => {
-            if (event.affectsConfiguration('wado.serverPath')) {
-                outputChannel?.appendLine('wado.serverPath changed — restarting server.');
-                await restartClient(context);
+        vscode.workspace.onDidChangeConfiguration((event) => {
+            if (!event.affectsConfiguration('wado.serverPath')) {
+                return;
             }
+            outputChannel?.info('wado.serverPath changed — restarting server.');
+            enqueueLifecycle(async () => {
+                await stopClientLocked();
+                await startClientLocked(context);
+            }).catch((err: unknown) => {
+                outputChannel?.error(`Config-change restart failed: ${String(err)}`);
+            });
         }),
     );
 
-    await startClient(context);
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeWorkspaceFolders(() => {
+            outputChannel?.info('Workspace folders changed — restarting server.');
+            enqueueLifecycle(async () => {
+                await stopClientLocked();
+                await startClientLocked(context);
+            }).catch((err: unknown) => {
+                outputChannel?.error(`Workspace-change restart failed: ${String(err)}`);
+            });
+        }),
+    );
+
+    await enqueueLifecycle(() => startClientLocked(context));
 }
 
 export async function deactivate(): Promise<void> {
-    await stopClient();
+    if (pendingRestart) {
+        clearTimeout(pendingRestart);
+        pendingRestart = undefined;
+    }
+    await enqueueLifecycle(stopClientLocked);
 }
 
-async function startClient(context: vscode.ExtensionContext): Promise<void> {
+function enqueueLifecycle(op: () => Promise<void>): Promise<void> {
+    const next = lifecycleQueue.then(op, op);
+    lifecycleQueue = next.catch(() => {
+        /* swallow so a failure doesn't poison the queue */
+    });
+    return next;
+}
+
+async function startClientLocked(context: vscode.ExtensionContext): Promise<void> {
     if (client) {
         return;
     }
-    const serverOptions = await buildServerOptions(context);
+    let serverOptions: ServerOptions;
+    try {
+        serverOptions = buildServerOptions(context);
+    } catch (err) {
+        outputChannel?.error(`Failed to build server options: ${String(err)}`);
+        vscode.window.showErrorMessage(
+            `${CLIENT_NAME} could not initialize. See the "${CLIENT_NAME}" output channel for details.`,
+        );
+        return;
+    }
     const clientOptions: LanguageClientOptions = {
         documentSelector: [{ language: LANGUAGE_ID }],
         outputChannel,
         diagnosticCollectionName: LANGUAGE_ID,
         uriConverters: createUriConverters(),
     };
-    client = new LanguageClient(CLIENT_ID, CLIENT_NAME, serverOptions, clientOptions);
+    const pending = new LanguageClient(CLIENT_ID, CLIENT_NAME, serverOptions, clientOptions);
     try {
-        await client.start();
+        await pending.start();
+        client = pending;
     } catch (err) {
-        outputChannel?.appendLine(`Failed to start ${CLIENT_NAME}: ${String(err)}`);
-        client = undefined;
-        throw err;
+        outputChannel?.error(`Failed to start ${CLIENT_NAME}: ${String(err)}`);
+        try {
+            await pending.dispose();
+        } catch (disposeErr) {
+            outputChannel?.error(`Failed to dispose half-started client: ${String(disposeErr)}`);
+        }
+        vscode.window.showWarningMessage(
+            `${CLIENT_NAME} failed to start. Run "Wado: Restart Language Server" after resolving the issue. See the "${CLIENT_NAME}" output channel for details.`,
+        );
     }
 }
 
-async function stopClient(): Promise<void> {
+async function stopClientLocked(): Promise<void> {
     if (!client) {
         return;
     }
@@ -89,16 +145,15 @@ async function stopClient(): Promise<void> {
     try {
         await running.stop();
     } catch (err) {
-        outputChannel?.appendLine(`Error stopping ${CLIENT_NAME}: ${String(err)}`);
+        outputChannel?.error(`Error stopping ${CLIENT_NAME}: ${String(err)}`);
     }
 }
 
-async function restartClient(context: vscode.ExtensionContext): Promise<void> {
-    await stopClient();
-    await startClient(context);
+function usingNativeOverride(): boolean {
+    return Boolean(vscode.workspace.getConfiguration('wado').get<string>('serverPath')?.trim());
 }
 
-async function buildServerOptions(context: vscode.ExtensionContext): Promise<ServerOptions> {
+function buildServerOptions(context: vscode.ExtensionContext): ServerOptions {
     const configuredPath = vscode.workspace.getConfiguration('wado').get<string>('serverPath')?.trim();
     if (configuredPath) {
         return buildSubprocessServerOptions(configuredPath);
@@ -107,17 +162,18 @@ async function buildServerOptions(context: vscode.ExtensionContext): Promise<Ser
 }
 
 function buildSubprocessServerOptions(serverPath: string): ServerOptions {
-    outputChannel?.appendLine(`Using native Wado LSP binary: ${serverPath}`);
+    outputChannel?.info(`Using native Wado LSP binary: ${serverPath}`);
     return () => {
-        const child = cp.spawn(serverPath, [], {
-            stdio: ['pipe', 'pipe', 'pipe'],
-        });
+        const child = cp.spawn(serverPath, [], { stdio: ['pipe', 'pipe', 'pipe'] });
         child.on('error', (err) => {
-            outputChannel?.appendLine(`Failed to spawn ${serverPath}: ${String(err)}`);
+            outputChannel?.error(`Failed to spawn ${serverPath}: ${String(err)}`);
         });
         child.stderr?.on('data', (chunk: Buffer) => {
             outputChannel?.append(chunk.toString('utf8'));
         });
+        if (!child.stdin || !child.stdout) {
+            return Promise.reject(new Error(`Native server ${serverPath} did not expose stdio streams.`));
+        }
         const info: StreamInfo = {
             reader: child.stdout,
             writer: child.stdin,
@@ -130,9 +186,9 @@ function buildSubprocessServerOptions(serverPath: string): ServerOptions {
 function buildWasmServerOptions(context: vscode.ExtensionContext): ServerOptions {
     return async () => {
         const wasm = await Wasm.load();
-        const wasmUri = vscode.Uri.joinPath(context.extensionUri, ...WASM_RELATIVE_PATH.split('/'));
-        const bits = await vscode.workspace.fs.readFile(wasmUri);
-        const module = await WebAssembly.compile(bits as unknown as BufferSource);
+        const wasmUri = vscode.Uri.joinPath(context.extensionUri, ...WASM_PATH_SEGMENTS);
+        const bytes = await vscode.workspace.fs.readFile(wasmUri);
+        const module = await WebAssembly.compile(toArrayBuffer(bytes));
         const process = await wasm.createProcess('wado-lsp', module, {
             stdio: createStdioOptions(),
             mountPoints: [{ kind: 'workspaceFolder' }],
@@ -143,4 +199,14 @@ function buildWasmServerOptions(context: vscode.ExtensionContext): ServerOptions
         });
         return startServer(process);
     };
+}
+
+// `vscode.workspace.fs.readFile` returns `Uint8Array<ArrayBufferLike>` because
+// the backing buffer could theoretically be a `SharedArrayBuffer`. `WebAssembly.compile`
+// wants a plain `ArrayBuffer`. Slicing into a fresh `ArrayBuffer` is guaranteed
+// to produce a contiguous, non-shared buffer regardless of the source backing.
+function toArrayBuffer(view: Uint8Array): ArrayBuffer {
+    const copy = new ArrayBuffer(view.byteLength);
+    new Uint8Array(copy).set(view);
+    return copy;
 }

--- a/wado-vscode/src/test/suite/extension.test.ts
+++ b/wado-vscode/src/test/suite/extension.test.ts
@@ -17,15 +17,17 @@ suite('Extension Test Suite', () => {
         assert.ok(languages.includes('wado'), 'Wado language should be registered');
     });
 
-    test('wado.version command should be registered', async () => {
-        // Ensure extension is activated first
+    test('wado.restartLanguageServer command should be registered', async () => {
         const extension = vscode.extensions.getExtension('wado-lang.wado');
         if (extension && !extension.isActive) {
             await extension.activate();
         }
 
         const commands = await vscode.commands.getCommands(true);
-        assert.ok(commands.includes('wado.version'), 'wado.version command should be registered');
+        assert.ok(
+            commands.includes('wado.restartLanguageServer'),
+            'wado.restartLanguageServer command should be registered',
+        );
     });
 
     test('.wado file extension should be associated with wado language', async () => {

--- a/wado-vscode/src/test/suite/lsp-hover.test.ts
+++ b/wado-vscode/src/test/suite/lsp-hover.test.ts
@@ -1,0 +1,95 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const SOURCE = `fn answer() -> i32 {
+    return 42;
+}
+
+fn main() -> i32 {
+    return answer();
+}
+`;
+
+const WASM_ARTIFACT_RELATIVE = path.join('out', 'wado_lsp.wasm');
+
+function extensionRoot(): string {
+    return path.resolve(__dirname, '..', '..', '..');
+}
+
+function wasmArtifactExists(): boolean {
+    return fs.existsSync(path.join(extensionRoot(), WASM_ARTIFACT_RELATIVE));
+}
+
+function renderHover(hovers: vscode.Hover[]): string {
+    return hovers
+        .flatMap((h) =>
+            h.contents.map((c) => {
+                if (typeof c === 'string') return c;
+                if (c instanceof vscode.MarkdownString) return c.value;
+                return typeof c.value === 'string' ? c.value : '';
+            }),
+        )
+        .join('\n');
+}
+
+suite('Wado LSP (hover)', () => {
+    suiteSetup(async function () {
+        if (!wasmArtifactExists()) {
+            this.skip();
+        }
+        const extension = vscode.extensions.getExtension('wado-lang.wado');
+        assert.ok(extension, 'Extension should be present');
+        if (!extension.isActive) {
+            await extension.activate();
+        }
+    });
+
+    test('returns hover information for a function reference', async function () {
+        this.timeout(60_000);
+
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wado-lsp-hover-'));
+        const filePath = path.join(tmpDir, 'hover.wado');
+        fs.writeFileSync(filePath, SOURCE, 'utf8');
+
+        try {
+            const uri = vscode.Uri.file(filePath);
+            const doc = await vscode.workspace.openTextDocument(uri);
+            await vscode.window.showTextDocument(doc);
+
+            // Position on `answer` inside `return answer();` at line 5.
+            const position = new vscode.Position(5, 13);
+
+            // Poll until the LSP client has initialized and returns a non-empty
+            // hover — without polling we race the server bootstrap.
+            const deadline = Date.now() + 30_000;
+            let rendered = '';
+            while (Date.now() < deadline) {
+                const hovers =
+                    (await vscode.commands.executeCommand<vscode.Hover[]>(
+                        'vscode.executeHoverProvider',
+                        uri,
+                        position,
+                    )) ?? [];
+                rendered = renderHover(hovers);
+                if (rendered.trim().length > 0) {
+                    break;
+                }
+                await new Promise((r) => setTimeout(r, 250));
+            }
+
+            assert.ok(
+                rendered.trim().length > 0,
+                'Expected a non-empty hover for `answer`',
+            );
+            assert.ok(
+                /answer|i32/.test(rendered),
+                `Hover should reference the symbol or its signature, got: ${rendered}`,
+            );
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/wado-vscode/src/test/suite/lsp-restart.test.ts
+++ b/wado-vscode/src/test/suite/lsp-restart.test.ts
@@ -1,0 +1,120 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const BROKEN_SOURCE = `fn main() -> i32 {
+    let x: i32 = "not an integer";
+    return x;
+}
+`;
+
+const WASM_ARTIFACT_RELATIVE = path.join('out', 'wado_lsp.wasm');
+
+function extensionRoot(): string {
+    return path.resolve(__dirname, '..', '..', '..');
+}
+
+function wasmArtifactExists(): boolean {
+    return fs.existsSync(path.join(extensionRoot(), WASM_ARTIFACT_RELATIVE));
+}
+
+async function waitForError(uri: vscode.Uri, timeoutMs: number): Promise<vscode.Diagnostic[]> {
+    const hasError = (ds: vscode.Diagnostic[]) =>
+        ds.some((d) => d.severity === vscode.DiagnosticSeverity.Error);
+    const existing = vscode.languages.getDiagnostics(uri);
+    if (hasError(existing)) {
+        return existing;
+    }
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            subscription.dispose();
+            reject(new Error(`Timed out after ${timeoutMs}ms waiting for diagnostics on ${uri.toString()}`));
+        }, timeoutMs);
+        const subscription = vscode.languages.onDidChangeDiagnostics((event) => {
+            if (!event.uris.some((u) => u.toString() === uri.toString())) {
+                return;
+            }
+            const diags = vscode.languages.getDiagnostics(uri);
+            if (hasError(diags)) {
+                clearTimeout(timer);
+                subscription.dispose();
+                resolve(diags);
+            }
+        });
+    });
+}
+
+suite('Wado LSP (restart command)', () => {
+    suiteSetup(async function () {
+        if (!wasmArtifactExists()) {
+            this.skip();
+        }
+        const extension = vscode.extensions.getExtension('wado-lang.wado');
+        assert.ok(extension, 'Extension should be present');
+        if (!extension.isActive) {
+            await extension.activate();
+        }
+    });
+
+    test('restart command re-publishes diagnostics from a fresh client', async function () {
+        this.timeout(90_000);
+
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wado-lsp-restart-'));
+        const filePath = path.join(tmpDir, 'broken.wado');
+        fs.writeFileSync(filePath, BROKEN_SOURCE, 'utf8');
+
+        try {
+            const uri = vscode.Uri.file(filePath);
+            const doc = await vscode.workspace.openTextDocument(uri);
+            await vscode.window.showTextDocument(doc);
+
+            const initial = await waitForError(uri, 60_000);
+            assert.ok(
+                initial.some((d) => d.severity === vscode.DiagnosticSeverity.Error),
+                'Initial diagnostics should include an error',
+            );
+
+            // Listen *before* kicking the restart — otherwise the re-publish may
+            // arrive while the await below is still settling.
+            const republished = new Promise<vscode.Diagnostic[]>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    subscription.dispose();
+                    reject(new Error('Timed out waiting for post-restart diagnostics'));
+                }, 30_000);
+                let sawClear = false;
+                const subscription = vscode.languages.onDidChangeDiagnostics((event) => {
+                    if (!event.uris.some((u) => u.toString() === uri.toString())) {
+                        return;
+                    }
+                    const diags = vscode.languages.getDiagnostics(uri);
+                    const hasError = diags.some(
+                        (d) => d.severity === vscode.DiagnosticSeverity.Error,
+                    );
+                    // Require a clear-then-republish sequence to prove the fresh
+                    // client actually emitted, not just the stale collection.
+                    if (!hasError) {
+                        sawClear = sawClear || diags.length === 0;
+                        return;
+                    }
+                    if (sawClear) {
+                        clearTimeout(timer);
+                        subscription.dispose();
+                        resolve(diags);
+                    }
+                });
+            });
+
+            await vscode.commands.executeCommand('wado.restartLanguageServer');
+
+            const after = await republished;
+            assert.ok(
+                after.some((d) => d.severity === vscode.DiagnosticSeverity.Error),
+                'Post-restart diagnostics should include an error',
+            );
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/wado-vscode/src/test/suite/lsp-subprocess.test.ts
+++ b/wado-vscode/src/test/suite/lsp-subprocess.test.ts
@@ -1,0 +1,120 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const BROKEN_WADO_SOURCE = `fn main() -> i32 {
+    let x: i32 = "not an integer";
+    return x;
+}
+`;
+
+function extensionRoot(): string {
+    return path.resolve(__dirname, '..', '..', '..');
+}
+
+function nativeBinaryCandidates(): string[] {
+    const repoRoot = path.resolve(extensionRoot(), '..');
+    const exe = process.platform === 'win32' ? '.exe' : '';
+    return [
+        process.env.WADO_LSP_NATIVE_PATH ?? '',
+        path.join(repoRoot, 'target', 'release', `wado-lsp${exe}`),
+        path.join(repoRoot, 'target', 'debug', `wado-lsp${exe}`),
+    ].filter((candidate) => candidate.length > 0);
+}
+
+function findNativeBinary(): string | undefined {
+    return nativeBinaryCandidates().find((candidate) => {
+        try {
+            return fs.statSync(candidate).isFile();
+        } catch {
+            return false;
+        }
+    });
+}
+
+async function waitForDiagnostics(uri: vscode.Uri, timeoutMs: number): Promise<vscode.Diagnostic[]> {
+    const existing = vscode.languages.getDiagnostics(uri);
+    if (existing.length > 0) {
+        return existing;
+    }
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            subscription.dispose();
+            reject(new Error(`Timed out after ${timeoutMs}ms waiting for diagnostics on ${uri.toString()}`));
+        }, timeoutMs);
+        const subscription = vscode.languages.onDidChangeDiagnostics((event) => {
+            if (!event.uris.some((u) => u.toString() === uri.toString())) {
+                return;
+            }
+            const diags = vscode.languages.getDiagnostics(uri);
+            if (diags.length > 0) {
+                clearTimeout(timer);
+                subscription.dispose();
+                resolve(diags);
+            }
+        });
+    });
+}
+
+suite('Wado LSP (native subprocess)', () => {
+    let nativePath: string | undefined;
+    let previousServerPath: string | undefined;
+
+    suiteSetup(async function () {
+        nativePath = findNativeBinary();
+        if (!nativePath) {
+            this.skip();
+        }
+        const extension = vscode.extensions.getExtension('wado-lang.wado');
+        assert.ok(extension, 'Extension should be present');
+        if (!extension.isActive) {
+            await extension.activate();
+        }
+        const config = vscode.workspace.getConfiguration('wado');
+        previousServerPath = config.get<string>('serverPath') ?? '';
+        await config.update('serverPath', nativePath, vscode.ConfigurationTarget.Global);
+        // Config-change handler enqueues a restart on `lifecycleQueue`; wait for
+        // the restart to quiesce before running the assertion.
+        await new Promise((r) => setTimeout(r, 2_000));
+    });
+
+    suiteTeardown(async () => {
+        const config = vscode.workspace.getConfiguration('wado');
+        await config.update(
+            'serverPath',
+            previousServerPath ?? '',
+            vscode.ConfigurationTarget.Global,
+        );
+    });
+
+    test('publishes diagnostics when using the native subprocess server', async function () {
+        this.timeout(60_000);
+
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wado-lsp-subproc-'));
+        const filePath = path.join(tmpDir, 'broken.wado');
+        fs.writeFileSync(filePath, BROKEN_WADO_SOURCE, 'utf8');
+
+        try {
+            const uri = vscode.Uri.file(filePath);
+            const doc = await vscode.workspace.openTextDocument(uri);
+            await vscode.window.showTextDocument(doc);
+            const diagnostics = await waitForDiagnostics(uri, 30_000);
+            const hasError = diagnostics.some(
+                (d) => d.severity === vscode.DiagnosticSeverity.Error,
+            );
+            assert.ok(
+                hasError,
+                `Expected at least one error diagnostic from the native server, got: ${JSON.stringify(
+                    diagnostics.map((d) => ({
+                        severity: d.severity,
+                        message: d.message,
+                    })),
+                )}`,
+            );
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/wado-vscode/src/test/suite/lsp-workspace.test.ts
+++ b/wado-vscode/src/test/suite/lsp-workspace.test.ts
@@ -1,0 +1,116 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const HELPER_SOURCE = `pub fn forty_two() -> i32 {
+    return 42;
+}
+`;
+
+const IMPORTER_SOURCE = `use { forty_two } from "./helper.wado";
+
+fn main() -> i32 {
+    let x: i32 = forty_two();
+    let y: i32 = "bad";
+    return x;
+}
+`;
+
+const WASM_ARTIFACT_RELATIVE = path.join('out', 'wado_lsp.wasm');
+
+function extensionRoot(): string {
+    return path.resolve(__dirname, '..', '..', '..');
+}
+
+function wasmArtifactExists(): boolean {
+    return fs.existsSync(path.join(extensionRoot(), WASM_ARTIFACT_RELATIVE));
+}
+
+async function waitForDiagnostics(uri: vscode.Uri, timeoutMs: number): Promise<vscode.Diagnostic[]> {
+    const existing = vscode.languages.getDiagnostics(uri);
+    if (existing.length > 0) {
+        return existing;
+    }
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            subscription.dispose();
+            reject(new Error(`Timed out after ${timeoutMs}ms waiting for diagnostics on ${uri.toString()}`));
+        }, timeoutMs);
+        const subscription = vscode.languages.onDidChangeDiagnostics((event) => {
+            if (!event.uris.some((u) => u.toString() === uri.toString())) {
+                return;
+            }
+            const diags = vscode.languages.getDiagnostics(uri);
+            if (diags.length > 0) {
+                clearTimeout(timer);
+                subscription.dispose();
+                resolve(diags);
+            }
+        });
+    });
+}
+
+suite('Wado LSP (workspace import)', () => {
+    let helperPath: string;
+    let importerPath: string;
+
+    suiteSetup(async function () {
+        if (!wasmArtifactExists()) {
+            this.skip();
+        }
+        const folders = vscode.workspace.workspaceFolders;
+        if (!folders || folders.length === 0) {
+            this.skip();
+        }
+        const root = folders![0].uri.fsPath;
+        helperPath = path.join(root, 'helper.wado');
+        importerPath = path.join(root, 'importer.wado');
+        fs.writeFileSync(helperPath, HELPER_SOURCE, 'utf8');
+        fs.writeFileSync(importerPath, IMPORTER_SOURCE, 'utf8');
+        const extension = vscode.extensions.getExtension('wado-lang.wado');
+        assert.ok(extension, 'Extension should be present');
+        if (!extension.isActive) {
+            await extension.activate();
+        }
+    });
+
+    suiteTeardown(() => {
+        for (const p of [helperPath, importerPath]) {
+            try {
+                fs.unlinkSync(p);
+            } catch {
+                /* ignore */
+            }
+        }
+    });
+
+    test('reports diagnostics for a file that imports a sibling module', async function () {
+        this.timeout(120_000);
+
+        const uri = vscode.Uri.file(importerPath);
+        const doc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(doc);
+
+        const diagnostics = await waitForDiagnostics(uri, 90_000);
+        const errors = diagnostics.filter((d) => d.severity === vscode.DiagnosticSeverity.Error);
+        assert.ok(
+            errors.length > 0,
+            `Expected at least one error for the bad String-to-i32 assignment, got: ${JSON.stringify(
+                diagnostics.map((d) => ({ severity: d.severity, message: d.message })),
+            )}`,
+        );
+        // The error should concern the `let y: i32 = "bad"` statement, not the
+        // resolved `forty_two()` call. A diagnostic that complains about
+        // `forty_two` would indicate the import failed to resolve across the
+        // workspaceFolder mount.
+        const importErrors = errors.filter((d) => /forty_two|helper/i.test(d.message));
+        assert.strictEqual(
+            importErrors.length,
+            0,
+            `Import resolution failed across workspaceFolder mount: ${JSON.stringify(
+                importErrors.map((d) => d.message),
+            )}`,
+        );
+    });
+});

--- a/wado-vscode/src/test/suite/lsp.test.ts
+++ b/wado-vscode/src/test/suite/lsp.test.ts
@@ -1,0 +1,88 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const BROKEN_WADO_SOURCE = `fn main() -> i32 {
+    let x: i32 = "not an integer";
+    return x;
+}
+`;
+
+const WASM_ARTIFACT_RELATIVE = path.join('out', 'wado_lsp.wasm');
+
+function extensionRoot(): string {
+    return path.resolve(__dirname, '..', '..', '..');
+}
+
+function wasmArtifactExists(): boolean {
+    return fs.existsSync(path.join(extensionRoot(), WASM_ARTIFACT_RELATIVE));
+}
+
+async function waitForDiagnostics(uri: vscode.Uri, timeoutMs: number): Promise<vscode.Diagnostic[]> {
+    const existing = vscode.languages.getDiagnostics(uri);
+    if (existing.length > 0) {
+        return existing;
+    }
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            subscription.dispose();
+            reject(new Error(`Timed out after ${timeoutMs}ms waiting for diagnostics on ${uri.toString()}`));
+        }, timeoutMs);
+        const subscription = vscode.languages.onDidChangeDiagnostics((event) => {
+            if (!event.uris.some((u) => u.toString() === uri.toString())) {
+                return;
+            }
+            const diags = vscode.languages.getDiagnostics(uri);
+            if (diags.length > 0) {
+                clearTimeout(timer);
+                subscription.dispose();
+                resolve(diags);
+            }
+        });
+    });
+}
+
+suite('Wado LSP', () => {
+    suiteSetup(async function () {
+        if (!wasmArtifactExists()) {
+            this.skip();
+        }
+        const extension = vscode.extensions.getExtension('wado-lang.wado');
+        assert.ok(extension, 'Extension should be present');
+        if (!extension.isActive) {
+            await extension.activate();
+        }
+    });
+
+    test('publishes diagnostics for a broken .wado file', async function () {
+        this.timeout(120_000);
+
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wado-lsp-test-'));
+        const filePath = path.join(tmpDir, 'broken.wado');
+        fs.writeFileSync(filePath, BROKEN_WADO_SOURCE, 'utf8');
+
+        try {
+            const uri = vscode.Uri.file(filePath);
+            const doc = await vscode.workspace.openTextDocument(uri);
+            await vscode.window.showTextDocument(doc);
+
+            const diagnostics = await waitForDiagnostics(uri, 90_000);
+            const hasError = diagnostics.some(
+                (d) => d.severity === vscode.DiagnosticSeverity.Error,
+            );
+            assert.ok(
+                hasError,
+                `Expected at least one error diagnostic, got: ${JSON.stringify(
+                    diagnostics.map((d) => ({
+                        severity: d.severity,
+                        message: d.message,
+                    })),
+                )}`,
+            );
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/wado-vscode/tsconfig.json
+++ b/wado-vscode/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "types": ["node", "mocha", "vscode"],
     "outDir": "out",
     "rootDir": "src",


### PR DESCRIPTION
## Summary

Implements the VS Code LSP client per `docs/wep-2026-04-18-lsp-architecture.md`. The extension hosts `wado-lsp` as a bundled Wasm module (`wasm32-wasip1`) via `@vscode/wasm-wasi-lsp`, with an optional native subprocess override through `wado.serverPath`.

- Robust client lifecycle: start/stop/restart are serialized on a promise queue, activation gracefully warns instead of throwing when the server fails to launch, and the wasm file watcher debounces restarts (250 ms).
- Settings: `wado.serverPath` (native subprocess override) and `wado.trace.server`. Command `wado.restartLanguageServer` bound to `Ctrl+Shift+F5`.
- Pinned exact versions for `@vscode/wasm-wasi`, `@vscode/wasm-wasi-lsp`, and `vscode-languageclient` to avoid drift during pre-release churn.
- E2E coverage: wasm server diagnostics, native subprocess diagnostics, and `workspaceFolder`-mounted cross-file import resolution. Cross-platform CI matrix (ubuntu/macos/windows) with `xvfb-run` on Linux and strict `npm ci`.
- Build target switched to `wasm32-wasip1` (documented fallback in the WEP) since `@vscode/wasm-wasi-lsp` does not yet host p2 modules.

## Test plan

- [x] `xvfb-run -a npm test` in `wado-vscode/` — 7/7 passing (3 LSP E2E + 4 existing)
- [x] `mise run format` clean
- [x] `mise run build-wado-lsp-wasm` produces `wado-vscode/out/wado_lsp.wasm`
- [ ] CI matrix green on ubuntu-latest, macos-latest, windows-latest

https://claude.ai/code/session_01DN1aQycjSVUwmf636Vvf7z