### PR TITLE
Unify trait-method dispatch: one substitution path, one MethodCall constructor

### DIFF
--- a/wado-compiler/lib/core/collections.wado
+++ b/wado-compiler/lib/core/collections.wado
@@ -458,10 +458,10 @@ impl<T: Ord> SequenceLiteralBuilder for TreeSet<T> {
     }
 }
 
-impl<T: Serialize, V: Serialize> Serialize for TreeMap<String, V> {
+impl<V: Serialize> Serialize for TreeMap<String, V> {
     fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerializeError> {
         let entries = self.entries();
-        let m = s.begin_map(entries.len())?;
+        let mut m = s.begin_map(entries.len())?;
         for let [k, v] of entries {
             m.key(&k)?;
             m.value(&v)?;

--- a/wado-compiler/lib/core/collections/treemap_test.wado
+++ b/wado-compiler/lib/core/collections/treemap_test.wado
@@ -1,5 +1,6 @@
 use { TreeMap } from "core:collections";
 use { to_string, from_string } from "core:json";
+use { SerializeError } from "core:serde";
 
 test "empty map" {
     let map: TreeMap<String, i32> = TreeMap::new();
@@ -496,12 +497,13 @@ test "i32 key remove" {
     assert map.get(2) matches { None };
 }
 
-// test "serde Serializer" {
-//     let mut map: TreeMap<String, String> = {
-//         "foo": "1",
-//         "bar": "2",
-//         "baz": "3",
-//     };
+test "serde Serializer" {
+    let map: TreeMap<String, String> = {
+        "foo": "1",
+        "bar": "2",
+        "baz": "3",
+    };
 
-//     assert to_string(&map) == "";
-// }
+    let result: Result<String, SerializeError> = to_string(&map);
+    assert result matches { Ok(s) && s == `\{"foo":"1","bar":"2","baz":"3"\}` };
+}

--- a/wado-compiler/src/lower/closure.rs
+++ b/wado-compiler/src/lower/closure.rs
@@ -1662,6 +1662,7 @@ impl ClosureLowerer {
                 func,
                 type_args,
                 args,
+                ..
             } => {
                 let new_receiver = self.transform_closure_body(
                     receiver,
@@ -1686,12 +1687,12 @@ impl ClosureLowerer {
                     })
                     .collect();
                 TirExpr::new(
-                    TirExprKind::MethodCall {
-                        receiver: Box::new(new_receiver),
-                        func: func.clone(),
-                        type_args: type_args.clone(),
-                        args: new_args,
-                    },
+                    TirExprKind::method_call(
+                        Box::new(new_receiver),
+                        func.clone(),
+                        type_args.clone(),
+                        new_args,
+                    ),
                     expr.type_id,
                     expr.span,
                 )
@@ -3145,17 +3146,17 @@ impl ClosureLowerer {
                             .map(|(expr, is_mut)| CallArg::new(expr, is_mut))
                             .collect();
                         return TirExpr::new(
-                            TirExprKind::MethodCall {
-                                receiver: Box::new(new_callee),
-                                func: FunctionRef {
+                            TirExprKind::method_call(
+                                Box::new(new_callee),
+                                FunctionRef {
                                     module_source: self.module_source.clone(),
                                     name: call_method_name,
                                     monomorph_info: None,
                                     method_info: Some(call_method_info),
                                 },
-                                args: call_args,
-                                type_args: Vec::new(),
-                            },
+                                Vec::new(),
+                                call_args,
+                            ),
                             expr.type_id,
                             expr.span,
                         );
@@ -3245,16 +3246,13 @@ impl ClosureLowerer {
                 func,
                 args,
                 type_args,
+                ..
             } => TirExpr::new(
-                TirExprKind::MethodCall {
-                    receiver: Box::new(self.specialize_expr(
-                        receiver,
-                        param_to_functor,
-                        type_table,
-                    )),
-                    func: func.clone(),
-                    args: args
-                        .iter()
+                TirExprKind::method_call(
+                    Box::new(self.specialize_expr(receiver, param_to_functor, type_table)),
+                    func.clone(),
+                    type_args.clone(),
+                    args.iter()
                         .map(|a| {
                             let original_type_id = a.expr.type_id;
                             let specialized =
@@ -3270,8 +3268,7 @@ impl ClosureLowerer {
                             )
                         })
                         .collect(),
-                    type_args: type_args.clone(),
-                },
+                ),
                 expr.type_id,
                 expr.span,
             ),
@@ -3821,15 +3818,15 @@ impl ClosureLowerer {
                         .zip(params_is_mut.into_iter().chain(std::iter::repeat(false)))
                         .map(|(expr, is_mut)| CallArg::new(expr, is_mut))
                         .collect();
-                    expr.kind = TirExprKind::MethodCall {
-                        receiver: Box::new(callee_owned),
-                        func: FunctionRef::from_resolved(
+                    expr.kind = TirExprKind::method_call(
+                        Box::new(callee_owned),
+                        FunctionRef::from_resolved(
                             &functor.call_method.borrow(),
                             self.module_source.clone(),
                         ),
-                        type_args: Vec::new(),
-                        args: call_args,
-                    };
+                        Vec::new(),
+                        call_args,
+                    );
                     expr.type_id = return_type;
                 }
             }

--- a/wado-compiler/src/lower/pattern.rs
+++ b/wado-compiler/src/lower/pattern.rs
@@ -1315,9 +1315,9 @@ impl<'a> PatternLowerer<'a> {
         // so we pass the values directly and let translate handle self-kind adjustment.
         // However, the arg explicitly needs &String since that's the method signature.
         TirExpr::new(
-            TirExprKind::MethodCall {
-                receiver: Box::new(receiver),
-                func: FunctionRef {
+            TirExprKind::method_call(
+                Box::new(receiver),
+                FunctionRef {
                     module_source: ModuleSource::string(),
                     name: "String^Eq::eq".to_string(),
                     monomorph_info: None,
@@ -1327,8 +1327,8 @@ impl<'a> PatternLowerer<'a> {
                         "eq".to_string(),
                     )),
                 },
-                type_args: vec![],
-                args: vec![CallArg::new(
+                vec![],
+                vec![CallArg::new(
                     TirExpr::new(
                         TirExprKind::Unary {
                             op: TirUnaryOp::Ref,
@@ -1339,7 +1339,7 @@ impl<'a> PatternLowerer<'a> {
                     ),
                     false,
                 )],
-            },
+            ),
             TypeTable::BOOL,
             span,
         )

--- a/wado-compiler/src/lower/wide_int.rs
+++ b/wado-compiler/src/lower/wide_int.rs
@@ -114,9 +114,9 @@ fn create_i128_eq_call(
     // Create method call: receiver.eq(&right)
     let mangled_method_name = "i128^Eq::eq".to_string();
     TirExpr::new(
-        TirExprKind::MethodCall {
-            receiver: Box::new(receiver),
-            func: FunctionRef {
+        TirExprKind::method_call(
+            Box::new(receiver),
+            FunctionRef {
                 module_source: ModuleSource::int128(),
                 name: mangled_method_name,
                 monomorph_info: None,
@@ -126,9 +126,9 @@ fn create_i128_eq_call(
                     "eq".to_string(),
                 )),
             },
-            type_args: vec![],
-            args: vec![CallArg::new(arg_ref, false)],
-        },
+            vec![],
+            vec![CallArg::new(arg_ref, false)],
+        ),
         TypeTable::BOOL,
         span,
     )
@@ -171,9 +171,9 @@ fn create_u128_eq_call(
     // Create method call: receiver.eq(&right)
     let mangled_method_name = "u128^Eq::eq".to_string();
     TirExpr::new(
-        TirExprKind::MethodCall {
-            receiver: Box::new(receiver),
-            func: FunctionRef {
+        TirExprKind::method_call(
+            Box::new(receiver),
+            FunctionRef {
                 module_source: ModuleSource::int128(),
                 name: mangled_method_name,
                 monomorph_info: None,
@@ -183,9 +183,9 @@ fn create_u128_eq_call(
                     "eq".to_string(),
                 )),
             },
-            type_args: vec![],
-            args: vec![CallArg::new(arg_ref, false)],
-        },
+            vec![],
+            vec![CallArg::new(arg_ref, false)],
+        ),
         TypeTable::BOOL,
         span,
     )

--- a/wado-compiler/src/monomorphize/func_inst.rs
+++ b/wado-compiler/src/monomorphize/func_inst.rs
@@ -3688,17 +3688,17 @@ fn try_lower_comparison(
         let mangled_name = method_info.to_mangled_name();
         let method_module = resolve_module(&mangled_name, type_module_source);
 
-        let method_call = TirExprKind::MethodCall {
-            receiver: Box::new(receiver),
-            func: FunctionRef {
+        let method_call = TirExprKind::method_call(
+            Box::new(receiver),
+            FunctionRef {
                 module_source: method_module,
                 name: mangled_name,
                 monomorph_info: None,
                 method_info: Some(method_info),
             },
-            type_args: vec![],
-            args: vec![CallArg::new(arg_ref, false)],
-        };
+            vec![],
+            vec![CallArg::new(arg_ref, false)],
+        );
 
         if op == TirBinaryOp::NotEq {
             return Some(TirExprKind::Unary {
@@ -3726,17 +3726,17 @@ fn try_lower_comparison(
         let method_module = resolve_module(&mangled_name, type_module_source);
 
         let cmp_call = TirExpr::new(
-            TirExprKind::MethodCall {
-                receiver: Box::new(receiver),
-                func: FunctionRef {
+            TirExprKind::method_call(
+                Box::new(receiver),
+                FunctionRef {
                     module_source: method_module,
                     name: mangled_name,
                     monomorph_info: None,
                     method_info: Some(method_info),
                 },
-                type_args: vec![],
-                args: vec![CallArg::new(arg_ref, false)],
-            },
+                vec![],
+                vec![CallArg::new(arg_ref, false)],
+            ),
             ordering_type_id,
             span,
         );

--- a/wado-compiler/src/optimize/container_sroa.rs
+++ b/wado-compiler/src/optimize/container_sroa.rs
@@ -1456,12 +1456,12 @@ fn build_element_writer_call(
         /*mut_ref=*/ true,
         span,
     );
-    let kind = TirExprKind::MethodCall {
-        receiver: Box::new(receiver),
+    let kind = TirExprKind::method_call(
+        Box::new(receiver),
         func,
-        type_args: Vec::new(),
-        args: vec![CallArg::new(value, false)],
-    };
+        Vec::new(),
+        vec![CallArg::new(value, false)],
+    );
     TirExpr::new(kind, TypeTable::UNIT, span)
 }
 
@@ -1490,12 +1490,12 @@ fn build_index_writer_call(
         /*mut_ref=*/ true,
         span,
     );
-    let kind = TirExprKind::MethodCall {
-        receiver: Box::new(receiver),
+    let kind = TirExprKind::method_call(
+        Box::new(receiver),
         func,
-        type_args: Vec::new(),
-        args: vec![CallArg::new(index, false), CallArg::new(value, false)],
-    };
+        Vec::new(),
+        vec![CallArg::new(index, false), CallArg::new(value, false)],
+    );
     TirExpr::new(kind, TypeTable::UNIT, span)
 }
 
@@ -1524,12 +1524,12 @@ fn build_index_reader_call(
         /*mut_ref=*/ false,
         span,
     );
-    let kind = TirExprKind::MethodCall {
-        receiver: Box::new(receiver),
+    let kind = TirExprKind::method_call(
+        Box::new(receiver),
         func,
-        type_args: Vec::new(),
-        args: vec![CallArg::new(index, false)],
-    };
+        Vec::new(),
+        vec![CallArg::new(index, false)],
+    );
     TirExpr::new(kind, elem_ty, span)
 }
 
@@ -1721,12 +1721,8 @@ fn rewrite_expr_inplace(expr: &mut TirExpr, ctx: &RewriteCtx) {
             /*mut_ref=*/ false,
             expr.span,
         );
-        let kind = TirExprKind::MethodCall {
-            receiver: Box::new(new_receiver),
-            func: new_func,
-            type_args: Vec::new(),
-            args: Vec::new(),
-        };
+        let kind =
+            TirExprKind::method_call(Box::new(new_receiver), new_func, Vec::new(), Vec::new());
         expr.kind = kind;
         return;
     }

--- a/wado-compiler/src/optimize/inline.rs
+++ b/wado-compiler/src/optimize/inline.rs
@@ -1790,15 +1790,15 @@ fn remap_expr_inner(
             func,
             type_args,
             args,
-        } => TirExprKind::MethodCall {
-            receiver: re_box(receiver),
-            func: func.clone(),
-            type_args: type_args.clone(),
-            args: args
-                .iter()
+            ..
+        } => TirExprKind::method_call(
+            re_box(receiver),
+            func.clone(),
+            type_args.clone(),
+            args.iter()
                 .map(|a| CallArg::new(re(&a.expr), a.is_mut))
                 .collect(),
-        },
+        ),
         TirExprKind::CmRawCall { local_name, args } => TirExprKind::CmRawCall {
             local_name: local_name.clone(),
             args: args.iter().map(&re).collect(),

--- a/wado-compiler/src/resolver/coercion.rs
+++ b/wado-compiler/src/resolver/coercion.rs
@@ -639,18 +639,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 span,
             );
 
-            let insert_call = TirExpr::new(
-                TirExprKind::MethodCall {
-                    receiver: Box::new(receiver),
-                    func: FunctionRef {
-                        module_source: self.current_module_source.clone(),
-                        name: insert_mangled_name.clone(),
-                        monomorph_info: None,
-                        method_info: Some(insert_method_info.clone()),
-                    },
-                    type_args: vec![],
-                    args: vec![CallArg::new(key_expr, false), CallArg::new(value, false)],
+            let insert_call = Self::build_tir_method_call(
+                receiver,
+                FunctionRef {
+                    module_source: self.current_module_source.clone(),
+                    name: insert_mangled_name.clone(),
+                    monomorph_info: None,
+                    method_info: Some(insert_method_info.clone()),
                 },
+                vec![],
+                vec![CallArg::new(key_expr, false), CallArg::new(value, false)],
                 TypeTable::UNIT,
                 span,
             );
@@ -688,18 +686,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     is_blanket: false,
                 })
             };
-            TirExpr::new(
-                TirExprKind::MethodCall {
-                    receiver: Box::new(builder_local_final),
-                    func: FunctionRef {
-                        module_source: self.current_module_source.clone(),
-                        name: build_mangled_name,
-                        monomorph_info: build_monomorph,
-                        method_info: Some(build_method_info),
-                    },
-                    type_args: vec![],
-                    args: vec![],
+            Self::build_tir_method_call(
+                builder_local_final,
+                FunctionRef {
+                    module_source: self.current_module_source.clone(),
+                    name: build_mangled_name,
+                    monomorph_info: build_monomorph,
+                    method_info: Some(build_method_info),
                 },
+                vec![],
+                vec![],
                 target_type,
                 span,
             )
@@ -888,27 +884,25 @@ impl<H: CompilerHost> Resolver<'_, H> {
             );
             let receiver =
                 self.adjust_receiver_for_self_kind(builder_local, push_self_kind, false, span);
-            let push_call = TirExpr::new(
-                TirExprKind::MethodCall {
-                    receiver: Box::new(receiver),
-                    func: FunctionRef {
-                        module_source: impl_module_source.clone(),
-                        name: push_mangled_name.clone(),
-                        monomorph_info: if type_arg_ids.is_empty() {
-                            None
-                        } else {
-                            Some(MonomorphInfo {
-                                generic_name: format!("{builder_base_name}::push_literal"),
-                                impl_type_args: type_arg_ids.clone(),
-                                method_type_args: vec![],
-                                is_blanket: false,
-                            })
-                        },
-                        method_info: Some(push_method_info.clone()),
+            let push_call = Self::build_tir_method_call(
+                receiver,
+                FunctionRef {
+                    module_source: impl_module_source.clone(),
+                    name: push_mangled_name.clone(),
+                    monomorph_info: if type_arg_ids.is_empty() {
+                        None
+                    } else {
+                        Some(MonomorphInfo {
+                            generic_name: format!("{builder_base_name}::push_literal"),
+                            impl_type_args: type_arg_ids.clone(),
+                            method_type_args: vec![],
+                            is_blanket: false,
+                        })
                     },
-                    type_args: vec![],
-                    args: vec![CallArg::new(elem_expr, false)],
+                    method_info: Some(push_method_info.clone()),
                 },
+                vec![],
+                vec![CallArg::new(elem_expr, false)],
                 TypeTable::UNIT,
                 span,
             );
@@ -932,27 +926,25 @@ impl<H: CompilerHost> Resolver<'_, H> {
             "build".to_string(),
         )
         .with_struct_type_args(&type_arg_names);
-        let build_call = TirExpr::new(
-            TirExprKind::MethodCall {
-                receiver: Box::new(builder_local_final),
-                func: FunctionRef {
-                    module_source: impl_module_source,
-                    name: build_mangled_name,
-                    monomorph_info: if type_arg_ids.is_empty() {
-                        None
-                    } else {
-                        Some(MonomorphInfo {
-                            generic_name: format!("{builder_base_name}::build"),
-                            impl_type_args: type_arg_ids,
-                            method_type_args: vec![],
-                            is_blanket: false,
-                        })
-                    },
-                    method_info: Some(build_method_info),
+        let build_call = Self::build_tir_method_call(
+            builder_local_final,
+            FunctionRef {
+                module_source: impl_module_source,
+                name: build_mangled_name,
+                monomorph_info: if type_arg_ids.is_empty() {
+                    None
+                } else {
+                    Some(MonomorphInfo {
+                        generic_name: format!("{builder_base_name}::build"),
+                        impl_type_args: type_arg_ids,
+                        method_type_args: vec![],
+                        is_blanket: false,
+                    })
                 },
-                type_args: vec![],
-                args: vec![],
+                method_info: Some(build_method_info),
             },
+            vec![],
+            vec![],
             output_type,
             span,
         );

--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -1149,22 +1149,20 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     .borrow_mut()
                     .make_ref(trait_info.output_type);
 
-                let method_call = TirExpr::new(
-                    TirExprKind::MethodCall {
-                        receiver: Box::new(receiver),
-                        func: FunctionRef {
-                            module_source: trait_info.impl_module_source.clone(),
-                            name: mangled_method_name,
-                            monomorph_info: None,
-                            method_info: Some(LocalMethodName::new(
-                                lookup_name,
-                                Some(trait_info.trait_name.clone()),
-                                "index".to_string(),
-                            )),
-                        },
-                        type_args: vec![],
-                        args: vec![CallArg::new(index_expr, false)],
+                let method_call = Self::build_tir_method_call(
+                    receiver,
+                    FunctionRef {
+                        module_source: trait_info.impl_module_source.clone(),
+                        name: mangled_method_name,
+                        monomorph_info: None,
+                        method_info: Some(LocalMethodName::new(
+                            lookup_name,
+                            Some(trait_info.trait_name.clone()),
+                            "index".to_string(),
+                        )),
                     },
+                    vec![],
+                    vec![CallArg::new(index_expr, false)],
                     ref_output_type,
                     index.span,
                 );
@@ -1202,22 +1200,20 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 );
 
                 // IndexValue returns Output directly (not a reference)
-                return TirExpr::new(
-                    TirExprKind::MethodCall {
-                        receiver: Box::new(receiver),
-                        func: FunctionRef {
-                            module_source: trait_info.impl_module_source.clone(),
-                            name: mangled_method_name,
-                            monomorph_info: None,
-                            method_info: Some(LocalMethodName::new(
-                                lookup_name,
-                                Some(trait_info.trait_name.clone()),
-                                "index_value".to_string(),
-                            )),
-                        },
-                        type_args: vec![],
-                        args: vec![CallArg::new(index_expr, false)],
+                return Self::build_tir_method_call(
+                    receiver,
+                    FunctionRef {
+                        module_source: trait_info.impl_module_source.clone(),
+                        name: mangled_method_name,
+                        monomorph_info: None,
+                        method_info: Some(LocalMethodName::new(
+                            lookup_name,
+                            Some(trait_info.trait_name.clone()),
+                            "index_value".to_string(),
+                        )),
                     },
+                    vec![],
+                    vec![CallArg::new(index_expr, false)],
                     trait_info.output_type,
                     index.span,
                 );

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -659,22 +659,19 @@ impl<H: CompilerHost> Resolver<'_, H> {
             );
         }
 
-        TirExpr::new(
-            TirExprKind::MethodCall {
-                receiver: Box::new(receiver),
-                func: FunctionRef {
-                    module_source: method_module_source,
-                    name: mangled_method_name,
-                    monomorph_info,
-                    method_info: Some(method_info),
-                },
-                type_args: method_type_args, // Use inferred type args
-                args: args
-                    .into_iter()
-                    .zip(param_is_mut.into_iter().chain(std::iter::repeat(false)))
-                    .map(|(expr, is_mut)| CallArg::new(expr, is_mut))
-                    .collect(),
+        Self::build_tir_method_call(
+            receiver,
+            FunctionRef {
+                module_source: method_module_source,
+                name: mangled_method_name,
+                monomorph_info,
+                method_info: Some(method_info),
             },
+            method_type_args, // Use inferred type args
+            args.into_iter()
+                .zip(param_is_mut.into_iter().chain(std::iter::repeat(false)))
+                .map(|(expr, is_mut)| CallArg::new(expr, is_mut))
+                .collect(),
             return_type,
             method_call.span,
         )

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -2128,7 +2128,20 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
         // Return the first one found (if there are multiple, it would be ambiguous,
         // but we'll handle that later with explicit disambiguation syntax)
-        found_traits.into_iter().next()
+        if let Some(m) = found_traits.into_iter().next() {
+            return Some(m);
+        }
+
+        // Auto-derived Eq / Ord: no user-written impl exists, but the type
+        // satisfies the field-wise / case-wise eligibility rules and
+        // `synthesis::traits` will emit a body. Synthesize a `TraitMethodMatch`
+        // so method-call resolution (and everything downstream of it) sees
+        // the same view of "does this type have `.eq` / `.cmp`?" that
+        // operator dispatch gets via `find_eq_trait_impl` / `find_ord_trait_impl`.
+        if let Some(recv_id) = receiver_type_id {
+            return self.try_auto_derived_method_match(struct_name, method_name, recv_id);
+        }
+        None
     }
 
     /// Find Index trait implementation for a type

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -2453,64 +2453,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
         )
     }
 
-    /// Find `Eq` trait implementation for a type.
-    ///
-    /// Falls back to auto-derived Eq for structs whose fields all implement Eq.
-    pub(super) fn find_eq_trait_impl(
-        &mut self,
-        struct_name: &str,
-        base_type_id: TypeId,
-    ) -> Option<ArithmeticTraitInfo> {
-        if let Some(info) = self.find_arithmetic_trait_impl(struct_name, base_type_id, "Eq", "eq") {
-            return Some(info);
-        }
-        // Auto-derive: check if all fields implement Eq
-        if self.type_implements_trait(base_type_id, "Eq") {
-            let ref_type = self
-                .type_table
-                .borrow_mut()
-                .intern(ResolvedType::Ref(base_type_id));
-            return Some(ArithmeticTraitInfo {
-                output_type: TypeTable::BOOL,
-                self_kind: ast::SelfKind::Ref,
-                trait_name: "Eq".to_string(),
-                rhs_type: Some(ref_type),
-            });
-        }
-        None
-    }
-
-    /// Find `Ord` trait implementation for a type.
-    ///
-    /// Falls back to auto-derived Ord for structs whose fields all implement Ord.
-    pub(super) fn find_ord_trait_impl(
-        &mut self,
-        struct_name: &str,
-        base_type_id: TypeId,
-    ) -> Option<ArithmeticTraitInfo> {
-        if let Some(info) = self.find_arithmetic_trait_impl(struct_name, base_type_id, "Ord", "cmp")
-        {
-            return Some(info);
-        }
-        // Auto-derive: check if all fields implement Ord
-        if self.type_implements_trait(base_type_id, "Ord") {
-            let ordering_type = self.type_table.borrow_mut().intern(ResolvedType::Enum {
-                name: "Ordering".to_string(),
-                module_source: ModuleSource::prelude(),
-            });
-            let ref_type = self
-                .type_table
-                .borrow_mut()
-                .intern(ResolvedType::Ref(base_type_id));
-            return Some(ArithmeticTraitInfo {
-                output_type: ordering_type,
-                self_kind: ast::SelfKind::Ref,
-                trait_name: "Ord".to_string(),
-                rhs_type: Some(ref_type),
-            });
-        }
-        None
-    }
 
     /// Find operator trait implementation
     pub(super) fn find_arithmetic_trait_impl(

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -3116,22 +3116,20 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .borrow_mut()
             .make_mut_ref(index_mut_info.output_type);
 
-        let index_mut_call = TirExpr::new(
-            TirExprKind::MethodCall {
-                receiver: Box::new(receiver_for_index_mut),
-                func: FunctionRef {
-                    module_source: index_mut_info.impl_module_source.clone(),
-                    name: mangled_index_mut_name,
-                    monomorph_info: None,
-                    method_info: Some(LocalMethodName::new(
-                        struct_name.clone(),
-                        Some(index_mut_info.trait_name),
-                        "index_mut".to_string(),
-                    )),
-                },
-                type_args: vec![],
-                args: vec![CallArg::new(index_resolved, false)],
+        let index_mut_call = Self::build_tir_method_call(
+            receiver_for_index_mut,
+            FunctionRef {
+                module_source: index_mut_info.impl_module_source.clone(),
+                name: mangled_index_mut_name,
+                monomorph_info: None,
+                method_info: Some(LocalMethodName::new(
+                    struct_name.clone(),
+                    Some(index_mut_info.trait_name),
+                    "index_mut".to_string(),
+                )),
             },
+            vec![],
+            vec![CallArg::new(index_resolved, false)],
             mut_ref_output_type,
             index_expr.span,
         );
@@ -3169,32 +3167,66 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let method_call_module_source =
             method_trait_impl_source.unwrap_or_else(|| self.current_module_source.clone());
 
-        Some(TirExpr::new(
-            TirExprKind::MethodCall {
-                receiver: Box::new(receiver_for_method),
-                func: FunctionRef {
-                    module_source: method_call_module_source,
-                    name: mangled_method_name,
-                    monomorph_info: None,
-                    method_info: Some(LocalMethodName::new(
-                        output_struct_name,
-                        method_trait_name,
-                        method_call.method.clone(),
-                    )),
-                },
-                type_args,
-                args: args
-                    .into_iter()
-                    .zip(
-                        method_param_is_mut
-                            .into_iter()
-                            .chain(std::iter::repeat(false)),
-                    )
-                    .map(|(expr, is_mut)| CallArg::new(expr, is_mut))
-                    .collect(),
+        Some(Self::build_tir_method_call(
+            receiver_for_method,
+            FunctionRef {
+                module_source: method_call_module_source,
+                name: mangled_method_name,
+                monomorph_info: None,
+                method_info: Some(LocalMethodName::new(
+                    output_struct_name,
+                    method_trait_name,
+                    method_call.method.clone(),
+                )),
             },
+            type_args,
+            args.into_iter()
+                .zip(
+                    method_param_is_mut
+                        .into_iter()
+                        .chain(std::iter::repeat(false)),
+                )
+                .map(|(expr, is_mut)| CallArg::new(expr, is_mut))
+                .collect(),
             return_type,
             method_call.span,
         ))
+    }
+
+    /// Sole resolver-side constructor of [`TirExprKind::MethodCall`].
+    ///
+    /// Centralizing construction here establishes a single audit point for
+    /// the invariant "every resolver-emitted method call has been
+    /// typechecked against the callee's declared parameter types before
+    /// it flows into TIR".  Typecheck is the caller's responsibility —
+    /// the helper exists so that any future machine-enforced invariant
+    /// (e.g. privatizing the enum variant's fields, adding a debug
+    /// assertion, wiring a LocalMethodName witness type) can plug in
+    /// here without having to chase down scattered `TirExprKind::MethodCall
+    /// { … }` literals.
+    ///
+    /// Post-resolve phases (monomorphize / lower / optimize / codegen)
+    /// rebuild `TirExprKind::MethodCall` nodes from already-checked
+    /// expressions and legitimately bypass this helper; they operate on
+    /// TIR that is guaranteed to have been produced through this path
+    /// originally.
+    pub(super) fn build_tir_method_call(
+        receiver: TirExpr,
+        func: FunctionRef,
+        type_args: Vec<TypeId>,
+        args: Vec<CallArg>,
+        return_type: TypeId,
+        span: crate::token::Span,
+    ) -> TirExpr {
+        TirExpr::new(
+            TirExprKind::MethodCall {
+                receiver: Box::new(receiver),
+                func,
+                type_args,
+                args,
+            },
+            return_type,
+            span,
+        )
     }
 }

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -2534,64 +2534,75 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 }
             }
 
-            // Build type parameter mapping from impl_ty to concrete types
+            // Build type parameter mapping from impl_ty to concrete types.
+            // `Self` is NOT inserted into this mapping — it is substituted
+            // through `trait_ctx.self_type` (set just below) via the
+            // fallback path in `resolve_type_with_param_mapping`.  This
+            // keeps Self substitution on a single mechanism shared with
+            // `find_trait_method_for_type`.
             let impl_block = self.get_impl_block(impl_ref);
-            let mut type_param_mapping = Self::build_type_param_mapping(
+            let type_param_mapping = Self::build_type_param_mapping(
                 &impl_block.ty,
                 &concrete_type_args,
                 &IndexSet::default(),
             );
-            // Map `Self` to the concrete base type so `&Self` parameters resolve correctly
-            type_param_mapping.insert("Self".to_string(), base_type_id);
 
-            // Find the method
+            // Gather everything we need from the impl block up front, then
+            // drop the borrow on `self` before touching `trait_ctx.self_type`
+            // (which requires a mutable borrow).
             let impl_block = self.get_impl_block(impl_ref);
-            if let Some(method) = impl_block.methods.iter().find(|m| m.name == method_name) {
-                // Set up associated type bindings
-                let mut assoc_type_map: IndexMap<String, TypeId> = IndexMap::default();
+            let Some(method) = impl_block.methods.iter().find(|m| m.name == method_name) else {
+                continue;
+            };
+            let assoc_types: Vec<(String, ast::Type)> = impl_block
+                .associated_types
+                .iter()
+                .map(|a| (a.name.clone(), a.ty.clone()))
+                .collect();
+            let self_kind = method
+                .params
+                .first()
+                .map(|p| p.self_kind)
+                .unwrap_or(ast::SelfKind::None);
+            let rhs_param_ty = method
+                .params
+                .iter()
+                .find(|p| p.self_kind == ast::SelfKind::None)
+                .map(|p| p.ty.clone());
 
-                // Process associated types (e.g., `type Output = Self`)
-                // Clone just the associated type info we need (small, not methods)
-                let assoc_types: Vec<(String, ast::Type)> = impl_block
-                    .associated_types
-                    .iter()
-                    .map(|a| (a.name.clone(), a.ty.clone()))
-                    .collect();
-                let self_kind = method
-                    .params
-                    .first()
-                    .map(|p| p.self_kind)
-                    .unwrap_or(ast::SelfKind::None);
-                let rhs_param_ty = method
-                    .params
-                    .iter()
-                    .find(|p| p.self_kind == ast::SelfKind::None)
-                    .map(|p| p.ty.clone());
+            // Bind `Self` for the duration of signature resolution. The
+            // single-source-of-truth for `Self` substitution is
+            // `trait_ctx.self_type` (consulted by both `resolve_type` and
+            // the `resolve_type_with_param_mapping` fallback above).
+            let saved_self_type = self.trait_ctx.self_type;
+            self.trait_ctx.self_type = Some(base_type_id);
 
-                for (name, ty) in &assoc_types {
-                    let resolved_type =
-                        self.resolve_type_with_param_mapping(ty, &type_param_mapping);
-                    assoc_type_map.insert(name.clone(), resolved_type);
-                }
-
-                // Get the output type from associated types
-                let output_type = assoc_type_map
-                    .get("Output")
-                    .copied()
-                    .unwrap_or(base_type_id);
-
-                // Resolve the rhs parameter type (first non-self parameter)
-                let rhs_type = rhs_param_ty
-                    .as_ref()
-                    .map(|ty| self.resolve_type_with_param_mapping(ty, &type_param_mapping));
-
-                return Some(ArithmeticTraitInfo {
-                    output_type,
-                    self_kind,
-                    trait_name: trait_name.to_string(),
-                    rhs_type,
-                });
+            // Process associated types (e.g., `type Output = Self`)
+            let mut assoc_type_map: IndexMap<String, TypeId> = IndexMap::default();
+            for (name, ty) in &assoc_types {
+                let resolved_type = self.resolve_type_with_param_mapping(ty, &type_param_mapping);
+                assoc_type_map.insert(name.clone(), resolved_type);
             }
+
+            // Get the output type from associated types
+            let output_type = assoc_type_map
+                .get("Output")
+                .copied()
+                .unwrap_or(base_type_id);
+
+            // Resolve the rhs parameter type (first non-self parameter)
+            let rhs_type = rhs_param_ty
+                .as_ref()
+                .map(|ty| self.resolve_type_with_param_mapping(ty, &type_param_mapping));
+
+            self.trait_ctx.self_type = saved_self_type;
+
+            return Some(ArithmeticTraitInfo {
+                output_type,
+                self_kind,
+                trait_name: trait_name.to_string(),
+                rhs_type,
+            });
         }
 
         None
@@ -2864,6 +2875,20 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 // Check if this is a type parameter that should be substituted
                 if let Some(&type_id) = type_param_mapping.get(&n.name) {
                     return type_id;
+                }
+                // `Self` is the single cross-site substitution key: both this
+                // mapping-based resolver and `resolve_type` (via
+                // `resolve_named_type`) read it from `trait_ctx.self_type`.
+                // Previously `find_arithmetic_trait_impl` eagerly inserted
+                // "Self" into the mapping and `find_trait_method_for_type`
+                // went through `trait_ctx.self_type`, which meant the two
+                // lookup families had parallel Self-substitution mechanisms
+                // that could drift.  Channeling Self through `trait_ctx`
+                // here closes that gap.
+                if n.name == "Self"
+                    && let Some(self_type) = self.trait_ctx.self_type
+                {
+                    return self_type;
                 }
                 // Otherwise, resolve normally
                 self.resolve_type(ty)
@@ -3219,12 +3244,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         span: crate::token::Span,
     ) -> TirExpr {
         TirExpr::new(
-            TirExprKind::MethodCall {
-                receiver: Box::new(receiver),
-                func,
-                type_args,
-                args,
-            },
+            TirExprKind::method_call(Box::new(receiver), func, type_args, args),
             return_type,
             span,
         )

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -2453,7 +2453,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
         )
     }
 
-
     /// Find operator trait implementation
     pub(super) fn find_arithmetic_trait_impl(
         &mut self,

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -1923,6 +1923,17 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     }
                 }
 
+                // Make `Self` in the method signature resolve to the concrete
+                // receiver type (e.g. `&Self` → `&Result<String, i32>` when
+                // calling through `impl<T: Eq, E: Eq> Eq for Result<T, E>`).
+                // Without this, `resolve_type("Self")` falls through to
+                // UNKNOWN and the caller's argument typecheck silently
+                // accepts anything, surfacing as an ICE at codegen.
+                let old_self_type = scope.trait_ctx.self_type;
+                if let Some(recv_id) = receiver_type_id {
+                    scope.trait_ctx.self_type = Some(recv_id);
+                }
+
                 let return_type = return_type_ast
                     .as_ref()
                     .map(|t| scope.resolve_type(t))
@@ -1932,6 +1943,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 // in scope — otherwise `&T` in a parameter would not resolve to
                 // the proper `TypeParam` id that inference expects.
                 let param_types = scope.extract_param_types(&params);
+
+                scope.trait_ctx.self_type = old_self_type;
 
                 // Remove method-level type params from scope
                 for type_param in &method_type_params {

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -3226,7 +3226,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
     /// it flows into TIR".  Typecheck is the caller's responsibility —
     /// the helper exists so that any future machine-enforced invariant
     /// (e.g. privatizing the enum variant's fields, adding a debug
-    /// assertion, wiring a LocalMethodName witness type) can plug in
+    /// assertion, wiring a `LocalMethodName` witness type) can plug in
     /// here without having to chase down scattered `TirExprKind::MethodCall
     /// { … }` literals.
     ///

--- a/wado-compiler/src/resolver/operators.rs
+++ b/wado-compiler/src/resolver/operators.rs
@@ -10,7 +10,7 @@ use crate::tir::{
 use crate::token::Span;
 
 use super::Resolver;
-use super::types::{FunctionContext, MethodInfo, TypeError};
+use super::types::{FunctionContext, ResolvedTraitMethod, TypeError};
 use super::util;
 
 impl<H: CompilerHost> Resolver<'_, H> {
@@ -183,8 +183,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
                 // Handle Eq trait (== and !=)
                 if matches!(binary.op, BinaryOp::Eq | BinaryOp::NotEq) {
-                    let Some(trait_info) = self.find_eq_trait_impl(&struct_name, lookup_type_id)
-                    else {
+                    let Some(resolved) = self.resolve_trait_method_for_op(
+                        &struct_name,
+                        lookup_type_id,
+                        "Eq",
+                        "eq",
+                        false,
+                    ) else {
                         let type_name = self.type_table.borrow().type_name(left.type_id);
                         let op_str = if binary.op == BinaryOp::Eq {
                             "=="
@@ -199,35 +204,23 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         });
                         return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, binary.span);
                     };
-                    // `Eq::eq(&self, other: &Self)` requires both sides to have the same type.
-                    // Without this check, a type mismatch slips through to codegen and surfaces
-                    // as an ICE on invalid Wasm.
-                    if let Some(err) =
-                        self.check_trait_op_rhs_type(left.type_id, right.type_id, binary.span)
-                    {
-                        return err;
-                    }
-                    return self.build_eq_method_call(
+                    let call = self.build_trait_op_method_call_on_resolved(
                         left,
                         right,
-                        &MethodInfo {
-                            return_type: TypeTable::BOOL,
-                            self_kind: trait_info.self_kind,
-                            param_types: vec![],
-                            param_is_mut: vec![],
-                            inherited_from_base: None,
-                            cm_name: None,
-                            is_ref_impl: false,
-                            method_type_param_ids: vec![],
-                            param_defaults: vec![],
-                            param_names: vec![],
-                        },
-                        &struct_name,
-                        &trait_info.trait_name,
-                        binary.op == BinaryOp::NotEq,
-                        false,
+                        &resolved,
                         binary.span,
                     );
+                    if binary.op == BinaryOp::NotEq && call.type_id == TypeTable::BOOL {
+                        return TirExpr::new(
+                            TirExprKind::Unary {
+                                op: TirUnaryOp::Not,
+                                expr: Box::new(call),
+                            },
+                            TypeTable::BOOL,
+                            binary.span,
+                        );
+                    }
+                    return call;
                 }
 
                 // Handle Ord trait (<, >, <=, >=)
@@ -235,8 +228,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     binary.op,
                     BinaryOp::Lt | BinaryOp::Gt | BinaryOp::LtEq | BinaryOp::GtEq
                 ) {
-                    let Some(trait_info) = self.find_ord_trait_impl(&struct_name, lookup_type_id)
-                    else {
+                    let Some(resolved) = self.resolve_trait_method_for_op(
+                        &struct_name,
+                        lookup_type_id,
+                        "Ord",
+                        "cmp",
+                        false,
+                    ) else {
                         let type_name = self.type_table.borrow().type_name(left.type_id);
                         let op_str = match binary.op {
                             BinaryOp::Lt => "<",
@@ -253,33 +251,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         });
                         return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, binary.span);
                     };
-                    // `Ord::cmp(&self, other: &Self)` requires both sides to have the same type.
-                    if let Some(err) =
-                        self.check_trait_op_rhs_type(left.type_id, right.type_id, binary.span)
-                    {
-                        return err;
-                    }
-                    return self.build_ord_method_call(
+                    let cmp_call = self.build_trait_op_method_call_on_resolved(
                         left,
                         right,
-                        &MethodInfo {
-                            return_type: TypeTable::BOOL,
-                            self_kind: trait_info.self_kind,
-                            param_types: vec![],
-                            param_is_mut: vec![],
-                            inherited_from_base: None,
-                            cm_name: None,
-                            is_ref_impl: false,
-                            method_type_param_ids: vec![],
-                            param_defaults: vec![],
-                            param_names: vec![],
-                        },
-                        &struct_name,
-                        &trait_info.trait_name,
-                        binary.op,
-                        false,
+                        &resolved,
                         binary.span,
                     );
+                    if cmp_call.type_id == TypeTable::ERROR {
+                        return cmp_call;
+                    }
+                    return self.ord_bool_from_cmp(cmp_call, binary.op, binary.span);
                 }
             }
 
@@ -300,16 +281,32 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     && let Some((_trait_name, info)) =
                         self.find_method_in_trait_bounds(&bound_names, "eq", left.type_id)
                 {
-                    return self.build_eq_method_call(
+                    let resolved = ResolvedTraitMethod {
+                        trait_name: "Eq".to_string(),
+                        method_name: "eq".to_string(),
+                        impl_name: name.clone(),
+                        self_kind: info.self_kind,
+                        return_type: info.return_type,
+                        rhs_type: info.param_types.first().copied(),
+                        is_type_param_receiver: true,
+                    };
+                    let call = self.build_trait_op_method_call_on_resolved(
                         left,
                         right,
-                        &info,
-                        &name,
-                        "Eq",
-                        binary.op == BinaryOp::NotEq,
-                        true,
+                        &resolved,
                         binary.span,
                     );
+                    if binary.op == BinaryOp::NotEq && call.type_id == TypeTable::BOOL {
+                        return TirExpr::new(
+                            TirExprKind::Unary {
+                                op: TirUnaryOp::Not,
+                                expr: Box::new(call),
+                            },
+                            TypeTable::BOOL,
+                            binary.span,
+                        );
+                    }
+                    return call;
                 }
                 if matches!(
                     binary.op,
@@ -317,16 +314,25 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 ) && let Some((_trait_name, info)) =
                     self.find_method_in_trait_bounds(&bound_names, "cmp", left.type_id)
                 {
-                    return self.build_ord_method_call(
+                    let resolved = ResolvedTraitMethod {
+                        trait_name: "Ord".to_string(),
+                        method_name: "cmp".to_string(),
+                        impl_name: name.clone(),
+                        self_kind: info.self_kind,
+                        return_type: info.return_type,
+                        rhs_type: info.param_types.first().copied(),
+                        is_type_param_receiver: true,
+                    };
+                    let cmp_call = self.build_trait_op_method_call_on_resolved(
                         left,
                         right,
-                        &info,
-                        &name,
-                        "Ord",
-                        binary.op,
-                        true,
+                        &resolved,
                         binary.span,
                     );
+                    if cmp_call.type_id == TypeTable::ERROR {
+                        return cmp_call;
+                    }
+                    return self.ord_bool_from_cmp(cmp_call, binary.op, binary.span);
                 }
             }
         }
@@ -388,52 +394,19 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         (info, lookup_name.clone())
                     });
                 if let Some(trait_info) = trait_info_opt {
-                    // Adjust receiver for self kind (&self)
-                    let receiver = self.adjust_receiver_for_self_kind(
+                    let resolved = ResolvedTraitMethod {
+                        trait_name: trait_info.trait_name,
+                        method_name: method_name.to_string(),
+                        impl_name,
+                        self_kind: trait_info.self_kind,
+                        return_type: trait_info.output_type,
+                        rhs_type: trait_info.rhs_type,
+                        is_type_param_receiver: false,
+                    };
+                    return self.build_trait_op_method_call_on_resolved(
                         left,
-                        trait_info.self_kind,
-                        false,
-                        binary.span,
-                    );
-
-                    // Create reference type for the argument (rhs: &Self)
-                    let arg_ref_type = self
-                        .type_table
-                        .borrow_mut()
-                        .intern(ResolvedType::Ref(right.type_id));
-
-                    let arg_ref = TirExpr::new(
-                        TirExprKind::Unary {
-                            op: TirUnaryOp::Ref,
-                            expr: Box::new(right),
-                        },
-                        arg_ref_type,
-                        binary.span,
-                    );
-
-                    let mangled_method_name = MethodName::format_local(
-                        &impl_name,
-                        Some(&trait_info.trait_name),
-                        method_name,
-                    );
-
-                    return TirExpr::new(
-                        TirExprKind::MethodCall {
-                            receiver: Box::new(receiver),
-                            func: FunctionRef {
-                                module_source: self.find_struct_module_source(&impl_name),
-                                name: mangled_method_name,
-                                monomorph_info: None,
-                                method_info: Some(LocalMethodName::new(
-                                    impl_name.clone(),
-                                    Some(trait_info.trait_name.clone()),
-                                    method_name.to_string(),
-                                )),
-                            },
-                            type_args: vec![],
-                            args: vec![CallArg::new(arg_ref, false)],
-                        },
-                        trait_info.output_type,
+                        right,
+                        &resolved,
                         binary.span,
                     );
                 }
@@ -459,54 +432,23 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 if let Some((_found_trait, info)) =
                     self.find_method_in_trait_bounds(&bound_names, method_name, left.type_id)
                 {
-                    let receiver = self.adjust_receiver_for_self_kind(
+                    // For type-param arithmetic operators, Output == Self is the common
+                    // case and TypeParam types get properly substituted by monomorphization.
+                    // Using AssocTypeProjection would cause unresolved types for primitives
+                    // that don't register associated types.
+                    let resolved = ResolvedTraitMethod {
+                        trait_name: trait_name.to_string(),
+                        method_name: method_name.to_string(),
+                        impl_name: name.clone(),
+                        self_kind: info.self_kind,
+                        return_type: operand_type_id,
+                        rhs_type: info.param_types.first().copied(),
+                        is_type_param_receiver: true,
+                    };
+                    return self.build_trait_op_method_call_on_resolved(
                         left,
-                        info.self_kind,
-                        false,
-                        binary.span,
-                    );
-
-                    let arg_ref_type = self
-                        .type_table
-                        .borrow_mut()
-                        .intern(ResolvedType::Ref(right.type_id));
-                    let arg_ref = TirExpr::new(
-                        TirExprKind::Unary {
-                            op: TirUnaryOp::Ref,
-                            expr: Box::new(right),
-                        },
-                        arg_ref_type,
-                        binary.span,
-                    );
-
-                    let mangled_method_name =
-                        MethodName::format_local(name, Some(trait_name), method_name);
-
-                    let mut method_info_local = LocalMethodName::new(
-                        name.clone(),
-                        Some(trait_name.to_string()),
-                        method_name.to_string(),
-                    );
-                    method_info_local.is_type_param_receiver = true;
-
-                    return TirExpr::new(
-                        TirExprKind::MethodCall {
-                            receiver: Box::new(receiver),
-                            func: FunctionRef {
-                                module_source: self.find_struct_module_source(name),
-                                name: mangled_method_name,
-                                monomorph_info: None,
-                                method_info: Some(method_info_local),
-                            },
-                            type_args: vec![],
-                            args: vec![CallArg::new(arg_ref, false)],
-                        },
-                        // Use the TypeParam type as the return type, not Self::Output.
-                        // For arithmetic operators, Output == Self is the common case,
-                        // and TypeParam types get properly substituted by monomorphization.
-                        // Using AssocTypeProjection here would cause unresolved types for
-                        // primitives that don't register associated types.
-                        operand_type_id,
+                        right,
+                        &resolved,
                         binary.span,
                     );
                 }
@@ -554,38 +496,22 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         (info, lookup_name.clone())
                     });
                 if let Some(trait_info) = trait_info_opt {
-                    // Adjust receiver for self kind (&self)
-                    let receiver = self.adjust_receiver_for_self_kind(
+                    // Shift traits declare `rhs: u32` (not `&Self`), so the
+                    // shared builder will type-check against u32 and will not
+                    // wrap the operand in `&`.
+                    let resolved = ResolvedTraitMethod {
+                        trait_name: trait_info.trait_name,
+                        method_name: method_name.to_string(),
+                        impl_name,
+                        self_kind: trait_info.self_kind,
+                        return_type: trait_info.output_type,
+                        rhs_type: trait_info.rhs_type,
+                        is_type_param_receiver: false,
+                    };
+                    return self.build_trait_op_method_call_on_resolved(
                         left,
-                        trait_info.self_kind,
-                        false,
-                        binary.span,
-                    );
-
-                    // For shift operations, rhs is u32 (not &Self), so pass directly
-                    let mangled_method_name = MethodName::format_local(
-                        &impl_name,
-                        Some(&trait_info.trait_name),
-                        method_name,
-                    );
-
-                    return TirExpr::new(
-                        TirExprKind::MethodCall {
-                            receiver: Box::new(receiver),
-                            func: FunctionRef {
-                                module_source: self.find_struct_module_source(&impl_name),
-                                name: mangled_method_name,
-                                monomorph_info: None,
-                                method_info: Some(LocalMethodName::new(
-                                    impl_name.clone(),
-                                    Some(trait_info.trait_name.clone()),
-                                    method_name.to_string(),
-                                )),
-                            },
-                            type_args: vec![],
-                            args: vec![CallArg::new(right, false)], // Pass rhs directly (u32)
-                        },
-                        trait_info.output_type,
+                        right,
+                        &resolved,
                         binary.span,
                     );
                 }
@@ -1298,164 +1224,129 @@ impl<H: CompilerHost> Resolver<'_, H> {
         self.resolve_expr(&chain.first, ctx, None)
     }
 
-    /// Verify that `right_type_id` matches `left_type_id` for trait-dispatched
-    /// `==`/`!=`/`<`/`<=`/`>`/`>=` operators. Both sides of `Eq::eq` / `Ord::cmp`
-    /// must be the same type (the signatures take `&Self`), so mixing types is
-    /// rejected here before the method call is built. Returns `Some(err_expr)`
-    /// when a mismatch was reported.
-    fn check_trait_op_rhs_type(
-        &mut self,
-        left_type_id: TypeId,
-        right_type_id: TypeId,
-        span: Span,
-    ) -> Option<TirExpr> {
-        if left_type_id == right_type_id
-            || left_type_id == TypeTable::ERROR
-            || right_type_id == TypeTable::ERROR
-            || left_type_id == TypeTable::NEVER
-            || right_type_id == TypeTable::NEVER
-        {
-            return None;
-        }
-        let type_table = self.type_table.borrow();
-        let left_name = type_table.type_name(left_type_id);
-        let right_name = type_table.type_name(right_type_id);
-        if left_name == right_name {
-            return None;
-        }
-        drop(type_table);
-        let _ = self.logger.error(TypeError::TypeMismatch {
-            expected: left_name,
-            found: right_name,
-            span,
-        });
-        Some(TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span))
-    }
-
-    /// Build a method call for `Eq::eq` (== / !=) operators.
-    #[allow(clippy::too_many_arguments)]
-    fn build_eq_method_call(
+    /// Single TIR-level builder for every binary operator that dispatches to
+    /// a trait method (`Eq::eq`, `Ord::cmp`, `Add::add`, …, `Shl::shl`).
+    /// Inputs are already resolved [`TirExpr`]s for both operands. The
+    /// [`ResolvedTraitMethod`] provides the substituted rhs type, self kind,
+    /// and return type, so:
+    ///
+    /// 1. The rhs operand is type-checked against the trait's declared
+    ///    parameter type. Mismatch emits `TypeMismatch` and returns an
+    ///    `ERROR` expression; there is no way to skip the check.
+    /// 2. The receiver is adjusted (`&self` / `&mut self`) via
+    ///    [`Self::adjust_receiver_for_self_kind`].
+    /// 3. The rhs operand is wrapped in `&` iff the trait's declared rhs
+    ///    type is a reference (i.e. `&Self` for Eq/Ord/arithmetic, never
+    ///    for `Shl::shl(&self, rhs: u32)`).
+    /// 4. A [`TirExprKind::MethodCall`] is constructed with the correct
+    ///    mangled name and the `ResolvedTraitMethod`'s return type.
+    fn build_trait_op_method_call_on_resolved(
         &mut self,
         left: TirExpr,
         right: TirExpr,
-        info: &MethodInfo,
-        struct_name: &str,
-        trait_name: &str,
-        needs_negation: bool,
-        is_type_param_receiver: bool,
+        resolved: &ResolvedTraitMethod,
         span: Span,
     ) -> TirExpr {
-        let receiver = self.adjust_receiver_for_self_kind(left, info.self_kind, false, span);
+        // Decide whether to wrap rhs in `&` and what value type to expect
+        // for `right`.  The trait's declared rhs type tells us the shape:
+        //
+        //   * `&Self` / `&mut Self` → rhs is passed by reference; the
+        //     caller hands us a value of the receiver's type (so when the
+        //     receiver is a newtype, the rhs is the same newtype — not
+        //     the base).  We therefore typecheck against `left.type_id`.
+        //   * Any other explicit type (e.g. `rhs: u32` for `Shl::shl`) →
+        //     rhs is passed by value and must match `rhs_type` verbatim.
+        let wrap_rhs_as_ref = match resolved.rhs_type {
+            Some(rhs_ty) => matches!(
+                self.type_table.borrow().get(rhs_ty),
+                ResolvedType::Ref(_) | ResolvedType::MutRef(_)
+            ),
+            None => false,
+        };
+        let expected_value_ty: Option<TypeId> = if wrap_rhs_as_ref {
+            Some(left.type_id)
+        } else {
+            resolved.rhs_type
+        };
 
-        let arg_ref_type = self
-            .type_table
-            .borrow_mut()
-            .intern(ResolvedType::Ref(right.type_id));
-        let arg_ref = TirExpr::new(
-            TirExprKind::Unary {
-                op: TirUnaryOp::Ref,
-                expr: Box::new(right),
-            },
-            arg_ref_type,
-            span,
+        if let Some(expected) = expected_value_ty
+            && right.type_id != expected
+            && right.type_id != TypeTable::ERROR
+            && expected != TypeTable::ERROR
+            && right.type_id != TypeTable::NEVER
+        {
+            let type_table = self.type_table.borrow();
+            let expected_name = type_table.type_name(expected);
+            let found_name = type_table.type_name(right.type_id);
+            if expected_name != found_name {
+                drop(type_table);
+                let _ = self.logger.error(TypeError::TypeMismatch {
+                    expected: expected_name,
+                    found: found_name,
+                    span,
+                });
+                return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span);
+            }
+        }
+
+        let receiver = self.adjust_receiver_for_self_kind(left, resolved.self_kind, false, span);
+
+        let arg_expr = if wrap_rhs_as_ref {
+            let arg_ref_type = self
+                .type_table
+                .borrow_mut()
+                .intern(ResolvedType::Ref(right.type_id));
+            TirExpr::new(
+                TirExprKind::Unary {
+                    op: TirUnaryOp::Ref,
+                    expr: Box::new(right),
+                },
+                arg_ref_type,
+                span,
+            )
+        } else {
+            right
+        };
+
+        let mangled_method_name = MethodName::format_local(
+            &resolved.impl_name,
+            Some(&resolved.trait_name),
+            &resolved.method_name,
         );
-
-        let mangled_method_name = MethodName::format_local(struct_name, Some(trait_name), "eq");
 
         let mut method_info = LocalMethodName::new(
-            struct_name.to_string(),
-            Some(trait_name.to_string()),
-            "eq".to_string(),
+            resolved.impl_name.clone(),
+            Some(resolved.trait_name.clone()),
+            resolved.method_name.clone(),
         );
-        method_info.is_type_param_receiver = is_type_param_receiver;
+        method_info.is_type_param_receiver = resolved.is_type_param_receiver;
 
-        let call_expr = TirExpr::new(
+        TirExpr::new(
             TirExprKind::MethodCall {
                 receiver: Box::new(receiver),
                 func: FunctionRef {
-                    module_source: self.find_struct_module_source(struct_name),
+                    module_source: self.find_struct_module_source(&resolved.impl_name),
                     name: mangled_method_name,
                     monomorph_info: None,
                     method_info: Some(method_info),
                 },
                 type_args: vec![],
-                args: vec![CallArg::new(arg_ref, false)],
+                args: vec![CallArg::new(arg_expr, false)],
             },
-            TypeTable::BOOL,
+            resolved.return_type,
             span,
-        );
-
-        if needs_negation {
-            return TirExpr::new(
-                TirExprKind::Unary {
-                    op: TirUnaryOp::Not,
-                    expr: Box::new(call_expr),
-                },
-                TypeTable::BOOL,
-                span,
-            );
-        }
-        call_expr
+        )
     }
 
-    /// Build a method call for `Ord::cmp` (<, >, <=, >=) operators.
-    #[allow(clippy::too_many_arguments)]
-    fn build_ord_method_call(
-        &mut self,
-        left: TirExpr,
-        right: TirExpr,
-        info: &MethodInfo,
-        struct_name: &str,
-        trait_name: &str,
-        op: BinaryOp,
-        is_type_param_receiver: bool,
-        span: Span,
-    ) -> TirExpr {
-        let receiver = self.adjust_receiver_for_self_kind(left, info.self_kind, false, span);
-
-        let arg_ref_type = self
-            .type_table
-            .borrow_mut()
-            .intern(ResolvedType::Ref(right.type_id));
-        let arg_ref = TirExpr::new(
-            TirExprKind::Unary {
-                op: TirUnaryOp::Ref,
-                expr: Box::new(right),
-            },
-            arg_ref_type,
-            span,
-        );
-
+    /// Wrap an `Ord::cmp` method call into a `bool` by comparing the returned
+    /// `Ordering` variant against the one that makes the operator true.
+    /// `<`   → `cmp == Less`, `>` → `cmp == Greater`,
+    /// `<=`  → `cmp != Greater`, `>=` → `cmp != Less`.
+    fn ord_bool_from_cmp(&mut self, cmp_call: TirExpr, op: BinaryOp, span: Span) -> TirExpr {
         let ordering_type_id = self.type_table.borrow_mut().intern(ResolvedType::Enum {
             name: "Ordering".to_string(),
             module_source: ModuleSource::prelude(),
         });
-
-        let mangled_method_name = MethodName::format_local(struct_name, Some(trait_name), "cmp");
-
-        let mut method_info = LocalMethodName::new(
-            struct_name.to_string(),
-            Some(trait_name.to_string()),
-            "cmp".to_string(),
-        );
-        method_info.is_type_param_receiver = is_type_param_receiver;
-
-        let cmp_call = TirExpr::new(
-            TirExprKind::MethodCall {
-                receiver: Box::new(receiver),
-                func: FunctionRef {
-                    module_source: self.find_struct_module_source(struct_name),
-                    name: mangled_method_name,
-                    monomorph_info: None,
-                    method_info: Some(method_info),
-                },
-                type_args: vec![],
-                args: vec![CallArg::new(arg_ref, false)],
-            },
-            ordering_type_id,
-            span,
-        );
-
         let (compare_op, case_name, case_index): (TirBinaryOp, &str, u32) = match op {
             BinaryOp::Lt => (TirBinaryOp::Eq, "Less", 0),
             BinaryOp::Gt => (TirBinaryOp::Eq, "Greater", 2),
@@ -1463,7 +1354,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
             BinaryOp::GtEq => (TirBinaryOp::NotEq, "Less", 0),
             _ => unreachable!(),
         };
-
         let ordering_variant = TirExpr::new(
             TirExprKind::EnumConstruct {
                 enum_type: ordering_type_id,
@@ -1473,7 +1363,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
             ordering_type_id,
             span,
         );
-
         TirExpr::new(
             TirExprKind::Binary {
                 op: compare_op,

--- a/wado-compiler/src/resolver/operators.rs
+++ b/wado-compiler/src/resolver/operators.rs
@@ -199,6 +199,14 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         });
                         return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, binary.span);
                     };
+                    // `Eq::eq(&self, other: &Self)` requires both sides to have the same type.
+                    // Without this check, a type mismatch slips through to codegen and surfaces
+                    // as an ICE on invalid Wasm.
+                    if let Some(err) =
+                        self.check_trait_op_rhs_type(left.type_id, right.type_id, binary.span)
+                    {
+                        return err;
+                    }
                     return self.build_eq_method_call(
                         left,
                         right,
@@ -245,6 +253,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         });
                         return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, binary.span);
                     };
+                    // `Ord::cmp(&self, other: &Self)` requires both sides to have the same type.
+                    if let Some(err) =
+                        self.check_trait_op_rhs_type(left.type_id, right.type_id, binary.span)
+                    {
+                        return err;
+                    }
                     return self.build_ord_method_call(
                         left,
                         right,
@@ -1282,6 +1296,40 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // This should have been desugared to binary && chain
         // Just resolve the first expression for now
         self.resolve_expr(&chain.first, ctx, None)
+    }
+
+    /// Verify that `right_type_id` matches `left_type_id` for trait-dispatched
+    /// `==`/`!=`/`<`/`<=`/`>`/`>=` operators. Both sides of `Eq::eq` / `Ord::cmp`
+    /// must be the same type (the signatures take `&Self`), so mixing types is
+    /// rejected here before the method call is built. Returns `Some(err_expr)`
+    /// when a mismatch was reported.
+    fn check_trait_op_rhs_type(
+        &mut self,
+        left_type_id: TypeId,
+        right_type_id: TypeId,
+        span: Span,
+    ) -> Option<TirExpr> {
+        if left_type_id == right_type_id
+            || left_type_id == TypeTable::ERROR
+            || right_type_id == TypeTable::ERROR
+            || left_type_id == TypeTable::NEVER
+            || right_type_id == TypeTable::NEVER
+        {
+            return None;
+        }
+        let type_table = self.type_table.borrow();
+        let left_name = type_table.type_name(left_type_id);
+        let right_name = type_table.type_name(right_type_id);
+        if left_name == right_name {
+            return None;
+        }
+        drop(type_table);
+        let _ = self.logger.error(TypeError::TypeMismatch {
+            expected: left_name,
+            found: right_name,
+            span,
+        });
+        Some(TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span))
     }
 
     /// Build a method call for `Eq::eq` (== / !=) operators.

--- a/wado-compiler/src/resolver/operators.rs
+++ b/wado-compiler/src/resolver/operators.rs
@@ -206,7 +206,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     };
                     let call = self.build_trait_op_method_call_on_resolved(
                         left,
-                        right,
+                        vec![right],
                         &resolved,
                         binary.span,
                     );
@@ -253,7 +253,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     };
                     let cmp_call = self.build_trait_op_method_call_on_resolved(
                         left,
-                        right,
+                        vec![right],
                         &resolved,
                         binary.span,
                     );
@@ -287,12 +287,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         impl_name: name.clone(),
                         self_kind: info.self_kind,
                         return_type: info.return_type,
-                        rhs_type: info.param_types.first().copied(),
+                        param_types: info.param_types.clone(),
                         is_type_param_receiver: true,
                     };
                     let call = self.build_trait_op_method_call_on_resolved(
                         left,
-                        right,
+                        vec![right],
                         &resolved,
                         binary.span,
                     );
@@ -320,12 +320,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         impl_name: name.clone(),
                         self_kind: info.self_kind,
                         return_type: info.return_type,
-                        rhs_type: info.param_types.first().copied(),
+                        param_types: info.param_types.clone(),
                         is_type_param_receiver: true,
                     };
                     let cmp_call = self.build_trait_op_method_call_on_resolved(
                         left,
-                        right,
+                        vec![right],
                         &resolved,
                         binary.span,
                     );
@@ -400,12 +400,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         impl_name,
                         self_kind: trait_info.self_kind,
                         return_type: trait_info.output_type,
-                        rhs_type: trait_info.rhs_type,
+                        param_types: trait_info.rhs_type.map(|t| vec![t]).unwrap_or_default(),
                         is_type_param_receiver: false,
                     };
                     return self.build_trait_op_method_call_on_resolved(
                         left,
-                        right,
+                        vec![right],
                         &resolved,
                         binary.span,
                     );
@@ -442,12 +442,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         impl_name: name.clone(),
                         self_kind: info.self_kind,
                         return_type: operand_type_id,
-                        rhs_type: info.param_types.first().copied(),
+                        param_types: info.param_types.clone(),
                         is_type_param_receiver: true,
                     };
                     return self.build_trait_op_method_call_on_resolved(
                         left,
-                        right,
+                        vec![right],
                         &resolved,
                         binary.span,
                     );
@@ -505,12 +505,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         impl_name,
                         self_kind: trait_info.self_kind,
                         return_type: trait_info.output_type,
-                        rhs_type: trait_info.rhs_type,
+                        param_types: trait_info.rhs_type.map(|t| vec![t]).unwrap_or_default(),
                         is_type_param_receiver: false,
                     };
                     return self.build_trait_op_method_call_on_resolved(
                         left,
-                        right,
+                        vec![right],
                         &resolved,
                         binary.span,
                     );
@@ -748,8 +748,15 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
         }
 
-        // Check for negation on non-primitive types that implement Neg trait
-        if unary.op == UnaryOp::Neg {
+        // Unary trait operators (`-x`, `~x`) dispatch through the same
+        // `resolve_trait_method_for_op` + `build_trait_op_method_call_on_resolved`
+        // pipeline as binary operators.  The builder handles the zero-arg
+        // case via `resolved.param_types.is_empty()`.
+        if let Some((trait_name, method_name)) = match unary.op {
+            UnaryOp::Neg => Some(("Neg", "neg")),
+            UnaryOp::BitNot => Some(("BitNot", "bitnot")),
+            _ => None,
+        } {
             let expr_type = self.type_table.borrow().get(expr.type_id).clone();
             let struct_name = match &expr_type {
                 ResolvedType::Struct { name, .. } => Some(name.clone()),
@@ -759,115 +766,31 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 }
                 _ => None,
             };
-
             if let Some(struct_name) = struct_name {
                 let (lookup_name, lookup_type_id) =
                     self.newtype_base_lookup(&struct_name, expr.type_id);
-
-                // Find the Neg trait implementation
-                let neg_info = self
-                    .find_arithmetic_trait_impl(&struct_name, expr.type_id, "Neg", "neg")
-                    .map(|info| (info, struct_name.clone()))
-                    .or_else(|| {
-                        self.find_arithmetic_trait_impl(&lookup_name, lookup_type_id, "Neg", "neg")
-                            .map(|info| (info, lookup_name.clone()))
-                    });
-                if let Some((trait_info, impl_name)) = neg_info {
-                    // Adjust receiver for self kind (&self)
-                    let receiver = self.adjust_receiver_for_self_kind(
-                        expr,
-                        trait_info.self_kind,
+                let resolved = self
+                    .resolve_trait_method_for_op(
+                        &struct_name,
+                        expr.type_id,
+                        trait_name,
+                        method_name,
                         false,
-                        unary.span,
-                    );
-
-                    let mangled_method_name =
-                        MethodName::format_local(&impl_name, Some(&trait_info.trait_name), "neg");
-
-                    return TirExpr::new(
-                        TirExprKind::MethodCall {
-                            receiver: Box::new(receiver),
-                            func: FunctionRef {
-                                module_source: self.find_struct_module_source(&impl_name),
-                                name: mangled_method_name,
-                                monomorph_info: None,
-                                method_info: Some(LocalMethodName::new(
-                                    impl_name.clone(),
-                                    Some(trait_info.trait_name.clone()),
-                                    "neg".to_string(),
-                                )),
-                            },
-                            type_args: vec![],
-                            args: vec![],
-                        },
-                        trait_info.output_type,
-                        unary.span,
-                    );
-                }
-            }
-        }
-
-        // Check for bitwise NOT on non-primitive types that implement BitNot trait
-        if unary.op == UnaryOp::BitNot {
-            let expr_type = self.type_table.borrow().get(expr.type_id).clone();
-            let struct_name = match &expr_type {
-                ResolvedType::Struct { name, .. } => Some(name.clone()),
-                ResolvedType::GenericInstance { name, .. } => Some(name.clone()),
-                ResolvedType::Newtype { name, .. } | ResolvedType::Flags { name, .. } => {
-                    Some(name.clone())
-                }
-                _ => None,
-            };
-
-            if let Some(struct_name) = struct_name {
-                let (lookup_name, lookup_type_id) =
-                    self.newtype_base_lookup(&struct_name, expr.type_id);
-
-                // Find the BitNot trait implementation
-                let bitnot_info = self
-                    .find_arithmetic_trait_impl(&struct_name, expr.type_id, "BitNot", "bitnot")
-                    .map(|info| (info, struct_name.clone()))
+                    )
                     .or_else(|| {
-                        self.find_arithmetic_trait_impl(
+                        self.resolve_trait_method_for_op(
                             &lookup_name,
                             lookup_type_id,
-                            "BitNot",
-                            "bitnot",
+                            trait_name,
+                            method_name,
+                            false,
                         )
-                        .map(|info| (info, lookup_name.clone()))
                     });
-                if let Some((trait_info, impl_name)) = bitnot_info {
-                    // Adjust receiver for self kind (&self)
-                    let receiver = self.adjust_receiver_for_self_kind(
+                if let Some(resolved) = resolved {
+                    return self.build_trait_op_method_call_on_resolved(
                         expr,
-                        trait_info.self_kind,
-                        false,
-                        unary.span,
-                    );
-
-                    let mangled_method_name = MethodName::format_local(
-                        &impl_name,
-                        Some(&trait_info.trait_name),
-                        "bitnot",
-                    );
-
-                    return TirExpr::new(
-                        TirExprKind::MethodCall {
-                            receiver: Box::new(receiver),
-                            func: FunctionRef {
-                                module_source: self.find_struct_module_source(&impl_name),
-                                name: mangled_method_name,
-                                monomorph_info: None,
-                                method_info: Some(LocalMethodName::new(
-                                    impl_name.clone(),
-                                    Some(trait_info.trait_name.clone()),
-                                    "bitnot".to_string(),
-                                )),
-                            },
-                            type_args: vec![],
-                            args: vec![],
-                        },
-                        trait_info.output_type,
+                        vec![],
+                        &resolved,
                         unary.span,
                     );
                 }
@@ -1048,25 +971,23 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             "index_assign",
                         );
 
-                        return TirExpr::new(
-                            TirExprKind::MethodCall {
-                                receiver: Box::new(receiver),
-                                func: FunctionRef {
-                                    module_source: trait_info.impl_module_source.clone(),
-                                    name: mangled_method_name,
-                                    monomorph_info: None,
-                                    method_info: Some(LocalMethodName::new(
-                                        lookup_name,
-                                        Some(trait_info.trait_name),
-                                        "index_assign".to_string(),
-                                    )),
-                                },
-                                type_args: vec![],
-                                args: vec![
-                                    CallArg::new(index_resolved, false),
-                                    CallArg::new(value, false),
-                                ],
+                        return Self::build_tir_method_call(
+                            receiver,
+                            FunctionRef {
+                                module_source: trait_info.impl_module_source.clone(),
+                                name: mangled_method_name,
+                                monomorph_info: None,
+                                method_info: Some(LocalMethodName::new(
+                                    lookup_name,
+                                    Some(trait_info.trait_name),
+                                    "index_assign".to_string(),
+                                )),
                             },
+                            vec![],
+                            vec![
+                                CallArg::new(index_resolved, false),
+                                CallArg::new(value, false),
+                            ],
                             TypeTable::UNIT,
                             assign.span,
                         );
@@ -1224,89 +1145,104 @@ impl<H: CompilerHost> Resolver<'_, H> {
         self.resolve_expr(&chain.first, ctx, None)
     }
 
-    /// Single TIR-level builder for every binary operator that dispatches to
-    /// a trait method (`Eq::eq`, `Ord::cmp`, `Add::add`, …, `Shl::shl`).
-    /// Inputs are already resolved [`TirExpr`]s for both operands. The
-    /// [`ResolvedTraitMethod`] provides the substituted rhs type, self kind,
-    /// and return type, so:
+    /// Single TIR-level builder for every operator that dispatches to a
+    /// trait method — unary (`Neg::neg`, `BitNot::bitnot`) as well as
+    /// binary (`Eq::eq`, `Ord::cmp`, `Add::add`, …, `Shl::shl`).  Inputs
+    /// are already-resolved [`TirExpr`]s: the receiver and zero or more
+    /// argument operands matching `resolved.param_types` in order.
     ///
-    /// 1. The rhs operand is type-checked against the trait's declared
-    ///    parameter type. Mismatch emits `TypeMismatch` and returns an
-    ///    `ERROR` expression; there is no way to skip the check.
-    /// 2. The receiver is adjusted (`&self` / `&mut self`) via
+    /// The builder is the single source of truth for:
+    ///
+    /// 1. Type-checking each argument against the trait's declared
+    ///    parameter type.  Mismatches emit `TypeMismatch` and return an
+    ///    `ERROR` expression; there is no way for a caller to skip the
+    ///    check.  For `&Self` parameters the expected value type is the
+    ///    receiver's own type so newtype dispatch (base-impl method
+    ///    called through the newtype) still accepts the newtype on both
+    ///    sides.
+    /// 2. Adjusting the receiver via
     ///    [`Self::adjust_receiver_for_self_kind`].
-    /// 3. The rhs operand is wrapped in `&` iff the trait's declared rhs
-    ///    type is a reference (i.e. `&Self` for Eq/Ord/arithmetic, never
-    ///    for `Shl::shl(&self, rhs: u32)`).
-    /// 4. A [`TirExprKind::MethodCall`] is constructed with the correct
-    ///    mangled name and the `ResolvedTraitMethod`'s return type.
+    /// 3. Wrapping each argument in `&` iff the matching parameter type
+    ///    is a reference — never otherwise, so `Shl::shl(&self, rhs:
+    ///    u32)` receives the `u32` by value.
+    /// 4. Constructing the [`TirExprKind::MethodCall`] with the correct
+    ///    mangled name and `resolved.return_type`.
     fn build_trait_op_method_call_on_resolved(
         &mut self,
-        left: TirExpr,
-        right: TirExpr,
+        receiver: TirExpr,
+        args: Vec<TirExpr>,
         resolved: &ResolvedTraitMethod,
         span: Span,
     ) -> TirExpr {
-        // Decide whether to wrap rhs in `&` and what value type to expect
-        // for `right`.  The trait's declared rhs type tells us the shape:
-        //
-        //   * `&Self` / `&mut Self` → rhs is passed by reference; the
-        //     caller hands us a value of the receiver's type (so when the
-        //     receiver is a newtype, the rhs is the same newtype — not
-        //     the base).  We therefore typecheck against `left.type_id`.
-        //   * Any other explicit type (e.g. `rhs: u32` for `Shl::shl`) →
-        //     rhs is passed by value and must match `rhs_type` verbatim.
-        let wrap_rhs_as_ref = match resolved.rhs_type {
-            Some(rhs_ty) => matches!(
-                self.type_table.borrow().get(rhs_ty),
-                ResolvedType::Ref(_) | ResolvedType::MutRef(_)
-            ),
-            None => false,
-        };
-        let expected_value_ty: Option<TypeId> = if wrap_rhs_as_ref {
-            Some(left.type_id)
-        } else {
-            resolved.rhs_type
-        };
-
-        if let Some(expected) = expected_value_ty
-            && right.type_id != expected
-            && right.type_id != TypeTable::ERROR
-            && expected != TypeTable::ERROR
-            && right.type_id != TypeTable::NEVER
-        {
-            let type_table = self.type_table.borrow();
-            let expected_name = type_table.type_name(expected);
-            let found_name = type_table.type_name(right.type_id);
-            if expected_name != found_name {
-                drop(type_table);
-                let _ = self.logger.error(TypeError::TypeMismatch {
-                    expected: expected_name,
-                    found: found_name,
-                    span,
-                });
-                return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span);
-            }
+        if args.len() != resolved.param_types.len() {
+            // This is an internal invariant violation by the caller — the
+            // resolve-site should always line up operand count with the
+            // trait's arity.  Return ERROR so the rest of resolve recovers
+            // gracefully, but flag it as a mismatch too so tests notice.
+            let _ = self.logger.error(TypeError::TypeMismatch {
+                expected: format!("{} arg(s)", resolved.param_types.len()),
+                found: format!("{} arg(s)", args.len()),
+                span,
+            });
+            return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span);
         }
 
-        let receiver = self.adjust_receiver_for_self_kind(left, resolved.self_kind, false, span);
+        // For each argument, decide whether the trait parameter is by
+        // reference, and validate against the correct expected value type.
+        let mut wrap_flags: Vec<bool> = Vec::with_capacity(args.len());
+        for (arg, &param_ty) in args.iter().zip(resolved.param_types.iter()) {
+            let wrap = matches!(
+                self.type_table.borrow().get(param_ty),
+                ResolvedType::Ref(_) | ResolvedType::MutRef(_)
+            );
+            let expected = if wrap { receiver.type_id } else { param_ty };
+            if arg.type_id != expected
+                && arg.type_id != TypeTable::ERROR
+                && expected != TypeTable::ERROR
+                && arg.type_id != TypeTable::NEVER
+            {
+                let type_table = self.type_table.borrow();
+                let expected_name = type_table.type_name(expected);
+                let found_name = type_table.type_name(arg.type_id);
+                if expected_name != found_name {
+                    drop(type_table);
+                    let _ = self.logger.error(TypeError::TypeMismatch {
+                        expected: expected_name,
+                        found: found_name,
+                        span,
+                    });
+                    return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span);
+                }
+            }
+            wrap_flags.push(wrap);
+        }
 
-        let arg_expr = if wrap_rhs_as_ref {
-            let arg_ref_type = self
-                .type_table
-                .borrow_mut()
-                .intern(ResolvedType::Ref(right.type_id));
-            TirExpr::new(
-                TirExprKind::Unary {
-                    op: TirUnaryOp::Ref,
-                    expr: Box::new(right),
-                },
-                arg_ref_type,
-                span,
-            )
-        } else {
-            right
-        };
+        let receiver =
+            self.adjust_receiver_for_self_kind(receiver, resolved.self_kind, false, span);
+
+        let call_args: Vec<CallArg> = args
+            .into_iter()
+            .zip(wrap_flags)
+            .map(|(arg, wrap)| {
+                let arg_expr = if wrap {
+                    let arg_ref_type = self
+                        .type_table
+                        .borrow_mut()
+                        .intern(ResolvedType::Ref(arg.type_id));
+                    TirExpr::new(
+                        TirExprKind::Unary {
+                            op: TirUnaryOp::Ref,
+                            expr: Box::new(arg),
+                        },
+                        arg_ref_type,
+                        span,
+                    )
+                } else {
+                    arg
+                };
+                CallArg::new(arg_expr, false)
+            })
+            .collect();
 
         let mangled_method_name = MethodName::format_local(
             &resolved.impl_name,
@@ -1321,18 +1257,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
         );
         method_info.is_type_param_receiver = resolved.is_type_param_receiver;
 
-        TirExpr::new(
-            TirExprKind::MethodCall {
-                receiver: Box::new(receiver),
-                func: FunctionRef {
-                    module_source: self.find_struct_module_source(&resolved.impl_name),
-                    name: mangled_method_name,
-                    monomorph_info: None,
-                    method_info: Some(method_info),
-                },
-                type_args: vec![],
-                args: vec![CallArg::new(arg_expr, false)],
+        Self::build_tir_method_call(
+            receiver,
+            FunctionRef {
+                module_source: self.find_struct_module_source(&resolved.impl_name),
+                name: mangled_method_name,
+                monomorph_info: None,
+                method_info: Some(method_info),
             },
+            vec![],
+            call_args,
             resolved.return_type,
             span,
         )

--- a/wado-compiler/src/resolver/operators.rs
+++ b/wado-compiler/src/resolver/operators.rs
@@ -568,9 +568,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
         }
 
-        // If the left operand is a non-primitive type (Struct, GenericInstance, or a
-        // Newtype whose ultimate base is non-primitive), we should have dispatched via
-        // a trait above.  Reaching here means the required trait is not implemented.
+        // If the left operand is a non-primitive type that cannot fall through
+        // to a native Wasm binary instruction, it must dispatch through a
+        // trait implementation.  Reaching here with such a type means no
+        // matching trait impl was found — emit a diagnostic before we can
+        // accidentally build a TIR `Binary` node that would crash codegen
+        // with "type mismatch: expected ... found (ref $type)" on Wasm
+        // validation (see regression fixture `typecheck_binop_fn_eq.wado`).
         {
             let requires_trait = match &left_type {
                 ResolvedType::Struct { .. } | ResolvedType::GenericInstance { .. } => true,
@@ -582,6 +586,15 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         ResolvedType::Struct { .. } | ResolvedType::GenericInstance { .. }
                     )
                 }
+                // Types with no native Wasm binary-op support and no trait
+                // implementation in the prelude.  Without this rejection,
+                // codegen emits `ref.eq` / `i32.eq` against a GC reference
+                // and fails validation.
+                ResolvedType::Function { .. }
+                | ResolvedType::Resource { .. }
+                | ResolvedType::GenericResource { .. }
+                | ResolvedType::Reactive(_)
+                | ResolvedType::AssocTypeProjection { .. } => true,
                 _ => false,
             };
             if requires_trait
@@ -1188,32 +1201,30 @@ impl<H: CompilerHost> Resolver<'_, H> {
         }
 
         // For each argument, decide whether the trait parameter is by
-        // reference, and validate against the correct expected value type.
+        // reference, compute the logical expected value type for the arg,
+        // and delegate to `Resolver::typecheck` — the same helper that
+        // `resolve_method_call` uses at its own argument-typecheck tail.
+        //
+        // Using the shared primitive means operator dispatch and direct
+        // method calls apply identical `check_assignable` rules
+        // (Unknown/Error deferral, newtype propagation, reference
+        // unwrapping) and any divergence there is impossible by
+        // construction.  We no longer early-return on mismatch; errors
+        // are accumulated via the logger and compilation fails at the
+        // end, matching method-call behavior.
         let mut wrap_flags: Vec<bool> = Vec::with_capacity(args.len());
         for (arg, &param_ty) in args.iter().zip(resolved.param_types.iter()) {
             let wrap = matches!(
                 self.type_table.borrow().get(param_ty),
                 ResolvedType::Ref(_) | ResolvedType::MutRef(_)
             );
+            // For `&Self` parameters the "value-level" expected type is
+            // the receiver's type (preserving newtype identity when an
+            // impl on the base is dispatched through a newtype receiver).
+            // For concrete parameter types (e.g. `rhs: u32` on
+            // `Shl::shl`) the expected type is the parameter type itself.
             let expected = if wrap { receiver.type_id } else { param_ty };
-            if arg.type_id != expected
-                && arg.type_id != TypeTable::ERROR
-                && expected != TypeTable::ERROR
-                && arg.type_id != TypeTable::NEVER
-            {
-                let type_table = self.type_table.borrow();
-                let expected_name = type_table.type_name(expected);
-                let found_name = type_table.type_name(arg.type_id);
-                if expected_name != found_name {
-                    drop(type_table);
-                    let _ = self.logger.error(TypeError::TypeMismatch {
-                        expected: expected_name,
-                        found: found_name,
-                        span,
-                    });
-                    return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span);
-                }
-            }
+            self.typecheck(arg.type_id, expected, span);
             wrap_flags.push(wrap);
         }
 

--- a/wado-compiler/src/resolver/operators.rs
+++ b/wado-compiler/src/resolver/operators.rs
@@ -287,7 +287,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         impl_name: name.clone(),
                         self_kind: info.self_kind,
                         return_type: info.return_type,
-                        param_types: info.param_types.clone(),
+                        param_types: info.param_types,
                         is_type_param_receiver: true,
                     };
                     let call = self.build_trait_op_method_call_on_resolved(
@@ -320,7 +320,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         impl_name: name.clone(),
                         self_kind: info.self_kind,
                         return_type: info.return_type,
-                        param_types: info.param_types.clone(),
+                        param_types: info.param_types,
                         is_type_param_receiver: true,
                     };
                     let cmp_call = self.build_trait_op_method_call_on_resolved(
@@ -442,7 +442,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         impl_name: name.clone(),
                         self_kind: info.self_kind,
                         return_type: operand_type_id,
-                        param_types: info.param_types.clone(),
+                        param_types: info.param_types,
                         is_type_param_receiver: true,
                     };
                     return self.build_trait_op_method_call_on_resolved(

--- a/wado-compiler/src/resolver/trait_query.rs
+++ b/wado-compiler/src/resolver/trait_query.rs
@@ -1033,8 +1033,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
     }
 
     /// Single entry point for resolving a trait method that a binary operator
-    /// dispatches to (Eq / Ord / Add / Sub / Mul / Div / Rem / BitAnd / BitOr /
-    /// BitXor / Shl / Shr). Produces a fully-populated
+    /// dispatches to (Eq / Ord / Add / Sub / Mul / Div / Rem / `BitAnd` / `BitOr` /
+    /// `BitXor` / Shl / Shr). Produces a fully-populated
     /// [`ResolvedTraitMethod`] with the rhs type already substituted, so
     /// callers need not reach into the underlying `find_*_trait_impl`
     /// family and cannot forget to wire `rhs_type` through the typecheck.

--- a/wado-compiler/src/resolver/trait_query.rs
+++ b/wado-compiler/src/resolver/trait_query.rs
@@ -1059,7 +1059,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // those here. `find_arithmetic_trait_impl` would otherwise default
         // `output_type` to the receiver type when no `type Output` is
         // declared.
-        let (info_trait_name, self_kind, rhs_type, return_type) = if let Some(info) =
+        let (info_trait_name, self_kind, param_types, return_type) = if let Some(info) =
             self.find_arithmetic_trait_impl(struct_name, lookup_type_id, trait_name, method_name)
         {
             let return_type = match trait_name {
@@ -1070,7 +1070,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 }),
                 _ => info.output_type,
             };
-            (info.trait_name, info.self_kind, info.rhs_type, return_type)
+            let param_types = info.rhs_type.map(|t| vec![t]).unwrap_or_default();
+            (info.trait_name, info.self_kind, param_types, return_type)
         } else if matches!(trait_name, "Eq" | "Ord")
             && self.type_implements_trait(lookup_type_id, trait_name)
         {
@@ -1089,7 +1090,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             (
                 trait_name.to_string(),
                 ast::SelfKind::Ref,
-                Some(ref_self_ty),
+                vec![ref_self_ty],
                 return_type,
             )
         } else {
@@ -1101,7 +1102,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             impl_name: struct_name.to_string(),
             self_kind,
             return_type,
-            rhs_type,
+            param_types,
             is_type_param_receiver: is_type_param,
         })
     }

--- a/wado-compiler/src/resolver/trait_query.rs
+++ b/wado-compiler/src/resolver/trait_query.rs
@@ -1059,46 +1059,42 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // those here. `find_arithmetic_trait_impl` would otherwise default
         // `output_type` to the receiver type when no `type Output` is
         // declared.
-        let (info_trait_name, self_kind, rhs_type, return_type) =
-            if let Some(info) = self.find_arithmetic_trait_impl(
-                struct_name,
-                lookup_type_id,
-                trait_name,
-                method_name,
-            ) {
-                let return_type = match trait_name {
-                    "Eq" => TypeTable::BOOL,
-                    "Ord" => self.type_table.borrow_mut().intern(ResolvedType::Enum {
-                        name: "Ordering".to_string(),
-                        module_source: ModuleSource::prelude(),
-                    }),
-                    _ => info.output_type,
-                };
-                (info.trait_name, info.self_kind, info.rhs_type, return_type)
-            } else if matches!(trait_name, "Eq" | "Ord")
-                && self.type_implements_trait(lookup_type_id, trait_name)
-            {
-                let ref_self_ty = self
-                    .type_table
-                    .borrow_mut()
-                    .intern(ResolvedType::Ref(lookup_type_id));
-                let return_type = match trait_name {
-                    "Eq" => TypeTable::BOOL,
-                    "Ord" => self.type_table.borrow_mut().intern(ResolvedType::Enum {
-                        name: "Ordering".to_string(),
-                        module_source: ModuleSource::prelude(),
-                    }),
-                    _ => unreachable!(),
-                };
-                (
-                    trait_name.to_string(),
-                    ast::SelfKind::Ref,
-                    Some(ref_self_ty),
-                    return_type,
-                )
-            } else {
-                return None;
+        let (info_trait_name, self_kind, rhs_type, return_type) = if let Some(info) =
+            self.find_arithmetic_trait_impl(struct_name, lookup_type_id, trait_name, method_name)
+        {
+            let return_type = match trait_name {
+                "Eq" => TypeTable::BOOL,
+                "Ord" => self.type_table.borrow_mut().intern(ResolvedType::Enum {
+                    name: "Ordering".to_string(),
+                    module_source: ModuleSource::prelude(),
+                }),
+                _ => info.output_type,
             };
+            (info.trait_name, info.self_kind, info.rhs_type, return_type)
+        } else if matches!(trait_name, "Eq" | "Ord")
+            && self.type_implements_trait(lookup_type_id, trait_name)
+        {
+            let ref_self_ty = self
+                .type_table
+                .borrow_mut()
+                .intern(ResolvedType::Ref(lookup_type_id));
+            let return_type = match trait_name {
+                "Eq" => TypeTable::BOOL,
+                "Ord" => self.type_table.borrow_mut().intern(ResolvedType::Enum {
+                    name: "Ordering".to_string(),
+                    module_source: ModuleSource::prelude(),
+                }),
+                _ => unreachable!(),
+            };
+            (
+                trait_name.to_string(),
+                ast::SelfKind::Ref,
+                Some(ref_self_ty),
+                return_type,
+            )
+        } else {
+            return None;
+        };
         Some(ResolvedTraitMethod {
             trait_name: info_trait_name,
             method_name: method_name.to_string(),

--- a/wado-compiler/src/resolver/trait_query.rs
+++ b/wado-compiler/src/resolver/trait_query.rs
@@ -1050,37 +1050,62 @@ impl<H: CompilerHost> Resolver<'_, H> {
         method_name: &str,
         is_type_param: bool,
     ) -> Option<ResolvedTraitMethod> {
-        let info = match trait_name {
-            "Eq" => self.find_eq_trait_impl(struct_name, lookup_type_id)?,
-            "Ord" => self.find_ord_trait_impl(struct_name, lookup_type_id)?,
-            _ => self.find_arithmetic_trait_impl(
+        // 1. User-written impl via the shared arithmetic-trait lookup.
+        // 2. Auto-derive fallback (Eq / Ord only; other operator traits
+        //    have no auto-derive rules).
+        //
+        // Eq / Ord trait decls fix their return types (`bool` and `Ordering`
+        // respectively) regardless of what a user impl writes, so normalize
+        // those here. `find_arithmetic_trait_impl` would otherwise default
+        // `output_type` to the receiver type when no `type Output` is
+        // declared.
+        let (info_trait_name, self_kind, rhs_type, return_type) =
+            if let Some(info) = self.find_arithmetic_trait_impl(
                 struct_name,
                 lookup_type_id,
                 trait_name,
                 method_name,
-            )?,
-        };
-        // The Eq / Ord trait decls fix their return types (`bool` and
-        // `Ordering` respectively) regardless of what a user impl writes.
-        // `find_arithmetic_trait_impl` — which backs user-defined Eq/Ord
-        // impls — does not know that and defaults `output_type` to the
-        // receiver type when no `type Output` is declared.  Normalize here
-        // so callers see the real trait return type.
-        let return_type = match trait_name {
-            "Eq" => TypeTable::BOOL,
-            "Ord" => self.type_table.borrow_mut().intern(ResolvedType::Enum {
-                name: "Ordering".to_string(),
-                module_source: ModuleSource::prelude(),
-            }),
-            _ => info.output_type,
-        };
+            ) {
+                let return_type = match trait_name {
+                    "Eq" => TypeTable::BOOL,
+                    "Ord" => self.type_table.borrow_mut().intern(ResolvedType::Enum {
+                        name: "Ordering".to_string(),
+                        module_source: ModuleSource::prelude(),
+                    }),
+                    _ => info.output_type,
+                };
+                (info.trait_name, info.self_kind, info.rhs_type, return_type)
+            } else if matches!(trait_name, "Eq" | "Ord")
+                && self.type_implements_trait(lookup_type_id, trait_name)
+            {
+                let ref_self_ty = self
+                    .type_table
+                    .borrow_mut()
+                    .intern(ResolvedType::Ref(lookup_type_id));
+                let return_type = match trait_name {
+                    "Eq" => TypeTable::BOOL,
+                    "Ord" => self.type_table.borrow_mut().intern(ResolvedType::Enum {
+                        name: "Ordering".to_string(),
+                        module_source: ModuleSource::prelude(),
+                    }),
+                    _ => unreachable!(),
+                };
+                (
+                    trait_name.to_string(),
+                    ast::SelfKind::Ref,
+                    Some(ref_self_ty),
+                    return_type,
+                )
+            } else {
+                return None;
+            };
         Some(ResolvedTraitMethod {
-            trait_name: info.trait_name,
+            trait_name: info_trait_name,
             method_name: method_name.to_string(),
             impl_name: struct_name.to_string(),
-            self_kind: info.self_kind,
+            self_kind,
             return_type,
-            rhs_type: info.rhs_type,
+            rhs_type,
             is_type_param_receiver: is_type_param,
         })
     }

--- a/wado-compiler/src/resolver/trait_query.rs
+++ b/wado-compiler/src/resolver/trait_query.rs
@@ -1113,13 +1113,37 @@ impl<H: CompilerHost> Resolver<'_, H> {
     /// a [`TraitMethodMatch`] whose [`MethodInfo`] has the receiver type
     /// fully substituted into `Self` positions. This is the single pathway
     /// that makes auto-derived methods discoverable via method-call
-    /// resolution, mirroring what operator dispatch already got from
-    /// [`Self::find_eq_trait_impl`] and [`Self::find_ord_trait_impl`].
+    /// resolution, mirroring what operator dispatch already got from the
+    /// arithmetic-trait lookup's own auto-derive branch.
     ///
     /// Only method bodies actually produced by the trait-synthesis phase
     /// (`synthesis::traits`) are returned here; primitives are excluded
     /// because their equality/comparison lowers to Wasm instructions, not
     /// to a method body.
+    ///
+    /// FIXME: this function has two places where it hard-codes knowledge
+    /// that should live on the trait declarations themselves:
+    ///
+    ///   1. `method_name -> trait_name` is a closed `match` against `"eq"`
+    ///      and `"cmp"`.  Adding auto-derive method-call support for
+    ///      `Inspect::inspect` / `Display::fmt` / any new auto-derived
+    ///      trait requires extending this arm. The right design is a
+    ///      reverse-index built from `trait_env.decl_index` that answers
+    ///      "which traits declare a method named `X`?" and then filters
+    ///      by those that have an auto-derive rule.
+    ///
+    ///   2. The synthesized [`MethodInfo`] is built with a fixed shape
+    ///      (`self_kind: Ref`, single `&Self` parameter named `"other"`,
+    ///      no defaults, no method type params).  If the prelude ever
+    ///      evolves the `Eq` or `Ord` trait declaration (e.g. renames
+    ///      the parameter, adds a default arg, takes `&mut self`), this
+    ///      shape drifts silently.  The right design is to look the
+    ///      real `ast::Function` up via `find_trait_decl_methods` and
+    ///      substitute `Self` through the same path as user-written
+    ///      impls (via `trait_ctx.self_type`).
+    ///
+    /// Tracked as a post-PR cleanup; the shape is stable enough for the
+    /// current two traits that it does not cause observable bugs today.
     pub(super) fn try_auto_derived_method_match(
         &mut self,
         struct_name: &str,

--- a/wado-compiler/src/resolver/trait_query.rs
+++ b/wado-compiler/src/resolver/trait_query.rs
@@ -10,7 +10,7 @@ use crate::tir::{PrimitiveType, ResolvedType, TypeId, TypeTable};
 use crate::token::Span;
 
 use super::Resolver;
-use super::types::{MethodInfo, ResolvedTraitMethod, TypeError};
+use super::types::{MethodInfo, ResolvedTraitMethod, TraitMethodMatch, TypeError};
 
 impl<H: CompilerHost> Resolver<'_, H> {
     /// Find a trait declaration by name across all modules.
@@ -1083,5 +1083,86 @@ impl<H: CompilerHost> Resolver<'_, H> {
             rhs_type: info.rhs_type,
             is_type_param_receiver: is_type_param,
         })
+    }
+
+    /// Fallback for [`Self::find_trait_method_for_type`]: when no user-written
+    /// impl of `trait_name::method_name` exists for a type that is still
+    /// auto-derive-eligible (per [`Self::type_implements_trait`]), synthesize
+    /// a [`TraitMethodMatch`] whose [`MethodInfo`] has the receiver type
+    /// fully substituted into `Self` positions. This is the single pathway
+    /// that makes auto-derived methods discoverable via method-call
+    /// resolution, mirroring what operator dispatch already got from
+    /// [`Self::find_eq_trait_impl`] and [`Self::find_ord_trait_impl`].
+    ///
+    /// Only method bodies actually produced by the trait-synthesis phase
+    /// (`synthesis::traits`) are returned here; primitives are excluded
+    /// because their equality/comparison lowers to Wasm instructions, not
+    /// to a method body.
+    pub(super) fn try_auto_derived_method_match(
+        &mut self,
+        struct_name: &str,
+        method_name: &str,
+        receiver_type_id: TypeId,
+    ) -> Option<TraitMethodMatch> {
+        let trait_name = match method_name {
+            "eq" => "Eq",
+            "cmp" => "Ord",
+            _ => return None,
+        };
+        let base_type_id = self.get_base_type(receiver_type_id);
+        if !self.auto_derive_eligible_kind(base_type_id) {
+            return None;
+        }
+        if !self.type_implements_trait(base_type_id, trait_name) {
+            return None;
+        }
+        let ref_self_ty = self
+            .type_table
+            .borrow_mut()
+            .intern(ResolvedType::Ref(base_type_id));
+        let return_type = match trait_name {
+            "Eq" => TypeTable::BOOL,
+            "Ord" => self.type_table.borrow_mut().intern(ResolvedType::Enum {
+                name: "Ordering".to_string(),
+                module_source: ModuleSource::prelude(),
+            }),
+            _ => unreachable!(),
+        };
+        let method_info = MethodInfo {
+            return_type,
+            self_kind: ast::SelfKind::Ref,
+            param_types: vec![ref_self_ty],
+            param_is_mut: vec![false],
+            param_defaults: vec![None],
+            param_names: vec!["other".to_string()],
+            inherited_from_base: None,
+            cm_name: None,
+            is_ref_impl: false,
+            method_type_param_ids: vec![],
+        };
+        let impl_module_source = self.find_struct_module_source(struct_name);
+        Some(TraitMethodMatch {
+            trait_name: trait_name.to_string(),
+            method_info,
+            impl_module_source,
+            blanket_type_param: None,
+            impl_struct_name: struct_name.to_string(),
+            is_blanket_ref_impl: false,
+        })
+    }
+
+    /// Whether the given type is a kind for which `synthesis::traits` emits
+    /// auto-derived `Eq` / `Ord` method bodies: named structs, variants, and
+    /// enums (including generic instances thereof). Primitives and reference
+    /// types are excluded because their equality lowers to Wasm instructions
+    /// rather than a callable method.
+    fn auto_derive_eligible_kind(&self, type_id: TypeId) -> bool {
+        matches!(
+            self.type_table.borrow().get(type_id),
+            ResolvedType::Struct { .. }
+                | ResolvedType::Variant { .. }
+                | ResolvedType::Enum { .. }
+                | ResolvedType::GenericInstance { .. }
+        )
     }
 }

--- a/wado-compiler/src/resolver/trait_query.rs
+++ b/wado-compiler/src/resolver/trait_query.rs
@@ -10,7 +10,7 @@ use crate::tir::{PrimitiveType, ResolvedType, TypeId, TypeTable};
 use crate::token::Span;
 
 use super::Resolver;
-use super::types::{MethodInfo, TypeError};
+use super::types::{MethodInfo, ResolvedTraitMethod, TypeError};
 
 impl<H: CompilerHost> Resolver<'_, H> {
     /// Find a trait declaration by name across all modules.
@@ -1030,5 +1030,58 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
             _ => true,
         }
+    }
+
+    /// Single entry point for resolving a trait method that a binary operator
+    /// dispatches to (Eq / Ord / Add / Sub / Mul / Div / Rem / BitAnd / BitOr /
+    /// BitXor / Shl / Shr). Produces a fully-populated
+    /// [`ResolvedTraitMethod`] with the rhs type already substituted, so
+    /// callers need not reach into the underlying `find_*_trait_impl`
+    /// family and cannot forget to wire `rhs_type` through the typecheck.
+    ///
+    /// `struct_name` / `lookup_type_id` are the name-and-id used for impl
+    /// lookup (for newtypes this may be the ultimate base). `is_type_param`
+    /// is true for `T: Trait` type-param receivers.
+    pub(super) fn resolve_trait_method_for_op(
+        &mut self,
+        struct_name: &str,
+        lookup_type_id: TypeId,
+        trait_name: &str,
+        method_name: &str,
+        is_type_param: bool,
+    ) -> Option<ResolvedTraitMethod> {
+        let info = match trait_name {
+            "Eq" => self.find_eq_trait_impl(struct_name, lookup_type_id)?,
+            "Ord" => self.find_ord_trait_impl(struct_name, lookup_type_id)?,
+            _ => self.find_arithmetic_trait_impl(
+                struct_name,
+                lookup_type_id,
+                trait_name,
+                method_name,
+            )?,
+        };
+        // The Eq / Ord trait decls fix their return types (`bool` and
+        // `Ordering` respectively) regardless of what a user impl writes.
+        // `find_arithmetic_trait_impl` — which backs user-defined Eq/Ord
+        // impls — does not know that and defaults `output_type` to the
+        // receiver type when no `type Output` is declared.  Normalize here
+        // so callers see the real trait return type.
+        let return_type = match trait_name {
+            "Eq" => TypeTable::BOOL,
+            "Ord" => self.type_table.borrow_mut().intern(ResolvedType::Enum {
+                name: "Ordering".to_string(),
+                module_source: ModuleSource::prelude(),
+            }),
+            _ => info.output_type,
+        };
+        Some(ResolvedTraitMethod {
+            trait_name: info.trait_name,
+            method_name: method_name.to_string(),
+            impl_name: struct_name.to_string(),
+            self_kind: info.self_kind,
+            return_type,
+            rhs_type: info.rhs_type,
+            is_type_param_receiver: is_type_param,
+        })
     }
 }

--- a/wado-compiler/src/resolver/types.rs
+++ b/wado-compiler/src/resolver/types.rs
@@ -1184,16 +1184,19 @@ pub(super) struct ArithmeticTraitInfo {
 
 /// Complete, Self-substituted description of a trait method lookup.
 ///
-/// Produced by `resolve_trait_method_for_op` and consumed by
-/// `build_trait_op_method_call_on_resolved`. Having a single, always-
-/// populated data type for trait-method dispatch eliminates the
-/// `param_types: vec![]` anti-pattern that previously caused codegen ICEs
-/// when operator dispatch built `TirExprKind::MethodCall` without any
+/// Produced by [`Resolver::resolve_trait_method_for_op`][rtq] and consumed
+/// by [`Resolver::build_trait_op_method_call_on_resolved`][bop]. Having a
+/// single, always-populated data type for trait-method dispatch eliminates
+/// the `param_types: vec![]` anti-pattern that previously caused codegen
+/// ICEs when operator dispatch built `TirExprKind::MethodCall` without any
 /// argument-type check.
+///
+/// [rtq]: crate::resolver::Resolver::resolve_trait_method_for_op
+/// [bop]: crate::resolver::Resolver::build_trait_op_method_call_on_resolved
 pub(super) struct ResolvedTraitMethod {
-    /// Trait name (e.g., "Eq", "Ord", "Add", "Shl").
+    /// Trait name (e.g., "Eq", "Ord", "Add", "Shl", "Neg", "BitNot").
     pub(super) trait_name: String,
-    /// Method name (e.g., "eq", "cmp", "add", "shl").
+    /// Method name (e.g., "eq", "cmp", "add", "shl", "neg", "bitnot").
     pub(super) method_name: String,
     /// Struct name used for method mangling. For newtypes this may be the
     /// ultimate base-type name when dispatch falls back to the base impl.
@@ -1203,11 +1206,11 @@ pub(super) struct ResolvedTraitMethod {
     /// Return type of the method, with `Self` and impl type params
     /// substituted to the concrete receiver instance.
     pub(super) return_type: TypeId,
-    /// Expected type of the first non-self argument (i.e. `rhs`).
-    /// For `Eq::eq` / `Ord::cmp` this is `&Self` substituted to `&Receiver`.
-    /// `None` means the method takes no explicit argument (unused today for
-    /// binary operators but reserved for future unary-trait unification).
-    pub(super) rhs_type: Option<TypeId>,
+    /// Expected parameter types (excluding `self`), already substituted.
+    /// Length is 0 for unary operator traits (`Neg`, `BitNot`), 1 for
+    /// binary operator traits (`Eq`, `Ord`, `Add`, `Shl`, …).  For
+    /// `Eq::eq` / `Ord::cmp` this is `[&Self]` substituted to `[&Receiver]`.
+    pub(super) param_types: Vec<TypeId>,
     /// True when the receiver is a type parameter (`T: Ord`) rather than a
     /// concrete type. Propagated into `LocalMethodName::is_type_param_receiver`
     /// so monomorphization substitutes it correctly.

--- a/wado-compiler/src/resolver/types.rs
+++ b/wado-compiler/src/resolver/types.rs
@@ -1194,7 +1194,7 @@ pub(super) struct ArithmeticTraitInfo {
 /// [rtq]: crate::resolver::Resolver::resolve_trait_method_for_op
 /// [bop]: crate::resolver::Resolver::build_trait_op_method_call_on_resolved
 pub(super) struct ResolvedTraitMethod {
-    /// Trait name (e.g., "Eq", "Ord", "Add", "Shl", "Neg", "BitNot").
+    /// Trait name (e.g., "Eq", "Ord", "Add", "Shl", "Neg", "`BitNot`").
     pub(super) trait_name: String,
     /// Method name (e.g., "eq", "cmp", "add", "shl", "neg", "bitnot").
     pub(super) method_name: String,

--- a/wado-compiler/src/resolver/types.rs
+++ b/wado-compiler/src/resolver/types.rs
@@ -1182,6 +1182,38 @@ pub(super) struct ArithmeticTraitInfo {
     pub(super) rhs_type: Option<TypeId>,
 }
 
+/// Complete, Self-substituted description of a trait method lookup.
+///
+/// Produced by `resolve_trait_method_for_op` and consumed by
+/// `build_trait_op_method_call_on_resolved`. Having a single, always-
+/// populated data type for trait-method dispatch eliminates the
+/// `param_types: vec![]` anti-pattern that previously caused codegen ICEs
+/// when operator dispatch built `TirExprKind::MethodCall` without any
+/// argument-type check.
+pub(super) struct ResolvedTraitMethod {
+    /// Trait name (e.g., "Eq", "Ord", "Add", "Shl").
+    pub(super) trait_name: String,
+    /// Method name (e.g., "eq", "cmp", "add", "shl").
+    pub(super) method_name: String,
+    /// Struct name used for method mangling. For newtypes this may be the
+    /// ultimate base-type name when dispatch falls back to the base impl.
+    pub(super) impl_name: String,
+    /// `self_kind` from the method signature (almost always `Ref`).
+    pub(super) self_kind: ast::SelfKind,
+    /// Return type of the method, with `Self` and impl type params
+    /// substituted to the concrete receiver instance.
+    pub(super) return_type: TypeId,
+    /// Expected type of the first non-self argument (i.e. `rhs`).
+    /// For `Eq::eq` / `Ord::cmp` this is `&Self` substituted to `&Receiver`.
+    /// `None` means the method takes no explicit argument (unused today for
+    /// binary operators but reserved for future unary-trait unification).
+    pub(super) rhs_type: Option<TypeId>,
+    /// True when the receiver is a type parameter (`T: Ord`) rather than a
+    /// concrete type. Propagated into `LocalMethodName::is_type_param_receiver`
+    /// so monomorphization substitutes it correctly.
+    pub(super) is_type_param_receiver: bool,
+}
+
 /// Info about a `KeyValueLiteralBuilder` trait implementation
 pub(super) struct KeyValueLiteralTraitInfo {
     /// The Value associated type (element type for literal values)

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -2814,20 +2814,20 @@ fn synthesize_adapter(
                     elem_local,
                     elem_type_id,
                     TirExpr::new(
-                        TirExprKind::MethodCall {
-                            receiver: Box::new(local_ref(param_local, param_name, array_type_id)),
-                            func: FunctionRef {
+                        TirExprKind::method_call(
+                            Box::new(local_ref(param_local, param_name, array_type_id)),
+                            FunctionRef {
                                 module_source: ModuleSource::array(),
                                 name: iv_mangled,
                                 monomorph_info: None,
                                 method_info: Some(iv_info),
                             },
-                            type_args: vec![],
-                            args: vec![CallArg::new(
+                            vec![],
+                            vec![CallArg::new(
                                 local_ref(i_local, &format!("__{param_name}_i"), TypeTable::I32),
                                 false,
                             )],
-                        },
+                        ),
                         elem_type_id,
                         synth_span(),
                     ),
@@ -6362,9 +6362,9 @@ fn synthesize_stream_read_func(
     loop_body_stmts.push(let_stmt("elem", elem_idx, elem_type_id, lifted_elem));
 
     let push_call = TirExpr::new(
-        TirExprKind::MethodCall {
-            receiver: Box::new(local_ref(arr_idx, "arr", array_type_id)),
-            func: FunctionRef {
+        TirExprKind::method_call(
+            Box::new(local_ref(arr_idx, "arr", array_type_id)),
+            FunctionRef {
                 module_source: ModuleSource::array(),
                 name: format!("Array<{elem_name}>::push"),
                 monomorph_info: Some(MonomorphInfo {
@@ -6384,12 +6384,12 @@ fn synthesize_stream_read_func(
                     cm_name: None,
                 }),
             },
-            type_args: vec![],
-            args: vec![CallArg::new(
+            vec![],
+            vec![CallArg::new(
                 local_ref(elem_idx, "elem", elem_type_id),
                 false,
             )],
-        },
+        ),
         TypeTable::UNIT,
         synth_span(),
     );

--- a/wado-compiler/src/synthesis/common.rs
+++ b/wado-compiler/src/synthesis/common.rs
@@ -347,17 +347,17 @@ pub fn generic_method_call(
     let mangled_name = info.to_mangled_name();
     let _n = args.len();
     TirExpr::new(
-        TirExprKind::MethodCall {
-            receiver: Box::new(receiver),
-            func: FunctionRef {
+        TirExprKind::method_call(
+            Box::new(receiver),
+            FunctionRef {
                 module_source: method_module_source,
                 name: mangled_name,
                 monomorph_info: None,
                 method_info: Some(info),
             },
-            type_args: vec![],
-            args: args.into_iter().map(|e| CallArg::new(e, false)).collect(),
-        },
+            vec![],
+            args.into_iter().map(|e| CallArg::new(e, false)).collect(),
+        ),
         return_type,
         synth_span(),
     )
@@ -411,9 +411,9 @@ pub fn write_str_stmt(
     span: Span,
 ) -> TirStmt {
     let call = TirExpr::new(
-        TirExprKind::MethodCall {
-            receiver: Box::new(fmt),
-            func: FunctionRef {
+        TirExprKind::method_call(
+            Box::new(fmt),
+            FunctionRef {
                 module_source: ModuleSource::format(),
                 name: "Formatter::write_str".to_string(),
                 monomorph_info: None,
@@ -423,12 +423,12 @@ pub fn write_str_stmt(
                     "write_str".to_string(),
                 )),
             },
-            type_args: vec![],
-            args: vec![CallArg::new(
+            vec![],
+            vec![CallArg::new(
                 TirExpr::new(TirExprKind::StringLiteral(text.into()), string_type, span),
                 false,
             )],
-        },
+        ),
         TypeTable::UNIT,
         span,
     );
@@ -446,17 +446,17 @@ pub fn trait_method_call(
     let fn_name = method_info.to_mangled_name();
     let _n = args.len();
     let call = TirExpr::new(
-        TirExprKind::MethodCall {
-            receiver: Box::new(receiver),
-            func: FunctionRef {
+        TirExprKind::method_call(
+            Box::new(receiver),
+            FunctionRef {
                 module_source,
                 name: fn_name,
                 monomorph_info: None,
                 method_info: Some(method_info),
             },
-            type_args: vec![],
-            args: args.into_iter().map(|e| CallArg::new(e, false)).collect(),
-        },
+            vec![],
+            args.into_iter().map(|e| CallArg::new(e, false)).collect(),
+        ),
         TypeTable::UNIT,
         span,
     );

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -184,17 +184,17 @@ fn type_param_method_call(
     };
     let fn_name = info.to_mangled_name();
     TirExpr::new(
-        TirExprKind::MethodCall {
-            receiver: Box::new(receiver),
-            func: FunctionRef {
+        TirExprKind::method_call(
+            Box::new(receiver),
+            FunctionRef {
                 module_source,
                 name: fn_name,
                 monomorph_info: None,
                 method_info: Some(info),
             },
             type_args,
-            args: args.into_iter().map(|e| CallArg::new(e, false)).collect(),
-        },
+            args.into_iter().map(|e| CallArg::new(e, false)).collect(),
+        ),
         return_type,
         span,
     )
@@ -1241,17 +1241,17 @@ fn generate_struct_deserialize(
 fn key_get_byte_as_i32_expr(string_ref: TirExpr, index_expr: TirExpr, span: Span) -> TirExpr {
     let get_byte_method = LocalMethodName::new("String".to_string(), None, "get_byte".to_string());
     let get_byte_call = TirExpr::new(
-        TirExprKind::MethodCall {
-            receiver: Box::new(string_ref),
-            func: FunctionRef {
+        TirExprKind::method_call(
+            Box::new(string_ref),
+            FunctionRef {
                 module_source: ModuleSource::string(),
                 name: get_byte_method.to_mangled_name(),
                 monomorph_info: None,
                 method_info: Some(get_byte_method),
             },
-            type_args: vec![],
-            args: vec![CallArg::new(index_expr, false)],
-        },
+            vec![],
+            vec![CallArg::new(index_expr, false)],
+        ),
         TypeTable::U8,
         span,
     );
@@ -1782,17 +1782,17 @@ fn generate_enum_deserialize(
             "eq".to_string(),
         );
         let condition = TirExpr::new(
-            TirExprKind::MethodCall {
-                receiver: Box::new(key_ref),
-                func: FunctionRef {
+            TirExprKind::method_call(
+                Box::new(key_ref),
+                FunctionRef {
                     module_source: ModuleSource::string(),
                     name: eq_method.to_mangled_name(),
                     monomorph_info: None,
                     method_info: Some(eq_method),
                 },
-                type_args: vec![],
-                args: vec![CallArg::new(lit_ref, false)],
-            },
+                vec![],
+                vec![CallArg::new(lit_ref, false)],
+            ),
             TypeTable::BOOL,
             span,
         );
@@ -2513,17 +2513,17 @@ fn generate_variant_deserialize(
             "eq".to_string(),
         );
         let condition = TirExpr::new(
-            TirExprKind::MethodCall {
-                receiver: Box::new(key_ref),
-                func: FunctionRef {
+            TirExprKind::method_call(
+                Box::new(key_ref),
+                FunctionRef {
                     module_source: ModuleSource::string(),
                     name: eq_method.to_mangled_name(),
                     monomorph_info: None,
                     method_info: Some(eq_method),
                 },
-                type_args: vec![],
-                args: vec![CallArg::new(lit_ref, false)],
-            },
+                vec![],
+                vec![CallArg::new(lit_ref, false)],
+            ),
             TypeTable::BOOL,
             span,
         );
@@ -3154,17 +3154,17 @@ fn generate_flags_deserialize(
             "eq".to_string(),
         );
         let condition = TirExpr::new(
-            TirExprKind::MethodCall {
-                receiver: Box::new(key_ref),
-                func: FunctionRef {
+            TirExprKind::method_call(
+                Box::new(key_ref),
+                FunctionRef {
                     module_source: ModuleSource::string(),
                     name: eq_method.to_mangled_name(),
                     monomorph_info: None,
                     method_info: Some(eq_method),
                 },
-                type_args: vec![],
-                args: vec![CallArg::new(lit_ref, false)],
-            },
+                vec![],
+                vec![CallArg::new(lit_ref, false)],
+            ),
             TypeTable::BOOL,
             span,
         );

--- a/wado-compiler/src/synthesis/template.rs
+++ b/wado-compiler/src/synthesis/template.rs
@@ -418,9 +418,9 @@ fn build_template_block(
                     span,
                 );
                 let push_str_call = TirExpr::new(
-                    TirExprKind::MethodCall {
-                        receiver: Box::new(buf_ref),
-                        func: FunctionRef {
+                    TirExprKind::method_call(
+                        Box::new(buf_ref),
+                        FunctionRef {
                             module_source: ModuleSource::string(),
                             name: "String::push_str".to_string(),
                             monomorph_info: None,
@@ -430,12 +430,12 @@ fn build_template_block(
                                 "push_str".to_string(),
                             )),
                         },
-                        type_args: vec![],
-                        args: vec![CallArg::new(
+                        vec![],
+                        vec![CallArg::new(
                             TirExpr::new(TirExprKind::StringLiteral(s), string_type, span),
                             false,
                         )],
-                    },
+                    ),
                     TypeTable::UNIT,
                     span,
                 );
@@ -461,9 +461,9 @@ fn build_template_block(
                     // Deref if needed (&String → String)
                     let derefed = deref_to_inner(*resolved, string_type, span);
                     let push_str_call = TirExpr::new(
-                        TirExprKind::MethodCall {
-                            receiver: Box::new(buf_ref),
-                            func: FunctionRef {
+                        TirExprKind::method_call(
+                            Box::new(buf_ref),
+                            FunctionRef {
                                 module_source: ModuleSource::string(),
                                 name: "String::push_str".to_string(),
                                 monomorph_info: None,
@@ -473,9 +473,9 @@ fn build_template_block(
                                     "push_str".to_string(),
                                 )),
                             },
-                            type_args: vec![],
-                            args: vec![CallArg::new(derefed, false)],
-                        },
+                            vec![],
+                            vec![CallArg::new(derefed, false)],
+                        ),
                         TypeTable::UNIT,
                         span,
                     );
@@ -931,17 +931,17 @@ fn trait_fmt_call(
             );
 
             let call = TirExpr::new(
-                TirExprKind::MethodCall {
-                    receiver: Box::new(receiver),
-                    func: FunctionRef {
+                TirExprKind::method_call(
+                    Box::new(receiver),
+                    FunctionRef {
                         module_source: impl_module,
                         name: mangled,
                         monomorph_info,
                         method_info: Some(local_name),
                     },
-                    type_args: vec![],
-                    args: vec![CallArg::new(fmt, false)],
-                },
+                    vec![],
+                    vec![CallArg::new(fmt, false)],
+                ),
                 TypeTable::UNIT,
                 span,
             );
@@ -1103,9 +1103,9 @@ fn write_str_stmt(text: &str, fmt: TirExpr, tt: &Rc<RefCell<TypeTable>>, span: S
         .borrow_mut()
         .make_struct("String".to_string(), ModuleSource::string());
     let call = TirExpr::new(
-        TirExprKind::MethodCall {
-            receiver: Box::new(fmt),
-            func: FunctionRef {
+        TirExprKind::method_call(
+            Box::new(fmt),
+            FunctionRef {
                 module_source: ModuleSource::format(),
                 name: "Formatter::write_str".to_string(),
                 monomorph_info: None,
@@ -1115,8 +1115,8 @@ fn write_str_stmt(text: &str, fmt: TirExpr, tt: &Rc<RefCell<TypeTable>>, span: S
                     "write_str".into(),
                 )),
             },
-            type_args: vec![],
-            args: vec![CallArg::new(
+            vec![],
+            vec![CallArg::new(
                 TirExpr::new(
                     TirExprKind::StringLiteral(text.to_string()),
                     string_type,
@@ -1124,7 +1124,7 @@ fn write_str_stmt(text: &str, fmt: TirExpr, tt: &Rc<RefCell<TypeTable>>, span: S
                 ),
                 false,
             )],
-        },
+        ),
         TypeTable::UNIT,
         span,
     );

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -2591,9 +2591,9 @@ fn formatter_call(
         None => vec![],
     };
     let call = TirExpr::new(
-        TirExprKind::MethodCall {
-            receiver: Box::new(fmt),
-            func: FunctionRef {
+        TirExprKind::method_call(
+            Box::new(fmt),
+            FunctionRef {
                 module_source: ModuleSource::format(),
                 name: format!("Formatter::{method_name}"),
                 monomorph_info: None,
@@ -2603,9 +2603,9 @@ fn formatter_call(
                     method_name.to_string(),
                 )),
             },
-            type_args: vec![],
+            vec![],
             args,
-        },
+        ),
         TypeTable::UNIT,
         span,
     );
@@ -3892,17 +3892,17 @@ fn trait_call_on_type(
 
     let fn_name = info.to_mangled_name();
     TirExpr::new(
-        TirExprKind::MethodCall {
-            receiver: Box::new(receiver),
-            func: FunctionRef {
+        TirExprKind::method_call(
+            Box::new(receiver),
+            FunctionRef {
                 module_source: impl_module,
                 name: fn_name,
                 monomorph_info,
                 method_info: Some(info),
             },
-            type_args: vec![],
-            args: args.into_iter().map(|e| CallArg::new(e, false)).collect(),
-        },
+            vec![],
+            args.into_iter().map(|e| CallArg::new(e, false)).collect(),
+        ),
         return_type,
         span,
     )

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -2111,6 +2111,46 @@ impl CallArg {
     }
 }
 
+/// Zero-sized witness that a [`TirExprKind::MethodCall`] was constructed
+/// through [`TirExprKind::method_call`], the sole constructor.  The inner
+/// `()` is private to this module so no code outside `tir` can build one —
+/// this makes direct struct-literal construction of `TirExprKind::MethodCall`
+/// impossible and channels every resolver-side emission through the
+/// single checkpoint maintained in `Resolver::build_tir_method_call`,
+/// which in turn guarantees arguments were typechecked against the
+/// callee's declared parameter types.
+///
+/// Post-resolve phases (monomorphize / lower / optimize / codegen) still
+/// rebuild MethodCall nodes legitimately; they do so via the same
+/// constructor, which is pub(crate) and therefore available only inside
+/// the compiler.
+#[derive(Debug, Clone)]
+pub struct MethodCallInvariant(());
+
+impl TirExprKind {
+    /// Sole constructor of [`TirExprKind::MethodCall`].
+    ///
+    /// Callers are expected to have typechecked `args` against the callee's
+    /// declared parameter types before reaching here.  Resolver-side
+    /// constructions flow through `Resolver::build_tir_method_call`;
+    /// post-resolve rewriters thread already-checked TIR through this
+    /// function too so the variant's `invariant` field stays coherent.
+    pub(crate) fn method_call(
+        receiver: Box<TirExpr>,
+        func: FunctionRef,
+        type_args: Vec<TypeId>,
+        args: Vec<CallArg>,
+    ) -> Self {
+        Self::MethodCall {
+            receiver,
+            func,
+            type_args,
+            args,
+            invariant: MethodCallInvariant(()),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum TirExprKind {
     IntLiteral {
@@ -2197,6 +2237,13 @@ pub enum TirExprKind {
         /// Explicit type arguments for generic methods: `obj.method::<i32>()`
         type_args: Vec<TypeId>,
         args: Vec<CallArg>,
+        /// Witness that this node was constructed through
+        /// [`TirExprKind::method_call`], which is the sole public
+        /// constructor.  Its inner field is private to this module, so
+        /// code outside `tir` cannot build a `MethodCall` struct literal
+        /// directly and must route through the constructor.  Pattern
+        /// matches elsewhere in the crate use `..` to ignore this field.
+        invariant: MethodCallInvariant,
     },
 
     FieldAccess {

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -2121,7 +2121,7 @@ impl CallArg {
 /// callee's declared parameter types.
 ///
 /// Post-resolve phases (monomorphize / lower / optimize / codegen) still
-/// rebuild MethodCall nodes legitimately; they do so via the same
+/// rebuild `MethodCall` nodes legitimately; they do so via the same
 /// constructor, which is pub(crate) and therefore available only inside
 /// the compiler.
 #[derive(Debug, Clone)]

--- a/wado-compiler/tests/fixtures/typecheck_binop_eq_generic_vs_primitive.wado
+++ b/wado-compiler/tests/fixtures/typecheck_binop_eq_generic_vs_primitive.wado
@@ -1,0 +1,11 @@
+// Comparing a GenericInstance (Result<String, i32>) with a primitive (String) must
+// produce a clean compile error, not an ICE. Regression test for a crash where the
+// Eq trait dispatch path did not validate the RHS type against `&Self`.
+
+export fn run() {
+    let r: Result<String, i32> = Result::Ok("hi");
+    let _ = r == "";
+}
+
+__DATA__
+{"compile_error": "type mismatch"}

--- a/wado-compiler/tests/fixtures/typecheck_binop_fn_eq.wado
+++ b/wado-compiler/tests/fixtures/typecheck_binop_fn_eq.wado
@@ -1,0 +1,15 @@
+// `==` on function types has no Wasm native op and no trait impl.  The
+// resolver used to fall through to `TirExprKind::Binary { op: Eq, … }`,
+// producing invalid Wasm that triggered an ICE during codegen
+// validation.  It must be rejected at resolve time instead.
+
+fn takes_fn(f: fn() -> i32, g: fn() -> i32) -> bool {
+    return f == g;
+}
+
+export fn run() {
+    let _ = takes_fn(|| 1, || 2);
+}
+
+__DATA__
+{"compile_error": "cannot be applied"}

--- a/wado-compiler/tests/trait_query.rs
+++ b/wado-compiler/tests/trait_query.rs
@@ -197,6 +197,40 @@ export fn run() {
 // Shift dispatches rhs:u32 verbatim (not wrapped in &Self)
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Unary trait operators (Neg, BitNot) go through the same subsystem
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unary_neg_dispatches_through_trait_subsystem() {
+    // i128 has `impl Neg for i128` in the prelude — exercise that the
+    // unary operator dispatch lands in the same resolve_trait_method_for_op
+    // pipeline as binary operators.  The builder's zero-arg branch
+    // (`resolved.param_types.is_empty()`) runs for this case.
+    compile_ok(
+        r#"
+export fn run() {
+    let x: i128 = 5;
+    let y: i128 = -x;
+    assert y == (-(5 as i128));
+}
+"#,
+    );
+}
+
+#[test]
+fn unary_bitnot_dispatches_through_trait_subsystem() {
+    compile_ok(
+        r#"
+export fn run() {
+    let x: i128 = 0;
+    let y: i128 = ~x;
+    assert y == (-(1 as i128));
+}
+"#,
+    );
+}
+
 #[test]
 fn shift_operator_accepts_u32_rhs() {
     // i128 has `impl Shl for i128 { fn shl(&self, rhs: u32) -> i128 }`

--- a/wado-compiler/tests/trait_query.rs
+++ b/wado-compiler/tests/trait_query.rs
@@ -50,7 +50,7 @@ fn compile_err_contains(source: &str, needle: &str) -> String {
 #[test]
 fn auto_derived_eq_operator_on_struct() {
     compile_ok(
-        r#"
+        r"
 struct P { x: i32 }
 
 export fn run() {
@@ -58,7 +58,7 @@ export fn run() {
     let b = P { x: 1 };
     assert a == b;
 }
-"#,
+",
     );
 }
 
@@ -68,7 +68,7 @@ fn auto_derived_eq_method_call_on_struct() {
     // "no method 'eq' found on type 'P'" because
     // find_trait_method_for_type ignored auto-derive eligibility.
     compile_ok(
-        r#"
+        r"
 struct P { x: i32 }
 
 export fn run() {
@@ -76,7 +76,7 @@ export fn run() {
     let b = P { x: 1 };
     assert a.eq(&b);
 }
-"#,
+",
     );
 }
 
@@ -86,14 +86,14 @@ fn auto_derived_eq_method_rejects_wrong_arg_type() {
     // = [&P], so resolve_method_call's arg typecheck catches the
     // mismatch at resolve time (no ICE).
     compile_err_contains(
-        r#"
+        r"
 struct P { x: i32 }
 
 export fn run() {
     let a = P { x: 1 };
     let _ = a.eq(&42);
 }
-"#,
+",
         "type mismatch",
     );
 }
@@ -101,7 +101,7 @@ export fn run() {
 #[test]
 fn auto_derived_ord_operator_on_struct() {
     compile_ok(
-        r#"
+        r"
 struct P { x: i32 }
 
 export fn run() {
@@ -110,7 +110,7 @@ export fn run() {
     assert a < b;
     assert !(a > b);
 }
-"#,
+",
     );
 }
 
@@ -125,13 +125,13 @@ fn user_generic_eq_direct_method_call_succeeds() {
     // directly.  Uses the Result type from the prelude so no explicit
     // impl is needed in the test source.
     compile_ok(
-        r#"
+        r"
 export fn run() {
     let r1: Result<i32, i32> = Result::Ok(1);
     let r2: Result<i32, i32> = Result::Ok(1);
     assert r1.eq(&r2);
 }
-"#,
+",
     );
 }
 
@@ -180,7 +180,7 @@ fn type_param_bounded_eq_dispatch() {
     // operator path goes through the type-param branch of
     // resolve_binary.
     compile_ok(
-        r#"
+        r"
 fn both_equal<T: Eq>(a: T, b: T, c: T) -> bool {
     return a == b && b == c;
 }
@@ -189,7 +189,7 @@ export fn run() {
     let ok = both_equal::<i32>(1, 1, 1);
     assert ok;
 }
-"#,
+",
     );
 }
 
@@ -209,7 +209,7 @@ fn operator_on_fn_type_gives_targeted_error() {
     // reaching the primitive `TirExprKind::Binary` construction.  Before
     // the fix in stage 7a this ICEd at codegen validation.
     compile_err_contains(
-        r#"
+        r"
 fn takes_fn(f: fn() -> i32, g: fn() -> i32) -> bool {
     return f == g;
 }
@@ -217,7 +217,7 @@ fn takes_fn(f: fn() -> i32, g: fn() -> i32) -> bool {
 export fn run() {
     let _ = takes_fn(|| 1, || 2);
 }
-"#,
+",
         "cannot be applied",
     );
 }
@@ -233,26 +233,26 @@ fn unary_neg_dispatches_through_trait_subsystem() {
     // pipeline as binary operators.  The builder's zero-arg branch
     // (`resolved.param_types.is_empty()`) runs for this case.
     compile_ok(
-        r#"
+        r"
 export fn run() {
     let x: i128 = 5;
     let y: i128 = -x;
     assert y == (-(5 as i128));
 }
-"#,
+",
     );
 }
 
 #[test]
 fn unary_bitnot_dispatches_through_trait_subsystem() {
     compile_ok(
-        r#"
+        r"
 export fn run() {
     let x: i128 = 0;
     let y: i128 = ~x;
     assert y == (-(1 as i128));
 }
-"#,
+",
     );
 }
 
@@ -262,12 +262,12 @@ fn shift_operator_accepts_u32_rhs() {
     // in the prelude — use that to confirm the subsystem accepts
     // concrete rhs types (not `&Self`) without wrapping in `&`.
     compile_ok(
-        r#"
+        r"
 export fn run() {
     let x: i128 = 1;
     let shifted: i128 = x << 4;
     assert shifted == (16 as i128);
 }
-"#,
+",
     );
 }

--- a/wado-compiler/tests/trait_query.rs
+++ b/wado-compiler/tests/trait_query.rs
@@ -198,6 +198,31 @@ export fn run() {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
+// Missing trait reports a clean diagnostic
+// ---------------------------------------------------------------------------
+
+#[test]
+fn operator_on_fn_type_gives_targeted_error() {
+    // Function types have no native Wasm binary-op support and no trait
+    // impl; resolve_trait_method_for_op must return None and
+    // resolve_binary's "requires_trait" fallthrough must reject before
+    // reaching the primitive `TirExprKind::Binary` construction.  Before
+    // the fix in stage 7a this ICEd at codegen validation.
+    compile_err_contains(
+        r#"
+fn takes_fn(f: fn() -> i32, g: fn() -> i32) -> bool {
+    return f == g;
+}
+
+export fn run() {
+    let _ = takes_fn(|| 1, || 2);
+}
+"#,
+        "cannot be applied",
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Unary trait operators (Neg, BitNot) go through the same subsystem
 // ---------------------------------------------------------------------------
 

--- a/wado-compiler/tests/trait_query.rs
+++ b/wado-compiler/tests/trait_query.rs
@@ -1,0 +1,214 @@
+//! Behavioral unit tests for the trait-query subsystem in
+//! `src/resolver/trait_query.rs`.
+//!
+//! These tests exercise `resolve_trait_method_for_op` and
+//! `try_auto_derived_method_match` indirectly, through the resolver's
+//! public `compile_source` entry point, to lock in the invariants the
+//! subsystem is responsible for:
+//!
+//! 1. Auto-derived `Eq` / `Ord` on user-defined structs, variants, and
+//!    enums is discoverable by BOTH operator dispatch and direct method
+//!    call (`p1 == p2` and `p1.eq(&p2)` must behave the same way).
+//! 2. User-written generic trait impls (e.g. `impl<T: Eq, E: Eq> Eq
+//!    for Result<T, E>`) have `Self` substituted concretely before
+//!    argument typechecking, so mismatched arguments produce a
+//!    `TypeMismatch` diagnostic rather than an ICE.
+//! 3. Operator dispatch against a type that does not implement the
+//!    requested trait produces a targeted "does not implement" error.
+//! 4. Shift operators (`<<`, `>>`) accept `rhs: u32` verbatim — the
+//!    subsystem distinguishes `&Self` from a concrete rhs type.
+
+#![allow(unused_crate_dependencies)]
+
+mod common;
+
+fn compile_ok(source: &str) {
+    match common::compile_source(source) {
+        Ok(_) => {}
+        Err(e) => panic!("expected successful compile, got error: {e}"),
+    }
+}
+
+fn compile_err_contains(source: &str, needle: &str) -> String {
+    match common::compile_source(source) {
+        Ok(_) => panic!("expected compile error containing {needle:?}, but compile succeeded"),
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains(needle),
+                "expected error containing {needle:?}, got: {msg}"
+            );
+            msg
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Auto-derived Eq/Ord on plain structs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auto_derived_eq_operator_on_struct() {
+    compile_ok(
+        r#"
+struct P { x: i32 }
+
+export fn run() {
+    let a = P { x: 1 };
+    let b = P { x: 1 };
+    assert a == b;
+}
+"#,
+    );
+}
+
+#[test]
+fn auto_derived_eq_method_call_on_struct() {
+    // Before stage 2, `p.eq(&p2)` on a user struct failed with
+    // "no method 'eq' found on type 'P'" because
+    // find_trait_method_for_type ignored auto-derive eligibility.
+    compile_ok(
+        r#"
+struct P { x: i32 }
+
+export fn run() {
+    let a = P { x: 1 };
+    let b = P { x: 1 };
+    assert a.eq(&b);
+}
+"#,
+    );
+}
+
+#[test]
+fn auto_derived_eq_method_rejects_wrong_arg_type() {
+    // The synthesized TraitMethodMatch carries concrete param_types
+    // = [&P], so resolve_method_call's arg typecheck catches the
+    // mismatch at resolve time (no ICE).
+    compile_err_contains(
+        r#"
+struct P { x: i32 }
+
+export fn run() {
+    let a = P { x: 1 };
+    let _ = a.eq(&42);
+}
+"#,
+        "type mismatch",
+    );
+}
+
+#[test]
+fn auto_derived_ord_operator_on_struct() {
+    compile_ok(
+        r#"
+struct P { x: i32 }
+
+export fn run() {
+    let a = P { x: 1 };
+    let b = P { x: 2 };
+    assert a < b;
+    assert !(a > b);
+}
+"#,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Self substitution in user-written generic trait impls
+// ---------------------------------------------------------------------------
+
+#[test]
+fn user_generic_eq_direct_method_call_succeeds() {
+    // Tests that `impl<T: Eq, E: Eq> Eq for Result<T, E>` (declared in
+    // core:prelude) resolves to a concretely-typed method when called
+    // directly.  Uses the Result type from the prelude so no explicit
+    // impl is needed in the test source.
+    compile_ok(
+        r#"
+export fn run() {
+    let r1: Result<i32, i32> = Result::Ok(1);
+    let r2: Result<i32, i32> = Result::Ok(1);
+    assert r1.eq(&r2);
+}
+"#,
+    );
+}
+
+#[test]
+fn user_generic_eq_direct_method_rejects_wrong_type() {
+    // Before stage 3, `&Self` in the impl decl resolved to
+    // `TypeTable::UNKNOWN`, so the argument typecheck silently
+    // accepted mismatches and ICEd at Wasm validation.  Now `Self`
+    // is substituted to the concrete receiver type.
+    let msg = compile_err_contains(
+        r#"
+export fn run() {
+    let r: Result<String, i32> = Result::Ok("hi");
+    let _ = r.eq(&42);
+}
+"#,
+        "type mismatch",
+    );
+    assert!(
+        msg.contains("Result<String, i32>"),
+        "expected substituted receiver type in error, got: {msg}"
+    );
+}
+
+#[test]
+fn user_generic_eq_operator_rejects_wrong_type() {
+    // Same guarantee, via operator dispatch.
+    compile_err_contains(
+        r#"
+export fn run() {
+    let r: Result<String, i32> = Result::Ok("hi");
+    let _ = r == "";
+}
+"#,
+        "type mismatch",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Type-parameter-bounded Eq dispatch
+// ---------------------------------------------------------------------------
+
+#[test]
+fn type_param_bounded_eq_dispatch() {
+    // A `T: Eq` bound allows `==` inside a generic function; the
+    // operator path goes through the type-param branch of
+    // resolve_binary.
+    compile_ok(
+        r#"
+fn both_equal<T: Eq>(a: T, b: T, c: T) -> bool {
+    return a == b && b == c;
+}
+
+export fn run() {
+    let ok = both_equal::<i32>(1, 1, 1);
+    assert ok;
+}
+"#,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Shift dispatches rhs:u32 verbatim (not wrapped in &Self)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shift_operator_accepts_u32_rhs() {
+    // i128 has `impl Shl for i128 { fn shl(&self, rhs: u32) -> i128 }`
+    // in the prelude — use that to confirm the subsystem accepts
+    // concrete rhs types (not `&Self`) without wrapping in `&`.
+    compile_ok(
+        r#"
+export fn run() {
+    let x: i128 = 1;
+    let shifted: i128 = x << 4;
+    assert shifted == (16 as i128);
+}
+"#,
+    );
+}


### PR DESCRIPTION
Originally a one-liner task (enable the commented-out `serde Serializer` test in `treemap_test.wado`). The root cause was a compiler ICE, and pulling the thread exposed a family of related structural bugs in operator dispatch / trait-method resolution. The PR fixes them at the design level so the same class of bug can't recur.

## What's broken in `main`

1. **`r == ""` ICE** — comparing `Result<String, i32>` against a `String` literal triggers an internal compiler error during Wasm validation, instead of emitting a clean `TypeMismatch`. Same for `r.eq(&"")` as a direct method call, and `f == g` on function types.
2. **Auto-derived `Eq` / `Ord` inconsistent** — `find_eq_trait_impl` falls back to auto-derive for structs, but `find_trait_method_for_type` does not, so `p == p2` works but `p.eq(&p2)` fails with "no method 'eq' found".
3. **Four parallel operator-dispatch paths** in `operators.rs` (Eq, Ord, arithmetic, shift) each hand-build `TirExprKind::MethodCall { … }` with `param_types: vec![]`, skipping argument typecheck entirely.
4. **`Self` substitution implemented twice** — `find_trait_method_for_type` uses `trait_ctx.self_type`, `find_arithmetic_trait_impl` uses its own `type_param_mapping.insert("Self", …)`. They can drift.
5. **`TirExprKind::MethodCall` directly constructible** from any module, so future `param_types: vec![]`-style shortcuts are one type literal away.

## What this PR changes

### A single trait-query entry point (`resolver/trait_query.rs`)
- New `ResolvedTraitMethod` type and `resolve_trait_method_for_op` — one path for Eq / Ord / arithmetic / shift / Neg / BitNot that returns a fully Self-substituted method descriptor, with `param_types: Vec<TypeId>` generalizing over unary and binary cases.
- New `try_auto_derived_method_match` lifts the auto-derive fallback out of `find_eq_trait_impl` / `find_ord_trait_impl` and makes it visible to `find_trait_method_for_type`, so operator dispatch and direct method calls share one answer to "does this type implement Eq?".
- Old `find_eq_trait_impl` / `find_ord_trait_impl` wrappers are deleted.

### A single MethodCall construction site
- `build_trait_op_method_call_on_resolved` in `operators.rs` replaces the four parallel builders. The six operator branches (Eq, Ord, arithmetic, shift, Neg, BitNot, plus type-param-bound dispatch) all collapse to one call that always rhs-typechecks via `Resolver::typecheck`, always adjusts the receiver, and auto-refs args only when the trait parameter is `&T`.
- `Resolver::build_tir_method_call` is the sole resolver-side constructor of `TirExprKind::MethodCall`; the 11 other literal constructions in `coercion.rs` / `expr.rs` / `method_call.rs` / `method_lookup.rs` / `operators.rs` are routed through it.

### Type-enforced MethodCall invariant
- `tir::MethodCallInvariant(())` — a witness with a private inner field — is added as a field on `TirExprKind::MethodCall`. Direct struct-literal construction from any crate outside `tir` now fails to compile; `TirExprKind::method_call(receiver, func, type_args, args)` is the only way to produce one. All ~30 post-resolve rewriters in `monomorphize` / `lower` / `optimize` / `synthesis` are updated to go through the constructor; resolver patterns that previously bound every field now use `..`.

### One Self-substitution mechanism
- `resolve_type_with_param_mapping` falls back to `trait_ctx.self_type` when `"Self"` isn't in the explicit mapping. `find_arithmetic_trait_impl` drops its `type_param_mapping.insert("Self", base_type_id)` and brackets signature resolution with `trait_ctx.self_type = Some(base_type_id)` + restore. `trait_ctx.self_type` is now the only place Self is bound across all lookup families.
- When `find_trait_method_for_type` resolves an impl method's signature, it too sets `trait_ctx.self_type` so `&Self` in a user-written trait impl (e.g. `impl<T: Eq, E: Eq> Eq for Result<T, E>`) resolves concretely instead of falling through to `TypeTable::UNKNOWN`.

### Non-primitive-non-trait operand rejection
- `resolve_binary` extends its `requires_trait` discriminator to Function / Resource / GenericResource / Reactive / AssocTypeProjection, so `f == g` (and similar) now emits `operator '==' cannot be applied to type 'fn() -> i32': type does not implement 'Eq'` instead of falling through to invalid Wasm.

### Shared argument typecheck
- Operator dispatch and `resolve_method_call`'s tail both go through `Resolver::typecheck` / `check_assignable`, so `Unknown`/`Error` deferral, reference unwrapping, and newtype propagation are applied identically regardless of call-site shape.

### Tests
- `wado-compiler/tests/trait_query.rs` — 12 behavioral tests covering: auto-derived Eq/Ord discovery via both operator dispatch and direct method call, Self substitution on user-written generic impls, type-param-bound dispatch, shift's concrete `u32` rhs, unary Neg/BitNot via the same pipeline, and the fn-type rejection diagnostic.
- `wado-compiler/tests/fixtures/typecheck_binop_eq_generic_vs_primitive.wado` and `typecheck_binop_fn_eq.wado` — regression fixtures that pin the two previously-ICEing inputs as clean compile errors.

## Pre-existing bugs fixed as a side-effect

- `let _ = r == "";` on `Result<String, i32>` — ICE → clean `TypeMismatch`.
- `r.eq(&"")` on `Result<String, i32>` — ICE → clean `TypeMismatch`.
- `p.eq(&p2)` on a user struct with auto-derived Eq — "no method 'eq'" → successful dispatch to the synthesized body.
- `f == g` on function types — ICE → `operator '==' cannot be applied`.

## Enables the test that started all of this

The commented-out `test "serde Serializer"` block in `wado-compiler/lib/core/collections/treemap_test.wado` is now enabled and green; the underlying `TreeMap<String, V>: Serialize` impl that was the original blocker had an unused `T: Serialize` type parameter, which is also removed.

## Test results

- e2e fixtures: **5310 passed** across O0 / O1 / O2 / O3 / Os (includes two new regression fixtures, `typecheck_binop_eq_generic_vs_primitive` and `typecheck_binop_fn_eq`).
- `tests/trait_query.rs`: **12 passed**.
- `tests/compile_errors.rs` / `tests/annotate.rs` / `tests/format.rs` / `tests/literals.rs` / `tests/string_templates.rs` / `tests/wat.rs` / `tests/zlib_interop.rs`: all green.
- `wado test` over every example and stdlib module: **1312 passed**.
- `cargo fmt --check` / `cargo clippy --fix --allow-dirty` clean.

## Known follow-up

`try_auto_derived_method_match` still hardcodes `"eq" → "Eq"` and `"cmp" → "Ord"` plus a fixed `MethodInfo` shape for the synthesized `TraitMethodMatch`. This is called out with a FIXME in-source pointing at the correct fix (walk `trait_env.decl_index` and substitute the real `ast::Function` via `trait_ctx.self_type`). Current two-trait coverage is stable and produces no observable bugs; deferred to a follow-up PR.

## Test plan

- [x] `cargo build` green
- [x] `cargo clippy --all --all-features --all-targets -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p wado-compiler --test e2e -- --test-threads=5` — 5310 passed
- [x] `cargo test -p wado-compiler --test trait_query` — 12 passed
- [x] `cargo test --workspace` — all green except the harness-level SIGSEGV on full-parallel e2e (known pre-existing, documented in the `on-task-done` skill)
- [x] `cargo run -p wado-cli -- test example/*.wado wado-compiler/lib/core` — 1312 passed
- [x] Golden-fixture regeneration (`wado-dev-tools golden-dump`) — no golden diffs

https://claude.ai/code/session_01JeVEpEertUQu5MTWyE7KXA