### PR TITLE
gale: surface grammar options, named actions, and rule visibility

### DIFF
--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -10,20 +10,7 @@ exception). The remaining work is mostly about **propagating** parsed
 information into the IR and **using** it in the code generator so that
 generated parsers are semantically correct, not just syntactically accepted.
 
-## A. IR → pipeline wiring
-
-- `Grammar.options.superClass` / `tokenVocab` / `language` — completely
-  ignored. `tokenVocab` in particular is non-trivial: it implies loading
-  another grammar's token ids.
-- `Grammar.named_actions` — stored for presence/position but not
-  surfaced anywhere. At minimum, generated output could include a
-  comment marker so downstream tooling can see where actions used to be.
-- `ParserRule.visibility` / `LexerRule.visibility` — stored but unused.
-  ANTLR4 itself ignores these at codegen, so matching ANTLR4's behavior
-  is fine, but a lint or doc comment in the generated output would make
-  the information observable.
-
-## B. Driver-level verification (remaining gaps)
+## A. Driver-level verification (remaining gaps)
 
 - **Parser-side `~TOK` / `~(block)`.** No driver-test grammar currently
   uses a parser-level complement. Either add a minimal new grammar, or
@@ -43,7 +30,7 @@ generated parsers are semantically correct, not just syntactically accepted.
 - **Wildcard `.` at parser level.** Only lexer-level `.` is exercised
   today. A parser rule like `any : . ;` has no driver-level test.
 
-## C. Negative tests
+## B. Negative tests
 
 The parser test suite is overwhelmingly positive — it verifies that
 well-formed input parses. There are almost no negative tests that pin
@@ -127,3 +114,34 @@ scans per sql_stmt entry, not 9). Expect another perf improvement on
 ## Generated Parser Bugs
 
 (none currently)
+
+## Future Work: Actions and `superClass` (low priority)
+
+Gale currently skips the contents of `{ ... }` action blocks and semantic
+predicates — the g4 parser recognizes them (so real-world grammars parse
+cleanly) but the code generator discards the host-language source. This is
+intentional for the near term: emitting Wado from opaque Java/Rust/Python
+snippets requires a cross-language translator we do not have.
+
+Once action-body support is designed, `Grammar.options.superClass` becomes
+meaningful and can be wired through as a trait bound on the generated
+parser/lexer struct (something like `impl SuperClass for GeneratedParser`,
+with action bodies able to call `self.helper(...)`). Until then the option
+is surfaced only as a metadata comment.
+
+Rough sketch, for when this is picked up:
+
+- Extend the IR so `OptionValue::Action` and per-alt action elements carry
+  a language-tagged source fragment instead of being a placeholder string.
+- Add a pluggable "action translator" interface; ship at minimum an
+  identity translator for Wado-written action bodies.
+- Generate a `SuperClass` trait (name derived from `superClass = Foo`) and
+  require callers to `impl` it; emit action bodies as method calls on
+  `self` that resolve through that trait.
+- `tokenVocab` falls out naturally at that point — another grammar's
+  generated `TokenKind` enum can be imported by name rather than merged at
+  IR time.
+
+No work here blocks any current Gale user. Re-prioritize only when a real
+grammar outside the `clean` set (ANTLR4, Rust, TypeScript lexers) needs its
+action semantics reproduced, not just skipped.

--- a/package-gale/src/gen_util.wado
+++ b/package-gale/src/gen_util.wado
@@ -1,5 +1,25 @@
-use { Alternative, Element } from "./ir.wado";
+use { Alternative, Element, Visibility } from "./ir.wado";
+use { CodeWriter } from "./wadopoet.wado";
 use { TreeSet } from "core:collections";
+
+/// Emit a `// rule visibility: <name> (ignored by codegen, matches ANTLR4)`
+/// comment for a rule whose .g4 source carried a `public` / `private` /
+/// `protected` modifier. ANTLR4 itself ignores these modifiers at code
+/// generation time, so Gale matches that behavior but surfaces the value as
+/// a doc comment above the generated `parse_X` / `try_X` function so the
+/// modifier stays observable in the output.
+pub fn gen_visibility_comment(w: &mut CodeWriter, visibility: &Visibility) {
+    let label = match *visibility {
+        Default => "",
+        Public => "public",
+        Private => "private",
+        Protected => "protected",
+    };
+    if label == "" {
+        return;
+    }
+    w.line(&`// rule visibility: {label} (ignored by codegen, matches ANTLR4)`);
+}
 
 fn is_wado_reserved(name: &String) -> bool {
     return match *name {

--- a/package-gale/src/generator.wado
+++ b/package-gale/src/generator.wado
@@ -1,4 +1,4 @@
-use { Grammar, ParserRule, Alternative, Element, RepeatElement, LabelElement, NotElement, RepeatKind, LexerRule } from "./ir.wado";
+use { Grammar, OptionValue, ParserRule, Alternative, Element, RepeatElement, LabelElement, NotElement, RepeatKind, LexerRule } from "./ir.wado";
 use {
     to_pascal_case,
     to_snake_case,
@@ -40,6 +40,7 @@ pub struct GenerateOptions {
 pub fn generate(grammar: &Grammar, options: &GenerateOptions) -> String {
     let mut w = CodeWriter::new();
     gen_header(&mut w, grammar);
+    gen_grammar_metadata(&mut w, grammar);
     gen_runtime(&mut w);
     gen_token_kind(&mut w, &grammar.lexer_rules);
     gen_cst_types(&mut w, &grammar.parser_rules);
@@ -87,6 +88,51 @@ fn gen_runtime(w: &mut CodeWriter) {
     w.raw(#include_str("./runtime.wado"));
     w.raw("\n");
 }
+
+/// Surface grammar-level options and named actions from the .g4 prequel as
+/// pass-through comments in the generated output. ANTLR4 stores these on the
+/// IR (`Grammar.options`, `Grammar.named_actions`) but most values have no
+/// semantic effect on Gale's Wado codegen (e.g. `language`, `superClass`,
+/// `tokenVocab`, or `@header` bodies whose host-language code is discarded).
+/// Emitting them as a comment block keeps the information observable for
+/// downstream tooling and makes the .g4 prequel round-trip visible.
+fn gen_grammar_metadata(w: &mut CodeWriter, grammar: &Grammar) {
+    if grammar.options.is_empty() && grammar.named_actions.is_empty() {
+        return;
+    }
+    w.line("// Grammar metadata from source .g4 prequels:");
+    for let opt of &grammar.options {
+        w.line(&`//   option {opt.name} = {format_option_value(&opt.value)}`);
+    }
+    for let act of &grammar.named_actions {
+        if let Some(scope) = &act.scope {
+            w.line(&`//   @{*scope}::{act.name}`);
+        } else {
+            w.line(&`//   @{act.name}`);
+        }
+    }
+    w.blank();
+}
+
+fn format_option_value(v: &OptionValue) -> String {
+    return match *v {
+        Ident(s) => s,
+        Qualified(parts) => {
+            let mut out = String::with_capacity(16);
+            for let mut i = 0; i < parts.len(); i += 1 {
+                if i > 0 {
+                    out.push('.');
+                }
+                out.push_str(parts[i]);
+            }
+            out
+        },
+        Str(s) => `"{s}"`,
+        Int(n) => `{n}`,
+        Action(_) => "{ ... }",
+    };
+}
+
 
 fn gen_token_kind(w: &mut CodeWriter, lexer_rules: &Array<LexerRule>) {
     let mut e = EnumSpec::new("TokenKind");

--- a/package-gale/src/generator_test.wado
+++ b/package-gale/src/generator_test.wado
@@ -1,5 +1,8 @@
 use {
     Grammar,
+    GrammarOption,
+    OptionValue,
+    NamedAction,
     ParserRule,
     Alternative,
     Element,
@@ -856,6 +859,163 @@ SEMI : ';' ;";
     // Non-letter literal must not be duplicated — plain mismatch form.
     assert str_contains(&output, "chars[pos] != ';'");
     assert !str_contains(&output, "chars[pos].eq_ignore_ascii_case(");
+}
+
+test "metadata comment lists grammar-level options" {
+    let grammar = Grammar {
+        name: "Test",
+        parser_rules: [],
+        lexer_rules: [],
+        mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [
+            GrammarOption { name: "language", value: OptionValue::Ident("Python") },
+            GrammarOption { name: "superClass", value: OptionValue::Qualified(["my", "pkg", "BaseParser"]) },
+            GrammarOption { name: "tokenVocab", value: OptionValue::Ident("TestLexer") },
+            GrammarOption { name: "caseInsensitive", value: OptionValue::Ident("true") },
+        ],
+        named_actions: [],
+        source_files: [],
+    };
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    assert str_contains(&output, "// Grammar metadata from source .g4 prequels:"),
+        `missing metadata header:\n{output}`;
+    assert str_contains(&output, "//   option language = Python"),
+        `missing language option:\n{output}`;
+    assert str_contains(&output, "//   option superClass = my.pkg.BaseParser"),
+        `missing superClass option:\n{output}`;
+    assert str_contains(&output, "//   option tokenVocab = TestLexer"),
+        `missing tokenVocab option:\n{output}`;
+    assert str_contains(&output, "//   option caseInsensitive = true"),
+        `missing caseInsensitive option:\n{output}`;
+}
+
+test "metadata comment formats string and int option values" {
+    let grammar = Grammar {
+        name: "Test",
+        parser_rules: [],
+        lexer_rules: [],
+        mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [
+            GrammarOption { name: "tokenVocab", value: OptionValue::Str("foo.g4") },
+            GrammarOption { name: "k", value: OptionValue::Int(3) },
+            GrammarOption { name: "init", value: OptionValue::Action("some code;") },
+        ],
+        named_actions: [],
+        source_files: [],
+    };
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    assert str_contains(&output, "//   option tokenVocab = \"foo.g4\""),
+        `missing quoted string option:\n{output}`;
+    assert str_contains(&output, "//   option k = 3"),
+        `missing int option:\n{output}`;
+    assert str_contains(&output, "//   option init = { ... }"),
+        `action body should be elided:\n{output}`;
+}
+
+test "metadata comment lists named actions" {
+    let grammar = Grammar {
+        name: "Test",
+        parser_rules: [],
+        lexer_rules: [],
+        mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [
+            NamedAction { scope: null, name: "header" },
+            NamedAction { scope: Option::<String>::Some("parser"), name: "members" },
+            NamedAction { scope: Option::<String>::Some("lexer"), name: "members" },
+        ],
+        source_files: [],
+    };
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    assert str_contains(&output, "// Grammar metadata from source .g4 prequels:"),
+        `missing metadata header:\n{output}`;
+    assert str_contains(&output, "//   @header"),
+        `missing @header action marker:\n{output}`;
+    assert str_contains(&output, "//   @parser::members"),
+        `missing @parser::members action marker:\n{output}`;
+    assert str_contains(&output, "//   @lexer::members"),
+        `missing @lexer::members action marker:\n{output}`;
+}
+
+test "metadata block omitted when no options and no named actions" {
+    let grammar = Grammar {
+        name: "Test",
+        parser_rules: [],
+        lexer_rules: [],
+        mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
+        source_files: [],
+    };
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    assert !str_contains(&output, "// Grammar metadata from source .g4 prequels:"),
+        `metadata header should be omitted when empty:\n{output}`;
+}
+
+test "visibility comment emitted on non-default parser rule" {
+    let grammar = Grammar {
+        name: "Test",
+        parser_rules: [
+            ParserRule {
+                name: "expr",
+                visibility: Visibility::Public,
+                options: [],
+                alternatives: [
+                    Alternative {
+                        label: null,
+                        options: [],
+                        elements: [Element::TokenRef(TokenRefElement::new("ID"))],
+                    },
+                ],
+            },
+            ParserRule {
+                name: "plain",
+                visibility: Visibility::Default,
+                options: [],
+                alternatives: [
+                    Alternative {
+                        label: null,
+                        options: [],
+                        elements: [Element::TokenRef(TokenRefElement::new("ID"))],
+                    },
+                ],
+            },
+        ],
+        lexer_rules: [LexerRule::new("ID", false, false, [])],
+        mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
+        source_files: [],
+    };
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    assert str_contains(&output, "// rule visibility: public (ignored by codegen, matches ANTLR4)"),
+        `expected visibility comment for Public rule:\n{output}`;
+    // Default visibility must not add any comment.
+    assert !str_contains(&output, "// rule visibility: default"),
+        `Default visibility must not emit a comment:\n{output}`;
+}
+
+test "visibility comment emitted on non-default lexer rule" {
+    let mut id_rule = LexerRule::new("ID", false, false, []);
+    id_rule.visibility = Visibility::Protected;
+    let grammar = Grammar {
+        name: "Test",
+        parser_rules: [],
+        lexer_rules: [id_rule],
+        mode_names: ["DEFAULT_MODE"],
+        channels: [],
+        options: [],
+        named_actions: [],
+        source_files: [],
+    };
+    let output = generate(&grammar, &DEFAULT_OPTIONS);
+    assert str_contains(&output, "// rule visibility: protected (ignored by codegen, matches ANTLR4)"),
+        `expected visibility comment for Protected lexer rule:\n{output}`;
 }
 
 fn str_contains(haystack: &String, needle: &String) -> bool {

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -16,7 +16,7 @@ use {
     RepeatElement,
     LabelElement,
 } from "./ir.wado";
-use { to_lower, escape_char, literal_const_name } from "./gen_util.wado";
+use { to_lower, escape_char, literal_const_name, gen_visibility_comment } from "./gen_util.wado";
 use { CodeWriter, StructSpec, ImplSpec, FnSpec, GlobalSpec } from "./wadopoet.wado";
 
 pub struct LitToken {
@@ -282,6 +282,7 @@ fn gen_lexer_match_fn(
 ) {
     let fn_name = `try_{to_lower(&rule.name)}`;
     let ci = resolve_ci(grammar_opts, &rule.options);
+    gen_visibility_comment(w, &rule.visibility);
     let mut f = FnSpec::new(&fn_name);
     f.add_param("chars", "&Array<char>");
     f.add_param("start", "i32");

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -29,6 +29,7 @@ use {
     str_set_from,
     str_set_insert_all,
     case_names_for_rule,
+    gen_visibility_comment,
 } from "./gen_util.wado";
 use { GenContext, is_nullable, sets_overlap, is_simple_token_group } from "./gen_context.wado";
 use { CodeWriter, StructSpec, ImplSpec, FnSpec } from "./wadopoet.wado";
@@ -2261,6 +2262,7 @@ fn gen_parse_fn(w: &mut CodeWriter, rule: &ParserRule, ctx: &mut GenContext) {
     ctx.group_counter = 0;
     let type_name = rule_type_name(&rule.name);
     let fn_name = `parse_{to_snake_case(&rule.name)}`;
+    gen_visibility_comment(w, &rule.visibility);
 
     // Precompute the starting group counter for each alternative.
     // This matches the type gen which processes alts in index order.

--- a/package-gale/tests/golden/antlr4.wado
+++ b/package-gale/tests/golden/antlr4.wado
@@ -1,5 +1,9 @@
 #![generated(by = "gale", sources = ["package-gale/tests/grammars/ANTLRv4Lexer.g4", "package-gale/tests/grammars/ANTLRv4Parser.g4"])]
 
+// Grammar metadata from source .g4 prequels:
+//   option superClass = LexerAdaptor
+//   option tokenVocab = ANTLRv4Lexer
+
 /// Span represents a byte range in source text.
 pub struct Span {
     pub start: i32,

--- a/package-gale/tests/golden/ci_sql.wado
+++ b/package-gale/tests/golden/ci_sql.wado
@@ -1,5 +1,8 @@
 #![generated(by = "gale", sources = ["package-gale/tests/grammars/ci_sql.g4"])]
 
+// Grammar metadata from source .g4 prequels:
+//   option caseInsensitive = true
+
 /// Span represents a byte range in source text.
 pub struct Span {
     pub start: i32,

--- a/package-gale/tests/golden/css3.wado
+++ b/package-gale/tests/golden/css3.wado
@@ -1,5 +1,8 @@
 #![generated(by = "gale", sources = ["package-gale/tests/grammars/css3Lexer.g4", "package-gale/tests/grammars/css3Parser.g4"])]
 
+// Grammar metadata from source .g4 prequels:
+//   option tokenVocab = css3Lexer
+
 /// Span represents a byte range in source text.
 pub struct Span {
     pub start: i32,

--- a/package-gale/tests/golden/html.wado
+++ b/package-gale/tests/golden/html.wado
@@ -1,5 +1,8 @@
 #![generated(by = "gale", sources = ["package-gale/tests/grammars/HTMLLexer.g4", "package-gale/tests/grammars/HTMLParser.g4"])]
 
+// Grammar metadata from source .g4 prequels:
+//   option tokenVocab = HTMLLexer
+
 /// Span represents a byte range in source text.
 pub struct Span {
     pub start: i32,

--- a/package-gale/tests/golden/rust.wado
+++ b/package-gale/tests/golden/rust.wado
@@ -1,5 +1,9 @@
 #![generated(by = "gale", sources = ["package-gale/tests/grammars/RustLexer.g4", "package-gale/tests/grammars/RustParser.g4"])]
 
+// Grammar metadata from source .g4 prequels:
+//   option superClass = RustParserBase
+//   option tokenVocab = RustLexer
+
 /// Span represents a byte range in source text.
 pub struct Span {
     pub start: i32,

--- a/package-gale/tests/golden/typescript.wado
+++ b/package-gale/tests/golden/typescript.wado
@@ -1,5 +1,9 @@
 #![generated(by = "gale", sources = ["package-gale/tests/grammars/TypeScriptLexer.g4", "package-gale/tests/grammars/TypeScriptParser.g4"])]
 
+// Grammar metadata from source .g4 prequels:
+//   option superClass = TypeScriptParserBase
+//   option tokenVocab = TypeScriptLexer
+
 /// Span represents a byte range in source text.
 pub struct Span {
     pub start: i32,


### PR DESCRIPTION
## Summary

Closes the "IR → pipeline wiring" item from `package-gale/TODO.md §A`.
Previously `Grammar.options` / `Grammar.named_actions` / `ParserRule.visibility` / `LexerRule.visibility` were parsed into the IR but silently dropped at codegen. They now surface in the generated `.wado`:

- **Grammar prequels** (`option ... ;` and `@header`/`@members`/`@parser::name`) are emitted as a pass-through metadata comment block right after the `#![generated(...)]` header.
- **Rule visibility modifiers** (`public` / `private` / `protected`) emit a one-line comment above the generated parse/try fn. ANTLR4 ignores these at codegen too, so behavior is matched — but the information is now observable for downstream tooling.

`superClass` / `tokenVocab` / `language` stay surface-only for now (no trait or token-id wiring). The rationale and a sketch for when that work is worth doing are recorded in `TODO.md` under "Future Work: Actions and `superClass`" — both are gated on having an action-body translator, which we do not have.

## Changes

- `package-gale/src/generator.wado`: new `gen_grammar_metadata` helper + `format_option_value` for the five `OptionValue` variants.
- `package-gale/src/gen_util.wado`: `gen_visibility_comment` helper (placed here to avoid the `generator → parser_gen → generator` import cycle).
- `package-gale/src/parser_gen.wado` / `lexer_gen.wado`: call the helper at the top of the per-rule codegen.
- `package-gale/src/generator_test.wado`: 6 new unit tests covering all four metadata paths + both visibility paths.
- `package-gale/tests/golden/{antlr4,ci_sql,css3,html,rust,typescript}.wado`: regenerated to include the metadata comment block. Clean grammars (JSON, sexpression, calculator, SQLite) carry no `option`/`@header` prequels so they are unchanged. No real-world test grammar uses visibility modifiers, so that path is exercised by unit tests only.
- `package-gale/TODO.md`: close §A, renumber remaining sections, append the future-work entry.

## Test plan

- [x] `wado test package-gale/src/generator_test.wado` — 6 new tests pass
- [x] `mise run update-gale-golden` — only metadata-block additions, no other diffs
- [x] `mise run on-task-done` — full suite green (cargo 5170 pass, wado 1798 pass, benchmarks 10 pass, 0 failures, 16m35s)
- [x] `mise run format` — no formatting drift introduced

https://claude.ai/code/session_5d4f580c-14e8-48e3-982c-14a4a8606200