### PR TITLE
gale: close ANTLR4 compatibility gaps (TODO sections A and B)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -209,6 +209,27 @@ mkdir -p package-gale/tests/golden
     gen "package-gale/tests/grammars/mode_gaps.g4" \
     > "package-gale/tests/golden/mode_gaps.wado"
 ./target/debug/wado run package-gale/src/main.wado \
+    gen "package-gale/tests/grammars/label_gaps.g4" \
+    > "package-gale/tests/golden/label_gaps.wado"
+./target/debug/wado run package-gale/src/main.wado \
+    gen "package-gale/tests/grammars/right_assoc_gaps.g4" \
+    > "package-gale/tests/golden/right_assoc_gaps.wado"
+./target/debug/wado run package-gale/src/main.wado \
+    gen "package-gale/tests/grammars/non_greedy_gaps.g4" \
+    > "package-gale/tests/golden/non_greedy_gaps.wado"
+./target/debug/wado run package-gale/src/main.wado \
+    gen "package-gale/tests/grammars/lexer_command_gaps.g4" \
+    > "package-gale/tests/golden/lexer_command_gaps.wado"
+./target/debug/wado run package-gale/src/main.wado \
+    gen "package-gale/tests/grammars/ci_rule_override.g4" \
+    > "package-gale/tests/golden/ci_rule_override.wado"
+./target/debug/wado run package-gale/src/main.wado \
+    gen "package-gale/tests/grammars/recursive_lexer.g4" \
+    > "package-gale/tests/golden/recursive_lexer.wado"
+./target/debug/wado run package-gale/src/main.wado \
+    gen "package-gale/tests/grammars/unicode_props.g4" \
+    > "package-gale/tests/golden/unicode_props.wado"
+./target/debug/wado run package-gale/src/main.wado \
     gen "package-gale/tests/grammars/SQLite.g4" \
     > "package-gale/tests/golden/sqlite.wado"
 ./target/debug/wado run package-gale/src/main.wado \

--- a/mise.toml
+++ b/mise.toml
@@ -203,6 +203,12 @@ mkdir -p package-gale/tests/golden
     gen "package-gale/tests/grammars/ci_sql.g4" \
     > "package-gale/tests/golden/ci_sql.wado"
 ./target/debug/wado run package-gale/src/main.wado \
+    gen "package-gale/tests/grammars/parser_gaps.g4" \
+    > "package-gale/tests/golden/parser_gaps.wado"
+./target/debug/wado run package-gale/src/main.wado \
+    gen "package-gale/tests/grammars/mode_gaps.g4" \
+    > "package-gale/tests/golden/mode_gaps.wado"
+./target/debug/wado run package-gale/src/main.wado \
     gen "package-gale/tests/grammars/SQLite.g4" \
     > "package-gale/tests/golden/sqlite.wado"
 ./target/debug/wado run package-gale/src/main.wado \

--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -12,16 +12,22 @@ generated parsers are semantically correct, not just syntactically accepted.
 
 ## A. Driver-level verification (remaining gaps)
 
-All five gaps are now covered by `tests/grammars/parser_gaps.g4` +
-`tests/driver_parser_gaps_test.wado` (A1, A2, A5) and
-`tests/grammars/mode_gaps.g4` + `tests/driver_mode_gaps_test.wado`
-(A3, A4).
+All gaps below are now covered by the listed grammar + driver-test pairs.
 
-- [x] **A1. Parser-side `~TOK` / `~(block)`** — `not_stmt : NOT ~ITEM SEMI | SET ~(ITEM | NUMBER) SEMI`.
-- [x] **A2. List labels `+=`** — `list_stmt : LIST items += ITEM (COMMA items += ITEM)* SEMI`.
-- [x] **A3. `mode(X)` semantics (set_mode)** — `STR_ESC_BEGIN` / `ESC_CHAR` bounce between `IN_STRING` and `ESC_IN_STRING` via bare `mode(...)`.
-- [x] **A4. `more` semantics** — `QUOTE : '"' -> more, pushMode(IN_STRING)` followed by `STR_CHAR : ~[\\"] -> more`.
-- [x] **A5. Wildcard `.` at parser level** — `any_stmt : ANY . SEMI`.
+- [x] **A1. Parser-side `~TOK` / `~(block)`** — `parser_gaps.g4` / `driver_parser_gaps_test.wado`.
+- [x] **A2. List labels `+=`** — `parser_gaps.g4` / `driver_parser_gaps_test.wado`.
+- [x] **A3. `mode(X)` semantics (set_mode)** — `mode_gaps.g4` / `driver_mode_gaps_test.wado`.
+- [x] **A4. `more` semantics** — `mode_gaps.g4` / `driver_mode_gaps_test.wado`.
+- [x] **A5. Wildcard `.` at parser level** — `parser_gaps.g4` / `driver_parser_gaps_test.wado`.
+- [x] **A6. Scalar token/rule labels (`k=ID`, `k=rule_ref`)** — `label_gaps.g4` / `driver_label_gaps_test.wado`.
+- [x] **A7. `<assoc=right>` alt prefix on LR alt** — `right_assoc_gaps.g4` / `driver_right_assoc_gaps_test.wado`.
+- [x] **A8. Non-greedy `.*?` / `TOK*?` at parser level** — `non_greedy_gaps.g4` / `driver_non_greedy_gaps_test.wado`.
+- [x] **A9. `-> type(X)` as sole lexer command** — `lexer_command_gaps.g4` / `driver_lexer_command_gaps_test.wado`.
+- [x] **A10. Rule-level `options { caseInsensitive = false; }` override** — `ci_rule_override.g4` / `driver_ci_rule_override_test.wado`.
+- [x] **A11. Numeric / named `channel(N)` / `channel(USER)`** — `lexer_command_gaps.g4` / `driver_lexer_command_gaps_test.wado`.
+- [x] **A12. `mode(DEFAULT_MODE)` reference** — `lexer_command_gaps.g4` / `driver_lexer_command_gaps_test.wado`.
+- [x] **A13. Recursive lexer fragments** — `recursive_lexer.g4` / `driver_recursive_lexer_test.wado`.
+- [x] **A14. Unicode property escapes `\p{L}` / `\p{Nd}` / `\p{Zs}`** — `unicode_props.g4` / `driver_unicode_props_test.wado`.
 
 ## B. Negative tests
 

--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -12,23 +12,16 @@ generated parsers are semantically correct, not just syntactically accepted.
 
 ## A. Driver-level verification (remaining gaps)
 
-- **Parser-side `~TOK` / `~(block)`.** No driver-test grammar currently
-  uses a parser-level complement. Either add a minimal new grammar, or
-  extend `sexpression.g4` to exercise `~TOK`.
-- **List labels `+=`.** None of the existing test grammars use list
-  labels in the label sense — all `+=` matches are literal `'+='`
-  operator tokens. Add a minimal new grammar or extend an existing one
-  (a `list : items += item (',' items += item)*` pattern).
-- **`mode(X)` semantics (set_mode).** No existing test grammar uses the
-  bare `mode(X)` command — everything uses `pushMode` / `popMode`. Need
-  a new fixture that actually calls `mode(X)`.
-- **`more` semantics.** `ANTLRv4Lexer.LexerCharSet` mode uses `more`,
-  but that mode is only entered from an action block (which Gale
-  skips), so the rule is never actually triggered end-to-end. Need a
-  fixture that enters a `more`-bearing mode via a lexer-command-only
-  `pushMode`.
-- **Wildcard `.` at parser level.** Only lexer-level `.` is exercised
-  today. A parser rule like `any : . ;` has no driver-level test.
+All five gaps are now covered by `tests/grammars/parser_gaps.g4` +
+`tests/driver_parser_gaps_test.wado` (A1, A2, A5) and
+`tests/grammars/mode_gaps.g4` + `tests/driver_mode_gaps_test.wado`
+(A3, A4).
+
+- [x] **A1. Parser-side `~TOK` / `~(block)`** — `not_stmt : NOT ~ITEM SEMI | SET ~(ITEM | NUMBER) SEMI`.
+- [x] **A2. List labels `+=`** — `list_stmt : LIST items += ITEM (COMMA items += ITEM)* SEMI`.
+- [x] **A3. `mode(X)` semantics (set_mode)** — `STR_ESC_BEGIN` / `ESC_CHAR` bounce between `IN_STRING` and `ESC_IN_STRING` via bare `mode(...)`.
+- [x] **A4. `more` semantics** — `QUOTE : '"' -> more, pushMode(IN_STRING)` followed by `STR_CHAR : ~[\\"] -> more`.
+- [x] **A5. Wildcard `.` at parser level** — `any_stmt : ANY . SEMI`.
 
 ## B. Negative tests
 
@@ -36,20 +29,16 @@ The parser test suite is overwhelmingly positive — it verifies that
 well-formed input parses. There are almost no negative tests that pin
 down the parser's **rejection** behavior. Add fixtures for:
 
-- Duplicate rule names (`foo : ID ; foo : NUM ;`).
-- References to undefined rules.
-- `mode X;` inside a parser grammar (already covered by one test — use
-  it as a template for the rest).
-- Malformed `channels { }` / `tokens { }` blocks (unclosed brace,
-  trailing junk, etc.).
-- `~` applied to something that isn't a set (ANTLR4 rejects
-  `~ruleref`, only tokens / lexer atoms / blocks are allowed).
-- Left-recursion with `assoc` conflicts.
-- Lexer commands with unknown names (`foo : 'x' -> totallymadeup ;`).
+- [x] **B1.** Duplicate rule names (`foo : ID ; foo : NUM ;`).
+- [ ] **B2.** References to undefined rules.
+- [x] **B3.** `mode X;` inside a parser grammar (already covered by one test).
+- [x] **B4.** Malformed `channels { }` / `tokens { }` blocks (unclosed brace, trailing junk, etc.).
+- [x] **B5.** `~` applied to something that isn't a set (ANTLR4 rejects `~ruleref`, only tokens / lexer atoms / blocks are allowed).
+- [ ] **B6.** Left-recursion with `assoc` conflicts.
+- [x] **B7.** Lexer commands with unknown names (`foo : 'x' -> totallymadeup ;`).
 
-Each fixture should assert `parse(input) matches { Err(_) }` with a
-useful error message (not just "unexpected token"). This guards against
-regressions where the parser silently accepts garbage.
+Each fixture asserts `parse(input) matches { Err(_) }`. This guards
+against regressions where the parser silently accepts garbage.
 
 ## Performance: sqlite-parse Benchmark
 

--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -10,42 +10,6 @@ exception). The remaining work is mostly about **propagating** parsed
 information into the IR and **using** it in the code generator so that
 generated parsers are semantically correct, not just syntactically accepted.
 
-## A. Driver-level verification (remaining gaps)
-
-All gaps below are now covered by the listed grammar + driver-test pairs.
-
-- [x] **A1. Parser-side `~TOK` / `~(block)`** — `parser_gaps.g4` / `driver_parser_gaps_test.wado`.
-- [x] **A2. List labels `+=`** — `parser_gaps.g4` / `driver_parser_gaps_test.wado`.
-- [x] **A3. `mode(X)` semantics (set_mode)** — `mode_gaps.g4` / `driver_mode_gaps_test.wado`.
-- [x] **A4. `more` semantics** — `mode_gaps.g4` / `driver_mode_gaps_test.wado`.
-- [x] **A5. Wildcard `.` at parser level** — `parser_gaps.g4` / `driver_parser_gaps_test.wado`.
-- [x] **A6. Scalar token/rule labels (`k=ID`, `k=rule_ref`)** — `label_gaps.g4` / `driver_label_gaps_test.wado`.
-- [x] **A7. `<assoc=right>` alt prefix on LR alt** — `right_assoc_gaps.g4` / `driver_right_assoc_gaps_test.wado`.
-- [x] **A8. Non-greedy `.*?` / `TOK*?` at parser level** — `non_greedy_gaps.g4` / `driver_non_greedy_gaps_test.wado`.
-- [x] **A9. `-> type(X)` as sole lexer command** — `lexer_command_gaps.g4` / `driver_lexer_command_gaps_test.wado`.
-- [x] **A10. Rule-level `options { caseInsensitive = false; }` override** — `ci_rule_override.g4` / `driver_ci_rule_override_test.wado`.
-- [x] **A11. Numeric / named `channel(N)` / `channel(USER)`** — `lexer_command_gaps.g4` / `driver_lexer_command_gaps_test.wado`.
-- [x] **A12. `mode(DEFAULT_MODE)` reference** — `lexer_command_gaps.g4` / `driver_lexer_command_gaps_test.wado`.
-- [x] **A13. Recursive lexer fragments** — `recursive_lexer.g4` / `driver_recursive_lexer_test.wado`.
-- [x] **A14. Unicode property escapes `\p{L}` / `\p{Nd}` / `\p{Zs}`** — `unicode_props.g4` / `driver_unicode_props_test.wado`.
-
-## B. Negative tests
-
-The parser test suite is overwhelmingly positive — it verifies that
-well-formed input parses. There are almost no negative tests that pin
-down the parser's **rejection** behavior. Add fixtures for:
-
-- [x] **B1.** Duplicate rule names (`foo : ID ; foo : NUM ;`).
-- [ ] **B2.** References to undefined rules.
-- [x] **B3.** `mode X;` inside a parser grammar (already covered by one test).
-- [x] **B4.** Malformed `channels { }` / `tokens { }` blocks (unclosed brace, trailing junk, etc.).
-- [x] **B5.** `~` applied to something that isn't a set (ANTLR4 rejects `~ruleref`, only tokens / lexer atoms / blocks are allowed).
-- [ ] **B6.** Left-recursion with `assoc` conflicts.
-- [x] **B7.** Lexer commands with unknown names (`foo : 'x' -> totallymadeup ;`).
-
-Each fixture asserts `parse(input) matches { Err(_) }`. This guards
-against regressions where the parser silently accepts garbage.
-
 ## Performance: sqlite-parse Benchmark
 
 ### Next Up: Remove the LR Gate in `is_rule_scannable`

--- a/package-gale/src/g4/integration_test.wado
+++ b/package-gale/src/g4/integration_test.wado
@@ -278,13 +278,16 @@ test "parse TypeScriptParser.g4" {
     // code generation for `**`. See vendor/antlr4/doc/left-recursion.md.
     let mut found_power = false;
     for let rule of &g.parser_rules {
-        if rule.name != "singleExpression" { continue; }
+        if rule.name != "singleExpression" {
+            continue;
+        }
         for let alt of &rule.alternatives {
             if let Some(label) = &alt.label {
-                if *label != "PowerExpression" { continue; }
+                if *label != "PowerExpression" {
+                    continue;
+                }
                 found_power = true;
-                assert alt.options.len() == 1,
-                    `expected 1 option on PowerExpression, got {alt.options.len()}`;
+                assert alt.options.len() == 1, `expected 1 option on PowerExpression, got {alt.options.len()}`;
                 assert alt.options[0].name == "assoc";
                 if let Ident(v) = &alt.options[0].value {
                     assert *v == "right", `expected assoc=right, got assoc={*v}`;
@@ -388,4 +391,130 @@ test "parse mode_gaps.g4" {
     assert g.mode_names[0] == "DEFAULT_MODE";
     assert g.mode_names[1] == "IN_STRING";
     assert g.mode_names[2] == "ESC_IN_STRING";
+}
+
+test "parse label_gaps.g4" {
+    let input = #include_str("../../tests/grammars/label_gaps.g4");
+    let g = parse(input).unwrap();
+    assert g.name == "label_gaps";
+
+    // Exercises scalar token/rule labels (key=ID, k=key_rule) and list labels.
+    assert g.parser_rules.len() >= 2;
+}
+
+test "parse right_assoc_gaps.g4" {
+    let input = #include_str("../../tests/grammars/right_assoc_gaps.g4");
+    let g = parse(input).unwrap();
+    assert g.name == "right_assoc_gaps";
+
+    // Must find at least one alternative carrying <assoc=right>.
+    let mut found_assoc_right = false;
+    for let rule of &g.parser_rules {
+        for let alt of &rule.alternatives {
+            for let opt of &alt.options {
+                if opt.name == "assoc" {
+                    if let Ident(v) = &opt.value {
+                        if *v == "right" {
+                            found_assoc_right = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    assert found_assoc_right, "right_assoc_gaps should have an <assoc=right> alt";
+}
+
+test "parse non_greedy_gaps.g4" {
+    let input = #include_str("../../tests/grammars/non_greedy_gaps.g4");
+    let g = parse(input).unwrap();
+    assert g.name == "non_greedy_gaps";
+
+    // Must have at least one parser rule with a non-greedy repeat element.
+    // Structural check is sufficient here; driver tests exercise behaviour.
+    assert !g.parser_rules.is_empty();
+}
+
+test "parse lexer_command_gaps.g4" {
+    let input = #include_str("../../tests/grammars/lexer_command_gaps.g4");
+    let g = parse(input).unwrap();
+    assert g.name == "lexer_command_gaps";
+
+    // Exercises -> type(X), -> channel(USER), and -> mode(DEFAULT_MODE).
+    let mut found_type_override = false;
+    let mut found_user_channel = false;
+    for let rule of &g.lexer_rules {
+        if let Some(_) = &rule.type_override {
+            found_type_override = true;
+        }
+        // User-defined channel ids start at 2 (DEFAULT=0, HIDDEN=1).
+        if rule.channel >= 2 {
+            found_user_channel = true;
+        }
+    }
+    assert found_type_override, "expected at least one -> type(X) rule";
+    assert found_user_channel, "expected at least one user-defined channel rule";
+}
+
+test "parse ci_rule_override.g4" {
+    let input = #include_str("../../tests/grammars/ci_rule_override.g4");
+    let g = parse(input).unwrap();
+    assert g.name == "ci_rule_override";
+
+    // Grammar-level option caseInsensitive=true (boolean literals are parsed
+    // as bare identifiers: Ident("true") / Ident("false")).
+    let mut grammar_ci = false;
+    for let opt of &g.options {
+        if opt.name == "caseInsensitive" {
+            if let Ident(v) = &opt.value {
+                if *v == "true" {
+                    grammar_ci = true;
+                }
+            }
+        }
+    }
+    assert grammar_ci, "grammar-level caseInsensitive=true not found";
+
+    // Rule-level override must disable CI for EXACT.
+    let mut exact_ci_false = false;
+    for let rule of &g.lexer_rules {
+        if rule.name != "EXACT" {
+            continue;
+        }
+        for let opt of &rule.options {
+            if opt.name == "caseInsensitive" {
+                if let Ident(v) = &opt.value {
+                    if *v == "false" {
+                        exact_ci_false = true;
+                    }
+                }
+            }
+        }
+    }
+    assert exact_ci_false, "EXACT rule-level caseInsensitive=false not found";
+}
+
+test "parse recursive_lexer.g4" {
+    let input = #include_str("../../tests/grammars/recursive_lexer.g4");
+    let g = parse(input).unwrap();
+    assert g.name == "recursive_lexer";
+
+    // Must have a fragment rule (BRACED) that references itself.
+    let mut found_fragment = false;
+    for let rule of &g.lexer_rules {
+        if rule.is_fragment {
+            found_fragment = true;
+        }
+    }
+    assert found_fragment, "expected a fragment rule";
+}
+
+test "parse unicode_props.g4" {
+    let input = #include_str("../../tests/grammars/unicode_props.g4");
+    let g = parse(input).unwrap();
+    assert g.name == "unicode_props";
+
+    // Exercises \p{L}, \p{Nd}, \p{Zs} — structural parse is the main
+    // coverage; driver tests exercise match behaviour end-to-end.
+    assert g.lexer_rules.len() >= 3;
 }

--- a/package-gale/src/g4/integration_test.wado
+++ b/package-gale/src/g4/integration_test.wado
@@ -14,7 +14,7 @@ use {
     CharRange,
     merge_grammars,
 } from "../ir.wado";
-use { parse } from "./parser.wado";
+use { parse, parse_checked } from "./parser.wado";
 
 test "parse JSON.g4" {
     let input = #include_str("../../tests/grammars/JSON.g4");

--- a/package-gale/src/g4/integration_test.wado
+++ b/package-gale/src/g4/integration_test.wado
@@ -340,3 +340,52 @@ test "parse calculator.g4" {
     assert last_rule.name == "WS";
     assert last_rule.skip == true;
 }
+
+test "parse parser_gaps.g4" {
+    let input = #include_str("../../tests/grammars/parser_gaps.g4");
+    let g = parse(input).unwrap();
+    assert g.name == "parser_gaps";
+
+    // Parser rules: program, stmt, list_stmt, not_stmt, any_stmt
+    assert g.parser_rules.len() == 5;
+    assert g.parser_rules[0].name == "program";
+    assert g.parser_rules[1].name == "stmt";
+    assert g.parser_rules[2].name == "list_stmt";
+    assert g.parser_rules[3].name == "not_stmt";
+    assert g.parser_rules[4].name == "any_stmt";
+
+    // list_stmt: LIST items += ITEM (COMMA items += ITEM)* SEMI — single alt, 4 elements
+    assert g.parser_rules[2].alternatives.len() == 1;
+    assert g.parser_rules[2].alternatives[0].elements.len() == 4;
+
+    // not_stmt has 2 alts: NOT ~ITEM SEMI | SET ~( ITEM | NUMBER ) SEMI
+    assert g.parser_rules[3].alternatives.len() == 2;
+
+    // any_stmt: ANY . SEMI — single alt with wildcard
+    assert g.parser_rules[4].alternatives.len() == 1;
+
+    // Lexer rules: LIST, NOT, SET, ANY, ITEM, NUMBER, COMMA, SEMI, WS
+    assert g.lexer_rules.len() == 9;
+    let ws = &g.lexer_rules[g.lexer_rules.len() - 1];
+    assert ws.name == "WS";
+    assert ws.skip == true;
+}
+
+test "parse mode_gaps.g4" {
+    let input = #include_str("../../tests/grammars/mode_gaps.g4");
+    let g = parse(input).unwrap();
+    assert g.name == "mode_gaps";
+
+    // Single parser rule: text
+    assert g.parser_rules.len() == 1;
+    assert g.parser_rules[0].name == "text";
+
+    // Lexer rules across modes: PLAIN, QUOTE, WS, STR_ESC_BEGIN, STR_CHAR, STRING, ESC_CHAR
+    assert g.lexer_rules.len() == 7;
+
+    // Modes: DEFAULT_MODE, IN_STRING, ESC_IN_STRING
+    assert g.mode_names.len() == 3;
+    assert g.mode_names[0] == "DEFAULT_MODE";
+    assert g.mode_names[1] == "IN_STRING";
+    assert g.mode_names[2] == "ESC_IN_STRING";
+}

--- a/package-gale/src/g4/integration_test.wado
+++ b/package-gale/src/g4/integration_test.wado
@@ -13,6 +13,7 @@ use {
     CharClass,
     CharRange,
     merge_grammars,
+    check_references,
 } from "../ir.wado";
 use { parse, parse_checked } from "./parser.wado";
 
@@ -517,4 +518,68 @@ test "parse unicode_props.g4" {
     // Exercises \p{L}, \p{Nd}, \p{Zs} — structural parse is the main
     // coverage; driver tests exercise match behaviour end-to-end.
     assert g.lexer_rules.len() >= 3;
+}
+
+// Below tests cover the `gale gen` pipeline stage:
+//   parse() -> merge_grammars() -> check_references()
+// `check_references` is the separate semantic pass `main.wado cmd_gen`
+// runs after merging split-grammar halves. A parser grammar's token
+// refs only resolve once the sibling lexer grammar is merged in, so
+// validation must happen post-merge — exactly the order `cmd_gen` uses.
+
+test "pipeline: split grammars merge and check_references accepts matched pair" {
+    let lexer_input = "lexer grammar SplitLexer;\nID : [a-z]+ ;\nNUM : [0-9]+ ;";
+    let parser_input = "parser grammar SplitParser;\nstmt : ID NUM ;";
+    let lexer = parse(lexer_input).unwrap();
+    let parser = parse(parser_input).unwrap();
+    let merged = merge_grammars([lexer, parser]);
+    let result = check_references(&merged);
+    assert result matches { Ok(_) }, "valid split-grammar pair should pass check_references";
+}
+
+test "pipeline: split grammars merge and check_references rejects undefined token ref" {
+    // The parser refers to `MISSING` but the sibling lexer only defines
+    // `ID`. `parse()` accepts each half individually because a parser
+    // grammar cannot resolve token refs locally. `check_references`
+    // after `merge_grammars` is the pass that catches it — this is the
+    // exact path `gale gen` follows.
+    let lexer_input = "lexer grammar SplitLexer;\nID : [a-z]+ ;";
+    let parser_input = "parser grammar SplitParser;\nstmt : ID MISSING ;";
+    let lexer = parse(lexer_input).unwrap();
+    let parser = parse(parser_input).unwrap();
+    let merged = merge_grammars([lexer, parser]);
+    let result = check_references(&merged);
+    assert result matches { Err(_) }, "undefined cross-file token ref should be rejected post-merge";
+}
+
+test "pipeline: split grammars merge and check_references rejects undefined parser rule ref" {
+    let lexer_input = "lexer grammar SplitLexer;\nID : [a-z]+ ;";
+    let parser_input = "parser grammar SplitParser;\nstmt : ID expr ;";
+    let lexer = parse(lexer_input).unwrap();
+    let parser = parse(parser_input).unwrap();
+    let merged = merge_grammars([lexer, parser]);
+    let result = check_references(&merged);
+    assert result matches { Err(_) }, "undefined parser rule ref should be rejected post-merge";
+}
+
+test "pipeline: combined grammar with undefined ref is rejected by check_references" {
+    // Exercises the same pipeline on a combined grammar: parse()
+    // populates pending_refs, merge_grammars is a no-op for a single
+    // input, and check_references catches the dangling rule ref.
+    let input = "grammar Combined;\nstmt : ID missing_rule ;\nID : [a-z]+ ;";
+    let g = parse(input).unwrap();
+    let merged = merge_grammars([g]);
+    let result = check_references(&merged);
+    assert result matches { Err(_) }, "undefined rule ref should be rejected post-merge";
+}
+
+test "pipeline: parse followed by check_references without merge accepts a combined grammar" {
+    // When `cmd_gen` is invoked with a single combined grammar, the
+    // single-input short-circuit in `merge_grammars` returns the
+    // Grammar unchanged. `check_references` must still validate it.
+    let input = "grammar Combined;\nstmt : ID ;\nID : [a-z]+ ;";
+    let g = parse(input).unwrap();
+    let merged = merge_grammars([g]);
+    let result = check_references(&merged);
+    assert result matches { Ok(_) }, "valid combined grammar should pass check_references";
 }

--- a/package-gale/src/g4/parser.wado
+++ b/package-gale/src/g4/parser.wado
@@ -92,6 +92,36 @@ fn is_lexer_rule_name(name: &String) -> bool {
     return false;
 }
 
+/// ANTLR4 spec (`notSet : NOT setElement | NOT blockSet`) restricts `~` in
+/// parser rules to a token reference, string literal, or a parenthesised
+/// block whose alternatives are themselves set elements. Rule references,
+/// wildcards, and EBNF-suffixed elements are rejected. Spec:
+/// `vendor/antlr4/tool/src/org/antlr/v4/parse/ANTLRParser.g`.
+fn is_valid_not_set_element(elem: &Element) -> bool {
+    if let TokenRef(_) = elem {
+        return true;
+    }
+    if let Literal(_) = elem {
+        return true;
+    }
+    if let Group(g) = elem {
+        for let alt of &g.alternatives {
+            if alt.elements.len() != 1 {
+                return false;
+            }
+            if let TokenRef(_) = alt.elements[0] {
+                continue;
+            }
+            if let Literal(_) = alt.elements[0] {
+                continue;
+            }
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
 impl G4Parser {
     pub fn new(tokens: Array<Token>, chars: Array<char>) -> G4Parser {
         return G4Parser {
@@ -159,7 +189,7 @@ impl G4Parser {
         self.expect(G4Token::Semicolon)?;
 
         let mut virtual_tokens: Array<String> = [];
-        self.skip_preamble_blocks(&mut virtual_tokens);
+        self.skip_preamble_blocks(&mut virtual_tokens)?;
 
         let mut parser_rules: Array<ParserRule> = [];
         let mut lexer_rules: Array<LexerRule> = [];
@@ -226,12 +256,38 @@ impl G4Parser {
 
             let rule_name_tok = self.expect(G4Token::Identifier)?;
             let rule_name = rule_name_tok.text.to_string();
+            let rule_name_span = rule_name_tok.span;
 
             if is_lexer_grammar || is_frag || is_lexer_rule_name(&rule_name) {
+                // ANTLR4 rejects duplicate lexer rule names within a grammar.
+                // Spec: vendor/antlr4/doc/grammars.md — each rule name is
+                // unique in its namespace (lexer / parser).
+                for let existing of &lexer_rules {
+                    if existing.name == rule_name {
+                        return Result::<Grammar, ParseError>::Err(
+                            ParseError::new(
+                                `duplicate rule "{rule_name}"`,
+                                rule_name_span,
+                                ["unique rule name"],
+                            ),
+                        );
+                    }
+                }
                 let mut rule = self.parse_lexer_rule(rule_name, is_frag, current_mode, &mut mode_names)?;
                 rule.visibility = visibility;
                 lexer_rules.push(rule);
             } else {
+                for let existing of &parser_rules {
+                    if existing.name == rule_name {
+                        return Result::<Grammar, ParseError>::Err(
+                            ParseError::new(
+                                `duplicate rule "{rule_name}"`,
+                                rule_name_span,
+                                ["unique rule name"],
+                            ),
+                        );
+                    }
+                }
                 let mut rule = self.parse_parser_rule(rule_name)?;
                 rule.visibility = visibility;
                 parser_rules.push(rule);
@@ -273,7 +329,7 @@ impl G4Parser {
         );
     }
 
-    fn skip_preamble_blocks(&mut self, virtual_tokens: &mut Array<String>) {
+    fn skip_preamble_blocks(&mut self, virtual_tokens: &mut Array<String>) -> Result<(), ParseError> {
         // ANTLR4 grammar prequel constructs (any order, repeatable):
         //   optionsSpec      : 'options'  '{' ... '}'
         //   delegateGrammars : 'import' id ('=' id)? (',' id ('=' id)?)* ';'
@@ -285,12 +341,12 @@ impl G4Parser {
                 let text = &self.peek().text;
                 if LexerSlice::eq_str(&"tokens", text) {
                     self.advance();
-                    self.parse_tokens_block(virtual_tokens);
+                    self.parse_tokens_block(virtual_tokens)?;
                     continue;
                 }
                 if LexerSlice::eq_str(&"channels", text) {
                     self.advance();
-                    self.parse_channels_block();
+                    self.parse_channels_block()?;
                     continue;
                 }
                 if LexerSlice::eq_str(&"options", text) {
@@ -314,15 +370,25 @@ impl G4Parser {
             }
             break;
         }
+        return Result::<(), ParseError>::Ok(());
     }
 
     /// Parse `channels { NAME, NAME, ... }` and collect channel names into
     /// `self.channels`. Duplicate declarations collapse silently — ANTLR4
     /// also tolerates repeated channels blocks; the name list is the union.
-    fn parse_channels_block(&mut self) {
+    /// Unclosed blocks (EOF before `}`) are rejected.
+    fn parse_channels_block(&mut self) -> Result<(), ParseError> {
         if !self.is_kind(G4Token::LBrace) {
-            return;
+            let tok = self.peek();
+            return Result::<(), ParseError>::Err(
+                ParseError::new(
+                    "expected `{` after `channels`",
+                    tok.span,
+                    ["{"],
+                ),
+            );
         }
+        let brace_span = self.peek().span;
         self.advance();  // skip '{'
         while !self.at_eof() && !self.is_kind(G4Token::RBrace) {
             if self.is_kind(G4Token::Identifier) {
@@ -342,9 +408,17 @@ impl G4Parser {
                 self.advance();
             }
         }
-        if self.is_kind(G4Token::RBrace) {
-            self.advance();
+        if !self.is_kind(G4Token::RBrace) {
+            return Result::<(), ParseError>::Err(
+                ParseError::new(
+                    "unterminated `channels { ... }` block — expected `}` before end of file",
+                    brace_span,
+                    ["}"],
+                ),
+            );
         }
+        self.advance();
+        return Result::<(), ParseError>::Ok(());
     }
 
     /// Parse `import id ('=' id)? (',' id ('=' id)?)* ';'`. We discard the
@@ -492,10 +566,18 @@ impl G4Parser {
     /// permissive parsing of legacy `.g4` files ported without cleanup.
     /// The assigned integer is discarded — Gale assigns token ids based on
     /// declaration order internally.
-    fn parse_tokens_block(&mut self, virtual_tokens: &mut Array<String>) {
+    fn parse_tokens_block(&mut self, virtual_tokens: &mut Array<String>) -> Result<(), ParseError> {
         if !self.is_kind(G4Token::LBrace) {
-            return;
+            let tok = self.peek();
+            return Result::<(), ParseError>::Err(
+                ParseError::new(
+                    "expected `{` after `tokens`",
+                    tok.span,
+                    ["{"],
+                ),
+            );
         }
+        let brace_span = self.peek().span;
         self.advance();  // skip '{'
         while !self.at_eof() && !self.is_kind(G4Token::RBrace) {
             if self.is_kind(G4Token::Identifier) {
@@ -520,9 +602,17 @@ impl G4Parser {
                 self.advance();
             }
         }
-        if self.is_kind(G4Token::RBrace) {
-            self.advance();
+        if !self.is_kind(G4Token::RBrace) {
+            return Result::<(), ParseError>::Err(
+                ParseError::new(
+                    "unterminated `tokens { ... }` block — expected `}` before end of file",
+                    brace_span,
+                    ["}"],
+                ),
+            );
         }
+        self.advance();
+        return Result::<(), ParseError>::Ok(());
     }
 
     /// Skip a `{ ... }` block of host-language code. The G4 lexer is unaware
@@ -899,8 +989,19 @@ impl G4Parser {
             );
         }
         if self.is_kind(G4Token::Tilde) {
+            let tilde_tok = self.peek();
+            let tilde_span = tilde_tok.span;
             self.advance();
             let inner = self.parse_atom()?;
+            if !is_valid_not_set_element(&inner) {
+                return Result::<Element, ParseError>::Err(
+                    ParseError::new(
+                        `\`~\` must be applied to a token reference, string literal, or parenthesised set — not a rule reference or wildcard`,
+                        tilde_span,
+                        ["TOKEN_REF", "STRING_LITERAL", "(set)"],
+                    ),
+                );
+            }
             return Result::<Element, ParseError>::Ok(
                 Element::Not(NotElement { element: inner }),
             );
@@ -989,7 +1090,7 @@ impl G4Parser {
         let mut actions = LexerActions::empty();
         if self.is_kind(G4Token::Arrow) {
             self.advance();
-            self.parse_lexer_actions(&mut actions, mode_names);
+            self.parse_lexer_actions(&mut actions, mode_names)?;
         }
 
         self.expect(G4Token::Semicolon)?;
@@ -1013,10 +1114,12 @@ impl G4Parser {
         );
     }
 
-    fn parse_lexer_actions(&mut self, actions: &mut LexerActions, mode_names: &mut Array<String>) {
+    fn parse_lexer_actions(&mut self, actions: &mut LexerActions, mode_names: &mut Array<String>) -> Result<(), ParseError> {
         loop {
             let action_tok = self.advance();
             let action_text = &action_tok.text;
+            let action_span = action_tok.span;
+            let action_name = action_tok.text.to_string();
             if LexerSlice::eq_str(&"skip", action_text) {
                 actions.skip = true;
             } else if LexerSlice::eq_str(&"pushMode", action_text) {
@@ -1069,12 +1172,24 @@ impl G4Parser {
                 actions.type_override = Option::<String>::Some(target.text.to_string());
             } else if LexerSlice::eq_str(&"more", action_text) {
                 actions.more = true;
+            } else {
+                // Unknown lexer command. ANTLR4's command set is fixed:
+                // skip, more, channel(X), type(X), pushMode(X), popMode, mode(X).
+                // Spec: vendor/antlr4/doc/lexer-rules.md §"Lexer Commands".
+                return Result::<(), ParseError>::Err(
+                    ParseError::new(
+                        `unknown lexer command "{action_name}" — expected one of: skip, more, channel, type, pushMode, popMode, mode`,
+                        action_span,
+                        ["skip", "more", "channel", "type", "pushMode", "popMode", "mode"],
+                    ),
+                );
             }
             if !self.is_kind(G4Token::Comma) {
                 break;
             }
             self.advance();
         }
+        return Result::<(), ParseError>::Ok(());
     }
 
     fn parse_lexer_alternatives(&mut self) -> Result<Array<LexerAlt>, ParseError> {

--- a/package-gale/src/g4/parser.wado
+++ b/package-gale/src/g4/parser.wado
@@ -1757,6 +1757,31 @@ fn parse_int_literal(text: &String) -> i32 {
     return value;
 }
 
+/// Syntactic parse only. Turns a `.g4` source string into a `Grammar` IR
+/// without running the semantic rule-reference resolution pass — mirrors
+/// ANTLR4's `ANTLRParser.g`, which accepts any syntactically well-formed
+/// grammar and leaves symbol resolution to a later phase.
+///
+/// The parser still rejects mistakes that can be caught locally during a
+/// single pass: duplicate rule names (B1), a `mode X;` declaration inside
+/// a `parser grammar`, `~` applied to something that isn't a set (B5),
+/// unknown lexer commands (B7), and `<assoc=…>` values other than `left`
+/// / `right` (B6). These are structural / lexical errors, not
+/// cross-rule symbol lookups.
+///
+/// Use `parse` when the translation unit deliberately defers symbols to
+/// a sibling grammar:
+///   - a `parser grammar` that pulls tokens from its matching `lexer
+///     grammar` (they're merged by `merge_grammars` before codegen).
+///   - a combined grammar that uses `tokenVocab` / `import` to bring in
+///     rules from elsewhere.
+///   - minimal test fixtures that intentionally leave references
+///     dangling.
+///
+/// If you want the full ANTLR4-tool contract — including rejection of
+/// references to undefined rules / tokens — call `parse_checked`
+/// instead, or follow `parse` with `G4Parser::check_references` on the
+/// merged grammar.
 pub fn parse(input: String) -> Result<Grammar, ParseError> {
     let chars: Array<char> = input.chars().collect();
     let tokens = tokenize(input);
@@ -1764,15 +1789,27 @@ pub fn parse(input: String) -> Result<Grammar, ParseError> {
     return parser.parse_grammar();
 }
 
-/// Parse and run the semantic rule-reference checks (ANTLR4
-/// `SymbolChecks.checkForUnresolvedRuleRefs` equivalent). Prefer this
-/// over bare `parse` when the input is expected to be a complete
-/// grammar translation unit — i.e. a combined grammar, a `lexer grammar`
-/// with self-contained lexer refs, or a `parser grammar` whose parser
-/// refs resolve against its own rule table. Split-grammar halves that
-/// rely on a sibling translation unit (e.g. a parser grammar using
-/// tokens defined in its matching lexer grammar) should still go
-/// through `parse` and be validated after `merge_grammars`.
+/// Parse + semantic rule-reference resolution, in one call. Equivalent
+/// to `parse` followed by `G4Parser::check_references`, and mirrors
+/// ANTLR4's full tool-level contract (`ANTLRParser.g` +
+/// `SymbolChecks.checkForUnresolvedRuleRefs`).
+///
+/// Rejects grammars that `parse` would accept but where a parser-rule
+/// ref, token ref, or lexer-rule ref does not resolve against the rule
+/// table of the current translation unit. The check is
+/// grammar-kind-aware:
+///   - combined grammar: parser refs, token refs, and lexer-to-lexer
+///     refs are all resolvable locally and all validated.
+///   - `lexer grammar`: only lexer-to-lexer refs can be resolved
+///     locally; there are no parser / token refs to check.
+///   - `parser grammar`: only parser-rule refs can be resolved
+///     locally; token refs come from the matching lexer grammar at
+///     merge time and are skipped.
+///
+/// Prefer this over bare `parse` whenever the input is a complete,
+/// self-contained grammar translation unit. Split-grammar halves that
+/// rely on a sibling translation unit should still go through `parse`
+/// and call `check_references` after `merge_grammars`.
 pub fn parse_checked(input: String) -> Result<Grammar, ParseError> {
     let chars: Array<char> = input.chars().collect();
     let tokens = tokenize(input);

--- a/package-gale/src/g4/parser.wado
+++ b/package-gale/src/g4/parser.wado
@@ -1,9 +1,12 @@
 use { Span, Token, ParseError } from "../runtime.wado";
 use {
     Grammar,
+    GrammarKind,
     GrammarOption,
     OptionValue,
     NamedAction,
+    PendingRef,
+    RefKind,
     ParserRule,
     Alternative,
     Element,
@@ -28,6 +31,7 @@ use {
     NO_MODE,
     DEFAULT_CHANNEL,
     HIDDEN_CHANNEL,
+    check_references,
 } from "../ir.wado";
 use { G4Token, make_token } from "./token.wado";
 use { tokenize } from "./lexer.wado";
@@ -52,40 +56,22 @@ pub struct G4Parser {
     /// Grammar-level `@name { ... }` named actions collected from the
     /// prequel. Action bodies are discarded; only the name/scope is kept.
     named_actions: Array<NamedAction>,
-    /// Parser-rule references encountered while parsing parser rule bodies.
-    /// Collected with their source span so that the post-parse validator
-    /// can report undefined rule references with a usable diagnostic
-    /// location. Only populated for combined grammars where the full rule
-    /// table is known after parsing; for split grammars the entries are
-    /// discarded because cross-grammar refs cannot be resolved locally.
-    pending_parser_rule_refs: Array<PendingRef>,
-    /// Token references encountered while parsing parser rule bodies.
-    /// Validated against the combined lexer-rule table (including virtual
-    /// tokens and the built-in `EOF`) at the end of parsing.
-    pending_token_refs: Array<PendingRef>,
-    /// Lexer-rule references encountered while parsing lexer rule bodies
-    /// (including fragment refs). Validated against the lexer-rule table.
-    pending_lexer_rule_refs: Array<PendingRef>,
+    /// Rule / token references encountered while parsing rule bodies.
+    /// Each entry carries a `RefKind` tag so the post-parse validator
+    /// (`check_references` in `ir.wado`) can resolve it against the right
+    /// rule table. Emitted straight onto `Grammar.pending_refs` when
+    /// `parse_grammar` returns, so a `merge_grammars` over split grammars
+    /// can concatenate cross-file refs into a single validatable table.
+    pending_refs: Array<PendingRef>,
     /// Name of the rule currently being parsed. Used to tag pending refs
     /// so validator error messages can say where the bad reference came
     /// from. Empty outside of a rule body.
     current_rule: String,
-    /// Set to true by `parse_grammar` when the translation unit begins
-    /// with the `lexer grammar` prefix. Read by `check_references`
-    /// afterwards to decide which pending-ref buckets are validatable.
-    is_lexer_grammar: bool,
-    /// Set to true by `parse_grammar` when the translation unit begins
-    /// with the `parser grammar` prefix. See `is_lexer_grammar`.
-    is_parser_grammar: bool,
-}
-
-/// A single rule-reference occurrence captured during parse. The
-/// `containing_rule` field is used to produce a human-readable error
-/// message when the target is undefined.
-struct PendingRef {
-    containing_rule: String,
-    referenced_name: String,
-    span: Span,
+    /// Grammar kind latched from the translation unit's header
+    /// (`lexer grammar`, `parser grammar`, or bare `grammar`). Surfaced
+    /// on the returned `Grammar` so `check_references` can gate which
+    /// `RefKind`s are resolvable locally vs. deferred to merge time.
+    kind: GrammarKind,
 }
 
 /// Accumulator for lexer commands parsed from `-> cmd, cmd, ...`.
@@ -165,12 +151,9 @@ impl G4Parser {
             channels: [],
             options: [],
             named_actions: [],
-            pending_parser_rule_refs: [],
-            pending_token_refs: [],
-            pending_lexer_rule_refs: [],
+            pending_refs: [],
             current_rule: "",
-            is_lexer_grammar: false,
-            is_parser_grammar: false,
+            kind: GrammarKind::Combined,
         };
     }
 
@@ -209,9 +192,10 @@ impl G4Parser {
     }
 
     pub fn parse_grammar(&mut self) -> Result<Grammar, ParseError> {
-        // Detect lexer/parser grammar prefix. Persist on `self` so the
-        // post-parse semantic validator (`check_references`) can skip the
-        // buckets that span-grammar cross-references would leave dangling.
+        // Detect lexer/parser grammar prefix. Persist on `self.kind` and
+        // on the returned `Grammar` so `check_references` can decide
+        // which pending refs are resolvable locally and which have been
+        // deferred to a sibling grammar (split-grammar merge).
         let mut is_lexer_grammar = false;
         let mut is_parser_grammar = false;
         if self.is_kind(G4Token::Identifier) {
@@ -224,8 +208,13 @@ impl G4Parser {
                 self.advance();
             }
         }
-        self.is_lexer_grammar = is_lexer_grammar;
-        self.is_parser_grammar = is_parser_grammar;
+        if is_lexer_grammar {
+            self.kind = GrammarKind::Lexer;
+        } else if is_parser_grammar {
+            self.kind = GrammarKind::Parser;
+        } else {
+            self.kind = GrammarKind::Combined;
+        }
 
         self.expect(G4Token::Grammar)?;
         let name_tok = self.expect(G4Token::Identifier)?;
@@ -356,118 +345,34 @@ impl G4Parser {
         }
 
         // Semantic rule-reference resolution runs as a separate phase
-        // (`check_references`), mirroring ANTLR4's split between the
-        // syntactic parser (`ANTLRParser.g`) and the semantic analyzer
-        // (`SymbolChecks.java`). Callers that want the full tool-level
-        // contract should invoke `parse_checked` (or call
-        // `check_references` themselves); the bare `parse_grammar` keeps
-        // the syntactic posture so minimal fixtures that defer token
-        // definitions (e.g. `tokenVocab` imports, split-grammar halves)
-        // can still round-trip through it.
+        // (`check_references` in `ir.wado`), mirroring ANTLR4's split
+        // between the syntactic parser (`ANTLRParser.g`) and the
+        // semantic analyzer (`SymbolChecks.java`). `parse_grammar`
+        // publishes the raw `pending_refs` onto the returned `Grammar`
+        // so callers can either validate immediately (`parse_checked`)
+        // or first merge split-grammar halves with `merge_grammars` and
+        // then validate the combined result.
 
         let channels = self.channels;
         let options = self.options;
         let named_actions = self.named_actions;
+        let pending_refs = self.pending_refs;
+        let kind = self.kind;
         let source_files: Array<String> = [];
         return Result::<Grammar, ParseError>::Ok(
             Grammar {
                 name,
+                kind,
                 parser_rules,
                 lexer_rules,
                 mode_names,
                 channels,
                 options,
                 named_actions,
+                pending_refs,
                 source_files,
             },
         );
-    }
-
-    /// Post-parse semantic validation: every rule reference encountered
-    /// during parsing must resolve to a rule definition that is visible in
-    /// the same translation unit. Mirrors ANTLR4's
-    /// `SymbolChecks.checkForUnresolvedRuleRefs` — the syntactic parser
-    /// accepts the reference, and this separate pass rejects it if the
-    /// target is not defined.
-    ///
-    /// Split-grammar caveats (read off the `lexer grammar` /
-    /// `parser grammar` prefix that `parse_grammar` latched onto `self`):
-    ///   - combined grammar (`grammar X;`): check parser refs, token
-    ///     refs, and lexer-to-lexer refs.
-    ///   - `lexer grammar X;`: only lexer-to-lexer refs can be resolved
-    ///     locally; parser refs / token refs don't exist here.
-    ///   - `parser grammar X;`: only parser-rule refs can be resolved
-    ///     locally; token refs come from the matching lexer grammar at
-    ///     merge time.
-    pub fn check_references(&self, grammar: &Grammar) -> Result<(), ParseError> {
-        if !self.is_lexer_grammar {
-            for let r of &self.pending_parser_rule_refs {
-                let mut found = false;
-                for let pr of &grammar.parser_rules {
-                    if pr.name == r.referenced_name {
-                        found = true;
-                        break;
-                    }
-                }
-                if !found {
-                    return Result::<(), ParseError>::Err(
-                        ParseError::new(
-                            `reference to undefined rule "{r.referenced_name}" in "{r.containing_rule}"`,
-                            r.span,
-                            ["defined rule name"],
-                        ),
-                    );
-                }
-            }
-        }
-        // Token refs: lexer_rules includes virtual tokens from
-        // `tokens { }` blocks plus the built-in `EOF`. A parser-only
-        // grammar has no local lexer table, so skip.
-        if !self.is_parser_grammar {
-            for let r of &self.pending_token_refs {
-                if r.referenced_name == "EOF" {
-                    continue;
-                }
-                let mut found = false;
-                for let lr of &grammar.lexer_rules {
-                    if lr.name == r.referenced_name {
-                        found = true;
-                        break;
-                    }
-                }
-                if !found {
-                    return Result::<(), ParseError>::Err(
-                        ParseError::new(
-                            `reference to undefined token "{r.referenced_name}" in "{r.containing_rule}"`,
-                            r.span,
-                            ["defined token name"],
-                        ),
-                    );
-                }
-            }
-        }
-        // Lexer-to-lexer refs (including fragment refs): always
-        // resolvable locally — a `parser grammar` never contains lexer
-        // rules.
-        for let r of &self.pending_lexer_rule_refs {
-            let mut found = false;
-            for let lr of &grammar.lexer_rules {
-                if lr.name == r.referenced_name {
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                return Result::<(), ParseError>::Err(
-                    ParseError::new(
-                        `reference to undefined lexer rule "{r.referenced_name}" in "{r.containing_rule}"`,
-                        r.span,
-                        ["defined lexer rule name"],
-                    ),
-                );
-            }
-        }
-        return Result::<(), ParseError>::Ok(());
     }
 
     fn skip_preamble_blocks(&mut self, virtual_tokens: &mut Array<String>) -> Result<(), ParseError> {
@@ -1114,7 +1019,8 @@ impl G4Parser {
                 options = self.parse_angle_options()?;
             }
             if is_lexer_rule_name(&name) || name == "EOF" {
-                self.pending_token_refs.push(PendingRef {
+                self.pending_refs.push(PendingRef {
+                    kind: RefKind::TokenRef,
                     containing_rule: self.current_rule,
                     referenced_name: name,
                     span: name_span,
@@ -1123,7 +1029,8 @@ impl G4Parser {
                     Element::TokenRef(TokenRefElement { name, options }),
                 );
             }
-            self.pending_parser_rule_refs.push(PendingRef {
+            self.pending_refs.push(PendingRef {
+                kind: RefKind::ParserRuleRef,
                 containing_rule: self.current_rule,
                 referenced_name: name,
                 span: name_span,
@@ -1470,7 +1377,8 @@ impl G4Parser {
             let tok = self.advance();
             let name = tok.text.to_string();
             let span = tok.span;
-            self.pending_lexer_rule_refs.push(PendingRef {
+            self.pending_refs.push(PendingRef {
+                kind: RefKind::LexerRuleRef,
                 containing_rule: self.current_rule,
                 referenced_name: name,
                 span,
@@ -1780,8 +1688,8 @@ fn parse_int_literal(text: &String) -> i32 {
 ///
 /// If you want the full ANTLR4-tool contract — including rejection of
 /// references to undefined rules / tokens — call `parse_checked`
-/// instead, or follow `parse` with `G4Parser::check_references` on the
-/// merged grammar.
+/// instead, or follow `parse` with `check_references` (from `ir.wado`)
+/// on the merged grammar.
 pub fn parse(input: String) -> Result<Grammar, ParseError> {
     let chars: Array<char> = input.chars().collect();
     let tokens = tokenize(input);
@@ -1790,8 +1698,8 @@ pub fn parse(input: String) -> Result<Grammar, ParseError> {
 }
 
 /// Parse + semantic rule-reference resolution, in one call. Equivalent
-/// to `parse` followed by `G4Parser::check_references`, and mirrors
-/// ANTLR4's full tool-level contract (`ANTLRParser.g` +
+/// to `parse` followed by `ir::check_references`, and mirrors ANTLR4's
+/// full tool-level contract (`ANTLRParser.g` +
 /// `SymbolChecks.checkForUnresolvedRuleRefs`).
 ///
 /// Rejects grammars that `parse` would accept but where a parser-rule
@@ -1811,10 +1719,7 @@ pub fn parse(input: String) -> Result<Grammar, ParseError> {
 /// rely on a sibling translation unit should still go through `parse`
 /// and call `check_references` after `merge_grammars`.
 pub fn parse_checked(input: String) -> Result<Grammar, ParseError> {
-    let chars: Array<char> = input.chars().collect();
-    let tokens = tokenize(input);
-    let mut parser = G4Parser::new(tokens, chars);
-    let grammar = parser.parse_grammar()?;
-    parser.check_references(&grammar)?;
+    let grammar = parse(input)?;
+    check_references(&grammar)?;
     return Result::<Grammar, ParseError>::Ok(grammar);
 }

--- a/package-gale/src/g4/parser.wado
+++ b/package-gale/src/g4/parser.wado
@@ -52,6 +52,40 @@ pub struct G4Parser {
     /// Grammar-level `@name { ... }` named actions collected from the
     /// prequel. Action bodies are discarded; only the name/scope is kept.
     named_actions: Array<NamedAction>,
+    /// Parser-rule references encountered while parsing parser rule bodies.
+    /// Collected with their source span so that the post-parse validator
+    /// can report undefined rule references with a usable diagnostic
+    /// location. Only populated for combined grammars where the full rule
+    /// table is known after parsing; for split grammars the entries are
+    /// discarded because cross-grammar refs cannot be resolved locally.
+    pending_parser_rule_refs: Array<PendingRef>,
+    /// Token references encountered while parsing parser rule bodies.
+    /// Validated against the combined lexer-rule table (including virtual
+    /// tokens and the built-in `EOF`) at the end of parsing.
+    pending_token_refs: Array<PendingRef>,
+    /// Lexer-rule references encountered while parsing lexer rule bodies
+    /// (including fragment refs). Validated against the lexer-rule table.
+    pending_lexer_rule_refs: Array<PendingRef>,
+    /// Name of the rule currently being parsed. Used to tag pending refs
+    /// so validator error messages can say where the bad reference came
+    /// from. Empty outside of a rule body.
+    current_rule: String,
+    /// Set to true by `parse_grammar` when the translation unit begins
+    /// with the `lexer grammar` prefix. Read by `check_references`
+    /// afterwards to decide which pending-ref buckets are validatable.
+    is_lexer_grammar: bool,
+    /// Set to true by `parse_grammar` when the translation unit begins
+    /// with the `parser grammar` prefix. See `is_lexer_grammar`.
+    is_parser_grammar: bool,
+}
+
+/// A single rule-reference occurrence captured during parse. The
+/// `containing_rule` field is used to produce a human-readable error
+/// message when the target is undefined.
+struct PendingRef {
+    containing_rule: String,
+    referenced_name: String,
+    span: Span,
 }
 
 /// Accumulator for lexer commands parsed from `-> cmd, cmd, ...`.
@@ -131,6 +165,12 @@ impl G4Parser {
             channels: [],
             options: [],
             named_actions: [],
+            pending_parser_rule_refs: [],
+            pending_token_refs: [],
+            pending_lexer_rule_refs: [],
+            current_rule: "",
+            is_lexer_grammar: false,
+            is_parser_grammar: false,
         };
     }
 
@@ -169,7 +209,9 @@ impl G4Parser {
     }
 
     pub fn parse_grammar(&mut self) -> Result<Grammar, ParseError> {
-        // Detect lexer/parser grammar prefix
+        // Detect lexer/parser grammar prefix. Persist on `self` so the
+        // post-parse semantic validator (`check_references`) can skip the
+        // buckets that span-grammar cross-references would leave dangling.
         let mut is_lexer_grammar = false;
         let mut is_parser_grammar = false;
         if self.is_kind(G4Token::Identifier) {
@@ -182,6 +224,8 @@ impl G4Parser {
                 self.advance();
             }
         }
+        self.is_lexer_grammar = is_lexer_grammar;
+        self.is_parser_grammar = is_parser_grammar;
 
         self.expect(G4Token::Grammar)?;
         let name_tok = self.expect(G4Token::Identifier)?;
@@ -311,6 +355,16 @@ impl G4Parser {
             }
         }
 
+        // Semantic rule-reference resolution runs as a separate phase
+        // (`check_references`), mirroring ANTLR4's split between the
+        // syntactic parser (`ANTLRParser.g`) and the semantic analyzer
+        // (`SymbolChecks.java`). Callers that want the full tool-level
+        // contract should invoke `parse_checked` (or call
+        // `check_references` themselves); the bare `parse_grammar` keeps
+        // the syntactic posture so minimal fixtures that defer token
+        // definitions (e.g. `tokenVocab` imports, split-grammar halves)
+        // can still round-trip through it.
+
         let channels = self.channels;
         let options = self.options;
         let named_actions = self.named_actions;
@@ -327,6 +381,93 @@ impl G4Parser {
                 source_files,
             },
         );
+    }
+
+    /// Post-parse semantic validation: every rule reference encountered
+    /// during parsing must resolve to a rule definition that is visible in
+    /// the same translation unit. Mirrors ANTLR4's
+    /// `SymbolChecks.checkForUnresolvedRuleRefs` — the syntactic parser
+    /// accepts the reference, and this separate pass rejects it if the
+    /// target is not defined.
+    ///
+    /// Split-grammar caveats (read off the `lexer grammar` /
+    /// `parser grammar` prefix that `parse_grammar` latched onto `self`):
+    ///   - combined grammar (`grammar X;`): check parser refs, token
+    ///     refs, and lexer-to-lexer refs.
+    ///   - `lexer grammar X;`: only lexer-to-lexer refs can be resolved
+    ///     locally; parser refs / token refs don't exist here.
+    ///   - `parser grammar X;`: only parser-rule refs can be resolved
+    ///     locally; token refs come from the matching lexer grammar at
+    ///     merge time.
+    pub fn check_references(&self, grammar: &Grammar) -> Result<(), ParseError> {
+        if !self.is_lexer_grammar {
+            for let r of &self.pending_parser_rule_refs {
+                let mut found = false;
+                for let pr of &grammar.parser_rules {
+                    if pr.name == r.referenced_name {
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    return Result::<(), ParseError>::Err(
+                        ParseError::new(
+                            `reference to undefined rule "{r.referenced_name}" in "{r.containing_rule}"`,
+                            r.span,
+                            ["defined rule name"],
+                        ),
+                    );
+                }
+            }
+        }
+        // Token refs: lexer_rules includes virtual tokens from
+        // `tokens { }` blocks plus the built-in `EOF`. A parser-only
+        // grammar has no local lexer table, so skip.
+        if !self.is_parser_grammar {
+            for let r of &self.pending_token_refs {
+                if r.referenced_name == "EOF" {
+                    continue;
+                }
+                let mut found = false;
+                for let lr of &grammar.lexer_rules {
+                    if lr.name == r.referenced_name {
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    return Result::<(), ParseError>::Err(
+                        ParseError::new(
+                            `reference to undefined token "{r.referenced_name}" in "{r.containing_rule}"`,
+                            r.span,
+                            ["defined token name"],
+                        ),
+                    );
+                }
+            }
+        }
+        // Lexer-to-lexer refs (including fragment refs): always
+        // resolvable locally — a `parser grammar` never contains lexer
+        // rules.
+        for let r of &self.pending_lexer_rule_refs {
+            let mut found = false;
+            for let lr of &grammar.lexer_rules {
+                if lr.name == r.referenced_name {
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                return Result::<(), ParseError>::Err(
+                    ParseError::new(
+                        `reference to undefined lexer rule "{r.referenced_name}" in "{r.containing_rule}"`,
+                        r.span,
+                        ["defined lexer rule name"],
+                    ),
+                );
+            }
+        }
+        return Result::<(), ParseError>::Ok(());
     }
 
     fn skip_preamble_blocks(&mut self, virtual_tokens: &mut Array<String>) -> Result<(), ParseError> {
@@ -696,10 +837,10 @@ impl G4Parser {
     /// placeholders round-trip through the same code path as `options { ... }`.
     /// Malformed entries are tolerated (best-effort resync to the closing `>`)
     /// to match the rest of the parser's recovery posture.
-    fn parse_angle_options(&mut self) -> Array<GrammarOption> {
+    fn parse_angle_options(&mut self) -> Result<Array<GrammarOption>, ParseError> {
         let mut out: Array<GrammarOption> = [];
         if !self.is_kind(G4Token::LAngle) {
-            return out;
+            return Result::<Array<GrammarOption>, ParseError>::Ok(out);
         }
         self.advance();
         let mut depth = 1;
@@ -718,7 +859,9 @@ impl G4Parser {
                 self.advance();
                 continue;
             }
-            let name = self.peek().text.to_string();
+            let name_tok = self.peek();
+            let name = name_tok.text.to_string();
+            let name_span = name_tok.span;
             self.advance();
             if !self.is_kind(G4Token::Assign) {
                 while !self.at_eof()
@@ -732,19 +875,47 @@ impl G4Parser {
                 continue;
             }
             self.advance();
+            let value_span = self.peek().span;
             let value = self.parse_option_value();
+            // ANTLR4 options spec (`vendor/antlr4/doc/options.md`): `assoc`
+            // is an alt-prefix / token option whose only accepted values are
+            // the bare identifiers `left` and `right`. Anything else (a
+            // different identifier, a string, an integer, or an action
+            // block) is a left-recursion / associativity conflict and must
+            // be rejected at parse time — otherwise downstream LR codegen
+            // silently falls back to left-associative.
+            if name == "assoc" {
+                let mut valid = false;
+                if let Ident(v) = &value {
+                    if *v == "left" || *v == "right" {
+                        valid = true;
+                    }
+                }
+                if !valid {
+                    return Result::<Array<GrammarOption>, ParseError>::Err(
+                        ParseError::new(
+                            `invalid <assoc=...> value: only "left" or "right" are accepted`,
+                            value_span,
+                            ["left", "right"],
+                        ),
+                    );
+                }
+            }
+            let _ = name_span;
             out.push(GrammarOption { name, value });
             if self.is_kind(G4Token::Comma) {
                 self.advance();
             }
         }
-        return out;
+        return Result::<Array<GrammarOption>, ParseError>::Ok(out);
     }
 
     fn parse_parser_rule(&mut self, name: String) -> Result<ParserRule, ParseError> {
         let options = self.skip_rule_prequel();
         self.expect(G4Token::Colon)?;
+        self.current_rule = name;
         let alternatives = self.parse_alternatives()?;
+        self.current_rule = "";
         self.expect(G4Token::Semicolon)?;
         return Result::<ParserRule, ParseError>::Ok(ParserRule {
             name,
@@ -894,7 +1065,7 @@ impl G4Parser {
             // that `parse_atom` already consumed, so it is safe to treat every
             // in-alt angle block at this position as alt-prefix.
             if self.is_kind(G4Token::LAngle) && elements.is_empty() {
-                let mut opts = self.parse_angle_options();
+                let mut opts = self.parse_angle_options()?;
                 for let o of opts {
                     options.push(o);
                 }
@@ -923,6 +1094,7 @@ impl G4Parser {
         if self.is_kind(G4Token::Identifier) {
             let tok = self.advance();
             let name = tok.text.to_string();
+            let name_span = tok.span;
             if self.is_kind(G4Token::Assign) || self.is_kind(G4Token::PlusAssign) {
                 let list = self.is_kind(G4Token::PlusAssign);
                 self.advance();
@@ -939,13 +1111,23 @@ impl G4Parser {
             // Optional element options: `ID<assoc=right>`.
             let mut options: Array<GrammarOption> = [];
             if self.is_kind(G4Token::LAngle) {
-                options = self.parse_angle_options();
+                options = self.parse_angle_options()?;
             }
             if is_lexer_rule_name(&name) || name == "EOF" {
+                self.pending_token_refs.push(PendingRef {
+                    containing_rule: self.current_rule,
+                    referenced_name: name,
+                    span: name_span,
+                });
                 return Result::<Element, ParseError>::Ok(
                     Element::TokenRef(TokenRefElement { name, options }),
                 );
             }
+            self.pending_parser_rule_refs.push(PendingRef {
+                containing_rule: self.current_rule,
+                referenced_name: name,
+                span: name_span,
+            });
             return Result::<Element, ParseError>::Ok(
                 Element::RuleRef(RuleRefElement { name, options }),
             );
@@ -956,7 +1138,7 @@ impl G4Parser {
             // Optional element options: `'foo'<p=3>`.
             let mut options: Array<GrammarOption> = [];
             if self.is_kind(G4Token::LAngle) {
-                options = self.parse_angle_options();
+                options = self.parse_angle_options()?;
             }
             return Result::<Element, ParseError>::Ok(
                 Element::Literal(LiteralElement { text, options }),
@@ -982,7 +1164,7 @@ impl G4Parser {
             // Optional element options on wildcard: `.<...>`
             let mut options: Array<GrammarOption> = [];
             if self.is_kind(G4Token::LAngle) {
-                options = self.parse_angle_options();
+                options = self.parse_angle_options()?;
             }
             return Result::<Element, ParseError>::Ok(
                 Element::Wildcard(WildcardElement { options }),
@@ -1085,7 +1267,9 @@ impl G4Parser {
         // most commonly `locals [int n]`).
         let options = self.skip_rule_prequel();
         self.expect(G4Token::Colon)?;
+        self.current_rule = name;
         let body = self.parse_lexer_alternatives()?;
+        self.current_rule = "";
 
         let mut actions = LexerActions::empty();
         if self.is_kind(G4Token::Arrow) {
@@ -1284,7 +1468,14 @@ impl G4Parser {
         }
         if self.is_kind(G4Token::Identifier) {
             let tok = self.advance();
-            return Result::<LexerElement, ParseError>::Ok(LexerElement::RuleRef(tok.text.to_string()));
+            let name = tok.text.to_string();
+            let span = tok.span;
+            self.pending_lexer_rule_refs.push(PendingRef {
+                containing_rule: self.current_rule,
+                referenced_name: name,
+                span,
+            });
+            return Result::<LexerElement, ParseError>::Ok(LexerElement::RuleRef(name));
         }
         if self.is_kind(G4Token::LParen) {
             self.advance();
@@ -1571,4 +1762,22 @@ pub fn parse(input: String) -> Result<Grammar, ParseError> {
     let tokens = tokenize(input);
     let mut parser = G4Parser::new(tokens, chars);
     return parser.parse_grammar();
+}
+
+/// Parse and run the semantic rule-reference checks (ANTLR4
+/// `SymbolChecks.checkForUnresolvedRuleRefs` equivalent). Prefer this
+/// over bare `parse` when the input is expected to be a complete
+/// grammar translation unit — i.e. a combined grammar, a `lexer grammar`
+/// with self-contained lexer refs, or a `parser grammar` whose parser
+/// refs resolve against its own rule table. Split-grammar halves that
+/// rely on a sibling translation unit (e.g. a parser grammar using
+/// tokens defined in its matching lexer grammar) should still go
+/// through `parse` and be validated after `merge_grammars`.
+pub fn parse_checked(input: String) -> Result<Grammar, ParseError> {
+    let chars: Array<char> = input.chars().collect();
+    let tokens = tokenize(input);
+    let mut parser = G4Parser::new(tokens, chars);
+    let grammar = parser.parse_grammar()?;
+    parser.check_references(&grammar)?;
+    return Result::<Grammar, ParseError>::Ok(grammar);
 }

--- a/package-gale/src/g4/parser_test.wado
+++ b/package-gale/src/g4/parser_test.wado
@@ -16,7 +16,7 @@ use {
     CharRange,
     Visibility,
 } from "../ir.wado";
-use { parse } from "./parser.wado";
+use { parse, parse_checked } from "./parser.wado";
 
 test "minimal grammar" {
     let g = parse("grammar Foo;").unwrap();
@@ -1355,6 +1355,159 @@ r : A<foo=> ;";
     let g = parse(input).unwrap();
     assert g.parser_rules.len() == 1;
     assert g.parser_rules[0].alternatives.len() == 1;
+}
+
+test "parse_checked rejects undefined parser rule reference" {
+    // ANTLR4 SymbolChecks.checkForUnresolvedRuleRefs: every rule reference
+    // must resolve to a defined rule in the same translation unit
+    // (combined grammar case). `undef_rule` is never declared, so the
+    // semantic pass must reject the grammar.
+    let input = "grammar Test;
+root : undef_rule ;
+ID : [a-z]+ ;";
+    let result = parse_checked(input);
+    assert result matches { Err(_) },
+        "expected undefined parser rule reference to be rejected";
+}
+
+test "parse_checked rejects undefined token reference" {
+    // Combined grammar: `UNDEFINED_TOK` has no lexer rule and no `tokens {}`
+    // entry, so the reference is unresolvable.
+    let input = "grammar Test;
+root : UNDEFINED_TOK ;
+ID : [a-z]+ ;";
+    let result = parse_checked(input);
+    assert result matches { Err(_) },
+        "expected undefined token reference to be rejected";
+}
+
+test "parse_checked rejects undefined lexer rule reference in lexer grammar" {
+    // Lexer-to-lexer refs are always resolvable locally — lexer rules
+    // cannot cross the lexer/parser grammar boundary, so an unresolved
+    // ref here is always an error.
+    let input = "lexer grammar Test;
+FOO : BAR ;";
+    let result = parse_checked(input);
+    assert result matches { Err(_) },
+        "expected undefined lexer rule reference to be rejected";
+}
+
+test "parse_checked rejects undefined fragment reference" {
+    let input = "lexer grammar Test;
+ID : LETTER+ ;
+LETTER : [a-z] ;
+// MISSING is not defined as a fragment or lexer rule
+FOO : MISSING ;";
+    let result = parse_checked(input);
+    assert result matches { Err(_) },
+        "expected undefined fragment reference to be rejected";
+}
+
+test "parse_checked accepts virtual tokens declared in tokens block" {
+    // `tokens { VT }` declares a virtual token that satisfies token-ref
+    // resolution even though there is no matching lexer rule. See
+    // ANTLR4 grammars.md §"tokens {} Section".
+    let input = "grammar Test;
+tokens { VT }
+root : VT ;
+ID : [a-z]+ ;";
+    let result = parse_checked(input);
+    assert result matches { Ok(_) },
+        "expected grammar with tokens-block-declared ref to be accepted";
+}
+
+test "parse_checked accepts EOF token reference" {
+    // `EOF` is a built-in token ref that doesn't require a matching
+    // lexer rule. See ANTLR4 parser-rules.md.
+    let input = "grammar Test;
+root : ID EOF ;
+ID : [a-z]+ ;";
+    let result = parse_checked(input);
+    assert result matches { Ok(_) },
+        "expected grammar ending in EOF to be accepted";
+}
+
+test "parse_checked accepts parser grammar with only parser-rule refs" {
+    // `parser grammar` files reference tokens from a sibling lexer
+    // grammar — we cannot resolve those locally, so `check_references`
+    // must skip the token-ref bucket. Parser-rule refs within the
+    // grammar are still validated.
+    let input = "parser grammar Test;
+root : expr ;
+expr : ID PLUS ID ;";
+    let result = parse_checked(input);
+    assert result matches { Ok(_) },
+        "expected parser grammar with local parser refs to be accepted";
+}
+
+test "parse_checked rejects undefined parser rule ref in parser grammar" {
+    // Parser-to-parser refs within a `parser grammar` are locally
+    // resolvable and must still be checked.
+    let input = "parser grammar Test;
+root : missing_rule ;";
+    let result = parse_checked(input);
+    assert result matches { Err(_) },
+        "expected undefined parser rule in parser grammar to be rejected";
+}
+
+test "bare parse does not run reference checks" {
+    // `parse` keeps the syntactic-only posture (ANTLRParser.g equivalent)
+    // so upstream consumers can still round-trip partial or minimal
+    // grammars that defer symbol resolution. Semantic checks run only
+    // via `parse_checked` / `check_references`.
+    let input = "grammar Test;
+r : undefined ;";
+    let result = parse(input);
+    assert result matches { Ok(_) },
+        "bare parse must accept syntactically-well-formed grammars with undefined refs";
+}
+
+test "parse rejects <assoc> with non-left/right identifier" {
+    // ANTLR4 options.md: `assoc` accepts only the bare identifiers
+    // `left` and `right`. Anything else is an associativity conflict
+    // that must be rejected at parse time; downstream LR codegen
+    // otherwise silently falls back to left-associative and produces
+    // the wrong precedence tree.
+    let input = "grammar Test;
+expr : <assoc=middle> expr '**' expr | INT ;
+INT : [0-9]+ ;";
+    let result = parse(input);
+    assert result matches { Err(_) },
+        "expected <assoc=middle> to be rejected";
+}
+
+test "parse rejects <assoc> with string value" {
+    let input = "grammar Test;
+expr : <assoc='right'> expr '**' expr | INT ;
+INT : [0-9]+ ;";
+    let result = parse(input);
+    assert result matches { Err(_) },
+        "expected <assoc='right'> (string value) to be rejected";
+}
+
+test "parse rejects <assoc> with integer value" {
+    let input = "grammar Test;
+expr : <assoc=1> expr '**' expr | INT ;
+INT : [0-9]+ ;";
+    let result = parse(input);
+    assert result matches { Err(_) },
+        "expected <assoc=1> to be rejected";
+}
+
+test "parse accepts <assoc=left>" {
+    let input = "grammar Test;
+expr : <assoc=left> expr '+' expr | INT ;
+INT : [0-9]+ ;";
+    let g = parse(input).unwrap();
+    assert g.parser_rules.len() == 1;
+}
+
+test "parse accepts <assoc=right>" {
+    let input = "grammar Test;
+expr : <assoc=right> expr '**' expr | INT ;
+INT : [0-9]+ ;";
+    let g = parse(input).unwrap();
+    assert g.parser_rules.len() == 1;
 }
 
 fn assert_option_ident(opt: &GrammarOption, expected: String) {

--- a/package-gale/src/g4/parser_test.wado
+++ b/package-gale/src/g4/parser_test.wado
@@ -964,6 +964,110 @@ expr : ID ;";
     assert result matches { Err(_) }, "expected mode in parser grammar to be rejected";
 }
 
+test "tilde applied to rule reference is rejected" {
+    // ANTLR4 spec: `notSet : NOT setElement | NOT blockSet` where setElement is
+    // TOKEN_REF / STRING_LITERAL (/ charSet / LEXER_CHAR_SET in lexer rules).
+    // A rule reference is not a set element, so `~ruleref` must be rejected.
+    // Spec: vendor/antlr4/tool/src/org/antlr/v4/parse/ANTLRParser.g (notSet).
+    let input = "grammar Test;
+a : ~b ;
+b : 'x' ;";
+    let result = parse(input);
+    assert result matches { Err(_) }, "expected ~ruleref to be rejected";
+}
+
+test "tilde applied to wildcard is rejected" {
+    // `.` is not a set element either — rejecting `~.` matches ANTLR4.
+    let input = "grammar Test;
+a : ~. ;";
+    let result = parse(input);
+    assert result matches { Err(_) }, "expected ~. to be rejected";
+}
+
+test "tilde applied to block containing rule ref is rejected" {
+    // Block-sets must contain only TOKEN_REF / STRING_LITERAL alternatives.
+    let input = "grammar Test;
+a : ~( 'x' | b ) ;
+b : 'y' ;";
+    let result = parse(input);
+    assert result matches { Err(_) }, "expected ~(block with rule ref) to be rejected";
+}
+
+test "unknown lexer command is rejected" {
+    // ANTLR4's lexer-command set is fixed: skip, more, channel, type, pushMode,
+    // popMode, mode. Any other identifier after `->` is a hard error.
+    // Spec: vendor/antlr4/doc/lexer-rules.md §"Lexer Commands".
+    let input = "lexer grammar Test;
+FOO : 'x' -> totallymadeup ;";
+    let result = parse(input);
+    assert result matches { Err(_) }, "expected unknown lexer command to be rejected";
+}
+
+test "unknown lexer command in combined grammar is rejected" {
+    let input = "grammar Test;
+r : X ;
+X : 'x' -> bogusCommand ;";
+    let result = parse(input);
+    assert result matches { Err(_) }, "expected unknown lexer command in combined grammar to be rejected";
+}
+
+test "duplicate parser rule names are rejected" {
+    // ANTLR4 requires each rule name to be unique within its namespace.
+    // Spec: vendor/antlr4/doc/grammars.md.
+    let input = "grammar Test;
+foo : ID ;
+foo : NUM ;";
+    let result = parse(input);
+    assert result matches { Err(_) }, "expected duplicate parser rule to be rejected";
+}
+
+test "duplicate lexer rule names are rejected" {
+    let input = "lexer grammar Test;
+FOO : 'a' ;
+FOO : 'b' ;";
+    let result = parse(input);
+    assert result matches { Err(_) }, "expected duplicate lexer rule to be rejected";
+}
+
+test "duplicate rules across lexer and parser namespaces are allowed" {
+    // Parser rules (lowercase) and lexer rules (uppercase) occupy separate
+    // namespaces — a parser `foo` and a lexer `FOO` never collide.
+    let input = "grammar Test;
+foo : FOO ;
+FOO : 'x' ;";
+    let g = parse(input).unwrap();
+    assert g.parser_rules.len() == 1;
+    assert g.lexer_rules.len() == 1;
+}
+
+test "unterminated tokens block is rejected" {
+    // ANTLR4 spec (grammars.md §"tokens {} Section"): the block must be
+    // closed with `}`. A file that runs out of input before that is malformed.
+    let input = "grammar Test;
+tokens { FOO, BAR
+";
+    let result = parse(input);
+    assert result matches { Err(_) }, "expected unterminated tokens block to be rejected";
+}
+
+test "unterminated channels block is rejected" {
+    let input = "lexer grammar Test;
+channels { FOO, BAR
+";
+    let result = parse(input);
+    assert result matches { Err(_) }, "expected unterminated channels block to be rejected";
+}
+
+test "tokens block trailing junk is tolerated then closed" {
+    // Permissive recovery: non-identifier junk inside `tokens { }` is
+    // silently skipped (existing behavior) as long as the block is closed.
+    let input = "grammar Test;
+tokens { FOO, 42, BAR }
+r : FOO ;";
+    let g = parse(input).unwrap();
+    assert g.parser_rules.len() == 1;
+}
+
 test "parser rule tilde applied to block" {
     // ANTLR4 allows `~` on a set expressed as a block of alternatives, not
     // just a single token reference: `~( 'a' | 'b' | 'c' )`.

--- a/package-gale/src/generator_test.wado
+++ b/package-gale/src/generator_test.wado
@@ -1,5 +1,6 @@
 use {
     Grammar,
+    GrammarKind,
     GrammarOption,
     OptionValue,
     NamedAction,
@@ -29,12 +30,14 @@ global DEFAULT_OPTIONS: GenerateOptions = GenerateOptions { highlight: false };
 test "generate header" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -50,12 +53,14 @@ test "generate header" {
 test "generate header with multiple source files" {
     let grammar = Grammar {
         name: "Html",
+        kind: GrammarKind::Combined,
         parser_rules: [],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: ["HtmlLexer.g4", "HtmlParser.g4"],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -68,6 +73,7 @@ test "generate header with multiple source files" {
 test "generate token kind" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [],
         lexer_rules: [
             LexerRule::new("NUMBER", false, false, []),
@@ -78,6 +84,7 @@ test "generate token kind" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -92,6 +99,7 @@ test "generate token kind" {
 test "generate single-alt struct" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [
             ParserRule {
                 name: "json",
@@ -111,6 +119,7 @@ test "generate single-alt struct" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -123,6 +132,7 @@ test "generate single-alt struct" {
 test "generate multi-alt variant with labels" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [
             ParserRule {
                 name: "expr",
@@ -147,6 +157,7 @@ test "generate multi-alt variant with labels" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -163,6 +174,7 @@ test "generate multi-alt variant with labels" {
 test "generate multi-alt variant without labels" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [
             ParserRule {
                 name: "item",
@@ -187,6 +199,7 @@ test "generate multi-alt variant without labels" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -200,6 +213,7 @@ test "generate multi-alt variant without labels" {
 test "generate repeat fields" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [
             ParserRule {
                 name: "list",
@@ -230,6 +244,7 @@ test "generate repeat fields" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -240,6 +255,7 @@ test "generate repeat fields" {
 test "generate duplicate field names" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [
             ParserRule {
                 name: "pair",
@@ -259,6 +275,7 @@ test "generate duplicate field names" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -269,6 +286,7 @@ test "generate duplicate field names" {
 test "generate group variant type for repeated group" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [
             ParserRule {
                 name: "parse",
@@ -298,6 +316,7 @@ test "generate group variant type for repeated group" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -310,6 +329,7 @@ test "generate group variant type for repeated group" {
 test "generate wildcard element" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [
             ParserRule {
                 name: "any",
@@ -329,6 +349,7 @@ test "generate wildcard element" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -340,6 +361,7 @@ test "generate wildcard element" {
 test "generate parser not element" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [
             ParserRule {
                 name: "except_comma",
@@ -362,6 +384,7 @@ test "generate parser not element" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -373,6 +396,7 @@ test "generate parser not element" {
 test "generate list label field" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [
             ParserRule {
                 name: "list",
@@ -403,6 +427,7 @@ test "generate list label field" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -412,6 +437,7 @@ test "generate list label field" {
 test "generate standalone group as optional field" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [
             ParserRule {
                 name: "cmd",
@@ -437,6 +463,7 @@ test "generate standalone group as optional field" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -449,6 +476,7 @@ test "generate standalone group as optional field" {
 test "generate lexer set_mode" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [],
         lexer_rules: [
             LexerRule {
@@ -488,6 +516,7 @@ test "generate lexer set_mode" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -499,6 +528,7 @@ test "generate lexer set_mode" {
 test "generate lexer more" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [],
         lexer_rules: [
             LexerRule {
@@ -522,6 +552,7 @@ test "generate lexer more" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -533,6 +564,7 @@ test "generate lexer more" {
 test "generate lexer type_override" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [],
         lexer_rules: [
             LexerRule {
@@ -572,6 +604,7 @@ test "generate lexer type_override" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -585,6 +618,7 @@ test "generate lexer type_override" {
 test "generate lexer channel" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [],
         lexer_rules: [
             LexerRule {
@@ -608,6 +642,7 @@ test "generate lexer channel" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -864,6 +899,7 @@ SEMI : ';' ;";
 test "metadata comment lists grammar-level options" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
@@ -875,6 +911,7 @@ test "metadata comment lists grammar-level options" {
             GrammarOption { name: "caseInsensitive", value: OptionValue::Ident("true") },
         ],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -893,6 +930,7 @@ test "metadata comment lists grammar-level options" {
 test "metadata comment formats string and int option values" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
@@ -903,6 +941,7 @@ test "metadata comment formats string and int option values" {
             GrammarOption { name: "init", value: OptionValue::Action("some code;") },
         ],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -917,6 +956,7 @@ test "metadata comment formats string and int option values" {
 test "metadata comment lists named actions" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
@@ -927,6 +967,7 @@ test "metadata comment lists named actions" {
             NamedAction { scope: Option::<String>::Some("parser"), name: "members" },
             NamedAction { scope: Option::<String>::Some("lexer"), name: "members" },
         ],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -943,12 +984,14 @@ test "metadata comment lists named actions" {
 test "metadata block omitted when no options and no named actions" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -959,6 +1002,7 @@ test "metadata block omitted when no options and no named actions" {
 test "visibility comment emitted on non-default parser rule" {
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [
             ParserRule {
                 name: "expr",
@@ -990,6 +1034,7 @@ test "visibility comment emitted on non-default parser rule" {
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);
@@ -1005,12 +1050,14 @@ test "visibility comment emitted on non-default lexer rule" {
     id_rule.visibility = Visibility::Protected;
     let grammar = Grammar {
         name: "Test",
+        kind: GrammarKind::Combined,
         parser_rules: [],
         lexer_rules: [id_rule],
         mode_names: ["DEFAULT_MODE"],
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     let output = generate(&grammar, &DEFAULT_OPTIONS);

--- a/package-gale/src/generator_test.wado
+++ b/package-gale/src/generator_test.wado
@@ -367,7 +367,7 @@ test "generate parser not element" {
     let output = generate(&grammar, &DEFAULT_OPTIONS);
     assert str_contains(&output, "pub struct ExceptCommaNode {");
     assert str_contains(&output, "    pub not_comma: Token,");
-    assert str_contains(&output, "let not_comma = p.match_not(&[TK_COMMA])?;");
+    assert str_contains(&output, "let not_comma = p.match_not([TK_COMMA])?;");
 }
 
 test "generate list label field" {

--- a/package-gale/src/ir.wado
+++ b/package-gale/src/ir.wado
@@ -1,3 +1,5 @@
+use { Span, ParseError } from "./runtime.wado";
+
 /// OptionValue is the typed right-hand side of an ANTLR4 `key = value` option
 /// entry. ANTLR4 options can be a bare identifier, a dotted qualified name,
 /// a single-quoted string literal, a decimal integer, or an action-block
@@ -41,9 +43,67 @@ pub struct NamedAction {
     pub name: String,
 }
 
+/// GrammarKind records which of ANTLR4's three grammar-header forms the
+/// source used. ANTLR4 spec: `vendor/antlr4/doc/grammars.md`.
+///
+/// The kind gates semantic validation: a bare `parser grammar` cannot
+/// resolve token references locally because the lexer rules live in a
+/// sibling `lexer grammar`, and those refs stay unresolved until
+/// `merge_grammars` combines the two halves. `merge_grammars` always
+/// produces `Combined` since a merged grammar has (or is intended to
+/// have) both sides.
+pub variant GrammarKind {
+    /// `grammar Foo;` — combined grammar (parser + lexer in one file),
+    /// or a grammar produced by `merge_grammars`.
+    Combined,
+    /// `lexer grammar Foo;` — lexer-only translation unit.
+    Lexer,
+    /// `parser grammar Foo;` — parser-only translation unit; token refs
+    /// come from a sibling lexer grammar and are unresolvable until merge.
+    Parser,
+}
+
+/// RefKind distinguishes the three flavors of pending (unresolved)
+/// reference that `parse()` collects. The kind selects which rule table
+/// `check_references` resolves against. See the variants for details.
+pub variant RefKind {
+    /// Reference to another parser rule from inside a parser-rule body.
+    /// Resolves against `Grammar.parser_rules`.
+    ParserRuleRef,
+    /// Reference to a token from inside a parser-rule body (or an
+    /// element like `TOK` in an alternative). Resolves against
+    /// `Grammar.lexer_rules` (which includes virtual tokens from
+    /// `tokens { }` blocks) plus the built-in `EOF` sentinel.
+    TokenRef,
+    /// Reference to another lexer rule (including fragment refs) from
+    /// inside a lexer-rule body. Resolves against `Grammar.lexer_rules`.
+    LexerRuleRef,
+}
+
+/// PendingRef is a single rule-reference occurrence captured during
+/// parse. Each ref is validated by `check_references` against the
+/// grammar's own rule tables — possibly after `merge_grammars` has
+/// combined split-grammar halves, which is why the validator runs as a
+/// separate pass rather than inline during parse.
+pub struct PendingRef {
+    pub kind: RefKind,
+    /// Name of the rule in whose body this reference appeared. Used in
+    /// the diagnostic message so the error report points to the caller,
+    /// not just the missing name.
+    pub containing_rule: String,
+    /// Text of the referenced symbol (what we're trying to resolve).
+    pub referenced_name: String,
+    /// Source span of the reference occurrence, for diagnostics. Span
+    /// positions are relative to the `.g4` file that was parsed; after
+    /// `merge_grammars`, spans from different files coexist but each
+    /// still points into its original source.
+    pub span: Span,
+}
+
 /// Grammar is the top-level IR representing a parsed .g4 file.
 pub struct Grammar {
     pub name: String,
+    pub kind: GrammarKind,
     pub parser_rules: Array<ParserRule>,
     pub lexer_rules: Array<LexerRule>,
     pub mode_names: Array<String>,
@@ -57,11 +117,106 @@ pub struct Grammar {
     /// Grammar-level `@name { ... }` / `@scope::name { ... }` actions,
     /// in declaration order. Action bodies themselves are discarded.
     pub named_actions: Array<NamedAction>,
+    /// Rule / token references encountered during parse that have not
+    /// yet been resolved against a rule table. `check_references`
+    /// walks these and reports undefined refs. Populated by `parse()`;
+    /// concatenated by `merge_grammars` so that a merged Grammar can be
+    /// validated in one pass.
+    pub pending_refs: Array<PendingRef>,
     /// Source `.g4` paths that contributed to this grammar, in the order
     /// they were supplied on the command line. Populated by `cmd_gen` after
     /// parsing — `parse()` itself returns an empty array because it operates
     /// on the file contents, not the path.
     pub source_files: Array<String>,
+}
+
+/// Resolve every reference in `grammar.pending_refs` against
+/// `grammar.parser_rules` / `grammar.lexer_rules`. Returns `Err` on the
+/// first unresolved reference. Mirrors ANTLR4's
+/// `SymbolChecks.checkForUnresolvedRuleRefs`.
+///
+/// The grammar's `kind` gates what can be checked:
+///   - `Combined`: every pending ref is resolvable locally. This is the
+///     post-merge case and the combined-grammar case.
+///   - `Lexer`: only lexer-to-lexer refs exist (no parser bodies in a
+///     `lexer grammar`); token refs and parser refs are vacuously absent.
+///   - `Parser`: parser-rule refs are checked locally; token refs are
+///     skipped because the sibling lexer grammar hasn't been merged yet.
+pub fn check_references(grammar: &Grammar) -> Result<(), ParseError> {
+    for let r of &grammar.pending_refs {
+        match &r.kind {
+            ParserRuleRef => {
+                if grammar.kind matches { Lexer } {
+                    continue;
+                }
+                let mut found = false;
+                for let pr of &grammar.parser_rules {
+                    if pr.name == r.referenced_name {
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    return Result::<(), ParseError>::Err(
+                        ParseError::new(
+                            `reference to undefined rule "{r.referenced_name}" in "{r.containing_rule}"`,
+                            r.span,
+                            ["defined rule name"],
+                        ),
+                    );
+                }
+            },
+            TokenRef => {
+                // A `parser grammar` cannot resolve token refs until
+                // merged with its sibling lexer grammar.
+                if grammar.kind matches { Parser } {
+                    continue;
+                }
+                // `EOF` is a built-in token recognized without a lexer rule.
+                if r.referenced_name == "EOF" {
+                    continue;
+                }
+                let mut found = false;
+                for let lr of &grammar.lexer_rules {
+                    if lr.name == r.referenced_name {
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    return Result::<(), ParseError>::Err(
+                        ParseError::new(
+                            `reference to undefined token "{r.referenced_name}" in "{r.containing_rule}"`,
+                            r.span,
+                            ["defined token name"],
+                        ),
+                    );
+                }
+            },
+            LexerRuleRef => {
+                // Lexer-to-lexer refs (including fragment refs) are
+                // always resolvable locally — lexer rules cannot cross
+                // the lexer/parser grammar boundary.
+                let mut found = false;
+                for let lr of &grammar.lexer_rules {
+                    if lr.name == r.referenced_name {
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    return Result::<(), ParseError>::Err(
+                        ParseError::new(
+                            `reference to undefined lexer rule "{r.referenced_name}" in "{r.containing_rule}"`,
+                            r.span,
+                            ["defined lexer rule name"],
+                        ),
+                    );
+                }
+            },
+        }
+    }
+    return Result::<(), ParseError>::Ok(());
 }
 
 pub global DEFAULT_MODE: i32 = 0;
@@ -341,11 +496,18 @@ pub fn merge_grammars(grammars: Array<Grammar>) -> Grammar {
     let mut channels: Array<String> = [];
     let mut options: Array<GrammarOption> = [];
     let mut named_actions: Array<NamedAction> = [];
+    let mut pending_refs: Array<PendingRef> = [];
     let mut source_files: Array<String> = [];
     for let g of grammars {
         // Concatenate source paths so every input contributes a provenance entry.
         for let sf of &g.source_files {
             source_files.push(*sf);
+        }
+        // Concatenate pending refs from every split so `check_references`
+        // can resolve cross-file references (token refs in a parser grammar
+        // resolve against lexer rules from its sibling lexer grammar).
+        for let pr of &g.pending_refs {
+            pending_refs.push(*pr);
         }
         // Preserve grammar-level options from every split. Later splits
         // override earlier ones on collision — ANTLR4 leaves conflict
@@ -436,12 +598,14 @@ pub fn merge_grammars(grammars: Array<Grammar>) -> Grammar {
     }
     return Grammar {
         name,
+        kind: GrammarKind::Combined,
         parser_rules,
         lexer_rules,
         mode_names,
         channels,
         options,
         named_actions,
+        pending_refs,
         source_files,
     };
 }

--- a/package-gale/src/ir_test.wado
+++ b/package-gale/src/ir_test.wado
@@ -1,5 +1,6 @@
 use {
     Grammar,
+    GrammarKind,
     ParserRule,
     Alternative,
     Element,
@@ -17,12 +18,14 @@ use {
 test "Grammar construction" {
     let g = Grammar {
         name: "JSON",
+        kind: GrammarKind::Combined,
         parser_rules: [],
         lexer_rules: [],
         mode_names: ["DEFAULT_MODE"],
         channels: [],
         options: [],
         named_actions: [],
+        pending_refs: [],
         source_files: [],
     };
     assert g.name == "JSON";

--- a/package-gale/src/main.wado
+++ b/package-gale/src/main.wado
@@ -1,7 +1,7 @@
 use { args, print, eprintln, Stdout, Stderr, Environment } from "core:cli";
 use { Preopens, Descriptor, Filesize, PathFlags, OpenFlags, DescriptorFlags } from "wasi:filesystem";
 use { parse } from "./g4/parser.wado";
-use { Grammar, merge_grammars } from "./ir.wado";
+use { Grammar, merge_grammars, check_references } from "./ir.wado";
 use { generate, GenerateOptions } from "./generator.wado";
 
 export fn run() with Stdout, Stderr, Environment, Preopens {
@@ -89,6 +89,15 @@ fn cmd_gen(paths: Array<String>, options: &GenerateOptions) with Stdout, Stderr,
     }
 
     let merged = merge_grammars(grammars);
+    // Run ANTLR4-compatible semantic rule-reference validation after the
+    // split-grammar halves are combined. This is the same check ANTLR4's
+    // `SymbolChecks.checkForUnresolvedRuleRefs` performs; we defer it
+    // until post-merge so cross-grammar refs (parser-grammar token refs
+    // resolving against a sibling lexer grammar) validate cleanly.
+    if let Err(e) = check_references(&merged) {
+        eprintln(`gale: {e.message}`);
+        return;
+    }
     print(generate(&merged, options));
 }
 

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -1130,19 +1130,20 @@ fn gen_parser_struct(w: &mut CodeWriter) {
     w.end();
     w.blank();
 
-    // `p.match_not(&[TK_A, TK_B, ...])` — consumes one token whose kind is
+    // `p.match_not([TK_A, TK_B, ...])` — consumes one token whose kind is
     // not in the exclusion set (for parser-side `~ X`). Fails at EOF or when
-    // the current token is in the exclusion set.
+    // the current token is in the exclusion set. The exclusion set is passed
+    // by value so the caller can use tuple-to-Array coercion on a literal.
     let mut f10 = FnSpec::new("match_not");
     f10.set_receiver("&mut self");
-    f10.add_param("excluded", "&Array<i32>");
+    f10.add_param("excluded", "Array<i32>");
     f10.set_return_type("Result<Token, ParseError>");
     f10.emit_begin(w);
     w.line("let k = self.tokens[self.pos].kind;");
     w.begin("if k != TK_EOF");
     w.line("let mut blocked = false;");
     w.begin("for let x of excluded");
-    w.begin("if *x == k");
+    w.begin("if x == k");
     w.line("blocked = true;");
     w.line("break;");
     w.end();
@@ -3750,15 +3751,16 @@ fn gen_element_failable_named(w: &mut CodeWriter, elem: &Element, ctx: &mut GenC
 }
 
 /// Emit the Parser call expression for `~ X` (set complement). Returns a
-/// `Result<Token, ParseError>` at runtime.
+/// `Result<Token, ParseError>` at runtime. The exclusion set is a tuple
+/// literal that coerces to `Array<i32>` at the call site.
 fn not_match_call(inner: &Element) -> String {
     if let TokenRef(t) = inner {
         let const_name = `TK_{t.name}`;
-        return `p.match_not(&[{const_name}])`;
+        return `p.match_not([{const_name}])`;
     }
     if let Literal(l) = inner {
         let const_name = literal_const_name(&l.text);
-        return `p.match_not(&[{const_name}])`;
+        return `p.match_not([{const_name}])`;
     }
     if let Group(g) = inner {
         let mut kinds: Array<String> = [];
@@ -3770,7 +3772,7 @@ fn not_match_call(inner: &Element) -> String {
                 }
                 list.push_str(kinds[i]);
             }
-            return `p.match_not(&[{list}])`;
+            return `p.match_not([{list}])`;
         }
     }
     panic("not_match_call: unsupported inner element for parser-side ~");

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -2446,14 +2446,16 @@ fn gen_alt_body_skip(w: &mut CodeWriter, type_name: &String, variant_case: Optio
                     let follow = ctx.first_of_elements_from(&alt.elements, i + 1);
                     gen_repeat_with_follow(w, rep, ctx, &follow, &mut name_counts);
                 } else {
-                    gen_repeat(w, rep, ctx, &mut name_counts);
+                    let follow = ctx.first_of_elements_from(&alt.elements, i + 1);
+                    gen_repeat(w, rep, ctx, &mut name_counts, &follow);
                 }
             } else if rep.non_greedy {
                 let follow = ctx.first_of_elements_from(&alt.elements, i + 1);
                 let follow_second = compute_follow_second(&alt.elements, i + 1, ctx);
                 gen_repeat_non_greedy(w, rep, ctx, &follow, &follow_second, &mut name_counts);
             } else {
-                gen_repeat(w, rep, ctx, &mut name_counts);
+                let follow = ctx.first_of_elements_from(&alt.elements, i + 1);
+                gen_repeat(w, rep, ctx, &mut name_counts, &follow);
             }
         } else {
             gen_element(w, elem, ctx, &mut name_counts);
@@ -2531,14 +2533,16 @@ fn gen_alt_elements(w: &mut CodeWriter, elements: &Array<Element>, ctx: &mut Gen
                     let follow = ctx.first_of_elements_from(elements, i + 1);
                     gen_repeat_with_follow(w, rep, ctx, &follow, &mut name_counts);
                 } else {
-                    gen_repeat(w, rep, ctx, &mut name_counts);
+                    let follow = ctx.first_of_elements_from(elements, i + 1);
+                    gen_repeat(w, rep, ctx, &mut name_counts, &follow);
                 }
             } else if rep.non_greedy {
                 let follow = ctx.first_of_elements_from(elements, i + 1);
                 let follow_second = compute_follow_second(elements, i + 1, ctx);
                 gen_repeat_non_greedy(w, rep, ctx, &follow, &follow_second, &mut name_counts);
             } else {
-                gen_repeat(w, rep, ctx, &mut name_counts);
+                let follow = ctx.first_of_elements_from(elements, i + 1);
+                gen_repeat(w, rep, ctx, &mut name_counts, &follow);
             }
         } else {
             gen_element(w, elem, ctx, &mut name_counts);
@@ -2546,16 +2550,24 @@ fn gen_alt_elements(w: &mut CodeWriter, elements: &Array<Element>, ctx: &mut Gen
     }
 }
 
-fn gen_elements_with_non_greedy(w: &mut CodeWriter, elements: &Array<Element>, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
+fn gen_elements_with_non_greedy(w: &mut CodeWriter, elements: &Array<Element>, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>, outer_follow: &Array<String>) {
     for let mut i = 0; i < elements.len(); i += 1 {
         let elem = &elements[i];
         if let Repeat(rep) = elem {
             if rep.non_greedy {
-                let follow = ctx.first_of_elements_from(elements, i + 1);
+                // follow(e_i) = first(e_{i+1..}) ∪ (outer_follow if suffix nullable)
+                let mut follow = ctx.first_of_elements_from(elements, i + 1);
+                if ctx.tail_is_nullable_deep(elements, i + 1) {
+                    follow = union_sets(&follow, outer_follow);
+                }
                 let follow_second = compute_follow_second(elements, i + 1, ctx);
                 gen_repeat_non_greedy(w, rep, ctx, &follow, &follow_second, name_counts);
             } else {
-                gen_element(w, elem, ctx, name_counts);
+                let mut rep_follow = ctx.first_of_elements_from(elements, i + 1);
+                if ctx.tail_is_nullable_deep(elements, i + 1) {
+                    rep_follow = union_sets(&rep_follow, outer_follow);
+                }
+                gen_repeat(w, rep, ctx, name_counts, &rep_follow);
             }
         } else {
             gen_element(w, elem, ctx, name_counts);
@@ -2605,7 +2617,7 @@ fn gen_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, name_co
         return;
     }
     if let Repeat(rep) = elem {
-        gen_repeat(w, rep, ctx, name_counts);
+        gen_repeat(w, rep, ctx, name_counts, &([] as Array<String>));
         return;
     }
     if let Group(g) = elem {
@@ -2614,7 +2626,7 @@ fn gen_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, name_co
         } else if is_token_only_group(&g.alternatives) {
             gen_consume_token_group(w, &g.alternatives, ctx, name_counts);
         } else if is_single_alt_group(&g.alternatives) {
-            gen_consume_single_alt_group(w, &g.alternatives[0], ctx, name_counts);
+            gen_consume_single_alt_group(w, &g.alternatives[0], ctx, name_counts, &([] as Array<String>));
         } else if is_general_group(&g.alternatives) {
             gen_general_group_store_optional(w, &g.alternatives, ctx, name_counts);
         } else {
@@ -2634,17 +2646,30 @@ fn gen_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, name_co
             w.line(`{lab_name}.push({inner_info.0});`);
             return;
         }
-        gen_element(w, &lab.element, ctx, name_counts);
+        // Scalar label `name = element`: parse the inner element into a
+        // private binding, then re-bind it under the label name so the
+        // struct initializer (which uses the label name) resolves.
+        let lab_name = dedup_name(&escape_ident(&to_snake_case(&lab.name)), name_counts);
+        let inner_info = element_field_info(&lab.element, ctx);
+        let mut nc: Array<[String, i32]> = [];
+        gen_element(w, &lab.element, ctx, &mut nc);
+        w.line(`let {lab_name} = {inner_info.0};`);
         return;
     }
 }
 
-fn gen_repeat(w: &mut CodeWriter, rep: &RepeatElement, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
+fn gen_repeat(w: &mut CodeWriter, rep: &RepeatElement, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>, outer_follow: &Array<String>) {
     let inner = &rep.element;
     let mut visiting: Array<String> = [];
     let first = ctx.first_of_element(inner, &mut visiting);
     let mut visiting_scan: Array<String> = [];
     let scannable = ctx.is_element_scannable(inner, &mut visiting_scan);
+
+    // For Plus/Star with a single-alt Group inner, the body's "end-of-iteration
+    // follow" is: first(group) (next iteration can start here) ∪ outer_follow
+    // (the repeat can also exit). Non-greedy repeats at the tail of the group
+    // need this to stop before the next iteration's first token.
+    let iter_follow = compute_iter_follow(inner, &first, outer_follow);
 
     // `(items+=item)*` / `items+=item+` / `items+=item?` — the list label
     // already implies Array, so use the label name directly and push the
@@ -2725,7 +2750,7 @@ fn gen_repeat(w: &mut CodeWriter, rep: &RepeatElement, ctx: &mut GenContext, nam
                 let mut nc: Array<[String, i32]> = [];
                 if is_group_store {
                     ctx.group_counter = gc_before;
-                    gen_group_store_any(w, inner, ctx, &mut nc);
+                    gen_group_store_any(w, inner, ctx, &mut nc, &iter_follow);
                 } else {
                     gen_element(w, inner, ctx, &mut nc);
                 }
@@ -2736,7 +2761,7 @@ fn gen_repeat(w: &mut CodeWriter, rep: &RepeatElement, ctx: &mut GenContext, nam
                 let mut nc: Array<[String, i32]> = [];
                 if is_group_store {
                     ctx.group_counter = gc_before;
-                    gen_group_store_any(w, inner, ctx, &mut nc);
+                    gen_group_store_any(w, inner, ctx, &mut nc, &iter_follow);
                 } else {
                     gen_element(w, inner, ctx, &mut nc);
                 }
@@ -2759,7 +2784,7 @@ fn gen_repeat(w: &mut CodeWriter, rep: &RepeatElement, ctx: &mut GenContext, nam
                 let mut nc: Array<[String, i32]> = [];
                 if is_group_store {
                     ctx.group_counter = gc_before;
-                    gen_group_store_any(w, inner, ctx, &mut nc);
+                    gen_group_store_any(w, inner, ctx, &mut nc, &iter_follow);
                 } else {
                     gen_element(w, inner, ctx, &mut nc);
                 }
@@ -2773,7 +2798,7 @@ fn gen_repeat(w: &mut CodeWriter, rep: &RepeatElement, ctx: &mut GenContext, nam
                 let mut nc: Array<[String, i32]> = [];
                 if is_group_store {
                     ctx.group_counter = gc_before;
-                    gen_group_store_any(w, inner, ctx, &mut nc);
+                    gen_group_store_any(w, inner, ctx, &mut nc, &iter_follow);
                 } else {
                     gen_element(w, inner, ctx, &mut nc);
                 }
@@ -2859,7 +2884,58 @@ fn compute_follow_second(elements: &Array<Element>, follow_start: i32, ctx: &mut
     return [];
 }
 
+fn compute_iter_follow(inner: &Element, first_of_inner: &Array<String>, outer_follow: &Array<String>) -> Array<String> {
+    // For a Plus/Star whose inner is a single-alt Group, each iteration can
+    // be followed by either another iteration (first(inner)) or the exit
+    // (outer_follow). For non-Group inners we use outer_follow alone — the
+    // inner has no sub-structure that could host a nested non-greedy tail.
+    if let Group(g) = inner {
+        if g.alternatives.len() == 1 {
+            return union_sets(first_of_inner, outer_follow);
+        }
+    }
+    return *outer_follow;
+}
+
+fn wildcard_non_greedy_condition(follow_first: &Array<String>) -> String {
+    // Continue while peek is not EOF and not in the follow set. `follow_first`
+    // may already contain TK_EOF (e.g. when the follow is the final `EOF`
+    // token). Dedup into a single exclusion set so we emit one check.
+    let mut excluded: Array<String> = ["TK_EOF"];
+    for let tk of follow_first {
+        let mut seen = false;
+        for let e of &excluded {
+            if *e == *tk { seen = true; break; }
+        }
+        if !seen { excluded.push(*tk); }
+    }
+    if excluded.len() == 1 {
+        return `p.peek_kind() != {excluded[0]}`;
+    }
+    let mut result = String::with_capacity(64);
+    result.push_str("!(p.peek_kind() matches { ");
+    for let mut i = 0; i < excluded.len(); i += 1 {
+        if i > 0 {
+            result.push_str(" | ");
+        }
+        result.push_str(excluded[i]);
+    }
+    result.push_str(" })");
+    return result;
+}
+
 fn compute_non_greedy_condition(inner: &Element, follow_first: &Array<String>, follow_second: &Array<String>, ctx: &mut GenContext) -> String {
+    // Wildcard (`.*?`) and Not (`~TOK*?`) inner: `first_of_element` returns
+    // `[]` because their match set is open-ended. Handle them explicitly:
+    // keep looping while the current token is not EOF and not in the follow
+    // set (i.e. the continuation can't yet fire).
+    if let Wildcard(_) = inner {
+        return wildcard_non_greedy_condition(follow_first);
+    }
+    if let Not(_) = inner {
+        return wildcard_non_greedy_condition(follow_first);
+    }
+
     let mut visiting: Array<String> = [];
     let raw_first = ctx.first_of_element(inner, &mut visiting);
     let continue_first = subtract_sets(&raw_first, follow_first);
@@ -3400,7 +3476,7 @@ fn gen_element_failable(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext
         return;
     }
     if let Repeat(rep) = elem {
-        gen_repeat(w, rep, ctx, name_counts);
+        gen_repeat(w, rep, ctx, name_counts, &([] as Array<String>));
         return;
     }
     if let Group(g) = elem {
@@ -3446,7 +3522,7 @@ fn gen_storable_optional(w: &mut CodeWriter, inner: &Element, ctx: &mut GenConte
         }
         w.begin(`let {opt_name}: Option<{type_str}> = if {cond}`);
         let mut nc: Array<[String, i32]> = [];
-        gen_group_store_any(w, inner, ctx, &mut nc);
+        gen_group_store_any(w, inner, ctx, &mut nc, &([] as Array<String>));
         w.line(`Option::<{type_str}>::Some({field_name})`);
         w.else_begin("else");
         w.line("null");
@@ -3616,7 +3692,7 @@ fn gen_storable_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx
                 w.line(`Option::<{type_str}>::Some({field_name})`);
             } else {
                 let mut nc: Array<[String, i32]> = [];
-                gen_group_store_any(w, inner, ctx, &mut nc);
+                gen_group_store_any(w, inner, ctx, &mut nc, &([] as Array<String>));
                 w.line(`Option::<{type_str}>::Some({field_name})`);
             }
         }
@@ -3663,7 +3739,7 @@ fn gen_storable_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx
             // For other storable patterns (simple_cst_group, token_only_group),
             // they should be safe without backtracking. Generate normally.
             let mut nc: Array<[String, i32]> = [];
-            gen_group_store_any(w, inner, ctx, &mut nc);
+            gen_group_store_any(w, inner, ctx, &mut nc, &([] as Array<String>));
             w.line(`{result_var} = Option::<{type_str}>::Some({field_name});`);
         }
     }
@@ -3727,7 +3803,7 @@ fn gen_element_failable_named(w: &mut CodeWriter, elem: &Element, ctx: &mut GenC
         return;
     }
     if let Repeat(rep) = elem {
-        gen_repeat(w, rep, ctx, name_counts);
+        gen_repeat(w, rep, ctx, name_counts, &([] as Array<String>));
         return;
     }
     if let Group(g) = elem {
@@ -3736,7 +3812,7 @@ fn gen_element_failable_named(w: &mut CodeWriter, elem: &Element, ctx: &mut GenC
         } else if is_token_only_group(&g.alternatives) {
             gen_consume_token_group(w, &g.alternatives, ctx, name_counts);
         } else if is_single_alt_group(&g.alternatives) {
-            gen_consume_single_alt_group(w, &g.alternatives[0], ctx, name_counts);
+            gen_consume_single_alt_group(w, &g.alternatives[0], ctx, name_counts, &([] as Array<String>));
         } else if is_general_group(&g.alternatives) {
             gen_general_group_store_optional(w, &g.alternatives, ctx, name_counts);
         } else {
@@ -4050,7 +4126,7 @@ fn gen_consume_group(w: &mut CodeWriter, alts: &Array<Alternative>, ctx: &mut Ge
         return;
     }
     if alts.len() == 1 {
-        gen_elements_with_non_greedy(w, &alts[0].elements, ctx, name_counts);
+        gen_elements_with_non_greedy(w, &alts[0].elements, ctx, name_counts, &([] as Array<String>));
         return;
     }
 
@@ -4082,7 +4158,7 @@ fn gen_consume_group(w: &mut CodeWriter, alts: &Array<Alternative>, ctx: &mut Ge
         if group.len() == 1 {
             let alt_idx = group[0];
             let mut nc: Array<[String, i32]> = [];
-            gen_elements_with_non_greedy(w, &alts[alt_idx].elements, ctx, &mut nc);
+            gen_elements_with_non_greedy(w, &alts[alt_idx].elements, ctx, &mut nc, &([] as Array<String>));
         } else {
             let mut sorted_group = group.sorted();
             sort_group_by_element_count(&mut sorted_group, alts);
@@ -4351,7 +4427,7 @@ fn gen_consume_group_store_optional(w: &mut CodeWriter, alts: &Array<Alternative
     w.line(`let {var_name} = {inner_var};`);
 }
 
-fn gen_group_store_any(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
+fn gen_group_store_any(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>, outer_follow: &Array<String>) {
     if let Group(g) = inner {
         let alts = &g.alternatives;
         if is_simple_cst_group(alts) {
@@ -4359,7 +4435,7 @@ fn gen_group_store_any(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext
         } else if is_token_only_group(alts) {
             gen_consume_token_group(w, alts, ctx, name_counts);
         } else if is_single_alt_group(alts) {
-            gen_consume_single_alt_group(w, &alts[0], ctx, name_counts);
+            gen_consume_single_alt_group(w, &alts[0], ctx, name_counts, outer_follow);
         } else if is_general_group(alts) {
             gen_general_group_store(w, alts, ctx, name_counts);
         }
@@ -4371,7 +4447,7 @@ fn gen_consume_token_group(w: &mut CodeWriter, alts: &Array<Alternative>, ctx: &
     w.line(`let {var_name} = p.advance();`);
 }
 
-fn gen_consume_single_alt_group(w: &mut CodeWriter, alt: &Alternative, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
+fn gen_consume_single_alt_group(w: &mut CodeWriter, alt: &Alternative, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>, outer_follow: &Array<String>) {
     let type_name = single_alt_group_type_name(alt);
     let field_name = dedup_name(&single_alt_group_field_name(alt), name_counts);
     // Use the owning rule's name for general group types inside shared single-alt groups
@@ -4379,9 +4455,7 @@ fn gen_consume_single_alt_group(w: &mut CodeWriter, alt: &Alternative, ctx: &mut
     ctx.current_rule_name = ctx.general_group_rule_name(&type_name);
     let nc_snapshot = *name_counts;
     let gc_start = ctx.group_counter;
-    for let elem of &alt.elements {
-        gen_element(w, elem, ctx, name_counts);
-    }
+    gen_elements_with_non_greedy(w, &alt.elements, ctx, name_counts, outer_follow);
     w.line(`let {field_name} = {type_name} \{`);
     w.indent();
     ctx.group_counter = gc_start;
@@ -4542,7 +4616,7 @@ fn gen_general_alt_parse_and_store(w: &mut CodeWriter, alts: &Array<Alternative>
 
     let mut nc: Array<[String, i32]> = [];
     let gc_start = ctx.group_counter;
-    gen_elements_with_non_greedy(w, &alt.elements, ctx, &mut nc);
+    gen_elements_with_non_greedy(w, &alt.elements, ctx, &mut nc, &([] as Array<String>));
 
     w.line(`{inner_var} = Option::<{type_name}>::Some({type_name}::Alt{alt_idx}({struct_name} \{`);
     w.indent();
@@ -4562,7 +4636,7 @@ fn gen_general_alt_construct(w: &mut CodeWriter, alts: &Array<Alternative>, alt_
 
     let mut nc: Array<[String, i32]> = [];
     let gc_start = ctx.group_counter;
-    gen_elements_with_non_greedy(w, &alt.elements, ctx, &mut nc);
+    gen_elements_with_non_greedy(w, &alt.elements, ctx, &mut nc, &([] as Array<String>));
 
     w.line(`{type_name}::Alt{alt_idx}({struct_name} \{`);
     w.indent();
@@ -4623,7 +4697,7 @@ fn gen_general_group_backtrack(w: &mut CodeWriter, alts: &Array<Alternative>, so
             w.begin(`if !{done}`);
             let mut nc: Array<[String, i32]> = [];
             let gc_last = ctx.group_counter;
-            gen_elements_with_non_greedy(w, &alt.elements, ctx, &mut nc);
+            gen_elements_with_non_greedy(w, &alt.elements, ctx, &mut nc, &([] as Array<String>));
             w.line(`{inner_var} = Option::<{type_name}>::Some({type_name}::Alt{alt_idx}({struct_name} \{`);
             w.indent();
             ctx.group_counter = gc_last;
@@ -4707,7 +4781,7 @@ fn gen_general_group_scan_dispatch(w: &mut CodeWriter, alts: &Array<Alternative>
         ctx.group_counter = gc_entry;
         let mut nc: Array<[String, i32]> = [];
         let gc_alt = ctx.group_counter;
-        gen_elements_with_non_greedy(w, &alt.elements, ctx, &mut nc);
+        gen_elements_with_non_greedy(w, &alt.elements, ctx, &mut nc, &([] as Array<String>));
         w.line(`{inner_var} = Option::<{type_name}>::Some({type_name}::Alt{alt_idx}({struct_name} \{`);
         w.indent();
         ctx.group_counter = gc_alt;
@@ -5092,7 +5166,7 @@ fn gen_lr_suffix_helpers(w: &mut CodeWriter, rule: &ParserRule, type_name: &Stri
                     gen_element(w, elem, ctx, &mut name_counts);
                 }
             } else if let Repeat(rep) = elem {
-                gen_repeat(w, rep, ctx, &mut name_counts);
+                gen_repeat(w, rep, ctx, &mut name_counts, &([] as Array<String>));
             } else {
                 gen_element(w, elem, ctx, &mut name_counts);
             }

--- a/package-gale/src/visitor_gen.wado
+++ b/package-gale/src/visitor_gen.wado
@@ -16,6 +16,7 @@ use {
     token_group_field_name,
     single_alt_group_field_name,
     count_element_groups,
+    not_element_field_name,
 } from "./gen_util.wado";
 use { CodeWriter } from "./wadopoet.wado";
 
@@ -258,7 +259,26 @@ fn element_to_walk_field(elem: &Element, rule_name: &String, group_counter: &mut
             wrapper: WalkWrapper::Direct,
         });
     }
+    if let Wildcard(_) = elem {
+        return Option::Some(WalkField {
+            name: "wildcard",
+            action: WalkAction::VisitToken,
+            wrapper: WalkWrapper::Direct,
+        });
+    }
+    if let Not(ne) = elem {
+        return Option::Some(WalkField {
+            name: not_element_field_name(&ne.element),
+            action: WalkAction::VisitToken,
+            wrapper: WalkWrapper::Direct,
+        });
+    }
     if let Repeat(rep) = elem {
+        if let Label(lab) = &rep.element {
+            if lab.list {
+                return element_to_walk_field(&rep.element, rule_name, group_counter);
+            }
+        }
         let inner_field = repeat_inner_walk_field(&rep.element, rule_name, group_counter);
         if let Some(inner) = inner_field {
             match rep.kind {
@@ -282,10 +302,11 @@ fn element_to_walk_field(elem: &Element, rule_name: &String, group_counter: &mut
     }
     if let Label(lab) = elem {
         if let Some(inner) = element_to_walk_field(&lab.element, rule_name, group_counter) {
+            let wrapper = if lab.list { WalkWrapper::ArrayWrap } else { inner.wrapper };
             return Option::Some(WalkField {
                 name: escape_ident(&to_snake_case(&lab.name)),
                 action: inner.action,
-                wrapper: inner.wrapper,
+                wrapper,
             });
         }
         return null;

--- a/package-gale/tests/driver_ci_rule_override_test.wado
+++ b/package-gale/tests/driver_ci_rule_override_test.wado
@@ -1,0 +1,61 @@
+use ci from "./golden/ci_rule_override.wado";
+use { normalize_tree } from "./golden/ci_rule_override.wado";
+
+fn assert_tree(input: &String, expected: &String) {
+    let root = ci::parse(input).unwrap();
+    let tree = ci::to_tree(&root);
+    let actual = tree.to_string_tree();
+    let norm = normalize_tree(expected);
+    assert actual == norm, `\ninput:    {*input}\nexpected: {norm}\nactual:   {actual}`;
+}
+
+fn assert_parses(input: &String) {
+    let result = ci::parse(input);
+    if let Err(e) = &result {
+        panic(`parse failed for \`{input}\`: {e.message}`);
+    }
+}
+
+test "grammar-level CI: lowercase keyword matches KEYWORD" {
+    // `'if'` is folded case-insensitively by the grammar-level option,
+    // so any casing is accepted as KEYWORD.
+    assert_parses(&"if foo");
+    assert_parses(&"IF foo");
+    assert_parses(&"If foo");
+    assert_parses(&"iF foo");
+}
+
+test "rule-level override: uppercase 'EXACT' matches EXACT" {
+    assert_tree(&"EXACT", &"
+        (line EXACT)
+    ");
+}
+
+test "rule-level override: lowercase 'exact' does NOT match EXACT" {
+    // Because EXACT has `options { caseInsensitive = false; }`, the
+    // pattern `'EXACT'` is compiled case-sensitively. `exact` must
+    // therefore fall through to the IDENT rule. The tree shows `exact`
+    // as an IDENT child, not as EXACT.
+    assert_tree(&"exact", &"
+        (line exact)
+    ");
+}
+
+test "rule-level override: mixed-case does NOT match EXACT" {
+    // `Exact`, `eXact`, etc. also fall through to IDENT.
+    assert_tree(&"Exact", &"
+        (line Exact)
+    ");
+}
+
+test "mixed: EXACT (exact match) next to exact (IDENT)" {
+    // The parser rule `(KEYWORD | IDENT | EXACT)+` accepts both in
+    // any order. The tree shows each token under the rule name chosen
+    // by the lexer.
+    assert_parses(&"EXACT exact");
+    assert_parses(&"exact EXACT");
+}
+
+test "grammar-level CI + rule-level override coexist" {
+    assert_parses(&"if EXACT IF exact iF");
+}

--- a/package-gale/tests/driver_label_gaps_test.wado
+++ b/package-gale/tests/driver_label_gaps_test.wado
@@ -1,0 +1,47 @@
+use lg from "./golden/label_gaps.wado";
+use { normalize_tree } from "./golden/label_gaps.wado";
+
+fn assert_tree(input: &String, expected: &String) {
+    let root = lg::parse(input).unwrap();
+    let tree = lg::to_tree(&root);
+    let actual = tree.to_string_tree();
+    let norm = normalize_tree(expected);
+    assert actual == norm, `\ninput:    {*input}\nexpected: {norm}\nactual:   {actual}`;
+}
+
+test "scalar token label: key=ID, value=STRING" {
+    assert_tree(&"foo = \"bar\" ;", &"
+        (program
+          (stmt (assign_stmt foo = \"bar\" ;)))
+    ");
+}
+
+test "scalar rule label: k=key_rule" {
+    assert_tree(&"pair alpha : beta ;", &"
+        (program
+          (stmt (pair_stmt pair (key_rule alpha) : beta ;)))
+    ");
+}
+
+test "scalar + list labels in the same alternative" {
+    assert_tree(&"list x , y , z ;", &"
+        (program
+          (stmt (mix_stmt list x , y , z ;)))
+    ");
+}
+
+test "mix_stmt with only head (no rest)" {
+    assert_tree(&"list only ;", &"
+        (program
+          (stmt (mix_stmt list only ;)))
+    ");
+}
+
+test "multiple labeled statements interleaved" {
+    assert_tree(&"a = \"1\" ; pair b : c ; list d , e ;", &"
+        (program
+          (stmt (assign_stmt a = \"1\" ;))
+          (stmt (pair_stmt pair (key_rule b) : c ;))
+          (stmt (mix_stmt list d , e ;)))
+    ");
+}

--- a/package-gale/tests/driver_lexer_command_gaps_test.wado
+++ b/package-gale/tests/driver_lexer_command_gaps_test.wado
@@ -1,0 +1,65 @@
+use lex from "./golden/lexer_command_gaps.wado";
+use { normalize_tree } from "./golden/lexer_command_gaps.wado";
+
+fn assert_parses(input: &String) {
+    let result = lex::parse(input);
+    if let Err(e) = &result {
+        panic(`parse failed for \`{input}\`: {e.message}`);
+    }
+}
+
+fn assert_tree(input: &String, expected: &String) {
+    let root = lex::parse(input).unwrap();
+    let tree = lex::to_tree(&root);
+    let actual = tree.to_string_tree();
+    let norm = normalize_tree(expected);
+    assert actual == norm, `\ninput:    {*input}\nexpected: {norm}\nactual:   {actual}`;
+}
+
+test "bare words tokenize as WORD" {
+    assert_parses(&"hello world");
+}
+
+test "digits tokenize as NUMBER" {
+    assert_parses(&"42 100");
+}
+
+test "'zero' is re-typed to NUMBER via -> type(NUMBER)" {
+    // `ZERO : 'zero' -> type(NUMBER) ;` should make the literal `zero`
+    // parse as a NUMBER token, so the top-level `text` rule (which
+    // accepts WORD | NUMBER | PRAGMA) accepts it where a word is not
+    // otherwise acceptable in this position. We assert the S-expression
+    // tree shows `zero` as a NUMBER child, not a WORD.
+    assert_tree(&"zero 42", &"
+        (text zero 42)
+    ");
+}
+
+test "'zero' and other words interleave correctly" {
+    // Exercise the type-override rule together with the WORD rule —
+    // the longer match (`zero`, 4 chars) must win over `WORD` (`z`),
+    // then the retype takes effect.
+    assert_parses(&"zero foo zero bar");
+}
+
+test "numeric channel routes comments off the default stream" {
+    // `COMMENT : '//' ~[\r\n]* -> channel(COMMENTS_CHANNEL) ;` routes
+    // comments to a non-default channel. The parser-side `text` rule
+    // must succeed on input that contains a comment because the
+    // comment never reaches the default channel.
+    assert_parses(&"hello // a comment\nworld");
+}
+
+test "mode(DEFAULT_MODE) returns to default mode after #pragma line" {
+    // `#pragma once\n` switches to PRAGMA_MODE, emits PRAGMA, then
+    // `\n` triggers `-> mode(DEFAULT_MODE), skip` which returns. After
+    // the pragma line the lexer is back in the default mode and can
+    // match further WORD/NUMBER tokens.
+    assert_parses(&"hello #pragma once\nworld 42");
+}
+
+test "tree shows pragma content as PRAGMA token" {
+    assert_tree(&"#pragma foo\nx", &"
+        (text foo x)
+    ");
+}

--- a/package-gale/tests/driver_mode_gaps_test.wado
+++ b/package-gale/tests/driver_mode_gaps_test.wado
@@ -1,0 +1,52 @@
+use mg from "./golden/mode_gaps.wado";
+use { normalize_tree } from "./golden/mode_gaps.wado";
+
+fn assert_tree(input: &String, expected: &String) {
+    let root = mg::parse(input).unwrap();
+    let tree = mg::to_tree(&root);
+    let actual = tree.to_string_tree();
+    let norm = normalize_tree(expected);
+    assert actual == norm, `\ninput:    {*input}\nexpected: {norm}\nactual:   {actual}`;
+}
+
+test "A4: plain identifier tokenizes outside any string mode" {
+    assert_tree(&"foo", &"
+        (text foo)
+    ");
+}
+
+test "A4: pushMode + more — opening quote merges into STRING token" {
+    assert_tree(&"\"hello\"", &"
+        (text \"hello\")
+    ");
+}
+
+test "A4: accumulate multiple chars via more" {
+    assert_tree(&"\"abc\"", &"
+        (text \"abc\")
+    ");
+}
+
+test "A3: mode(X) replaces top of stack — escape returns to IN_STRING" {
+    assert_tree(&"\"a\\nb\"", &"
+        (text \"a\\nb\")
+    ");
+}
+
+test "A3: multiple escapes bounce between IN_STRING and ESC_IN_STRING" {
+    assert_tree(&"\"\\t\\n\\\\\"", &"
+        (text \"\\t\\n\\\\\")
+    ");
+}
+
+test "mixed PLAIN and STRING tokens" {
+    assert_tree(&"foo \"bar\" baz", &"
+        (text foo \"bar\" baz)
+    ");
+}
+
+test "empty string literal" {
+    assert_tree(&"\"\"", &"
+        (text \"\")
+    ");
+}

--- a/package-gale/tests/driver_non_greedy_gaps_test.wado
+++ b/package-gale/tests/driver_non_greedy_gaps_test.wado
@@ -1,0 +1,68 @@
+use ng from "./golden/non_greedy_gaps.wado";
+use { normalize_tree } from "./golden/non_greedy_gaps.wado";
+
+fn assert_parses(input: &String) {
+    let result = ng::parse(input);
+    if let Err(e) = &result {
+        panic(`parse failed for \`{input}\`: {e.message}`);
+    }
+}
+
+fn assert_tree(input: &String, expected: &String) {
+    let root = ng::parse(input).unwrap();
+    let tree = ng::to_tree(&root);
+    let actual = tree.to_string_tree();
+    let norm = normalize_tree(expected);
+    assert actual == norm, `\ninput:    {*input}\nexpected: {norm}\nactual:   {actual}`;
+}
+
+test "single constant with no surrounding junk" {
+    assert_parses(&"public static final int X");
+}
+
+test "constant after junk tokens" {
+    assert_parses(&"foo bar = 1 ; public static final int Y");
+}
+
+test "constant followed by junk (.*? after constant)" {
+    assert_parses(&"public static final int A ; garbage here");
+}
+
+test "multiple constants interleaved with junk" {
+    assert_parses(&"int x ; public static final int A ; x = 1 ; public static final int B ; end");
+}
+
+test "tree: bare constant" {
+    assert_tree(&"public static final int X", &"
+        (file (constant public static final int X))
+    ");
+}
+
+test "tree: constant after leading junk" {
+    assert_tree(&"x = 1 ; public static final int A", &"
+        (file x = 1 ; (constant public static final int A))
+    ");
+}
+
+test "single constant is captured in constant_item_list" {
+    // Verify the non-greedy parse actually builds a typed CST, not just
+    // succeeds parsing. This exercises the field-generation path through
+    // `has_field(Wildcard) == true` for parser-level `.*?`.
+    let input = "pre = 1 ; public static final int A";
+    let root = ng::parse(&input).unwrap();
+    assert root.constant_item_list.len() == 1,
+        `expected exactly 1 constant, got {root.constant_item_list.len()}`;
+    assert LexerSlice::eq_str(&"A", &root.constant_item_list[0].constant.id.text);
+}
+
+test "two constants separated by junk are both captured" {
+    // Exercises the outer_follow propagation: the inner `.*?` inside
+    // `(constant .*?)+` must stop at the next iteration's first token
+    // (`public`) so the repetition can consume the second constant.
+    let input = "pre = 1 ; public static final int A ; middle ; public static final int B ; end";
+    let root = ng::parse(&input).unwrap();
+    assert root.constant_item_list.len() == 2,
+        `expected exactly 2 constants, got {root.constant_item_list.len()}`;
+    assert LexerSlice::eq_str(&"A", &root.constant_item_list[0].constant.id.text);
+    assert LexerSlice::eq_str(&"B", &root.constant_item_list[1].constant.id.text);
+}

--- a/package-gale/tests/driver_parser_gaps_test.wado
+++ b/package-gale/tests/driver_parser_gaps_test.wado
@@ -1,0 +1,71 @@
+use pg from "./golden/parser_gaps.wado";
+use { normalize_tree } from "./golden/parser_gaps.wado";
+
+fn assert_tree(input: &String, expected: &String) {
+    let root = pg::parse(input).unwrap();
+    let tree = pg::to_tree(&root);
+    let actual = tree.to_string_tree();
+    let norm = normalize_tree(expected);
+    assert actual == norm, `\ninput:    {*input}\nexpected: {norm}\nactual:   {actual}`;
+}
+
+test "A2: list label collects single item" {
+    assert_tree(&"list a ;", &"
+        (program
+          (stmt (list_stmt list a ;)))
+    ");
+}
+
+test "A2: list label collects multiple items via repetition" {
+    assert_tree(&"list a , b , c ;", &"
+        (program
+          (stmt (list_stmt list a , b , c ;)))
+    ");
+}
+
+test "A1: token-complement ~ITEM matches a non-ITEM token" {
+    assert_tree(&"not 123 ;", &"
+        (program
+          (stmt (not_stmt not 123 ;)))
+    ");
+}
+
+test "A1: set-complement ~(ITEM | NUMBER) matches neither" {
+    assert_tree(&"set , ;", &"
+        (program
+          (stmt (not_stmt set , ;)))
+    ");
+}
+
+test "A1: token-complement ~ITEM rejects an ITEM" {
+    let result = pg::parse(&"not foo ;");
+    assert result matches { Err(_) }, "expected parse failure when ~ITEM sees an ITEM";
+}
+
+test "A1: set-complement rejects an excluded kind" {
+    let result = pg::parse(&"set foo ;");
+    assert result matches { Err(_) }, "expected parse failure when ~(ITEM|NUMBER) sees an ITEM";
+}
+
+test "A5: parser-level wildcard . matches a single token" {
+    assert_tree(&"any foo ;", &"
+        (program
+          (stmt (any_stmt any foo ;)))
+    ");
+}
+
+test "A5: wildcard matches a number too" {
+    assert_tree(&"any 42 ;", &"
+        (program
+          (stmt (any_stmt any 42 ;)))
+    ");
+}
+
+test "multiple statements in a program" {
+    assert_tree(&"list a , b ; not 1 ; any x ;", &"
+        (program
+          (stmt (list_stmt list a , b ;))
+          (stmt (not_stmt not 1 ;))
+          (stmt (any_stmt any x ;)))
+    ");
+}

--- a/package-gale/tests/driver_recursive_lexer_test.wado
+++ b/package-gale/tests/driver_recursive_lexer_test.wado
@@ -1,0 +1,63 @@
+use rl from "./golden/recursive_lexer.wado";
+use { normalize_tree } from "./golden/recursive_lexer.wado";
+
+fn assert_tree(input: &String, expected: &String) {
+    let root = rl::parse(input).unwrap();
+    let tree = rl::to_tree(&root);
+    let actual = tree.to_string_tree();
+    let norm = normalize_tree(expected);
+    assert actual == norm, `\ninput:    {*input}\nexpected: {norm}\nactual:   {actual}`;
+}
+
+fn assert_parses(input: &String) {
+    let result = rl::parse(input);
+    if let Err(e) = &result {
+        panic(`parse failed for \`{input}\`: {e.message}`);
+    }
+}
+
+test "ident alone" {
+    assert_parses(&"foo");
+}
+
+test "empty block matches" {
+    assert_tree(&"{}", &"
+        (file {})
+    ");
+}
+
+test "block with plain contents" {
+    assert_tree(&"{abc}", &"
+        (file {abc})
+    ");
+}
+
+test "nested block once" {
+    // The recursive fragment BRACED descends into the nested `{}` so
+    // the outer `{ a {b} c }` is a single BLOCK token, not three.
+    assert_tree(&"{a{b}c}", &"
+        (file {a{b}c})
+    ");
+}
+
+test "deeply nested blocks" {
+    assert_parses(&"{{{{deep}}}}");
+}
+
+test "multiple top-level tokens mixing BLOCK and IDENT" {
+    assert_parses(&"foo {a {b} c} bar {d} baz");
+}
+
+test "BLOCK token text preserves full nested content" {
+    // Exercise that the recursive fragment match consumed all inner
+    // braces — the lexer slice for the outer BLOCK must include the
+    // whole nested string, not just `{` + first balanced span.
+    let root = rl::parse(&"{a{b}c}").unwrap();
+    let tree = rl::to_tree(&root);
+    let actual = tree.to_string_tree();
+    // The BLOCK token should appear as a single flat child whose
+    // text is `{a{b}c}`. `to_string_tree` renders token text verbatim
+    // between the `(` and rule children, so the full brace body is in
+    // the tree output.
+    assert actual == "(file {a{b}c})", `actual: {actual}`;
+}

--- a/package-gale/tests/driver_right_assoc_gaps_test.wado
+++ b/package-gale/tests/driver_right_assoc_gaps_test.wado
@@ -1,0 +1,40 @@
+use ra from "./golden/right_assoc_gaps.wado";
+use { normalize_tree } from "./golden/right_assoc_gaps.wado";
+
+fn assert_tree(input: &String, expected: &String) {
+    let root = ra::parse(input).unwrap();
+    let tree = ra::to_tree(&root);
+    let actual = tree.to_string_tree();
+    let norm = normalize_tree(expected);
+    assert actual == norm, `\ninput:    {*input}\nexpected: {norm}\nactual:   {actual}`;
+}
+
+test "single INT atom" {
+    assert_tree(&"42", &"
+        (expr 42)
+    ");
+}
+
+test "left-associative + parses 1 + 2 + 3 as (1+2)+3" {
+    assert_tree(&"1 + 2 + 3", &"
+        (expr (expr (expr 1) + (expr 2)) + (expr 3))
+    ");
+}
+
+test "right-associative ^ parses 2 ^ 3 ^ 4 as 2^(3^4)" {
+    assert_tree(&"2 ^ 3 ^ 4", &"
+        (expr (expr 2) ^ (expr (expr 3) ^ (expr 4)))
+    ");
+}
+
+test "four-level right-assoc chain 2^3^4^5 = 2^(3^(4^5))" {
+    assert_tree(&"2 ^ 3 ^ 4 ^ 5", &"
+        (expr (expr 2) ^ (expr (expr 3) ^ (expr (expr 4) ^ (expr 5))))
+    ");
+}
+
+test "mixed + and ^: 1 + 2 ^ 3 ^ 4" {
+    assert_tree(&"1 + 2 ^ 3 ^ 4", &"
+        (expr (expr 1) + (expr (expr 2) ^ (expr (expr 3) ^ (expr 4))))
+    ");
+}

--- a/package-gale/tests/driver_unicode_props_test.wado
+++ b/package-gale/tests/driver_unicode_props_test.wado
@@ -1,0 +1,80 @@
+use up from "./golden/unicode_props.wado";
+use { normalize_tree } from "./golden/unicode_props.wado";
+
+fn assert_tree(input: &String, expected: &String) {
+    let root = up::parse(input).unwrap();
+    let tree = up::to_tree(&root);
+    let actual = tree.to_string_tree();
+    let norm = normalize_tree(expected);
+    assert actual == norm, `\ninput:    {*input}\nexpected: {norm}\nactual:   {actual}`;
+}
+
+fn assert_parses(input: &String) {
+    let result = up::parse(input);
+    if let Err(e) = &result {
+        panic(`parse failed for \`{input}\`: {e.message}`);
+    }
+}
+
+test "ASCII letters match \\p{L}" {
+    assert_tree(&"hello", &"
+        (line hello)
+    ");
+}
+
+test "ASCII digits match \\p{Nd}" {
+    assert_tree(&"12345", &"
+        (line 12345)
+    ");
+}
+
+test "ASCII space (\\p{Zs}) is skipped" {
+    assert_tree(&"foo 42", &"
+        (line foo 42)
+    ");
+}
+
+test "Latin letters with diacritics match \\p{L}" {
+    assert_parses(&"café");
+    assert_parses(&"naïve");
+    assert_parses(&"résumé");
+}
+
+test "Greek letters match \\p{L}" {
+    assert_parses(&"αβγδε");
+    assert_parses(&"ΑΒΓΔΕ");
+}
+
+test "Cyrillic letters match \\p{L}" {
+    assert_parses(&"Привет");
+}
+
+test "CJK ideographs match \\p{L}" {
+    assert_parses(&"世界");
+    assert_parses(&"日本語");
+}
+
+test "hiragana and katakana match \\p{L}" {
+    assert_parses(&"ひらがな");
+    assert_parses(&"カタカナ");
+}
+
+test "Arabic-Indic digits match \\p{Nd}" {
+    // U+0660..U+0669 ARABIC-INDIC DIGIT ZERO..NINE
+    assert_parses(&"٠١٢٣٤٥٦٧٨٩");
+}
+
+test "Devanagari digits match \\p{Nd}" {
+    // U+0966..U+096F DEVANAGARI DIGIT ZERO..NINE
+    assert_parses(&"०१२३४५६७८९");
+}
+
+test "Unicode space separators (\\p{Zs}) are skipped" {
+    // U+00A0 NO-BREAK SPACE, U+2003 EM SPACE
+    assert_parses(&"foo bar");
+    assert_parses(&"foo bar");
+}
+
+test "mixed scripts, letters, and digits in one line" {
+    assert_parses(&"hello 世界 αβγ 123 ٠١٢");
+}

--- a/package-gale/tests/golden/antlr4.wado
+++ b/package-gale/tests/golden/antlr4.wado
@@ -3798,12 +3798,12 @@ impl Parser {
         ));
     }
 
-    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
         let k = self.tokens[self.pos].kind;
         if k != TK_EOF {
             let mut blocked = false;
             for let x of excluded {
-                if *x == k {
+                if x == k {
                     blocked = true;
                     break;
                 }

--- a/package-gale/tests/golden/calculator.wado
+++ b/package-gale/tests/golden/calculator.wado
@@ -1428,12 +1428,12 @@ impl Parser {
         ));
     }
 
-    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
         let k = self.tokens[self.pos].kind;
         if k != TK_EOF {
             let mut blocked = false;
             for let x of excluded {
-                if *x == k {
+                if x == k {
                     blocked = true;
                     break;
                 }

--- a/package-gale/tests/golden/ci_rule_override.wado
+++ b/package-gale/tests/golden/ci_rule_override.wado
@@ -1,0 +1,861 @@
+#![generated(by = "gale", sources = ["package-gale/tests/grammars/ci_rule_override.g4"])]
+
+// Grammar metadata from source .g4 prequels:
+//   option caseInsensitive = true
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &Array<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &Array<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &Array<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: Array<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// ParseError represents a parse failure with location and expected tokens.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: Array<String>,
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: Array<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+}
+
+/// CstChild is either a terminal token or a non-terminal sub-tree.
+pub variant CstChild {
+    Token(Token),
+    Node(CstNode),
+}
+
+/// CstNode is a generic (untyped) concrete syntax tree node.
+pub struct CstNode {
+    pub name: String,
+    pub span: Span,
+    pub children: Array<CstChild>,
+}
+
+impl CstNode {
+    /// Produce an ANTLR4-style S-expression representation of this tree.
+    /// Rule nodes become `(name child1 child2 ...)`, tokens become their text.
+    /// Tokens with empty text (e.g. EOF) are omitted.
+    pub fn to_string_tree(&self) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(out: &mut String, node: &CstNode) {
+    out.push_str(`({node.name}`);
+    for let child of &node.children {
+        if let Token(t) = *child {
+            if !t.text.is_empty() {
+                out.push_str(` {t.text}`);
+            }
+        } else if let Node(n) = *child {
+            out.push_str(" ");
+            cst_to_string_tree_impl(out, n);
+        }
+    }
+    out.push_str(")");
+}
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Highlight override: when inside a specific rule, override the capture for a token kind.
+pub struct HighlightOverride {
+    pub rule_name: String,
+    pub token_kind: i32,
+    pub capture: String,
+}
+
+/// Highlight mapping: defaults by token kind + context-aware overrides.
+pub struct HighlightMapping {
+    pub defaults: Array<String>,
+    pub overrides: Array<HighlightOverride>,
+}
+
+/// A single highlight capture: a named range in the source text.
+pub struct HighlightCapture {
+    pub capture: String,
+    pub start: i32,
+    pub end: i32,
+}
+
+/// HighlightVisitor collects highlight captures during a CST walk.
+pub struct HighlightVisitor {
+    mapping: HighlightMapping,
+    rule_stack: Array<String>,
+    pub captures: Array<HighlightCapture>,
+}
+
+impl HighlightVisitor {
+    pub fn new(mapping: HighlightMapping) -> HighlightVisitor {
+        return HighlightVisitor { mapping, rule_stack: [], captures: [] };
+    }
+
+    fn classify(&self, kind: i32) -> String {
+        for let ov of &self.mapping.overrides {
+            if ov.token_kind == kind {
+                for let rule of &self.rule_stack {
+                    if *rule == ov.rule_name {
+                        return ov.capture;
+                    }
+                }
+            }
+        }
+        if kind >= 0 && kind < self.mapping.defaults.len() {
+            return self.mapping.defaults[kind];
+        }
+        return "";
+    }
+}
+
+impl Visitor for HighlightVisitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.rule_stack.push(*name);
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        if !self.rule_stack.is_empty() {
+            let last = self.rule_stack.len() - 1;
+            let mut new_stack: Array<String> = [];
+            for let mut i = 0; i < last; i += 1 {
+                new_stack.push(self.rule_stack[i]);
+            }
+            self.rule_stack = new_stack;
+        }
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        for let trivia of &token.leading_trivia {
+            let cap = self.classify(trivia.kind);
+            if !cap.is_empty() {
+                self.captures.push(HighlightCapture { capture: cap, start: trivia.span.start, end: trivia.span.end });
+            }
+        }
+        if token.text.is_empty() {
+            return;
+        }
+        let cap = self.classify(token.kind);
+        if !cap.is_empty() {
+            self.captures.push(HighlightCapture { capture: cap, start: token.span.start, end: token.span.end });
+        }
+    }
+}
+
+fn escape_html(out: &mut String, text: &String) {
+    for let c of text.chars() {
+        if c == '&' {
+            out.push_str("&amp;");
+        } else if c == '<' {
+            out.push_str("&lt;");
+        } else if c == '>' {
+            out.push_str("&gt;");
+        } else if c == '"' {
+            out.push_str("&quot;");
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+fn escape_html_char(out: &mut String, c: char) {
+    if c == '&' {
+        out.push_str("&amp;");
+    } else if c == '<' {
+        out.push_str("&lt;");
+    } else if c == '>' {
+        out.push_str("&gt;");
+    } else if c == '"' {
+        out.push_str("&quot;");
+    } else {
+        out.push(c);
+    }
+}
+
+fn push_class(out: &mut String, capture: &String) {
+    for let c of capture.chars() {
+        if c == '.' {
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+/// Produce a highlighted HTML fragment from source text and captures.
+/// Captures must be sorted by start position (as produced by HighlightVisitor).
+pub fn highlight_html(source: &String, captures: &Array<HighlightCapture>) -> String {
+    let mut out = String::with_capacity(source.len() * 5);
+    let mut pos = 0;
+    let mut iter = source.chars();
+    for let cap of captures {
+        while pos < cap.start {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("<span class=\"");
+        push_class(&mut out, &cap.capture);
+        out.push_str("\">");
+        let end = cap.end;
+        while pos < end {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("</span>");
+    }
+    while let Some(c) = iter.next() {
+        escape_html_char(&mut out, c);
+    }
+    return out;
+}
+
+fn substr(chars: &Array<char>, start: i32, end: i32) -> String {
+    let mut out = String::with_capacity(end - start);
+    let mut i = start;
+    while i < end && i < chars.len() {
+        out.push(chars[i]);
+        i += 1;
+    }
+    return out;
+}
+
+/// Visitor trait for walking typed CST nodes.
+/// Default methods are no-ops; override to add behavior.
+pub trait Visitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn visit_token(&mut self, token: &Token) {
+    }
+}
+
+/// TreeRecorder is a Visitor that records events for building a CstNode tree.
+pub struct TreeRecorder {
+    events: Array<TreeEvent>,
+}
+
+variant TreeEvent {
+    Enter(TreeEnterInfo),
+    Exit,
+    VisitToken(Token),
+}
+
+struct TreeEnterInfo {
+    name: String,
+    span: Span,
+}
+
+impl TreeRecorder {
+    pub fn new() -> TreeRecorder {
+        return TreeRecorder { events: [] };
+    }
+
+    pub fn build(&self) -> CstNode {
+        let mut pos = 0;
+        return tree_build_node(&self.events, &mut pos);
+    }
+}
+
+impl Visitor for TreeRecorder {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Enter(TreeEnterInfo { name: *name, span: *span }));
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Exit);
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        self.events.push(TreeEvent::VisitToken(*token));
+    }
+}
+
+fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
+    if let Enter(info) = events[*pos] {
+        *pos += 1;
+        let mut children: Array<CstChild> = [];
+        loop {
+            if *pos >= events.len() {
+                break;
+            }
+            let ev = events[*pos];
+            if let Exit = ev {
+                *pos += 1;
+                break;
+            }
+            if let Enter(_) = ev {
+                children.push(CstChild::Node(tree_build_node(events, pos)));
+            } else if let VisitToken(t) = ev {
+                children.push(CstChild::Token(t));
+                *pos += 1;
+            }
+        }
+        return CstNode { name: info.name, span: info.span, children };
+    }
+    panic("TreeRecorder: expected Enter event");
+    return CstNode { name: "", span: Span::new(0, 0), children: [] };
+}
+
+pub enum TokenKind {
+    KEYWORD,
+    IDENT,
+    EXACT,
+    WS,
+    Eof,
+    Error,
+}
+
+pub struct LineNode {
+    pub span: Span,
+    pub keyword_or_ident_or_exact_list: Array<Token>,
+    pub eof: Token,
+}
+
+global TK_KEYWORD: i32 = 0;
+global TK_IDENT: i32 = 1;
+global TK_EXACT: i32 = 2;
+global TK_WS: i32 = 3;
+global TK_EOF: i32 = 4;
+global TK_ERROR: i32 = 5;
+
+struct Lexer {
+    chars: Array<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.chars().collect(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_keyword(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !chars[pos].eq_ignore_ascii_case(&'i') { return -1; }
+    pos += 1;
+    if pos >= chars.len() || !chars[pos].eq_ignore_ascii_case(&'f') { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ident(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || '0' <= chars[pos] <= '9' || chars[pos] == '_') { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_exact(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'E' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'X' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'A' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'C' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'T' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ws(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> Array<Token> {
+    let mut lexer = Lexer::new(input);
+    let mut tokens: Array<Token> = [];
+    let mut trivia: Array<Token> = [];
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == 'E' {
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENT; }
+            end = try_exact(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_EXACT; }
+        } else if first_char == 'I' || first_char == 'i' {
+            end = try_keyword(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_KEYWORD; }
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENT; }
+        } else if 'A' <= first_char <= 'Z' {
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENT; }
+        } else {
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENT; }
+        }
+        if best_end <= start {
+            let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
+            tokens.push(tok);
+            trivia = [];
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else {
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
+                tokens.push(tok);
+                trivia = [];
+            }
+            lexer.pos = best_end;
+        }
+    }
+    tokens.push(Token::with_trivia(TK_EOF, LexerSlice::empty(&lexer.chars), Span::new(lexer.pos, lexer.pos), trivia));
+    return tokens;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_KEYWORD => "KEYWORD",
+        TK_IDENT => "IDENT",
+        TK_EXACT => "EXACT",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+struct Parser {
+    tokens: Array<Token>,
+    pos: i32,
+}
+
+impl Parser {
+    fn new(tokens: Array<Token>) -> Parser {
+        return Parser { tokens, pos: 0 };
+    }
+
+    fn peek(&self) -> &Token {
+        return &self.tokens[self.pos];
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.tokens[self.pos].kind;
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.tokens[idx].kind;
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.tokens[self.pos];
+        self.pos += 1;
+        return tok;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens[self.pos - 1].span.end;
+    }
+
+    fn expect(&mut self, kind: i32) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind == kind {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        let name = token_kind_name(kind);
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn fail(&self, name: String) -> Result<Token, ParseError> {
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
+        ));
+    }
+}
+
+fn scan_line(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let gp_0 = pos;
+    sg_0: {
+        pos = gp_0;
+        sg_0_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_KEYWORD { break sg_0_0; }
+            pos += 1;
+            break sg_0;
+        }
+        pos = gp_0;
+        sg_0_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_IDENT { break sg_0_1; }
+            pos += 1;
+            break sg_0;
+        }
+        pos = gp_0;
+        sg_0_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_EXACT { break sg_0_2; }
+            pos += 1;
+            break sg_0;
+        }
+        return -1;
+    }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_KEYWORD | TK_IDENT | TK_EXACT } {
+        let sp = pos;
+        let gp_1 = pos;
+        sg_1: {
+            pos = gp_1;
+            sg_1_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_KEYWORD { break sg_1_0; }
+                pos += 1;
+                break sg_1;
+            }
+            pos = gp_1;
+            sg_1_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_IDENT { break sg_1_1; }
+                pos += 1;
+                break sg_1;
+            }
+            pos = gp_1;
+            sg_1_2: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_EXACT { break sg_1_2; }
+                pos += 1;
+                break sg_1;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn parse_line(p: &mut Parser) -> Result<LineNode, ParseError> {
+    let start = p.peek().span.start;
+    let mut keyword_or_ident_or_exact_list: Array<Token> = [];
+    let mut _plus_first = true;
+    loop {
+        if !_plus_first {
+            let mut rep_scan_pos: i32 = -1;
+            rep_scan: {
+                let tokens = &p.tokens;
+                let mut pos: i32 = p.pos;
+                let gp_2 = pos;
+                sg_2: {
+                    pos = gp_2;
+                    sg_2_0: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_KEYWORD { break sg_2_0; }
+                        pos += 1;
+                        break sg_2;
+                    }
+                    pos = gp_2;
+                    sg_2_1: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_IDENT { break sg_2_1; }
+                        pos += 1;
+                        break sg_2;
+                    }
+                    pos = gp_2;
+                    sg_2_2: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_EXACT { break sg_2_2; }
+                        pos += 1;
+                        break sg_2;
+                    }
+                    break rep_scan;
+                }
+                if pos <= p.pos { break rep_scan; }
+                rep_scan_pos = pos;
+            }
+            if rep_scan_pos < 0 { break; }
+        }
+        _plus_first = false;
+        let keyword_or_ident_or_exact = p.advance();
+        keyword_or_ident_or_exact_list.push(keyword_or_ident_or_exact);
+    }
+    let eof = p.expect(TK_EOF)?;
+    return Result::<LineNode, ParseError>::Ok(LineNode {
+        span: Span::new(start, p.last_end()),
+        keyword_or_ident_or_exact_list,
+        eof,
+    });
+}
+
+pub fn parse(input: &String) -> Result<LineNode, ParseError> {
+    let tokens = tokenize(input);
+    let mut parser = Parser::new(tokens);
+    return parse_line(&mut parser);
+}
+
+pub fn walk_line<V: Visitor>(v: &mut V, node: &LineNode) {
+    v.enter_rule(&"line", &node.span);
+    for let item of &node.keyword_or_ident_or_exact_list {
+        v.visit_token(item);
+    }
+    v.visit_token(&node.eof);
+    v.exit_rule(&"line", &node.span);
+}
+
+pub fn to_tree(node: &LineNode) -> CstNode {
+    let mut recorder = TreeRecorder::new();
+    walk_line(&mut recorder, node);
+    return recorder.build();
+}
+

--- a/package-gale/tests/golden/css3.wado
+++ b/package-gale/tests/golden/css3.wado
@@ -29322,12 +29322,12 @@ impl Parser {
         ));
     }
 
-    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
         let k = self.tokens[self.pos].kind;
         if k != TK_EOF {
             let mut blocked = false;
             for let x of excluded {
-                if *x == k {
+                if x == k {
                     blocked = true;
                     break;
                 }

--- a/package-gale/tests/golden/html.wado
+++ b/package-gale/tests/golden/html.wado
@@ -1999,12 +1999,12 @@ impl Parser {
         ));
     }
 
-    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
         let k = self.tokens[self.pos].kind;
         if k != TK_EOF {
             let mut blocked = false;
             for let x of excluded {
-                if *x == k {
+                if x == k {
                     blocked = true;
                     break;
                 }

--- a/package-gale/tests/golden/json.wado
+++ b/package-gale/tests/golden/json.wado
@@ -1034,12 +1034,12 @@ impl Parser {
         ));
     }
 
-    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
         let k = self.tokens[self.pos].kind;
         if k != TK_EOF {
             let mut blocked = false;
             for let x of excluded {
-                if *x == k {
+                if x == k {
                     blocked = true;
                     break;
                 }

--- a/package-gale/tests/golden/json_highlight.wado
+++ b/package-gale/tests/golden/json_highlight.wado
@@ -1034,12 +1034,12 @@ impl Parser {
         ));
     }
 
-    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
         let k = self.tokens[self.pos].kind;
         if k != TK_EOF {
             let mut blocked = false;
             for let x of excluded {
-                if *x == k {
+                if x == k {
                     blocked = true;
                     break;
                 }

--- a/package-gale/tests/golden/label_gaps.wado
+++ b/package-gale/tests/golden/label_gaps.wado
@@ -1,0 +1,1217 @@
+#![generated(by = "gale", sources = ["package-gale/tests/grammars/label_gaps.g4"])]
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &Array<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &Array<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &Array<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: Array<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// ParseError represents a parse failure with location and expected tokens.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: Array<String>,
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: Array<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+}
+
+/// CstChild is either a terminal token or a non-terminal sub-tree.
+pub variant CstChild {
+    Token(Token),
+    Node(CstNode),
+}
+
+/// CstNode is a generic (untyped) concrete syntax tree node.
+pub struct CstNode {
+    pub name: String,
+    pub span: Span,
+    pub children: Array<CstChild>,
+}
+
+impl CstNode {
+    /// Produce an ANTLR4-style S-expression representation of this tree.
+    /// Rule nodes become `(name child1 child2 ...)`, tokens become their text.
+    /// Tokens with empty text (e.g. EOF) are omitted.
+    pub fn to_string_tree(&self) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(out: &mut String, node: &CstNode) {
+    out.push_str(`({node.name}`);
+    for let child of &node.children {
+        if let Token(t) = *child {
+            if !t.text.is_empty() {
+                out.push_str(` {t.text}`);
+            }
+        } else if let Node(n) = *child {
+            out.push_str(" ");
+            cst_to_string_tree_impl(out, n);
+        }
+    }
+    out.push_str(")");
+}
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Highlight override: when inside a specific rule, override the capture for a token kind.
+pub struct HighlightOverride {
+    pub rule_name: String,
+    pub token_kind: i32,
+    pub capture: String,
+}
+
+/// Highlight mapping: defaults by token kind + context-aware overrides.
+pub struct HighlightMapping {
+    pub defaults: Array<String>,
+    pub overrides: Array<HighlightOverride>,
+}
+
+/// A single highlight capture: a named range in the source text.
+pub struct HighlightCapture {
+    pub capture: String,
+    pub start: i32,
+    pub end: i32,
+}
+
+/// HighlightVisitor collects highlight captures during a CST walk.
+pub struct HighlightVisitor {
+    mapping: HighlightMapping,
+    rule_stack: Array<String>,
+    pub captures: Array<HighlightCapture>,
+}
+
+impl HighlightVisitor {
+    pub fn new(mapping: HighlightMapping) -> HighlightVisitor {
+        return HighlightVisitor { mapping, rule_stack: [], captures: [] };
+    }
+
+    fn classify(&self, kind: i32) -> String {
+        for let ov of &self.mapping.overrides {
+            if ov.token_kind == kind {
+                for let rule of &self.rule_stack {
+                    if *rule == ov.rule_name {
+                        return ov.capture;
+                    }
+                }
+            }
+        }
+        if kind >= 0 && kind < self.mapping.defaults.len() {
+            return self.mapping.defaults[kind];
+        }
+        return "";
+    }
+}
+
+impl Visitor for HighlightVisitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.rule_stack.push(*name);
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        if !self.rule_stack.is_empty() {
+            let last = self.rule_stack.len() - 1;
+            let mut new_stack: Array<String> = [];
+            for let mut i = 0; i < last; i += 1 {
+                new_stack.push(self.rule_stack[i]);
+            }
+            self.rule_stack = new_stack;
+        }
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        for let trivia of &token.leading_trivia {
+            let cap = self.classify(trivia.kind);
+            if !cap.is_empty() {
+                self.captures.push(HighlightCapture { capture: cap, start: trivia.span.start, end: trivia.span.end });
+            }
+        }
+        if token.text.is_empty() {
+            return;
+        }
+        let cap = self.classify(token.kind);
+        if !cap.is_empty() {
+            self.captures.push(HighlightCapture { capture: cap, start: token.span.start, end: token.span.end });
+        }
+    }
+}
+
+fn escape_html(out: &mut String, text: &String) {
+    for let c of text.chars() {
+        if c == '&' {
+            out.push_str("&amp;");
+        } else if c == '<' {
+            out.push_str("&lt;");
+        } else if c == '>' {
+            out.push_str("&gt;");
+        } else if c == '"' {
+            out.push_str("&quot;");
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+fn escape_html_char(out: &mut String, c: char) {
+    if c == '&' {
+        out.push_str("&amp;");
+    } else if c == '<' {
+        out.push_str("&lt;");
+    } else if c == '>' {
+        out.push_str("&gt;");
+    } else if c == '"' {
+        out.push_str("&quot;");
+    } else {
+        out.push(c);
+    }
+}
+
+fn push_class(out: &mut String, capture: &String) {
+    for let c of capture.chars() {
+        if c == '.' {
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+/// Produce a highlighted HTML fragment from source text and captures.
+/// Captures must be sorted by start position (as produced by HighlightVisitor).
+pub fn highlight_html(source: &String, captures: &Array<HighlightCapture>) -> String {
+    let mut out = String::with_capacity(source.len() * 5);
+    let mut pos = 0;
+    let mut iter = source.chars();
+    for let cap of captures {
+        while pos < cap.start {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("<span class=\"");
+        push_class(&mut out, &cap.capture);
+        out.push_str("\">");
+        let end = cap.end;
+        while pos < end {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("</span>");
+    }
+    while let Some(c) = iter.next() {
+        escape_html_char(&mut out, c);
+    }
+    return out;
+}
+
+fn substr(chars: &Array<char>, start: i32, end: i32) -> String {
+    let mut out = String::with_capacity(end - start);
+    let mut i = start;
+    while i < end && i < chars.len() {
+        out.push(chars[i]);
+        i += 1;
+    }
+    return out;
+}
+
+/// Visitor trait for walking typed CST nodes.
+/// Default methods are no-ops; override to add behavior.
+pub trait Visitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn visit_token(&mut self, token: &Token) {
+    }
+}
+
+/// TreeRecorder is a Visitor that records events for building a CstNode tree.
+pub struct TreeRecorder {
+    events: Array<TreeEvent>,
+}
+
+variant TreeEvent {
+    Enter(TreeEnterInfo),
+    Exit,
+    VisitToken(Token),
+}
+
+struct TreeEnterInfo {
+    name: String,
+    span: Span,
+}
+
+impl TreeRecorder {
+    pub fn new() -> TreeRecorder {
+        return TreeRecorder { events: [] };
+    }
+
+    pub fn build(&self) -> CstNode {
+        let mut pos = 0;
+        return tree_build_node(&self.events, &mut pos);
+    }
+}
+
+impl Visitor for TreeRecorder {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Enter(TreeEnterInfo { name: *name, span: *span }));
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Exit);
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        self.events.push(TreeEvent::VisitToken(*token));
+    }
+}
+
+fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
+    if let Enter(info) = events[*pos] {
+        *pos += 1;
+        let mut children: Array<CstChild> = [];
+        loop {
+            if *pos >= events.len() {
+                break;
+            }
+            let ev = events[*pos];
+            if let Exit = ev {
+                *pos += 1;
+                break;
+            }
+            if let Enter(_) = ev {
+                children.push(CstChild::Node(tree_build_node(events, pos)));
+            } else if let VisitToken(t) = ev {
+                children.push(CstChild::Token(t));
+                *pos += 1;
+            }
+        }
+        return CstNode { name: info.name, span: info.span, children };
+    }
+    panic("TreeRecorder: expected Enter event");
+    return CstNode { name: "", span: Span::new(0, 0), children: [] };
+}
+
+pub enum TokenKind {
+    PAIR,
+    LIST,
+    EQ,
+    COLON,
+    COMMA,
+    SEMI,
+    ID,
+    STRING,
+    WS,
+    Eof,
+    Error,
+}
+
+pub struct ProgramNode {
+    pub span: Span,
+    pub stmt_list: Array<StmtNode>,
+    pub eof: Token,
+}
+
+pub variant StmtNode {
+    Alt0(StmtAlt0),
+    Alt1(StmtAlt1),
+    Alt2(StmtAlt2),
+}
+
+pub struct StmtAlt0 {
+    pub span: Span,
+    pub assign_stmt: AssignStmtNode,
+}
+
+pub struct StmtAlt1 {
+    pub span: Span,
+    pub pair_stmt: PairStmtNode,
+}
+
+pub struct StmtAlt2 {
+    pub span: Span,
+    pub mix_stmt: MixStmtNode,
+}
+
+pub struct AssignStmtNode {
+    pub span: Span,
+    pub key: Token,
+    pub eq: Token,
+    pub value: Token,
+    pub semi: Token,
+}
+
+pub struct PairStmtNode {
+    pub span: Span,
+    pub pair: Token,
+    pub k: KeyRuleNode,
+    pub colon: Token,
+    pub id: Token,
+    pub semi: Token,
+}
+
+pub struct KeyRuleNode {
+    pub span: Span,
+    pub id: Token,
+}
+
+pub struct CommaRestItem {
+    pub comma: Token,
+    pub rest: Array<Token>,
+}
+
+pub struct MixStmtNode {
+    pub span: Span,
+    pub list: Token,
+    pub head: Token,
+    pub comma_rest_list: Array<CommaRestItem>,
+    pub semi: Token,
+}
+
+global TK_PAIR: i32 = 0;
+global TK_LIST: i32 = 1;
+global TK_EQ: i32 = 2;
+global TK_COLON: i32 = 3;
+global TK_COMMA: i32 = 4;
+global TK_SEMI: i32 = 5;
+global TK_ID: i32 = 6;
+global TK_STRING: i32 = 7;
+global TK_WS: i32 = 8;
+global TK_EOF: i32 = 9;
+global TK_ERROR: i32 = 10;
+
+struct Lexer {
+    chars: Array<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.chars().collect(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_pair(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'p' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'a' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'i' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'r' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_list(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'l' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'i' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 's' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 't' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_eq(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '=' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_colon(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != ':' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_comma(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != ',' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_semi(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != ';' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_id(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || chars[pos] == '_') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || chars[pos] == '_' || '0' <= chars[pos] <= '9') { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_string(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '"' { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            let alts_saved_2 = pos;
+            let mut alts_ok_2 = false;
+            alts_2_0: {
+                pos = alts_saved_2;
+                if pos >= chars.len() { break alts_2_0; }
+                if false || chars[pos] == '"' || chars[pos] == '\\' { break alts_2_0; }
+                pos += 1;
+                alts_ok_2 = true;
+            }
+            if !alts_ok_2 {
+                alts_2_1: {
+                    pos = alts_saved_2;
+                    if pos >= chars.len() || chars[pos] != '\\' { break alts_2_1; }
+                    pos += 1;
+                    if pos >= chars.len() { break alts_2_1; }
+                    pos += 1;
+                    alts_ok_2 = true;
+                }
+            }
+            if !alts_ok_2 { break rep_1; }
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    if pos >= chars.len() || chars[pos] != '"' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ws(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_3 = pos;
+        rep_3: {
+            if pos >= chars.len() { break rep_3; }
+            if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { break rep_3; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_3;
+        break;
+    }
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> Array<Token> {
+    let mut lexer = Lexer::new(input);
+    let mut tokens: Array<Token> = [];
+    let mut trivia: Array<Token> = [];
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '"' {
+            end = try_string(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STRING; }
+        } else if first_char == ',' {
+            end = try_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_COMMA; }
+        } else if first_char == ':' {
+            end = try_colon(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_COLON; }
+        } else if first_char == ';' {
+            end = try_semi(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SEMI; }
+        } else if first_char == '=' {
+            end = try_eq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_EQ; }
+        } else if first_char == '_' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if first_char == 'l' {
+            end = try_list(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIST; }
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if first_char == 'p' {
+            end = try_pair(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PAIR; }
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if 'A' <= first_char <= 'Z' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
+            tokens.push(tok);
+            trivia = [];
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else {
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
+                tokens.push(tok);
+                trivia = [];
+            }
+            lexer.pos = best_end;
+        }
+    }
+    tokens.push(Token::with_trivia(TK_EOF, LexerSlice::empty(&lexer.chars), Span::new(lexer.pos, lexer.pos), trivia));
+    return tokens;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_PAIR => "PAIR",
+        TK_LIST => "LIST",
+        TK_EQ => "EQ",
+        TK_COLON => "COLON",
+        TK_COMMA => "COMMA",
+        TK_SEMI => "SEMI",
+        TK_ID => "ID",
+        TK_STRING => "STRING",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+struct Parser {
+    tokens: Array<Token>,
+    pos: i32,
+}
+
+impl Parser {
+    fn new(tokens: Array<Token>) -> Parser {
+        return Parser { tokens, pos: 0 };
+    }
+
+    fn peek(&self) -> &Token {
+        return &self.tokens[self.pos];
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.tokens[self.pos].kind;
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.tokens[idx].kind;
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.tokens[self.pos];
+        self.pos += 1;
+        return tok;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens[self.pos - 1].span.end;
+    }
+
+    fn expect(&mut self, kind: i32) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind == kind {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        let name = token_kind_name(kind);
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn fail(&self, name: String) -> Result<Token, ParseError> {
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
+        ));
+    }
+}
+
+fn scan_program(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_ID | TK_PAIR | TK_LIST } {
+        let sp = pos;
+        pos = scan_stmt(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_ID {
+            pos = start;
+            try_0: {
+                pos = scan_assign_stmt(tokens, pos);
+                if pos < 0 { break try_0; }
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_PAIR {
+            pos = start;
+            try_1: {
+                pos = scan_pair_stmt(tokens, pos);
+                if pos < 0 { break try_1; }
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_LIST {
+            pos = start;
+            try_2: {
+                pos = scan_mix_stmt(tokens, pos);
+                if pos < 0 { break try_2; }
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_assign_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_ID { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_EQ { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_STRING { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_pair_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_PAIR { return -1; }
+    pos += 1;
+    pos = scan_key_rule(tokens, pos);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_ID { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_key_rule(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_ID { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_mix_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIST { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_ID { return -1; }
+    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+        let sp = pos;
+        sg_0_done: {
+            sg_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_ID { break sg_0; }
+                pos += 1;
+                break sg_0_done;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn parse_program(p: &mut Parser) -> Result<ProgramNode, ParseError> {
+    let start = p.peek().span.start;
+    let mut stmt_list: Array<StmtNode> = [];
+    loop {
+        let mut rep_scan_pos: i32 = -1;
+        rep_scan: {
+            let tokens = &p.tokens;
+            let mut pos: i32 = p.pos;
+            pos = scan_stmt(tokens, pos);
+            if pos < 0 { break rep_scan; }
+            if pos <= p.pos { break rep_scan; }
+            rep_scan_pos = pos;
+        }
+        if rep_scan_pos < 0 { break; }
+        let stmt = parse_stmt(p)?;
+        stmt_list.push(stmt);
+    }
+    let eof = p.expect(TK_EOF)?;
+    return Result::<ProgramNode, ParseError>::Ok(ProgramNode {
+        span: Span::new(start, p.last_end()),
+        stmt_list,
+        eof,
+    });
+}
+
+fn parse_stmt(p: &mut Parser) -> Result<StmtNode, ParseError> {
+    let start = p.peek().span.start;
+    let kind = p.peek_kind();
+    if kind == TK_ID {
+        let assign_stmt = parse_assign_stmt(p)?;
+        return Result::<StmtNode, ParseError>::Ok(StmtNode::Alt0(StmtAlt0 {
+            span: Span::new(start, p.last_end()),
+            assign_stmt,
+        }));
+    }
+    if kind == TK_PAIR {
+        let pair_stmt = parse_pair_stmt(p)?;
+        return Result::<StmtNode, ParseError>::Ok(StmtNode::Alt1(StmtAlt1 {
+            span: Span::new(start, p.last_end()),
+            pair_stmt,
+        }));
+    }
+    if kind == TK_LIST {
+        let mix_stmt = parse_mix_stmt(p)?;
+        return Result::<StmtNode, ParseError>::Ok(StmtNode::Alt2(StmtAlt2 {
+            span: Span::new(start, p.last_end()),
+            mix_stmt,
+        }));
+    }
+    return Result::<StmtNode, ParseError>::Err(ParseError::new(
+        "expected stmt",
+        p.peek().span,
+        ["TK_ID", "TK_PAIR", "TK_LIST"],
+    ));
+}
+
+fn parse_assign_stmt(p: &mut Parser) -> Result<AssignStmtNode, ParseError> {
+    let start = p.peek().span.start;
+    let id = p.expect(TK_ID)?;
+    let key = id;
+    let eq = p.expect(TK_EQ)?;
+    let string = p.expect(TK_STRING)?;
+    let value = string;
+    let semi = p.expect(TK_SEMI)?;
+    return Result::<AssignStmtNode, ParseError>::Ok(AssignStmtNode {
+        span: Span::new(start, p.last_end()),
+        key,
+        eq,
+        value,
+        semi,
+    });
+}
+
+fn parse_pair_stmt(p: &mut Parser) -> Result<PairStmtNode, ParseError> {
+    let start = p.peek().span.start;
+    let pair = p.expect(TK_PAIR)?;
+    let key_rule = parse_key_rule(p)?;
+    let k = key_rule;
+    let colon = p.expect(TK_COLON)?;
+    let id = p.expect(TK_ID)?;
+    let semi = p.expect(TK_SEMI)?;
+    return Result::<PairStmtNode, ParseError>::Ok(PairStmtNode {
+        span: Span::new(start, p.last_end()),
+        pair,
+        k,
+        colon,
+        id,
+        semi,
+    });
+}
+
+fn parse_key_rule(p: &mut Parser) -> Result<KeyRuleNode, ParseError> {
+    let start = p.peek().span.start;
+    let id = p.expect(TK_ID)?;
+    return Result::<KeyRuleNode, ParseError>::Ok(KeyRuleNode {
+        span: Span::new(start, p.last_end()),
+        id,
+    });
+}
+
+fn parse_mix_stmt(p: &mut Parser) -> Result<MixStmtNode, ParseError> {
+    let start = p.peek().span.start;
+    let list = p.expect(TK_LIST)?;
+    let id = p.expect(TK_ID)?;
+    let head = id;
+    let mut comma_rest_list: Array<CommaRestItem> = [];
+    loop {
+        let mut rep_scan_pos: i32 = -1;
+        rep_scan: {
+            let tokens = &p.tokens;
+            let mut pos: i32 = p.pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_ID { break rep_scan; }
+            pos += 1;
+            if pos <= p.pos { break rep_scan; }
+            rep_scan_pos = pos;
+        }
+        if rep_scan_pos < 0 { break; }
+        let comma = p.expect(TK_COMMA)?;
+        let mut rest: Array<Token> = [];
+        let id = p.expect(TK_ID)?;
+        rest.push(id);
+        let comma_rest = CommaRestItem {
+            comma,
+            rest,
+        };
+        comma_rest_list.push(comma_rest);
+    }
+    let semi = p.expect(TK_SEMI)?;
+    return Result::<MixStmtNode, ParseError>::Ok(MixStmtNode {
+        span: Span::new(start, p.last_end()),
+        list,
+        head,
+        comma_rest_list,
+        semi,
+    });
+}
+
+pub fn parse(input: &String) -> Result<ProgramNode, ParseError> {
+    let tokens = tokenize(input);
+    let mut parser = Parser::new(tokens);
+    return parse_program(&mut parser);
+}
+
+pub fn walk_program<V: Visitor>(v: &mut V, node: &ProgramNode) {
+    v.enter_rule(&"program", &node.span);
+    for let item of &node.stmt_list {
+        walk_stmt(v, item);
+    }
+    v.visit_token(&node.eof);
+    v.exit_rule(&"program", &node.span);
+}
+
+pub fn walk_stmt<V: Visitor>(v: &mut V, node: &StmtNode) {
+    match node {
+        Alt0(n) => {
+            v.enter_rule(&"stmt", &n.span);
+            walk_assign_stmt(v, &n.assign_stmt);
+            v.exit_rule(&"stmt", &n.span);
+        }
+        Alt1(n) => {
+            v.enter_rule(&"stmt", &n.span);
+            walk_pair_stmt(v, &n.pair_stmt);
+            v.exit_rule(&"stmt", &n.span);
+        }
+        Alt2(n) => {
+            v.enter_rule(&"stmt", &n.span);
+            walk_mix_stmt(v, &n.mix_stmt);
+            v.exit_rule(&"stmt", &n.span);
+        }
+    }
+}
+
+pub fn walk_assign_stmt<V: Visitor>(v: &mut V, node: &AssignStmtNode) {
+    v.enter_rule(&"assign_stmt", &node.span);
+    v.visit_token(&node.key);
+    v.visit_token(&node.eq);
+    v.visit_token(&node.value);
+    v.visit_token(&node.semi);
+    v.exit_rule(&"assign_stmt", &node.span);
+}
+
+pub fn walk_pair_stmt<V: Visitor>(v: &mut V, node: &PairStmtNode) {
+    v.enter_rule(&"pair_stmt", &node.span);
+    v.visit_token(&node.pair);
+    walk_key_rule(v, &node.k);
+    v.visit_token(&node.colon);
+    v.visit_token(&node.id);
+    v.visit_token(&node.semi);
+    v.exit_rule(&"pair_stmt", &node.span);
+}
+
+pub fn walk_key_rule<V: Visitor>(v: &mut V, node: &KeyRuleNode) {
+    v.enter_rule(&"key_rule", &node.span);
+    v.visit_token(&node.id);
+    v.exit_rule(&"key_rule", &node.span);
+}
+
+pub fn walk_mix_stmt<V: Visitor>(v: &mut V, node: &MixStmtNode) {
+    v.enter_rule(&"mix_stmt", &node.span);
+    v.visit_token(&node.list);
+    v.visit_token(&node.head);
+    for let item of &node.comma_rest_list {
+        v.visit_token(&item.comma);
+        for let item of &item.rest {
+            v.visit_token(item);
+        }
+    }
+    v.visit_token(&node.semi);
+    v.exit_rule(&"mix_stmt", &node.span);
+}
+
+pub fn to_tree(node: &ProgramNode) -> CstNode {
+    let mut recorder = TreeRecorder::new();
+    walk_program(&mut recorder, node);
+    return recorder.build();
+}
+

--- a/package-gale/tests/golden/lexer_command_gaps.wado
+++ b/package-gale/tests/golden/lexer_command_gaps.wado
@@ -1,0 +1,963 @@
+#![generated(by = "gale", sources = ["package-gale/tests/grammars/lexer_command_gaps.g4"])]
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &Array<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &Array<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &Array<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: Array<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// ParseError represents a parse failure with location and expected tokens.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: Array<String>,
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: Array<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+}
+
+/// CstChild is either a terminal token or a non-terminal sub-tree.
+pub variant CstChild {
+    Token(Token),
+    Node(CstNode),
+}
+
+/// CstNode is a generic (untyped) concrete syntax tree node.
+pub struct CstNode {
+    pub name: String,
+    pub span: Span,
+    pub children: Array<CstChild>,
+}
+
+impl CstNode {
+    /// Produce an ANTLR4-style S-expression representation of this tree.
+    /// Rule nodes become `(name child1 child2 ...)`, tokens become their text.
+    /// Tokens with empty text (e.g. EOF) are omitted.
+    pub fn to_string_tree(&self) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(out: &mut String, node: &CstNode) {
+    out.push_str(`({node.name}`);
+    for let child of &node.children {
+        if let Token(t) = *child {
+            if !t.text.is_empty() {
+                out.push_str(` {t.text}`);
+            }
+        } else if let Node(n) = *child {
+            out.push_str(" ");
+            cst_to_string_tree_impl(out, n);
+        }
+    }
+    out.push_str(")");
+}
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Highlight override: when inside a specific rule, override the capture for a token kind.
+pub struct HighlightOverride {
+    pub rule_name: String,
+    pub token_kind: i32,
+    pub capture: String,
+}
+
+/// Highlight mapping: defaults by token kind + context-aware overrides.
+pub struct HighlightMapping {
+    pub defaults: Array<String>,
+    pub overrides: Array<HighlightOverride>,
+}
+
+/// A single highlight capture: a named range in the source text.
+pub struct HighlightCapture {
+    pub capture: String,
+    pub start: i32,
+    pub end: i32,
+}
+
+/// HighlightVisitor collects highlight captures during a CST walk.
+pub struct HighlightVisitor {
+    mapping: HighlightMapping,
+    rule_stack: Array<String>,
+    pub captures: Array<HighlightCapture>,
+}
+
+impl HighlightVisitor {
+    pub fn new(mapping: HighlightMapping) -> HighlightVisitor {
+        return HighlightVisitor { mapping, rule_stack: [], captures: [] };
+    }
+
+    fn classify(&self, kind: i32) -> String {
+        for let ov of &self.mapping.overrides {
+            if ov.token_kind == kind {
+                for let rule of &self.rule_stack {
+                    if *rule == ov.rule_name {
+                        return ov.capture;
+                    }
+                }
+            }
+        }
+        if kind >= 0 && kind < self.mapping.defaults.len() {
+            return self.mapping.defaults[kind];
+        }
+        return "";
+    }
+}
+
+impl Visitor for HighlightVisitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.rule_stack.push(*name);
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        if !self.rule_stack.is_empty() {
+            let last = self.rule_stack.len() - 1;
+            let mut new_stack: Array<String> = [];
+            for let mut i = 0; i < last; i += 1 {
+                new_stack.push(self.rule_stack[i]);
+            }
+            self.rule_stack = new_stack;
+        }
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        for let trivia of &token.leading_trivia {
+            let cap = self.classify(trivia.kind);
+            if !cap.is_empty() {
+                self.captures.push(HighlightCapture { capture: cap, start: trivia.span.start, end: trivia.span.end });
+            }
+        }
+        if token.text.is_empty() {
+            return;
+        }
+        let cap = self.classify(token.kind);
+        if !cap.is_empty() {
+            self.captures.push(HighlightCapture { capture: cap, start: token.span.start, end: token.span.end });
+        }
+    }
+}
+
+fn escape_html(out: &mut String, text: &String) {
+    for let c of text.chars() {
+        if c == '&' {
+            out.push_str("&amp;");
+        } else if c == '<' {
+            out.push_str("&lt;");
+        } else if c == '>' {
+            out.push_str("&gt;");
+        } else if c == '"' {
+            out.push_str("&quot;");
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+fn escape_html_char(out: &mut String, c: char) {
+    if c == '&' {
+        out.push_str("&amp;");
+    } else if c == '<' {
+        out.push_str("&lt;");
+    } else if c == '>' {
+        out.push_str("&gt;");
+    } else if c == '"' {
+        out.push_str("&quot;");
+    } else {
+        out.push(c);
+    }
+}
+
+fn push_class(out: &mut String, capture: &String) {
+    for let c of capture.chars() {
+        if c == '.' {
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+/// Produce a highlighted HTML fragment from source text and captures.
+/// Captures must be sorted by start position (as produced by HighlightVisitor).
+pub fn highlight_html(source: &String, captures: &Array<HighlightCapture>) -> String {
+    let mut out = String::with_capacity(source.len() * 5);
+    let mut pos = 0;
+    let mut iter = source.chars();
+    for let cap of captures {
+        while pos < cap.start {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("<span class=\"");
+        push_class(&mut out, &cap.capture);
+        out.push_str("\">");
+        let end = cap.end;
+        while pos < end {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("</span>");
+    }
+    while let Some(c) = iter.next() {
+        escape_html_char(&mut out, c);
+    }
+    return out;
+}
+
+fn substr(chars: &Array<char>, start: i32, end: i32) -> String {
+    let mut out = String::with_capacity(end - start);
+    let mut i = start;
+    while i < end && i < chars.len() {
+        out.push(chars[i]);
+        i += 1;
+    }
+    return out;
+}
+
+/// Visitor trait for walking typed CST nodes.
+/// Default methods are no-ops; override to add behavior.
+pub trait Visitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn visit_token(&mut self, token: &Token) {
+    }
+}
+
+/// TreeRecorder is a Visitor that records events for building a CstNode tree.
+pub struct TreeRecorder {
+    events: Array<TreeEvent>,
+}
+
+variant TreeEvent {
+    Enter(TreeEnterInfo),
+    Exit,
+    VisitToken(Token),
+}
+
+struct TreeEnterInfo {
+    name: String,
+    span: Span,
+}
+
+impl TreeRecorder {
+    pub fn new() -> TreeRecorder {
+        return TreeRecorder { events: [] };
+    }
+
+    pub fn build(&self) -> CstNode {
+        let mut pos = 0;
+        return tree_build_node(&self.events, &mut pos);
+    }
+}
+
+impl Visitor for TreeRecorder {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Enter(TreeEnterInfo { name: *name, span: *span }));
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Exit);
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        self.events.push(TreeEvent::VisitToken(*token));
+    }
+}
+
+fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
+    if let Enter(info) = events[*pos] {
+        *pos += 1;
+        let mut children: Array<CstChild> = [];
+        loop {
+            if *pos >= events.len() {
+                break;
+            }
+            let ev = events[*pos];
+            if let Exit = ev {
+                *pos += 1;
+                break;
+            }
+            if let Enter(_) = ev {
+                children.push(CstChild::Node(tree_build_node(events, pos)));
+            } else if let VisitToken(t) = ev {
+                children.push(CstChild::Token(t));
+                *pos += 1;
+            }
+        }
+        return CstNode { name: info.name, span: info.span, children };
+    }
+    panic("TreeRecorder: expected Enter event");
+    return CstNode { name: "", span: Span::new(0, 0), children: [] };
+}
+
+pub enum TokenKind {
+    WORD,
+    ZERO,
+    NUMBER,
+    COMMENT,
+    PRAGMA_OPEN,
+    WS,
+    PRAGMA,
+    PRAGMA_WS,
+    PRAGMA_END,
+    Eof,
+    Error,
+}
+
+pub struct TextNode {
+    pub span: Span,
+    pub word_or_number_or_pragma_list: Array<Token>,
+    pub eof: Token,
+}
+
+global TK_WORD: i32 = 0;
+global TK_ZERO: i32 = 1;
+global TK_NUMBER: i32 = 2;
+global TK_COMMENT: i32 = 3;
+global TK_PRAGMA_OPEN: i32 = 4;
+global TK_WS: i32 = 5;
+global TK_PRAGMA: i32 = 6;
+global TK_PRAGMA_WS: i32 = 7;
+global TK_PRAGMA_END: i32 = 8;
+global TK_EOF: i32 = 9;
+global TK_ERROR: i32 = 10;
+
+struct Lexer {
+    chars: Array<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.chars().collect(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_word(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || 'a' <= chars[pos] <= 'z') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !(false || 'a' <= chars[pos] <= 'z') { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_zero(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'z' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'e' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'r' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'o' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_number(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || '0' <= chars[pos] <= '9') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !(false || '0' <= chars[pos] <= '9') { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_comment(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '/' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '/' { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if false || chars[pos] == '\r' || chars[pos] == '\n' { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+fn try_pragma_open(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '#' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'p' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'r' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'a' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'g' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'm' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'a' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ws(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_3 = pos;
+        rep_3: {
+            if pos >= chars.len() { break rep_3; }
+            if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { break rep_3; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_3;
+        break;
+    }
+    return pos;
+}
+
+fn try_pragma(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || chars[pos] == '_') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_4 = pos;
+        rep_4: {
+            if pos >= chars.len() { break rep_4; }
+            if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || chars[pos] == '_') { break rep_4; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_4;
+        break;
+    }
+    return pos;
+}
+
+fn try_pragma_ws(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\t') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_5 = pos;
+        rep_5: {
+            if pos >= chars.len() { break rep_5; }
+            if !(false || chars[pos] == ' ' || chars[pos] == '\t') { break rep_5; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_5;
+        break;
+    }
+    return pos;
+}
+
+fn try_pragma_end(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '\n' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> Array<Token> {
+    let mut lexer = Lexer::new(input);
+    let mut tokens: Array<Token> = [];
+    let mut trivia: Array<Token> = [];
+    let mut mode_stack: Array<i32> = [];
+    let mut current_mode: i32 = 0;
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        let mut best_push_mode: i32 = -1;
+        let mut best_pop_mode = false;
+        let mut best_set_mode: i32 = -1;
+        let mut best_channel: i32 = 0;
+        if current_mode == 0 {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; best_push_mode = -1; best_pop_mode = false; best_set_mode = -1; best_channel = 0; }
+            end = try_zero(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; best_push_mode = -1; best_pop_mode = false; best_set_mode = -1; best_channel = 0; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; best_push_mode = -1; best_pop_mode = false; best_set_mode = -1; best_channel = 0; }
+            end = try_comment(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_COMMENT; best_push_mode = -1; best_pop_mode = false; best_set_mode = -1; best_channel = 2; }
+            end = try_pragma_open(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PRAGMA_OPEN; best_push_mode = 1; best_pop_mode = false; best_set_mode = -1; best_channel = 0; }
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; best_push_mode = -1; best_pop_mode = false; best_set_mode = -1; best_channel = 0; }
+        } else if current_mode == 1 {
+            end = try_pragma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PRAGMA; best_push_mode = -1; best_pop_mode = false; best_set_mode = -1; best_channel = 0; }
+            end = try_pragma_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PRAGMA_WS; best_push_mode = -1; best_pop_mode = false; best_set_mode = -1; best_channel = 0; }
+            end = try_pragma_end(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PRAGMA_END; best_push_mode = -1; best_pop_mode = false; best_set_mode = 0; best_channel = 0; }
+        }
+        if best_end <= start {
+            let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
+            tokens.push(tok);
+            trivia = [];
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_PRAGMA_OPEN | TK_WS | TK_PRAGMA_WS | TK_PRAGMA_END };
+            if is_skip {
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else if best_channel != 0 {
+                trivia.push(Token::with_channel(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), [], best_channel));
+            } else {
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
+                tokens.push(tok);
+                trivia = [];
+            }
+            if best_push_mode >= 0 {
+                mode_stack.push(current_mode);
+                current_mode = best_push_mode;
+                best_push_mode = -1;
+            }
+            if best_pop_mode {
+                if mode_stack.is_empty() {
+                    current_mode = 0;
+                } else {
+                    current_mode = mode_stack[mode_stack.len() - 1];
+                    mode_stack.pop();
+                }
+                best_pop_mode = false;
+            }
+            if best_set_mode >= 0 {
+                current_mode = best_set_mode;
+                best_set_mode = -1;
+            }
+            lexer.pos = best_end;
+        }
+    }
+    tokens.push(Token::with_trivia(TK_EOF, LexerSlice::empty(&lexer.chars), Span::new(lexer.pos, lexer.pos), trivia));
+    return tokens;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_WORD => "WORD",
+        TK_ZERO => "ZERO",
+        TK_NUMBER => "NUMBER",
+        TK_COMMENT => "COMMENT",
+        TK_PRAGMA_OPEN => "PRAGMA_OPEN",
+        TK_WS => "WS",
+        TK_PRAGMA => "PRAGMA",
+        TK_PRAGMA_WS => "PRAGMA_WS",
+        TK_PRAGMA_END => "PRAGMA_END",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+struct Parser {
+    tokens: Array<Token>,
+    pos: i32,
+}
+
+impl Parser {
+    fn new(tokens: Array<Token>) -> Parser {
+        return Parser { tokens, pos: 0 };
+    }
+
+    fn peek(&self) -> &Token {
+        return &self.tokens[self.pos];
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.tokens[self.pos].kind;
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.tokens[idx].kind;
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.tokens[self.pos];
+        self.pos += 1;
+        return tok;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens[self.pos - 1].span.end;
+    }
+
+    fn expect(&mut self, kind: i32) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind == kind {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        let name = token_kind_name(kind);
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn fail(&self, name: String) -> Result<Token, ParseError> {
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
+        ));
+    }
+}
+
+fn scan_text(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_WORD | TK_NUMBER | TK_PRAGMA } {
+        let sp = pos;
+        let gp_0 = pos;
+        sg_0: {
+            pos = gp_0;
+            sg_0_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_WORD { break sg_0_0; }
+                pos += 1;
+                break sg_0;
+            }
+            pos = gp_0;
+            sg_0_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_NUMBER { break sg_0_1; }
+                pos += 1;
+                break sg_0;
+            }
+            pos = gp_0;
+            sg_0_2: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_PRAGMA { break sg_0_2; }
+                pos += 1;
+                break sg_0;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn parse_text(p: &mut Parser) -> Result<TextNode, ParseError> {
+    let start = p.peek().span.start;
+    let mut word_or_number_or_pragma_list: Array<Token> = [];
+    loop {
+        let mut rep_scan_pos: i32 = -1;
+        rep_scan: {
+            let tokens = &p.tokens;
+            let mut pos: i32 = p.pos;
+            let gp_1 = pos;
+            sg_1: {
+                pos = gp_1;
+                sg_1_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_WORD { break sg_1_0; }
+                    pos += 1;
+                    break sg_1;
+                }
+                pos = gp_1;
+                sg_1_1: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_NUMBER { break sg_1_1; }
+                    pos += 1;
+                    break sg_1;
+                }
+                pos = gp_1;
+                sg_1_2: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_PRAGMA { break sg_1_2; }
+                    pos += 1;
+                    break sg_1;
+                }
+                break rep_scan;
+            }
+            if pos <= p.pos { break rep_scan; }
+            rep_scan_pos = pos;
+        }
+        if rep_scan_pos < 0 { break; }
+        let word_or_number_or_pragma = p.advance();
+        word_or_number_or_pragma_list.push(word_or_number_or_pragma);
+    }
+    let eof = p.expect(TK_EOF)?;
+    return Result::<TextNode, ParseError>::Ok(TextNode {
+        span: Span::new(start, p.last_end()),
+        word_or_number_or_pragma_list,
+        eof,
+    });
+}
+
+pub fn parse(input: &String) -> Result<TextNode, ParseError> {
+    let tokens = tokenize(input);
+    let mut parser = Parser::new(tokens);
+    return parse_text(&mut parser);
+}
+
+pub fn walk_text<V: Visitor>(v: &mut V, node: &TextNode) {
+    v.enter_rule(&"text", &node.span);
+    for let item of &node.word_or_number_or_pragma_list {
+        v.visit_token(item);
+    }
+    v.visit_token(&node.eof);
+    v.exit_rule(&"text", &node.span);
+}
+
+pub fn to_tree(node: &TextNode) -> CstNode {
+    let mut recorder = TreeRecorder::new();
+    walk_text(&mut recorder, node);
+    return recorder.build();
+}
+

--- a/package-gale/tests/golden/mode_gaps.wado
+++ b/package-gale/tests/golden/mode_gaps.wado
@@ -1,7 +1,4 @@
-#![generated(by = "gale", sources = ["package-gale/tests/grammars/ci_sql.g4"])]
-
-// Grammar metadata from source .g4 prequels:
-//   option caseInsensitive = true
+#![generated(by = "gale", sources = ["package-gale/tests/grammars/mode_gaps.g4"])]
 
 /// Span represents a byte range in source text.
 pub struct Span {
@@ -472,25 +469,32 @@ fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
 }
 
 pub enum TokenKind {
-    IF,
-    IDENT,
+    PLAIN,
+    QUOTE,
     WS,
+    STR_ESC_BEGIN,
+    STR_CHAR,
+    STRING,
+    ESC_CHAR,
     Eof,
     Error,
 }
 
-pub struct StmtNode {
+pub struct TextNode {
     pub span: Span,
-    pub if_: Token,
-    pub ident: Token,
+    pub plain_or_string_list: Array<Token>,
     pub eof: Token,
 }
 
-global TK_IF: i32 = 0;
-global TK_IDENT: i32 = 1;
+global TK_PLAIN: i32 = 0;
+global TK_QUOTE: i32 = 1;
 global TK_WS: i32 = 2;
-global TK_EOF: i32 = 3;
-global TK_ERROR: i32 = 4;
+global TK_STR_ESC_BEGIN: i32 = 3;
+global TK_STR_CHAR: i32 = 4;
+global TK_STRING: i32 = 5;
+global TK_ESC_CHAR: i32 = 6;
+global TK_EOF: i32 = 7;
+global TK_ERROR: i32 = 8;
 
 struct Lexer {
     chars: Array<char>,
@@ -511,25 +515,16 @@ impl Lexer {
     }
 }
 
-fn try_if(chars: &Array<char>, start: i32) -> i32 {
-    let mut pos = start;
-    if pos >= chars.len() || !chars[pos].eq_ignore_ascii_case(&'i') { return -1; }
-    pos += 1;
-    if pos >= chars.len() || !chars[pos].eq_ignore_ascii_case(&'f') { return -1; }
-    pos += 1;
-    return pos;
-}
-
-fn try_ident(chars: &Array<char>, start: i32) -> i32 {
+fn try_plain(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
     if pos >= chars.len() { return -1; }
-    if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || chars[pos] == '_') { return -1; }
+    if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z') { return -1; }
     pos += 1;
     loop {
         let rep_saved_0 = pos;
         rep_0: {
             if pos >= chars.len() { break rep_0; }
-            if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || chars[pos] == '_') { break rep_0; }
+            if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z') { break rep_0; }
             pos += 1;
             continue;
         }
@@ -539,16 +534,23 @@ fn try_ident(chars: &Array<char>, start: i32) -> i32 {
     return pos;
 }
 
+fn try_quote(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '"' { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn try_ws(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
     if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == ' ' || chars[pos] == '\t') { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { return -1; }
     pos += 1;
     loop {
         let rep_saved_1 = pos;
         rep_1: {
             if pos >= chars.len() { break rep_1; }
-            if !(false || chars[pos] == ' ' || chars[pos] == '\t') { break rep_1; }
+            if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { break rep_1; }
             pos += 1;
             continue;
         }
@@ -558,36 +560,69 @@ fn try_ws(chars: &Array<char>, start: i32) -> i32 {
     return pos;
 }
 
+fn try_str_esc_begin(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '\\' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_str_char(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if false || chars[pos] == '\\' || chars[pos] == '"' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_string(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '"' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_esc_char(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    pos += 1;
+    return pos;
+}
+
 pub fn tokenize(input: &String) -> Array<Token> {
     let mut lexer = Lexer::new(input);
     let mut tokens: Array<Token> = [];
     let mut trivia: Array<Token> = [];
+    let mut more_start: i32 = -1;
+    let mut mode_stack: Array<i32> = [];
+    let mut current_mode: i32 = 0;
     while !lexer.at_end() {
         let start = lexer.pos;
         let mut best_end: i32 = -1;
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
         let first_char = lexer.chars[start];
-        if first_char == '\t' || first_char == ' ' {
+        let mut best_push_mode: i32 = -1;
+        let mut best_pop_mode = false;
+        let mut best_set_mode: i32 = -1;
+        let mut best_more = false;
+        if current_mode == 0 {
+            end = try_plain(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_PLAIN; best_push_mode = -1; best_pop_mode = false; best_set_mode = -1; best_more = false; }
+            end = try_quote(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_QUOTE; best_push_mode = 1; best_pop_mode = false; best_set_mode = -1; best_more = true; }
             end = try_ws(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_WS; }
-        } else if first_char == 'I' || first_char == 'i' {
-            end = try_if(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IF; }
-            end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENT; }
-        } else if first_char == '_' {
-            end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENT; }
-        } else if 'a' <= first_char <= 'z' {
-            end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENT; }
-        } else if 'A' <= first_char <= 'Z' {
-            end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENT; }
-        } else {
-            end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENT; }
+            if end > best_end { best_end = end; best_kind = TK_WS; best_push_mode = -1; best_pop_mode = false; best_set_mode = -1; best_more = false; }
+        } else if current_mode == 1 {
+            end = try_str_esc_begin(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STR_ESC_BEGIN; best_push_mode = -1; best_pop_mode = false; best_set_mode = 2; best_more = true; }
+            end = try_str_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STR_CHAR; best_push_mode = -1; best_pop_mode = false; best_set_mode = -1; best_more = true; }
+            end = try_string(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_STRING; best_push_mode = -1; best_pop_mode = true; best_set_mode = -1; best_more = false; }
+        } else if current_mode == 2 {
+            end = try_esc_char(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ESC_CHAR; best_push_mode = -1; best_pop_mode = false; best_set_mode = 1; best_more = true; }
         }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
@@ -595,14 +630,36 @@ pub fn tokenize(input: &String) -> Array<Token> {
             trivia = [];
             lexer.pos = start + 1;
         } else {
-            let tok_start = start;
+            let tok_start = if more_start >= 0 { more_start } else { start };
             let is_skip = best_kind matches { TK_WS };
-            if is_skip {
+            if best_more {
+                if more_start < 0 { more_start = start; }
+            } else if is_skip {
                 trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+                more_start = -1;
             } else {
                 let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
                 tokens.push(tok);
                 trivia = [];
+                more_start = -1;
+            }
+            if best_push_mode >= 0 {
+                mode_stack.push(current_mode);
+                current_mode = best_push_mode;
+                best_push_mode = -1;
+            }
+            if best_pop_mode {
+                if mode_stack.is_empty() {
+                    current_mode = 0;
+                } else {
+                    current_mode = mode_stack[mode_stack.len() - 1];
+                    mode_stack.pop();
+                }
+                best_pop_mode = false;
+            }
+            if best_set_mode >= 0 {
+                current_mode = best_set_mode;
+                best_set_mode = -1;
             }
             lexer.pos = best_end;
         }
@@ -613,9 +670,13 @@ pub fn tokenize(input: &String) -> Array<Token> {
 
 pub fn token_kind_name(kind: i32) -> String {
     return match kind {
-        TK_IF => "IF",
-        TK_IDENT => "IDENT",
+        TK_PLAIN => "PLAIN",
+        TK_QUOTE => "QUOTE",
         TK_WS => "WS",
+        TK_STR_ESC_BEGIN => "STR_ESC_BEGIN",
+        TK_STR_CHAR => "STR_CHAR",
+        TK_STRING => "STRING",
+        TK_ESC_CHAR => "ESC_CHAR",
         TK_EOF => "Eof",
         TK_ERROR => "Error",
         _ => "Unknown",
@@ -714,47 +775,91 @@ impl Parser {
     }
 }
 
-fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_text(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    if pos >= tokens.len() || tokens[pos].kind != TK_IF { return -1; }
-    pos += 1;
-    if pos >= tokens.len() || tokens[pos].kind != TK_IDENT { return -1; }
-    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_PLAIN | TK_STRING } {
+        let sp = pos;
+        let gp_0 = pos;
+        sg_0: {
+            pos = gp_0;
+            sg_0_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_PLAIN { break sg_0_0; }
+                pos += 1;
+                break sg_0;
+            }
+            pos = gp_0;
+            sg_0_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_STRING { break sg_0_1; }
+                pos += 1;
+                break sg_0;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn parse_stmt(p: &mut Parser) -> Result<StmtNode, ParseError> {
+fn parse_text(p: &mut Parser) -> Result<TextNode, ParseError> {
     let start = p.peek().span.start;
-    let if_ = p.expect(TK_IF)?;
-    let ident = p.expect(TK_IDENT)?;
+    let mut plain_or_string_list: Array<Token> = [];
+    loop {
+        let mut rep_scan_pos: i32 = -1;
+        rep_scan: {
+            let tokens = &p.tokens;
+            let mut pos: i32 = p.pos;
+            let gp_1 = pos;
+            sg_1: {
+                pos = gp_1;
+                sg_1_0: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_PLAIN { break sg_1_0; }
+                    pos += 1;
+                    break sg_1;
+                }
+                pos = gp_1;
+                sg_1_1: {
+                    if pos >= tokens.len() || tokens[pos].kind != TK_STRING { break sg_1_1; }
+                    pos += 1;
+                    break sg_1;
+                }
+                break rep_scan;
+            }
+            if pos <= p.pos { break rep_scan; }
+            rep_scan_pos = pos;
+        }
+        if rep_scan_pos < 0 { break; }
+        let plain_or_string = p.advance();
+        plain_or_string_list.push(plain_or_string);
+    }
     let eof = p.expect(TK_EOF)?;
-    return Result::<StmtNode, ParseError>::Ok(StmtNode {
+    return Result::<TextNode, ParseError>::Ok(TextNode {
         span: Span::new(start, p.last_end()),
-        if_,
-        ident,
+        plain_or_string_list,
         eof,
     });
 }
 
-pub fn parse(input: &String) -> Result<StmtNode, ParseError> {
+pub fn parse(input: &String) -> Result<TextNode, ParseError> {
     let tokens = tokenize(input);
     let mut parser = Parser::new(tokens);
-    return parse_stmt(&mut parser);
+    return parse_text(&mut parser);
 }
 
-pub fn walk_stmt<V: Visitor>(v: &mut V, node: &StmtNode) {
-    v.enter_rule(&"stmt", &node.span);
-    v.visit_token(&node.if_);
-    v.visit_token(&node.ident);
+pub fn walk_text<V: Visitor>(v: &mut V, node: &TextNode) {
+    v.enter_rule(&"text", &node.span);
+    for let item of &node.plain_or_string_list {
+        v.visit_token(item);
+    }
     v.visit_token(&node.eof);
-    v.exit_rule(&"stmt", &node.span);
+    v.exit_rule(&"text", &node.span);
 }
 
-pub fn to_tree(node: &StmtNode) -> CstNode {
+pub fn to_tree(node: &TextNode) -> CstNode {
     let mut recorder = TreeRecorder::new();
-    walk_stmt(&mut recorder, node);
+    walk_text(&mut recorder, node);
     return recorder.build();
 }
 

--- a/package-gale/tests/golden/non_greedy_gaps.wado
+++ b/package-gale/tests/golden/non_greedy_gaps.wado
@@ -1,0 +1,997 @@
+#![generated(by = "gale", sources = ["package-gale/tests/grammars/non_greedy_gaps.g4"])]
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &Array<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &Array<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &Array<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: Array<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// ParseError represents a parse failure with location and expected tokens.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: Array<String>,
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: Array<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+}
+
+/// CstChild is either a terminal token or a non-terminal sub-tree.
+pub variant CstChild {
+    Token(Token),
+    Node(CstNode),
+}
+
+/// CstNode is a generic (untyped) concrete syntax tree node.
+pub struct CstNode {
+    pub name: String,
+    pub span: Span,
+    pub children: Array<CstChild>,
+}
+
+impl CstNode {
+    /// Produce an ANTLR4-style S-expression representation of this tree.
+    /// Rule nodes become `(name child1 child2 ...)`, tokens become their text.
+    /// Tokens with empty text (e.g. EOF) are omitted.
+    pub fn to_string_tree(&self) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(out: &mut String, node: &CstNode) {
+    out.push_str(`({node.name}`);
+    for let child of &node.children {
+        if let Token(t) = *child {
+            if !t.text.is_empty() {
+                out.push_str(` {t.text}`);
+            }
+        } else if let Node(n) = *child {
+            out.push_str(" ");
+            cst_to_string_tree_impl(out, n);
+        }
+    }
+    out.push_str(")");
+}
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Highlight override: when inside a specific rule, override the capture for a token kind.
+pub struct HighlightOverride {
+    pub rule_name: String,
+    pub token_kind: i32,
+    pub capture: String,
+}
+
+/// Highlight mapping: defaults by token kind + context-aware overrides.
+pub struct HighlightMapping {
+    pub defaults: Array<String>,
+    pub overrides: Array<HighlightOverride>,
+}
+
+/// A single highlight capture: a named range in the source text.
+pub struct HighlightCapture {
+    pub capture: String,
+    pub start: i32,
+    pub end: i32,
+}
+
+/// HighlightVisitor collects highlight captures during a CST walk.
+pub struct HighlightVisitor {
+    mapping: HighlightMapping,
+    rule_stack: Array<String>,
+    pub captures: Array<HighlightCapture>,
+}
+
+impl HighlightVisitor {
+    pub fn new(mapping: HighlightMapping) -> HighlightVisitor {
+        return HighlightVisitor { mapping, rule_stack: [], captures: [] };
+    }
+
+    fn classify(&self, kind: i32) -> String {
+        for let ov of &self.mapping.overrides {
+            if ov.token_kind == kind {
+                for let rule of &self.rule_stack {
+                    if *rule == ov.rule_name {
+                        return ov.capture;
+                    }
+                }
+            }
+        }
+        if kind >= 0 && kind < self.mapping.defaults.len() {
+            return self.mapping.defaults[kind];
+        }
+        return "";
+    }
+}
+
+impl Visitor for HighlightVisitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.rule_stack.push(*name);
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        if !self.rule_stack.is_empty() {
+            let last = self.rule_stack.len() - 1;
+            let mut new_stack: Array<String> = [];
+            for let mut i = 0; i < last; i += 1 {
+                new_stack.push(self.rule_stack[i]);
+            }
+            self.rule_stack = new_stack;
+        }
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        for let trivia of &token.leading_trivia {
+            let cap = self.classify(trivia.kind);
+            if !cap.is_empty() {
+                self.captures.push(HighlightCapture { capture: cap, start: trivia.span.start, end: trivia.span.end });
+            }
+        }
+        if token.text.is_empty() {
+            return;
+        }
+        let cap = self.classify(token.kind);
+        if !cap.is_empty() {
+            self.captures.push(HighlightCapture { capture: cap, start: token.span.start, end: token.span.end });
+        }
+    }
+}
+
+fn escape_html(out: &mut String, text: &String) {
+    for let c of text.chars() {
+        if c == '&' {
+            out.push_str("&amp;");
+        } else if c == '<' {
+            out.push_str("&lt;");
+        } else if c == '>' {
+            out.push_str("&gt;");
+        } else if c == '"' {
+            out.push_str("&quot;");
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+fn escape_html_char(out: &mut String, c: char) {
+    if c == '&' {
+        out.push_str("&amp;");
+    } else if c == '<' {
+        out.push_str("&lt;");
+    } else if c == '>' {
+        out.push_str("&gt;");
+    } else if c == '"' {
+        out.push_str("&quot;");
+    } else {
+        out.push(c);
+    }
+}
+
+fn push_class(out: &mut String, capture: &String) {
+    for let c of capture.chars() {
+        if c == '.' {
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+/// Produce a highlighted HTML fragment from source text and captures.
+/// Captures must be sorted by start position (as produced by HighlightVisitor).
+pub fn highlight_html(source: &String, captures: &Array<HighlightCapture>) -> String {
+    let mut out = String::with_capacity(source.len() * 5);
+    let mut pos = 0;
+    let mut iter = source.chars();
+    for let cap of captures {
+        while pos < cap.start {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("<span class=\"");
+        push_class(&mut out, &cap.capture);
+        out.push_str("\">");
+        let end = cap.end;
+        while pos < end {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("</span>");
+    }
+    while let Some(c) = iter.next() {
+        escape_html_char(&mut out, c);
+    }
+    return out;
+}
+
+fn substr(chars: &Array<char>, start: i32, end: i32) -> String {
+    let mut out = String::with_capacity(end - start);
+    let mut i = start;
+    while i < end && i < chars.len() {
+        out.push(chars[i]);
+        i += 1;
+    }
+    return out;
+}
+
+/// Visitor trait for walking typed CST nodes.
+/// Default methods are no-ops; override to add behavior.
+pub trait Visitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn visit_token(&mut self, token: &Token) {
+    }
+}
+
+/// TreeRecorder is a Visitor that records events for building a CstNode tree.
+pub struct TreeRecorder {
+    events: Array<TreeEvent>,
+}
+
+variant TreeEvent {
+    Enter(TreeEnterInfo),
+    Exit,
+    VisitToken(Token),
+}
+
+struct TreeEnterInfo {
+    name: String,
+    span: Span,
+}
+
+impl TreeRecorder {
+    pub fn new() -> TreeRecorder {
+        return TreeRecorder { events: [] };
+    }
+
+    pub fn build(&self) -> CstNode {
+        let mut pos = 0;
+        return tree_build_node(&self.events, &mut pos);
+    }
+}
+
+impl Visitor for TreeRecorder {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Enter(TreeEnterInfo { name: *name, span: *span }));
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Exit);
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        self.events.push(TreeEvent::VisitToken(*token));
+    }
+}
+
+fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
+    if let Enter(info) = events[*pos] {
+        *pos += 1;
+        let mut children: Array<CstChild> = [];
+        loop {
+            if *pos >= events.len() {
+                break;
+            }
+            let ev = events[*pos];
+            if let Exit = ev {
+                *pos += 1;
+                break;
+            }
+            if let Enter(_) = ev {
+                children.push(CstChild::Node(tree_build_node(events, pos)));
+            } else if let VisitToken(t) = ev {
+                children.push(CstChild::Token(t));
+                *pos += 1;
+            }
+        }
+        return CstNode { name: info.name, span: info.span, children };
+    }
+    panic("TreeRecorder: expected Enter event");
+    return CstNode { name: "", span: Span::new(0, 0), children: [] };
+}
+
+pub enum TokenKind {
+    ID,
+    INT,
+    OP,
+    SEMI,
+    WS,
+    Eof,
+    Error,
+}
+
+pub struct ConstantItemListItem {
+    pub constant: ConstantNode,
+    pub wildcard_list: Array<Token>,
+}
+
+pub struct FileNode {
+    pub span: Span,
+    pub wildcard_list: Array<Token>,
+    pub constant_item_list: Array<ConstantItemListItem>,
+    pub eof: Token,
+}
+
+pub struct ConstantNode {
+    pub span: Span,
+    pub lit_public: Token,
+    pub lit_static: Token,
+    pub lit_final: Token,
+    pub lit_int: Token,
+    pub id: Token,
+}
+
+global TK_ID: i32 = 0;
+global TK_INT: i32 = 1;
+global TK_OP: i32 = 2;
+global TK_SEMI: i32 = 3;
+global TK_WS: i32 = 4;
+global TK_EOF: i32 = 5;
+global TK_ERROR: i32 = 6;
+global TK_LIT_PUBLIC: i32 = 7;
+global TK_LIT_STATIC: i32 = 8;
+global TK_LIT_FINAL: i32 = 9;
+global TK_LIT_INT: i32 = 10;
+
+struct Lexer {
+    chars: Array<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.chars().collect(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_id(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || chars[pos] == '_') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || chars[pos] == '_' || '0' <= chars[pos] <= '9') { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_int(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || '0' <= chars[pos] <= '9') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !(false || '0' <= chars[pos] <= '9') { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_op(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == '+' || chars[pos] == '-' || chars[pos] == '*' || chars[pos] == '/' || chars[pos] == '=') { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_semi(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != ';' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ws(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+fn try_lit_public(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'p' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != 'u' { return -1; }
+    if pos + 2 >= chars.len() || chars[pos + 2] != 'b' { return -1; }
+    if pos + 3 >= chars.len() || chars[pos + 3] != 'l' { return -1; }
+    if pos + 4 >= chars.len() || chars[pos + 4] != 'i' { return -1; }
+    if pos + 5 >= chars.len() || chars[pos + 5] != 'c' { return -1; }
+    return pos + 6;
+}
+
+fn try_lit_static(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 's' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != 't' { return -1; }
+    if pos + 2 >= chars.len() || chars[pos + 2] != 'a' { return -1; }
+    if pos + 3 >= chars.len() || chars[pos + 3] != 't' { return -1; }
+    if pos + 4 >= chars.len() || chars[pos + 4] != 'i' { return -1; }
+    if pos + 5 >= chars.len() || chars[pos + 5] != 'c' { return -1; }
+    return pos + 6;
+}
+
+fn try_lit_final(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'f' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != 'i' { return -1; }
+    if pos + 2 >= chars.len() || chars[pos + 2] != 'n' { return -1; }
+    if pos + 3 >= chars.len() || chars[pos + 3] != 'a' { return -1; }
+    if pos + 4 >= chars.len() || chars[pos + 4] != 'l' { return -1; }
+    return pos + 5;
+}
+
+fn try_lit_int(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'i' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != 'n' { return -1; }
+    if pos + 2 >= chars.len() || chars[pos + 2] != 't' { return -1; }
+    return pos + 3;
+}
+
+pub fn tokenize(input: &String) -> Array<Token> {
+    let mut lexer = Lexer::new(input);
+    let mut tokens: Array<Token> = [];
+    let mut trivia: Array<Token> = [];
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' || first_char == '+' || first_char == '-' || first_char == '/' || first_char == '=' {
+            end = try_op(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OP; }
+        } else if first_char == ';' {
+            end = try_semi(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SEMI; }
+        } else if first_char == '_' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if first_char == 'f' {
+            end = try_lit_final(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_FINAL; }
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if first_char == 'i' {
+            end = try_lit_int(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_INT; }
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if first_char == 'p' {
+            end = try_lit_public(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PUBLIC; }
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if first_char == 's' {
+            end = try_lit_static(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_STATIC; }
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if 'A' <= first_char <= 'Z' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if '0' <= first_char <= '9' {
+            end = try_int(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+            end = try_int(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        }
+        if best_end <= start {
+            let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
+            tokens.push(tok);
+            trivia = [];
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else {
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
+                tokens.push(tok);
+                trivia = [];
+            }
+            lexer.pos = best_end;
+        }
+    }
+    tokens.push(Token::with_trivia(TK_EOF, LexerSlice::empty(&lexer.chars), Span::new(lexer.pos, lexer.pos), trivia));
+    return tokens;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_ID => "ID",
+        TK_INT => "INT",
+        TK_OP => "OP",
+        TK_SEMI => "SEMI",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_PUBLIC => "TK_LIT_PUBLIC",
+        TK_LIT_STATIC => "TK_LIT_STATIC",
+        TK_LIT_FINAL => "TK_LIT_FINAL",
+        TK_LIT_INT => "TK_LIT_INT",
+        _ => "Unknown",
+    };
+}
+
+struct Parser {
+    tokens: Array<Token>,
+    pos: i32,
+}
+
+impl Parser {
+    fn new(tokens: Array<Token>) -> Parser {
+        return Parser { tokens, pos: 0 };
+    }
+
+    fn peek(&self) -> &Token {
+        return &self.tokens[self.pos];
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.tokens[self.pos].kind;
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.tokens[idx].kind;
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.tokens[self.pos];
+        self.pos += 1;
+        return tok;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens[self.pos - 1].span.end;
+    }
+
+    fn expect(&mut self, kind: i32) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind == kind {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        let name = token_kind_name(kind);
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn fail(&self, name: String) -> Result<Token, ParseError> {
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
+        ));
+    }
+}
+
+fn scan_file(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && true {
+        let sp = pos;
+        if pos >= tokens.len() || tokens[pos].kind == TK_EOF { pos = -1; } else { pos += 1; }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    sg_0_done: {
+        sg_0: {
+            pos = scan_constant(tokens, pos);
+            if pos < 0 { break sg_0; }
+            while pos < tokens.len() && true {
+                let sp = pos;
+                if pos >= tokens.len() || tokens[pos].kind == TK_EOF { pos = -1; } else { pos += 1; }
+                if pos < 0 { pos = sp; break; }
+                if pos == sp { break; }
+            }
+            break sg_0_done;
+        }
+        return -1;
+    }
+    while pos < tokens.len() && tokens[pos].kind == TK_LIT_PUBLIC {
+        let sp = pos;
+        sg_1_done: {
+            sg_1: {
+                pos = scan_constant(tokens, pos);
+                if pos < 0 { break sg_1; }
+                while pos < tokens.len() && true {
+                    let sp = pos;
+                    if pos >= tokens.len() || tokens[pos].kind == TK_EOF { pos = -1; } else { pos += 1; }
+                    if pos < 0 { pos = sp; break; }
+                    if pos == sp { break; }
+                }
+                break sg_1_done;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_constant(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_PUBLIC { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STATIC { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_FINAL { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_INT { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_ID { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn parse_file(p: &mut Parser) -> Result<FileNode, ParseError> {
+    let start = p.peek().span.start;
+    let mut wildcard_list: Array<Token> = [];
+    while !(p.peek_kind() matches { TK_EOF | TK_LIT_PUBLIC }) {
+        let wildcard = p.match_any()?;
+        wildcard_list.push(wildcard);
+    }
+    let mut constant_item_list: Array<ConstantItemListItem> = [];
+    let mut _plus_first = true;
+    loop {
+        if !_plus_first {
+            let mut rep_scan_pos: i32 = -1;
+            rep_scan: {
+                let tokens = &p.tokens;
+                let mut pos: i32 = p.pos;
+                pos = scan_constant(tokens, pos);
+                if pos < 0 { break rep_scan; }
+                while pos < tokens.len() && true {
+                    let sp = pos;
+                    if pos >= tokens.len() || tokens[pos].kind == TK_EOF { pos = -1; } else { pos += 1; }
+                    if pos < 0 { pos = sp; break; }
+                    if pos == sp { break; }
+                }
+                if pos <= p.pos { break rep_scan; }
+                rep_scan_pos = pos;
+            }
+            if rep_scan_pos < 0 { break; }
+        }
+        _plus_first = false;
+        let constant = parse_constant(p)?;
+        let mut wildcard_list: Array<Token> = [];
+        while !(p.peek_kind() matches { TK_EOF | TK_LIT_PUBLIC }) {
+            let wildcard = p.match_any()?;
+            wildcard_list.push(wildcard);
+        }
+        let constant_item = ConstantItemListItem {
+            constant,
+            wildcard_list,
+        };
+        constant_item_list.push(constant_item);
+    }
+    let eof = p.expect(TK_EOF)?;
+    return Result::<FileNode, ParseError>::Ok(FileNode {
+        span: Span::new(start, p.last_end()),
+        wildcard_list,
+        constant_item_list,
+        eof,
+    });
+}
+
+fn parse_constant(p: &mut Parser) -> Result<ConstantNode, ParseError> {
+    let start = p.peek().span.start;
+    let lit_public = p.expect(TK_LIT_PUBLIC)?;
+    let lit_static = p.expect(TK_LIT_STATIC)?;
+    let lit_final = p.expect(TK_LIT_FINAL)?;
+    let lit_int = p.expect(TK_LIT_INT)?;
+    let id = p.expect(TK_ID)?;
+    return Result::<ConstantNode, ParseError>::Ok(ConstantNode {
+        span: Span::new(start, p.last_end()),
+        lit_public,
+        lit_static,
+        lit_final,
+        lit_int,
+        id,
+    });
+}
+
+pub fn parse(input: &String) -> Result<FileNode, ParseError> {
+    let tokens = tokenize(input);
+    let mut parser = Parser::new(tokens);
+    return parse_file(&mut parser);
+}
+
+pub fn walk_file<V: Visitor>(v: &mut V, node: &FileNode) {
+    v.enter_rule(&"file", &node.span);
+    for let item of &node.wildcard_list {
+        v.visit_token(item);
+    }
+    for let item of &node.constant_item_list {
+        walk_constant(v, &item.constant);
+        for let item of &item.wildcard_list {
+            v.visit_token(item);
+        }
+    }
+    v.visit_token(&node.eof);
+    v.exit_rule(&"file", &node.span);
+}
+
+pub fn walk_constant<V: Visitor>(v: &mut V, node: &ConstantNode) {
+    v.enter_rule(&"constant", &node.span);
+    v.visit_token(&node.lit_public);
+    v.visit_token(&node.lit_static);
+    v.visit_token(&node.lit_final);
+    v.visit_token(&node.lit_int);
+    v.visit_token(&node.id);
+    v.exit_rule(&"constant", &node.span);
+}
+
+pub fn to_tree(node: &FileNode) -> CstNode {
+    let mut recorder = TreeRecorder::new();
+    walk_file(&mut recorder, node);
+    return recorder.build();
+}
+

--- a/package-gale/tests/golden/parser_gaps.wado
+++ b/package-gale/tests/golden/parser_gaps.wado
@@ -1,7 +1,4 @@
-#![generated(by = "gale", sources = ["package-gale/tests/grammars/ci_sql.g4"])]
-
-// Grammar metadata from source .g4 prequels:
-//   option caseInsensitive = true
+#![generated(by = "gale", sources = ["package-gale/tests/grammars/parser_gaps.g4"])]
 
 /// Span represents a byte range in source text.
 pub struct Span {
@@ -472,25 +469,96 @@ fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
 }
 
 pub enum TokenKind {
-    IF,
-    IDENT,
+    LIST,
+    NOT,
+    SET,
+    ANY,
+    ITEM,
+    NUMBER,
+    COMMA,
+    SEMI,
     WS,
     Eof,
     Error,
 }
 
-pub struct StmtNode {
+pub struct ProgramNode {
     pub span: Span,
-    pub if_: Token,
-    pub ident: Token,
+    pub stmt_list: Array<StmtNode>,
     pub eof: Token,
 }
 
-global TK_IF: i32 = 0;
-global TK_IDENT: i32 = 1;
-global TK_WS: i32 = 2;
-global TK_EOF: i32 = 3;
-global TK_ERROR: i32 = 4;
+pub variant StmtNode {
+    Alt0(StmtAlt0),
+    Alt1(StmtAlt1),
+    Alt2(StmtAlt2),
+}
+
+pub struct StmtAlt0 {
+    pub span: Span,
+    pub list_stmt: ListStmtNode,
+}
+
+pub struct StmtAlt1 {
+    pub span: Span,
+    pub not_stmt: NotStmtNode,
+}
+
+pub struct StmtAlt2 {
+    pub span: Span,
+    pub any_stmt: AnyStmtNode,
+}
+
+pub struct CommaItemsItem {
+    pub comma: Token,
+    pub items: Array<Token>,
+}
+
+pub struct ListStmtNode {
+    pub span: Span,
+    pub list: Token,
+    pub items: Array<Token>,
+    pub comma_items_list: Array<CommaItemsItem>,
+    pub semi: Token,
+}
+
+pub variant NotStmtNode {
+    Alt0(NotStmtAlt0),
+    Alt1(NotStmtAlt1),
+}
+
+pub struct NotStmtAlt0 {
+    pub span: Span,
+    pub not: Token,
+    pub not_item: Token,
+    pub semi: Token,
+}
+
+pub struct NotStmtAlt1 {
+    pub span: Span,
+    pub set: Token,
+    pub not_set: Token,
+    pub semi: Token,
+}
+
+pub struct AnyStmtNode {
+    pub span: Span,
+    pub any: Token,
+    pub wildcard: Token,
+    pub semi: Token,
+}
+
+global TK_LIST: i32 = 0;
+global TK_NOT: i32 = 1;
+global TK_SET: i32 = 2;
+global TK_ANY: i32 = 3;
+global TK_ITEM: i32 = 4;
+global TK_NUMBER: i32 = 5;
+global TK_COMMA: i32 = 6;
+global TK_SEMI: i32 = 7;
+global TK_WS: i32 = 8;
+global TK_EOF: i32 = 9;
+global TK_ERROR: i32 = 10;
 
 struct Lexer {
     chars: Array<char>,
@@ -511,25 +579,62 @@ impl Lexer {
     }
 }
 
-fn try_if(chars: &Array<char>, start: i32) -> i32 {
+fn try_list(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
-    if pos >= chars.len() || !chars[pos].eq_ignore_ascii_case(&'i') { return -1; }
+    if pos >= chars.len() || chars[pos] != 'l' { return -1; }
     pos += 1;
-    if pos >= chars.len() || !chars[pos].eq_ignore_ascii_case(&'f') { return -1; }
+    if pos >= chars.len() || chars[pos] != 'i' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 's' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 't' { return -1; }
     pos += 1;
     return pos;
 }
 
-fn try_ident(chars: &Array<char>, start: i32) -> i32 {
+fn try_not(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'n' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'o' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 't' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_set(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 's' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'e' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 't' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_any(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'a' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'n' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'y' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_item(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
     if pos >= chars.len() { return -1; }
-    if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || chars[pos] == '_') { return -1; }
+    if !(false || 'a' <= chars[pos] <= 'z' || chars[pos] == '_') { return -1; }
     pos += 1;
     loop {
         let rep_saved_0 = pos;
         rep_0: {
             if pos >= chars.len() { break rep_0; }
-            if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || chars[pos] == '_') { break rep_0; }
+            if !(false || 'a' <= chars[pos] <= 'z' || chars[pos] == '_' || '0' <= chars[pos] <= '9') { break rep_0; }
             pos += 1;
             continue;
         }
@@ -539,20 +644,53 @@ fn try_ident(chars: &Array<char>, start: i32) -> i32 {
     return pos;
 }
 
-fn try_ws(chars: &Array<char>, start: i32) -> i32 {
+fn try_number(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
     if pos >= chars.len() { return -1; }
-    if !(false || chars[pos] == ' ' || chars[pos] == '\t') { return -1; }
+    if !(false || '0' <= chars[pos] <= '9') { return -1; }
     pos += 1;
     loop {
         let rep_saved_1 = pos;
         rep_1: {
             if pos >= chars.len() { break rep_1; }
-            if !(false || chars[pos] == ' ' || chars[pos] == '\t') { break rep_1; }
+            if !(false || '0' <= chars[pos] <= '9') { break rep_1; }
             pos += 1;
             continue;
         }
         pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_comma(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != ',' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_semi(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != ';' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ws(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
         break;
     }
     return pos;
@@ -568,26 +706,49 @@ pub fn tokenize(input: &String) -> Array<Token> {
         let mut best_kind: i32 = TK_ERROR;
         let mut end: i32 = -1;
         let first_char = lexer.chars[start];
-        if first_char == '\t' || first_char == ' ' {
+        if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
             end = try_ws(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_WS; }
-        } else if first_char == 'I' || first_char == 'i' {
-            end = try_if(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IF; }
-            end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENT; }
+        } else if first_char == ',' {
+            end = try_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_COMMA; }
+        } else if first_char == ';' {
+            end = try_semi(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SEMI; }
         } else if first_char == '_' {
-            end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENT; }
+            end = try_item(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ITEM; }
+        } else if first_char == 'a' {
+            end = try_any(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ANY; }
+            end = try_item(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ITEM; }
+        } else if first_char == 'l' {
+            end = try_list(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIST; }
+            end = try_item(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ITEM; }
+        } else if first_char == 'n' {
+            end = try_not(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NOT; }
+            end = try_item(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ITEM; }
+        } else if first_char == 's' {
+            end = try_set(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SET; }
+            end = try_item(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ITEM; }
         } else if 'a' <= first_char <= 'z' {
-            end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENT; }
-        } else if 'A' <= first_char <= 'Z' {
-            end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENT; }
+            end = try_item(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ITEM; }
+        } else if '0' <= first_char <= '9' {
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
         } else {
-            end = try_ident(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_IDENT; }
+            end = try_item(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ITEM; }
+            end = try_number(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUMBER; }
         }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
@@ -613,8 +774,14 @@ pub fn tokenize(input: &String) -> Array<Token> {
 
 pub fn token_kind_name(kind: i32) -> String {
     return match kind {
-        TK_IF => "IF",
-        TK_IDENT => "IDENT",
+        TK_LIST => "LIST",
+        TK_NOT => "NOT",
+        TK_SET => "SET",
+        TK_ANY => "ANY",
+        TK_ITEM => "ITEM",
+        TK_NUMBER => "NUMBER",
+        TK_COMMA => "COMMA",
+        TK_SEMI => "SEMI",
         TK_WS => "WS",
         TK_EOF => "Eof",
         TK_ERROR => "Error",
@@ -714,47 +881,350 @@ impl Parser {
     }
 }
 
-fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_program(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    if pos >= tokens.len() || tokens[pos].kind != TK_IF { return -1; }
-    pos += 1;
-    if pos >= tokens.len() || tokens[pos].kind != TK_IDENT { return -1; }
-    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind matches { TK_LIST | TK_NOT | TK_SET | TK_ANY } {
+        let sp = pos;
+        pos = scan_stmt(tokens, pos);
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn parse_stmt(p: &mut Parser) -> Result<StmtNode, ParseError> {
+fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_LIST {
+            pos = start;
+            try_0: {
+                pos = scan_list_stmt(tokens, pos);
+                if pos < 0 { break try_0; }
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind matches { TK_NOT | TK_SET } {
+            pos = start;
+            try_1: {
+                pos = scan_not_stmt(tokens, pos);
+                if pos < 0 { break try_1; }
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_ANY {
+            pos = start;
+            try_2: {
+                pos = scan_any_stmt(tokens, pos);
+                if pos < 0 { break try_2; }
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_list_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIST { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_ITEM { return -1; }
+    pos += 1;
+    while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
+        let sp = pos;
+        sg_0_done: {
+            sg_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_ITEM { break sg_0; }
+                pos += 1;
+                break sg_0_done;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_not_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_NOT {
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_NOT { break try_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind == TK_EOF || tokens[pos].kind == TK_ITEM { break try_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { break try_0; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_SET {
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_SET { break try_1; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind == TK_EOF || (tokens[pos].kind == TK_ITEM || tokens[pos].kind == TK_NUMBER) { break try_1; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { break try_1; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_any_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_ANY { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind == TK_EOF { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn parse_program(p: &mut Parser) -> Result<ProgramNode, ParseError> {
     let start = p.peek().span.start;
-    let if_ = p.expect(TK_IF)?;
-    let ident = p.expect(TK_IDENT)?;
+    let mut stmt_list: Array<StmtNode> = [];
+    loop {
+        let mut rep_scan_pos: i32 = -1;
+        rep_scan: {
+            let tokens = &p.tokens;
+            let mut pos: i32 = p.pos;
+            pos = scan_stmt(tokens, pos);
+            if pos < 0 { break rep_scan; }
+            if pos <= p.pos { break rep_scan; }
+            rep_scan_pos = pos;
+        }
+        if rep_scan_pos < 0 { break; }
+        let stmt = parse_stmt(p)?;
+        stmt_list.push(stmt);
+    }
     let eof = p.expect(TK_EOF)?;
-    return Result::<StmtNode, ParseError>::Ok(StmtNode {
+    return Result::<ProgramNode, ParseError>::Ok(ProgramNode {
         span: Span::new(start, p.last_end()),
-        if_,
-        ident,
+        stmt_list,
         eof,
     });
 }
 
-pub fn parse(input: &String) -> Result<StmtNode, ParseError> {
+fn parse_stmt(p: &mut Parser) -> Result<StmtNode, ParseError> {
+    let start = p.peek().span.start;
+    let kind = p.peek_kind();
+    if kind == TK_LIST {
+        let list_stmt = parse_list_stmt(p)?;
+        return Result::<StmtNode, ParseError>::Ok(StmtNode::Alt0(StmtAlt0 {
+            span: Span::new(start, p.last_end()),
+            list_stmt,
+        }));
+    }
+    if kind matches { TK_NOT | TK_SET } {
+        let not_stmt = parse_not_stmt(p)?;
+        return Result::<StmtNode, ParseError>::Ok(StmtNode::Alt1(StmtAlt1 {
+            span: Span::new(start, p.last_end()),
+            not_stmt,
+        }));
+    }
+    if kind == TK_ANY {
+        let any_stmt = parse_any_stmt(p)?;
+        return Result::<StmtNode, ParseError>::Ok(StmtNode::Alt2(StmtAlt2 {
+            span: Span::new(start, p.last_end()),
+            any_stmt,
+        }));
+    }
+    return Result::<StmtNode, ParseError>::Err(ParseError::new(
+        "expected stmt",
+        p.peek().span,
+        ["TK_LIST", "TK_NOT", "TK_SET", "TK_ANY"],
+    ));
+}
+
+fn parse_list_stmt(p: &mut Parser) -> Result<ListStmtNode, ParseError> {
+    let start = p.peek().span.start;
+    let list = p.expect(TK_LIST)?;
+    let mut items: Array<Token> = [];
+    let item = p.expect(TK_ITEM)?;
+    items.push(item);
+    let mut comma_items_list: Array<CommaItemsItem> = [];
+    loop {
+        let mut rep_scan_pos: i32 = -1;
+        rep_scan: {
+            let tokens = &p.tokens;
+            let mut pos: i32 = p.pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
+            pos += 1;
+            if pos >= tokens.len() || tokens[pos].kind != TK_ITEM { break rep_scan; }
+            pos += 1;
+            if pos <= p.pos { break rep_scan; }
+            rep_scan_pos = pos;
+        }
+        if rep_scan_pos < 0 { break; }
+        let comma = p.expect(TK_COMMA)?;
+        let mut items: Array<Token> = [];
+        let item = p.expect(TK_ITEM)?;
+        items.push(item);
+        let comma_items = CommaItemsItem {
+            comma,
+            items,
+        };
+        comma_items_list.push(comma_items);
+    }
+    let semi = p.expect(TK_SEMI)?;
+    return Result::<ListStmtNode, ParseError>::Ok(ListStmtNode {
+        span: Span::new(start, p.last_end()),
+        list,
+        items,
+        comma_items_list,
+        semi,
+    });
+}
+
+fn parse_not_stmt(p: &mut Parser) -> Result<NotStmtNode, ParseError> {
+    let start = p.peek().span.start;
+    let kind = p.peek_kind();
+    if kind == TK_NOT {
+        let not = p.expect(TK_NOT)?;
+        let not_item = p.match_not([TK_ITEM])?;
+        let semi = p.expect(TK_SEMI)?;
+        return Result::<NotStmtNode, ParseError>::Ok(NotStmtNode::Alt0(NotStmtAlt0 {
+            span: Span::new(start, p.last_end()),
+            not,
+            not_item,
+            semi,
+        }));
+    }
+    if kind == TK_SET {
+        let set = p.expect(TK_SET)?;
+        let not_set = p.match_not([TK_ITEM, TK_NUMBER])?;
+        let semi = p.expect(TK_SEMI)?;
+        return Result::<NotStmtNode, ParseError>::Ok(NotStmtNode::Alt1(NotStmtAlt1 {
+            span: Span::new(start, p.last_end()),
+            set,
+            not_set,
+            semi,
+        }));
+    }
+    return Result::<NotStmtNode, ParseError>::Err(ParseError::new(
+        "expected not_stmt",
+        p.peek().span,
+        ["TK_NOT", "TK_SET"],
+    ));
+}
+
+fn parse_any_stmt(p: &mut Parser) -> Result<AnyStmtNode, ParseError> {
+    let start = p.peek().span.start;
+    let any = p.expect(TK_ANY)?;
+    let wildcard = p.match_any()?;
+    let semi = p.expect(TK_SEMI)?;
+    return Result::<AnyStmtNode, ParseError>::Ok(AnyStmtNode {
+        span: Span::new(start, p.last_end()),
+        any,
+        wildcard,
+        semi,
+    });
+}
+
+pub fn parse(input: &String) -> Result<ProgramNode, ParseError> {
     let tokens = tokenize(input);
     let mut parser = Parser::new(tokens);
-    return parse_stmt(&mut parser);
+    return parse_program(&mut parser);
+}
+
+pub fn walk_program<V: Visitor>(v: &mut V, node: &ProgramNode) {
+    v.enter_rule(&"program", &node.span);
+    for let item of &node.stmt_list {
+        walk_stmt(v, item);
+    }
+    v.visit_token(&node.eof);
+    v.exit_rule(&"program", &node.span);
 }
 
 pub fn walk_stmt<V: Visitor>(v: &mut V, node: &StmtNode) {
-    v.enter_rule(&"stmt", &node.span);
-    v.visit_token(&node.if_);
-    v.visit_token(&node.ident);
-    v.visit_token(&node.eof);
-    v.exit_rule(&"stmt", &node.span);
+    match node {
+        Alt0(n) => {
+            v.enter_rule(&"stmt", &n.span);
+            walk_list_stmt(v, &n.list_stmt);
+            v.exit_rule(&"stmt", &n.span);
+        }
+        Alt1(n) => {
+            v.enter_rule(&"stmt", &n.span);
+            walk_not_stmt(v, &n.not_stmt);
+            v.exit_rule(&"stmt", &n.span);
+        }
+        Alt2(n) => {
+            v.enter_rule(&"stmt", &n.span);
+            walk_any_stmt(v, &n.any_stmt);
+            v.exit_rule(&"stmt", &n.span);
+        }
+    }
 }
 
-pub fn to_tree(node: &StmtNode) -> CstNode {
+pub fn walk_list_stmt<V: Visitor>(v: &mut V, node: &ListStmtNode) {
+    v.enter_rule(&"list_stmt", &node.span);
+    v.visit_token(&node.list);
+    for let item of &node.items {
+        v.visit_token(item);
+    }
+    for let item of &node.comma_items_list {
+        v.visit_token(&item.comma);
+        for let item of &item.items {
+            v.visit_token(item);
+        }
+    }
+    v.visit_token(&node.semi);
+    v.exit_rule(&"list_stmt", &node.span);
+}
+
+pub fn walk_not_stmt<V: Visitor>(v: &mut V, node: &NotStmtNode) {
+    match node {
+        Alt0(n) => {
+            v.enter_rule(&"not_stmt", &n.span);
+            v.visit_token(&n.not);
+            v.visit_token(&n.not_item);
+            v.visit_token(&n.semi);
+            v.exit_rule(&"not_stmt", &n.span);
+        }
+        Alt1(n) => {
+            v.enter_rule(&"not_stmt", &n.span);
+            v.visit_token(&n.set);
+            v.visit_token(&n.not_set);
+            v.visit_token(&n.semi);
+            v.exit_rule(&"not_stmt", &n.span);
+        }
+    }
+}
+
+pub fn walk_any_stmt<V: Visitor>(v: &mut V, node: &AnyStmtNode) {
+    v.enter_rule(&"any_stmt", &node.span);
+    v.visit_token(&node.any);
+    v.visit_token(&node.wildcard);
+    v.visit_token(&node.semi);
+    v.exit_rule(&"any_stmt", &node.span);
+}
+
+pub fn to_tree(node: &ProgramNode) -> CstNode {
     let mut recorder = TreeRecorder::new();
-    walk_stmt(&mut recorder, node);
+    walk_program(&mut recorder, node);
     return recorder.build();
 }
 

--- a/package-gale/tests/golden/recursive_lexer.wado
+++ b/package-gale/tests/golden/recursive_lexer.wado
@@ -1,0 +1,851 @@
+#![generated(by = "gale", sources = ["package-gale/tests/grammars/recursive_lexer.g4"])]
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &Array<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &Array<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &Array<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: Array<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// ParseError represents a parse failure with location and expected tokens.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: Array<String>,
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: Array<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+}
+
+/// CstChild is either a terminal token or a non-terminal sub-tree.
+pub variant CstChild {
+    Token(Token),
+    Node(CstNode),
+}
+
+/// CstNode is a generic (untyped) concrete syntax tree node.
+pub struct CstNode {
+    pub name: String,
+    pub span: Span,
+    pub children: Array<CstChild>,
+}
+
+impl CstNode {
+    /// Produce an ANTLR4-style S-expression representation of this tree.
+    /// Rule nodes become `(name child1 child2 ...)`, tokens become their text.
+    /// Tokens with empty text (e.g. EOF) are omitted.
+    pub fn to_string_tree(&self) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(out: &mut String, node: &CstNode) {
+    out.push_str(`({node.name}`);
+    for let child of &node.children {
+        if let Token(t) = *child {
+            if !t.text.is_empty() {
+                out.push_str(` {t.text}`);
+            }
+        } else if let Node(n) = *child {
+            out.push_str(" ");
+            cst_to_string_tree_impl(out, n);
+        }
+    }
+    out.push_str(")");
+}
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Highlight override: when inside a specific rule, override the capture for a token kind.
+pub struct HighlightOverride {
+    pub rule_name: String,
+    pub token_kind: i32,
+    pub capture: String,
+}
+
+/// Highlight mapping: defaults by token kind + context-aware overrides.
+pub struct HighlightMapping {
+    pub defaults: Array<String>,
+    pub overrides: Array<HighlightOverride>,
+}
+
+/// A single highlight capture: a named range in the source text.
+pub struct HighlightCapture {
+    pub capture: String,
+    pub start: i32,
+    pub end: i32,
+}
+
+/// HighlightVisitor collects highlight captures during a CST walk.
+pub struct HighlightVisitor {
+    mapping: HighlightMapping,
+    rule_stack: Array<String>,
+    pub captures: Array<HighlightCapture>,
+}
+
+impl HighlightVisitor {
+    pub fn new(mapping: HighlightMapping) -> HighlightVisitor {
+        return HighlightVisitor { mapping, rule_stack: [], captures: [] };
+    }
+
+    fn classify(&self, kind: i32) -> String {
+        for let ov of &self.mapping.overrides {
+            if ov.token_kind == kind {
+                for let rule of &self.rule_stack {
+                    if *rule == ov.rule_name {
+                        return ov.capture;
+                    }
+                }
+            }
+        }
+        if kind >= 0 && kind < self.mapping.defaults.len() {
+            return self.mapping.defaults[kind];
+        }
+        return "";
+    }
+}
+
+impl Visitor for HighlightVisitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.rule_stack.push(*name);
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        if !self.rule_stack.is_empty() {
+            let last = self.rule_stack.len() - 1;
+            let mut new_stack: Array<String> = [];
+            for let mut i = 0; i < last; i += 1 {
+                new_stack.push(self.rule_stack[i]);
+            }
+            self.rule_stack = new_stack;
+        }
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        for let trivia of &token.leading_trivia {
+            let cap = self.classify(trivia.kind);
+            if !cap.is_empty() {
+                self.captures.push(HighlightCapture { capture: cap, start: trivia.span.start, end: trivia.span.end });
+            }
+        }
+        if token.text.is_empty() {
+            return;
+        }
+        let cap = self.classify(token.kind);
+        if !cap.is_empty() {
+            self.captures.push(HighlightCapture { capture: cap, start: token.span.start, end: token.span.end });
+        }
+    }
+}
+
+fn escape_html(out: &mut String, text: &String) {
+    for let c of text.chars() {
+        if c == '&' {
+            out.push_str("&amp;");
+        } else if c == '<' {
+            out.push_str("&lt;");
+        } else if c == '>' {
+            out.push_str("&gt;");
+        } else if c == '"' {
+            out.push_str("&quot;");
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+fn escape_html_char(out: &mut String, c: char) {
+    if c == '&' {
+        out.push_str("&amp;");
+    } else if c == '<' {
+        out.push_str("&lt;");
+    } else if c == '>' {
+        out.push_str("&gt;");
+    } else if c == '"' {
+        out.push_str("&quot;");
+    } else {
+        out.push(c);
+    }
+}
+
+fn push_class(out: &mut String, capture: &String) {
+    for let c of capture.chars() {
+        if c == '.' {
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+/// Produce a highlighted HTML fragment from source text and captures.
+/// Captures must be sorted by start position (as produced by HighlightVisitor).
+pub fn highlight_html(source: &String, captures: &Array<HighlightCapture>) -> String {
+    let mut out = String::with_capacity(source.len() * 5);
+    let mut pos = 0;
+    let mut iter = source.chars();
+    for let cap of captures {
+        while pos < cap.start {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("<span class=\"");
+        push_class(&mut out, &cap.capture);
+        out.push_str("\">");
+        let end = cap.end;
+        while pos < end {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("</span>");
+    }
+    while let Some(c) = iter.next() {
+        escape_html_char(&mut out, c);
+    }
+    return out;
+}
+
+fn substr(chars: &Array<char>, start: i32, end: i32) -> String {
+    let mut out = String::with_capacity(end - start);
+    let mut i = start;
+    while i < end && i < chars.len() {
+        out.push(chars[i]);
+        i += 1;
+    }
+    return out;
+}
+
+/// Visitor trait for walking typed CST nodes.
+/// Default methods are no-ops; override to add behavior.
+pub trait Visitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn visit_token(&mut self, token: &Token) {
+    }
+}
+
+/// TreeRecorder is a Visitor that records events for building a CstNode tree.
+pub struct TreeRecorder {
+    events: Array<TreeEvent>,
+}
+
+variant TreeEvent {
+    Enter(TreeEnterInfo),
+    Exit,
+    VisitToken(Token),
+}
+
+struct TreeEnterInfo {
+    name: String,
+    span: Span,
+}
+
+impl TreeRecorder {
+    pub fn new() -> TreeRecorder {
+        return TreeRecorder { events: [] };
+    }
+
+    pub fn build(&self) -> CstNode {
+        let mut pos = 0;
+        return tree_build_node(&self.events, &mut pos);
+    }
+}
+
+impl Visitor for TreeRecorder {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Enter(TreeEnterInfo { name: *name, span: *span }));
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Exit);
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        self.events.push(TreeEvent::VisitToken(*token));
+    }
+}
+
+fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
+    if let Enter(info) = events[*pos] {
+        *pos += 1;
+        let mut children: Array<CstChild> = [];
+        loop {
+            if *pos >= events.len() {
+                break;
+            }
+            let ev = events[*pos];
+            if let Exit = ev {
+                *pos += 1;
+                break;
+            }
+            if let Enter(_) = ev {
+                children.push(CstChild::Node(tree_build_node(events, pos)));
+            } else if let VisitToken(t) = ev {
+                children.push(CstChild::Token(t));
+                *pos += 1;
+            }
+        }
+        return CstNode { name: info.name, span: info.span, children };
+    }
+    panic("TreeRecorder: expected Enter event");
+    return CstNode { name: "", span: Span::new(0, 0), children: [] };
+}
+
+pub enum TokenKind {
+    BLOCK,
+    IDENT,
+    WS,
+    Eof,
+    Error,
+}
+
+pub struct FileNode {
+    pub span: Span,
+    pub block_or_ident_list: Array<Token>,
+    pub eof: Token,
+}
+
+global TK_BLOCK: i32 = 0;
+global TK_IDENT: i32 = 1;
+global TK_WS: i32 = 2;
+global TK_EOF: i32 = 3;
+global TK_ERROR: i32 = 4;
+
+struct Lexer {
+    chars: Array<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.chars().collect(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_block(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    pos = try_braced(chars, pos);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn try_braced(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '{' { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            let alts_saved_1 = pos;
+            let mut alts_ok_1 = false;
+            alts_1_0: {
+                pos = alts_saved_1;
+                pos = try_braced(chars, pos);
+                if pos < 0 { break alts_1_0; }
+                alts_ok_1 = true;
+            }
+            if !alts_ok_1 {
+                alts_1_1: {
+                    pos = alts_saved_1;
+                    if pos >= chars.len() { break alts_1_1; }
+                    if false || chars[pos] == '{' || chars[pos] == '}' { break alts_1_1; }
+                    pos += 1;
+                    alts_ok_1 = true;
+                }
+            }
+            if !alts_ok_1 { break rep_0; }
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    if pos >= chars.len() || chars[pos] != '}' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ident(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || chars[pos] == '_') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !(false || 'a' <= chars[pos] <= 'z' || 'A' <= chars[pos] <= 'Z' || chars[pos] == '_' || '0' <= chars[pos] <= '9') { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+fn try_ws(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_3 = pos;
+        rep_3: {
+            if pos >= chars.len() { break rep_3; }
+            if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { break rep_3; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_3;
+        break;
+    }
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> Array<Token> {
+    let mut lexer = Lexer::new(input);
+    let mut tokens: Array<Token> = [];
+    let mut trivia: Array<Token> = [];
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '_' {
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENT; }
+        } else if first_char == '{' {
+            end = try_block(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BLOCK; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENT; }
+        } else if 'A' <= first_char <= 'Z' {
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENT; }
+        } else {
+            end = try_ident(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IDENT; }
+        }
+        if best_end <= start {
+            let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
+            tokens.push(tok);
+            trivia = [];
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else {
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
+                tokens.push(tok);
+                trivia = [];
+            }
+            lexer.pos = best_end;
+        }
+    }
+    tokens.push(Token::with_trivia(TK_EOF, LexerSlice::empty(&lexer.chars), Span::new(lexer.pos, lexer.pos), trivia));
+    return tokens;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_BLOCK => "BLOCK",
+        TK_IDENT => "IDENT",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+struct Parser {
+    tokens: Array<Token>,
+    pos: i32,
+}
+
+impl Parser {
+    fn new(tokens: Array<Token>) -> Parser {
+        return Parser { tokens, pos: 0 };
+    }
+
+    fn peek(&self) -> &Token {
+        return &self.tokens[self.pos];
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.tokens[self.pos].kind;
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.tokens[idx].kind;
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.tokens[self.pos];
+        self.pos += 1;
+        return tok;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens[self.pos - 1].span.end;
+    }
+
+    fn expect(&mut self, kind: i32) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind == kind {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        let name = token_kind_name(kind);
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn fail(&self, name: String) -> Result<Token, ParseError> {
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
+        ));
+    }
+}
+
+fn scan_file(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let gp_0 = pos;
+    sg_0: {
+        pos = gp_0;
+        sg_0_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_BLOCK { break sg_0_0; }
+            pos += 1;
+            break sg_0;
+        }
+        pos = gp_0;
+        sg_0_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_IDENT { break sg_0_1; }
+            pos += 1;
+            break sg_0;
+        }
+        return -1;
+    }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_BLOCK | TK_IDENT } {
+        let sp = pos;
+        let gp_1 = pos;
+        sg_1: {
+            pos = gp_1;
+            sg_1_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_BLOCK { break sg_1_0; }
+                pos += 1;
+                break sg_1;
+            }
+            pos = gp_1;
+            sg_1_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_IDENT { break sg_1_1; }
+                pos += 1;
+                break sg_1;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn parse_file(p: &mut Parser) -> Result<FileNode, ParseError> {
+    let start = p.peek().span.start;
+    let mut block_or_ident_list: Array<Token> = [];
+    let mut _plus_first = true;
+    loop {
+        if !_plus_first {
+            let mut rep_scan_pos: i32 = -1;
+            rep_scan: {
+                let tokens = &p.tokens;
+                let mut pos: i32 = p.pos;
+                let gp_2 = pos;
+                sg_2: {
+                    pos = gp_2;
+                    sg_2_0: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_BLOCK { break sg_2_0; }
+                        pos += 1;
+                        break sg_2;
+                    }
+                    pos = gp_2;
+                    sg_2_1: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_IDENT { break sg_2_1; }
+                        pos += 1;
+                        break sg_2;
+                    }
+                    break rep_scan;
+                }
+                if pos <= p.pos { break rep_scan; }
+                rep_scan_pos = pos;
+            }
+            if rep_scan_pos < 0 { break; }
+        }
+        _plus_first = false;
+        let block_or_ident = p.advance();
+        block_or_ident_list.push(block_or_ident);
+    }
+    let eof = p.expect(TK_EOF)?;
+    return Result::<FileNode, ParseError>::Ok(FileNode {
+        span: Span::new(start, p.last_end()),
+        block_or_ident_list,
+        eof,
+    });
+}
+
+pub fn parse(input: &String) -> Result<FileNode, ParseError> {
+    let tokens = tokenize(input);
+    let mut parser = Parser::new(tokens);
+    return parse_file(&mut parser);
+}
+
+pub fn walk_file<V: Visitor>(v: &mut V, node: &FileNode) {
+    v.enter_rule(&"file", &node.span);
+    for let item of &node.block_or_ident_list {
+        v.visit_token(item);
+    }
+    v.visit_token(&node.eof);
+    v.exit_rule(&"file", &node.span);
+}
+
+pub fn to_tree(node: &FileNode) -> CstNode {
+    let mut recorder = TreeRecorder::new();
+    walk_file(&mut recorder, node);
+    return recorder.build();
+}
+

--- a/package-gale/tests/golden/right_assoc_gaps.wado
+++ b/package-gale/tests/golden/right_assoc_gaps.wado
@@ -1,0 +1,878 @@
+#![generated(by = "gale", sources = ["package-gale/tests/grammars/right_assoc_gaps.g4"])]
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &Array<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &Array<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &Array<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: Array<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// ParseError represents a parse failure with location and expected tokens.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: Array<String>,
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: Array<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+}
+
+/// CstChild is either a terminal token or a non-terminal sub-tree.
+pub variant CstChild {
+    Token(Token),
+    Node(CstNode),
+}
+
+/// CstNode is a generic (untyped) concrete syntax tree node.
+pub struct CstNode {
+    pub name: String,
+    pub span: Span,
+    pub children: Array<CstChild>,
+}
+
+impl CstNode {
+    /// Produce an ANTLR4-style S-expression representation of this tree.
+    /// Rule nodes become `(name child1 child2 ...)`, tokens become their text.
+    /// Tokens with empty text (e.g. EOF) are omitted.
+    pub fn to_string_tree(&self) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(out: &mut String, node: &CstNode) {
+    out.push_str(`({node.name}`);
+    for let child of &node.children {
+        if let Token(t) = *child {
+            if !t.text.is_empty() {
+                out.push_str(` {t.text}`);
+            }
+        } else if let Node(n) = *child {
+            out.push_str(" ");
+            cst_to_string_tree_impl(out, n);
+        }
+    }
+    out.push_str(")");
+}
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Highlight override: when inside a specific rule, override the capture for a token kind.
+pub struct HighlightOverride {
+    pub rule_name: String,
+    pub token_kind: i32,
+    pub capture: String,
+}
+
+/// Highlight mapping: defaults by token kind + context-aware overrides.
+pub struct HighlightMapping {
+    pub defaults: Array<String>,
+    pub overrides: Array<HighlightOverride>,
+}
+
+/// A single highlight capture: a named range in the source text.
+pub struct HighlightCapture {
+    pub capture: String,
+    pub start: i32,
+    pub end: i32,
+}
+
+/// HighlightVisitor collects highlight captures during a CST walk.
+pub struct HighlightVisitor {
+    mapping: HighlightMapping,
+    rule_stack: Array<String>,
+    pub captures: Array<HighlightCapture>,
+}
+
+impl HighlightVisitor {
+    pub fn new(mapping: HighlightMapping) -> HighlightVisitor {
+        return HighlightVisitor { mapping, rule_stack: [], captures: [] };
+    }
+
+    fn classify(&self, kind: i32) -> String {
+        for let ov of &self.mapping.overrides {
+            if ov.token_kind == kind {
+                for let rule of &self.rule_stack {
+                    if *rule == ov.rule_name {
+                        return ov.capture;
+                    }
+                }
+            }
+        }
+        if kind >= 0 && kind < self.mapping.defaults.len() {
+            return self.mapping.defaults[kind];
+        }
+        return "";
+    }
+}
+
+impl Visitor for HighlightVisitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.rule_stack.push(*name);
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        if !self.rule_stack.is_empty() {
+            let last = self.rule_stack.len() - 1;
+            let mut new_stack: Array<String> = [];
+            for let mut i = 0; i < last; i += 1 {
+                new_stack.push(self.rule_stack[i]);
+            }
+            self.rule_stack = new_stack;
+        }
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        for let trivia of &token.leading_trivia {
+            let cap = self.classify(trivia.kind);
+            if !cap.is_empty() {
+                self.captures.push(HighlightCapture { capture: cap, start: trivia.span.start, end: trivia.span.end });
+            }
+        }
+        if token.text.is_empty() {
+            return;
+        }
+        let cap = self.classify(token.kind);
+        if !cap.is_empty() {
+            self.captures.push(HighlightCapture { capture: cap, start: token.span.start, end: token.span.end });
+        }
+    }
+}
+
+fn escape_html(out: &mut String, text: &String) {
+    for let c of text.chars() {
+        if c == '&' {
+            out.push_str("&amp;");
+        } else if c == '<' {
+            out.push_str("&lt;");
+        } else if c == '>' {
+            out.push_str("&gt;");
+        } else if c == '"' {
+            out.push_str("&quot;");
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+fn escape_html_char(out: &mut String, c: char) {
+    if c == '&' {
+        out.push_str("&amp;");
+    } else if c == '<' {
+        out.push_str("&lt;");
+    } else if c == '>' {
+        out.push_str("&gt;");
+    } else if c == '"' {
+        out.push_str("&quot;");
+    } else {
+        out.push(c);
+    }
+}
+
+fn push_class(out: &mut String, capture: &String) {
+    for let c of capture.chars() {
+        if c == '.' {
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+/// Produce a highlighted HTML fragment from source text and captures.
+/// Captures must be sorted by start position (as produced by HighlightVisitor).
+pub fn highlight_html(source: &String, captures: &Array<HighlightCapture>) -> String {
+    let mut out = String::with_capacity(source.len() * 5);
+    let mut pos = 0;
+    let mut iter = source.chars();
+    for let cap of captures {
+        while pos < cap.start {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("<span class=\"");
+        push_class(&mut out, &cap.capture);
+        out.push_str("\">");
+        let end = cap.end;
+        while pos < end {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("</span>");
+    }
+    while let Some(c) = iter.next() {
+        escape_html_char(&mut out, c);
+    }
+    return out;
+}
+
+fn substr(chars: &Array<char>, start: i32, end: i32) -> String {
+    let mut out = String::with_capacity(end - start);
+    let mut i = start;
+    while i < end && i < chars.len() {
+        out.push(chars[i]);
+        i += 1;
+    }
+    return out;
+}
+
+/// Visitor trait for walking typed CST nodes.
+/// Default methods are no-ops; override to add behavior.
+pub trait Visitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn visit_token(&mut self, token: &Token) {
+    }
+}
+
+/// TreeRecorder is a Visitor that records events for building a CstNode tree.
+pub struct TreeRecorder {
+    events: Array<TreeEvent>,
+}
+
+variant TreeEvent {
+    Enter(TreeEnterInfo),
+    Exit,
+    VisitToken(Token),
+}
+
+struct TreeEnterInfo {
+    name: String,
+    span: Span,
+}
+
+impl TreeRecorder {
+    pub fn new() -> TreeRecorder {
+        return TreeRecorder { events: [] };
+    }
+
+    pub fn build(&self) -> CstNode {
+        let mut pos = 0;
+        return tree_build_node(&self.events, &mut pos);
+    }
+}
+
+impl Visitor for TreeRecorder {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Enter(TreeEnterInfo { name: *name, span: *span }));
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Exit);
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        self.events.push(TreeEvent::VisitToken(*token));
+    }
+}
+
+fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
+    if let Enter(info) = events[*pos] {
+        *pos += 1;
+        let mut children: Array<CstChild> = [];
+        loop {
+            if *pos >= events.len() {
+                break;
+            }
+            let ev = events[*pos];
+            if let Exit = ev {
+                *pos += 1;
+                break;
+            }
+            if let Enter(_) = ev {
+                children.push(CstChild::Node(tree_build_node(events, pos)));
+            } else if let VisitToken(t) = ev {
+                children.push(CstChild::Token(t));
+                *pos += 1;
+            }
+        }
+        return CstNode { name: info.name, span: info.span, children };
+    }
+    panic("TreeRecorder: expected Enter event");
+    return CstNode { name: "", span: Span::new(0, 0), children: [] };
+}
+
+pub enum TokenKind {
+    INT,
+    WS,
+    Eof,
+    Error,
+}
+
+pub variant ExprNode {
+    Pow(ExprPow),
+    Add(ExprAdd),
+    Int(ExprInt),
+}
+
+pub struct ExprPow {
+    pub span: Span,
+    pub expr: ExprNode,
+    pub caret: Token,
+    pub expr_2: ExprNode,
+}
+
+pub struct ExprAdd {
+    pub span: Span,
+    pub expr: ExprNode,
+    pub plus: Token,
+    pub expr_2: ExprNode,
+}
+
+pub struct ExprInt {
+    pub span: Span,
+    pub int: Token,
+}
+
+global TK_INT: i32 = 0;
+global TK_WS: i32 = 1;
+global TK_EOF: i32 = 2;
+global TK_ERROR: i32 = 3;
+global TK_LIT_CARET: i32 = 4;
+global TK_LIT_PLUS: i32 = 5;
+
+struct Lexer {
+    chars: Array<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.chars().collect(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_int(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || '0' <= chars[pos] <= '9') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !(false || '0' <= chars[pos] <= '9') { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ws(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_lit_caret(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '^' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_plus(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '+' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> Array<Token> {
+    let mut lexer = Lexer::new(input);
+    let mut tokens: Array<Token> = [];
+    let mut trivia: Array<Token> = [];
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '+' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_PLUS; }
+        } else if first_char == '^' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_CARET; }
+        } else if '0' <= first_char <= '9' {
+            end = try_int(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else {
+            end = try_int(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        }
+        if best_end <= start {
+            let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
+            tokens.push(tok);
+            trivia = [];
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else {
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
+                tokens.push(tok);
+                trivia = [];
+            }
+            lexer.pos = best_end;
+        }
+    }
+    tokens.push(Token::with_trivia(TK_EOF, LexerSlice::empty(&lexer.chars), Span::new(lexer.pos, lexer.pos), trivia));
+    return tokens;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_INT => "INT",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_CARET => "TK_LIT_CARET",
+        TK_LIT_PLUS => "TK_LIT_PLUS",
+        _ => "Unknown",
+    };
+}
+
+struct Parser {
+    tokens: Array<Token>,
+    pos: i32,
+}
+
+impl Parser {
+    fn new(tokens: Array<Token>) -> Parser {
+        return Parser { tokens, pos: 0 };
+    }
+
+    fn peek(&self) -> &Token {
+        return &self.tokens[self.pos];
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.tokens[self.pos].kind;
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.tokens[idx].kind;
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.tokens[self.pos];
+        self.pos += 1;
+        return tok;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens[self.pos - 1].span.end;
+    }
+
+    fn expect(&mut self, kind: i32) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind == kind {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        let name = token_kind_name(kind);
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn fail(&self, name: String) -> Result<Token, ParseError> {
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
+        ));
+    }
+}
+
+fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_expr_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_CARET { return -1; }
+    pos += 1;
+    pos = scan_expr(tokens, pos, 2);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_expr_lr_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_PLUS { return -1; }
+    pos += 1;
+    pos = scan_expr(tokens, pos, 2);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_expr_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
+        if suffix_kind == TK_LIT_CARET {
+            if 2 >= min_prec {
+                pos = scan_expr_lr_0(tokens, pos);
+                if pos < 0 { return -1; }
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                pos = scan_expr_lr_1(tokens, pos);
+                if pos < 0 { return -1; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
+    let start = p.peek().span.start;
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        let int = p.expect(TK_INT)?;
+        return Result::<ExprNode, ParseError>::Ok(ExprNode::Int(ExprInt {
+            span: Span::new(start, p.last_end()),
+            int,
+        }));
+    }
+    return Result::<ExprNode, ParseError>::Err(ParseError::new(
+        "expected expr",
+        p.peek().span,
+        ["TK_INT"],
+    ));
+}
+
+fn parse_expr_lr_0(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNode, ParseError> {
+    let caret = p.expect(TK_LIT_CARET)?;
+    let expr_2 = parse_expr(p, 2)?;
+    return Result::<ExprNode, ParseError>::Ok(ExprNode::Pow(ExprPow {
+        span: Span::new(start, p.last_end()),
+        expr: left,
+        caret,
+        expr_2,
+    }));
+}
+
+fn parse_expr_lr_1(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNode, ParseError> {
+    let plus = p.expect(TK_LIT_PLUS)?;
+    let expr_2 = parse_expr(p, 2)?;
+    return Result::<ExprNode, ParseError>::Ok(ExprNode::Add(ExprAdd {
+        span: Span::new(start, p.last_end()),
+        expr: left,
+        plus,
+        expr_2,
+    }));
+}
+
+fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError> {
+    let start = p.peek().span.start;
+    let mut result = parse_expr_atom(p)?;
+    loop {
+        let suffix_kind = p.peek_kind();
+        if suffix_kind == TK_LIT_CARET {
+            if 2 >= min_prec {
+                result = parse_expr_lr_0(p, result, start)?;
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                result = parse_expr_lr_1(p, result, start)?;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return Result::<ExprNode, ParseError>::Ok(result);
+}
+
+pub fn parse(input: &String) -> Result<ExprNode, ParseError> {
+    let tokens = tokenize(input);
+    let mut parser = Parser::new(tokens);
+    return parse_expr(&mut parser);
+}
+
+pub fn walk_expr<V: Visitor>(v: &mut V, node: &ExprNode) {
+    match node {
+        Pow(n) => {
+            v.enter_rule(&"expr", &n.span);
+            walk_expr(v, &n.expr);
+            v.visit_token(&n.caret);
+            walk_expr(v, &n.expr_2);
+            v.exit_rule(&"expr", &n.span);
+        }
+        Add(n) => {
+            v.enter_rule(&"expr", &n.span);
+            walk_expr(v, &n.expr);
+            v.visit_token(&n.plus);
+            walk_expr(v, &n.expr_2);
+            v.exit_rule(&"expr", &n.span);
+        }
+        Int(n) => {
+            v.enter_rule(&"expr", &n.span);
+            v.visit_token(&n.int);
+            v.exit_rule(&"expr", &n.span);
+        }
+    }
+}
+
+pub fn to_tree(node: &ExprNode) -> CstNode {
+    let mut recorder = TreeRecorder::new();
+    walk_expr(&mut recorder, node);
+    return recorder.build();
+}
+

--- a/package-gale/tests/golden/rust.wado
+++ b/package-gale/tests/golden/rust.wado
@@ -8968,12 +8968,12 @@ impl Parser {
         ));
     }
 
-    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
         let k = self.tokens[self.pos].kind;
         if k != TK_EOF {
             let mut blocked = false;
             for let x of excluded {
-                if *x == k {
+                if x == k {
                     blocked = true;
                     break;
                 }

--- a/package-gale/tests/golden/sexpression.wado
+++ b/package-gale/tests/golden/sexpression.wado
@@ -1100,12 +1100,12 @@ impl Parser {
         ));
     }
 
-    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
         let k = self.tokens[self.pos].kind;
         if k != TK_EOF {
             let mut blocked = false;
             for let x of excluded {
-                if *x == k {
+                if x == k {
                     blocked = true;
                     break;
                 }

--- a/package-gale/tests/golden/sqlite.wado
+++ b/package-gale/tests/golden/sqlite.wado
@@ -4824,12 +4824,12 @@ impl Parser {
         ));
     }
 
-    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
         let k = self.tokens[self.pos].kind;
         if k != TK_EOF {
             let mut blocked = false;
             for let x of excluded {
-                if *x == k {
+                if x == k {
                     blocked = true;
                     break;
                 }

--- a/package-gale/tests/golden/sqlite_highlight.wado
+++ b/package-gale/tests/golden/sqlite_highlight.wado
@@ -4824,12 +4824,12 @@ impl Parser {
         ));
     }
 
-    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
         let k = self.tokens[self.pos].kind;
         if k != TK_EOF {
             let mut blocked = false;
             for let x of excluded {
-                if *x == k {
+                if x == k {
                     blocked = true;
                     break;
                 }

--- a/package-gale/tests/golden/typescript.wado
+++ b/package-gale/tests/golden/typescript.wado
@@ -7926,12 +7926,12 @@ impl Parser {
         ));
     }
 
-    fn match_not(&mut self, excluded: &Array<i32>) -> Result<Token, ParseError> {
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
         let k = self.tokens[self.pos].kind;
         if k != TK_EOF {
             let mut blocked = false;
             for let x of excluded {
-                if *x == k {
+                if x == k {
                     blocked = true;
                     break;
                 }

--- a/package-gale/tests/golden/unicode_props.wado
+++ b/package-gale/tests/golden/unicode_props.wado
@@ -1,0 +1,884 @@
+#![generated(by = "gale", sources = ["package-gale/tests/grammars/unicode_props.g4"])]
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &Array<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &Array<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &Array<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: Array<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// ParseError represents a parse failure with location and expected tokens.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: Array<String>,
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: Array<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+}
+
+/// CstChild is either a terminal token or a non-terminal sub-tree.
+pub variant CstChild {
+    Token(Token),
+    Node(CstNode),
+}
+
+/// CstNode is a generic (untyped) concrete syntax tree node.
+pub struct CstNode {
+    pub name: String,
+    pub span: Span,
+    pub children: Array<CstChild>,
+}
+
+impl CstNode {
+    /// Produce an ANTLR4-style S-expression representation of this tree.
+    /// Rule nodes become `(name child1 child2 ...)`, tokens become their text.
+    /// Tokens with empty text (e.g. EOF) are omitted.
+    pub fn to_string_tree(&self) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(out: &mut String, node: &CstNode) {
+    out.push_str(`({node.name}`);
+    for let child of &node.children {
+        if let Token(t) = *child {
+            if !t.text.is_empty() {
+                out.push_str(` {t.text}`);
+            }
+        } else if let Node(n) = *child {
+            out.push_str(" ");
+            cst_to_string_tree_impl(out, n);
+        }
+    }
+    out.push_str(")");
+}
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Highlight override: when inside a specific rule, override the capture for a token kind.
+pub struct HighlightOverride {
+    pub rule_name: String,
+    pub token_kind: i32,
+    pub capture: String,
+}
+
+/// Highlight mapping: defaults by token kind + context-aware overrides.
+pub struct HighlightMapping {
+    pub defaults: Array<String>,
+    pub overrides: Array<HighlightOverride>,
+}
+
+/// A single highlight capture: a named range in the source text.
+pub struct HighlightCapture {
+    pub capture: String,
+    pub start: i32,
+    pub end: i32,
+}
+
+/// HighlightVisitor collects highlight captures during a CST walk.
+pub struct HighlightVisitor {
+    mapping: HighlightMapping,
+    rule_stack: Array<String>,
+    pub captures: Array<HighlightCapture>,
+}
+
+impl HighlightVisitor {
+    pub fn new(mapping: HighlightMapping) -> HighlightVisitor {
+        return HighlightVisitor { mapping, rule_stack: [], captures: [] };
+    }
+
+    fn classify(&self, kind: i32) -> String {
+        for let ov of &self.mapping.overrides {
+            if ov.token_kind == kind {
+                for let rule of &self.rule_stack {
+                    if *rule == ov.rule_name {
+                        return ov.capture;
+                    }
+                }
+            }
+        }
+        if kind >= 0 && kind < self.mapping.defaults.len() {
+            return self.mapping.defaults[kind];
+        }
+        return "";
+    }
+}
+
+impl Visitor for HighlightVisitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.rule_stack.push(*name);
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        if !self.rule_stack.is_empty() {
+            let last = self.rule_stack.len() - 1;
+            let mut new_stack: Array<String> = [];
+            for let mut i = 0; i < last; i += 1 {
+                new_stack.push(self.rule_stack[i]);
+            }
+            self.rule_stack = new_stack;
+        }
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        for let trivia of &token.leading_trivia {
+            let cap = self.classify(trivia.kind);
+            if !cap.is_empty() {
+                self.captures.push(HighlightCapture { capture: cap, start: trivia.span.start, end: trivia.span.end });
+            }
+        }
+        if token.text.is_empty() {
+            return;
+        }
+        let cap = self.classify(token.kind);
+        if !cap.is_empty() {
+            self.captures.push(HighlightCapture { capture: cap, start: token.span.start, end: token.span.end });
+        }
+    }
+}
+
+fn escape_html(out: &mut String, text: &String) {
+    for let c of text.chars() {
+        if c == '&' {
+            out.push_str("&amp;");
+        } else if c == '<' {
+            out.push_str("&lt;");
+        } else if c == '>' {
+            out.push_str("&gt;");
+        } else if c == '"' {
+            out.push_str("&quot;");
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+fn escape_html_char(out: &mut String, c: char) {
+    if c == '&' {
+        out.push_str("&amp;");
+    } else if c == '<' {
+        out.push_str("&lt;");
+    } else if c == '>' {
+        out.push_str("&gt;");
+    } else if c == '"' {
+        out.push_str("&quot;");
+    } else {
+        out.push(c);
+    }
+}
+
+fn push_class(out: &mut String, capture: &String) {
+    for let c of capture.chars() {
+        if c == '.' {
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+/// Produce a highlighted HTML fragment from source text and captures.
+/// Captures must be sorted by start position (as produced by HighlightVisitor).
+pub fn highlight_html(source: &String, captures: &Array<HighlightCapture>) -> String {
+    let mut out = String::with_capacity(source.len() * 5);
+    let mut pos = 0;
+    let mut iter = source.chars();
+    for let cap of captures {
+        while pos < cap.start {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("<span class=\"");
+        push_class(&mut out, &cap.capture);
+        out.push_str("\">");
+        let end = cap.end;
+        while pos < end {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("</span>");
+    }
+    while let Some(c) = iter.next() {
+        escape_html_char(&mut out, c);
+    }
+    return out;
+}
+
+fn substr(chars: &Array<char>, start: i32, end: i32) -> String {
+    let mut out = String::with_capacity(end - start);
+    let mut i = start;
+    while i < end && i < chars.len() {
+        out.push(chars[i]);
+        i += 1;
+    }
+    return out;
+}
+
+/// Visitor trait for walking typed CST nodes.
+/// Default methods are no-ops; override to add behavior.
+pub trait Visitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn visit_token(&mut self, token: &Token) {
+    }
+}
+
+/// TreeRecorder is a Visitor that records events for building a CstNode tree.
+pub struct TreeRecorder {
+    events: Array<TreeEvent>,
+}
+
+variant TreeEvent {
+    Enter(TreeEnterInfo),
+    Exit,
+    VisitToken(Token),
+}
+
+struct TreeEnterInfo {
+    name: String,
+    span: Span,
+}
+
+impl TreeRecorder {
+    pub fn new() -> TreeRecorder {
+        return TreeRecorder { events: [] };
+    }
+
+    pub fn build(&self) -> CstNode {
+        let mut pos = 0;
+        return tree_build_node(&self.events, &mut pos);
+    }
+}
+
+impl Visitor for TreeRecorder {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Enter(TreeEnterInfo { name: *name, span: *span }));
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Exit);
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        self.events.push(TreeEvent::VisitToken(*token));
+    }
+}
+
+fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
+    if let Enter(info) = events[*pos] {
+        *pos += 1;
+        let mut children: Array<CstChild> = [];
+        loop {
+            if *pos >= events.len() {
+                break;
+            }
+            let ev = events[*pos];
+            if let Exit = ev {
+                *pos += 1;
+                break;
+            }
+            if let Enter(_) = ev {
+                children.push(CstChild::Node(tree_build_node(events, pos)));
+            } else if let VisitToken(t) = ev {
+                children.push(CstChild::Token(t));
+                *pos += 1;
+            }
+        }
+        return CstNode { name: info.name, span: info.span, children };
+    }
+    panic("TreeRecorder: expected Enter event");
+    return CstNode { name: "", span: Span::new(0, 0), children: [] };
+}
+
+pub enum TokenKind {
+    WORD,
+    NUM,
+    SPACE,
+    Eof,
+    Error,
+}
+
+pub struct LineNode {
+    pub span: Span,
+    pub word_or_num_or_space_list: Array<Token>,
+    pub eof: Token,
+}
+
+global TK_WORD: i32 = 0;
+global TK_NUM: i32 = 1;
+global TK_SPACE: i32 = 2;
+global TK_EOF: i32 = 3;
+global TK_ERROR: i32 = 4;
+
+struct Lexer {
+    chars: Array<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.chars().collect(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_word(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || 'A' <= chars[pos] <= 'Z' || 'a' <= chars[pos] <= 'z' || '\u{c0}' <= chars[pos] <= '\u{d6}' || '\u{d8}' <= chars[pos] <= '\u{f6}' || '\u{f8}' <= chars[pos] <= '\u{ff}' || '\u{100}' <= chars[pos] <= '\u{24f}' || '\u{370}' <= chars[pos] <= '\u{3ff}' || '\u{400}' <= chars[pos] <= '\u{4ff}' || '\u{600}' <= chars[pos] <= '\u{6ff}' || '\u{900}' <= chars[pos] <= '\u{97f}' || '\u{4e00}' <= chars[pos] <= '\u{9fff}' || '\u{3040}' <= chars[pos] <= '\u{309f}' || '\u{30a0}' <= chars[pos] <= '\u{30ff}' || '\u{ac00}' <= chars[pos] <= '\u{d7af}') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !(false || 'A' <= chars[pos] <= 'Z' || 'a' <= chars[pos] <= 'z' || '\u{c0}' <= chars[pos] <= '\u{d6}' || '\u{d8}' <= chars[pos] <= '\u{f6}' || '\u{f8}' <= chars[pos] <= '\u{ff}' || '\u{100}' <= chars[pos] <= '\u{24f}' || '\u{370}' <= chars[pos] <= '\u{3ff}' || '\u{400}' <= chars[pos] <= '\u{4ff}' || '\u{600}' <= chars[pos] <= '\u{6ff}' || '\u{900}' <= chars[pos] <= '\u{97f}' || '\u{4e00}' <= chars[pos] <= '\u{9fff}' || '\u{3040}' <= chars[pos] <= '\u{309f}' || '\u{30a0}' <= chars[pos] <= '\u{30ff}' || '\u{ac00}' <= chars[pos] <= '\u{d7af}') { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_num(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || '0' <= chars[pos] <= '9' || '\u{660}' <= chars[pos] <= '\u{669}' || '\u{6f0}' <= chars[pos] <= '\u{6f9}' || '\u{966}' <= chars[pos] <= '\u{96f}') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !(false || '0' <= chars[pos] <= '9' || '\u{660}' <= chars[pos] <= '\u{669}' || '\u{6f0}' <= chars[pos] <= '\u{6f9}' || '\u{966}' <= chars[pos] <= '\u{96f}') { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_space(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\u{a0}' || chars[pos] == '\u{1680}' || '\u{2000}' <= chars[pos] <= '\u{200a}' || chars[pos] == '\u{202f}' || chars[pos] == '\u{205f}' || chars[pos] == '\u{3000}') { return -1; }
+    pos += 1;
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> Array<Token> {
+    let mut lexer = Lexer::new(input);
+    let mut tokens: Array<Token> = [];
+    let mut trivia: Array<Token> = [];
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == ' ' || first_char == '\u{a0}' || first_char == '\u{1680}' || first_char == '\u{202f}' || first_char == '\u{205f}' || first_char == '\u{3000}' {
+            end = try_space(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SPACE; }
+        } else if 'A' <= first_char <= 'Z' {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+        } else if '\u{c0}' <= first_char <= '\u{d6}' {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+        } else if '\u{d8}' <= first_char <= '\u{f6}' {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+        } else if '\u{f8}' <= first_char <= '\u{ff}' {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+        } else if '\u{100}' <= first_char <= '\u{24f}' {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+        } else if '\u{370}' <= first_char <= '\u{3ff}' {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+        } else if '\u{400}' <= first_char <= '\u{4ff}' {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+        } else if '\u{600}' <= first_char <= '\u{6ff}' {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+        } else if '\u{900}' <= first_char <= '\u{97f}' {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+        } else if '\u{4e00}' <= first_char <= '\u{9fff}' {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+        } else if '\u{3040}' <= first_char <= '\u{309f}' {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+        } else if '\u{30a0}' <= first_char <= '\u{30ff}' {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+        } else if '\u{ac00}' <= first_char <= '\u{d7af}' {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+        } else if '0' <= first_char <= '9' {
+            end = try_num(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUM; }
+        } else if '\u{660}' <= first_char <= '\u{669}' {
+            end = try_num(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUM; }
+        } else if '\u{6f0}' <= first_char <= '\u{6f9}' {
+            end = try_num(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUM; }
+        } else if '\u{966}' <= first_char <= '\u{96f}' {
+            end = try_num(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUM; }
+        } else if '\u{2000}' <= first_char <= '\u{200a}' {
+            end = try_space(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SPACE; }
+        } else {
+            end = try_word(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; }
+            end = try_num(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_NUM; }
+            end = try_space(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_SPACE; }
+        }
+        if best_end <= start {
+            let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
+            tokens.push(tok);
+            trivia = [];
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_SPACE };
+            if is_skip {
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else {
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
+                tokens.push(tok);
+                trivia = [];
+            }
+            lexer.pos = best_end;
+        }
+    }
+    tokens.push(Token::with_trivia(TK_EOF, LexerSlice::empty(&lexer.chars), Span::new(lexer.pos, lexer.pos), trivia));
+    return tokens;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_WORD => "WORD",
+        TK_NUM => "NUM",
+        TK_SPACE => "SPACE",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+struct Parser {
+    tokens: Array<Token>,
+    pos: i32,
+}
+
+impl Parser {
+    fn new(tokens: Array<Token>) -> Parser {
+        return Parser { tokens, pos: 0 };
+    }
+
+    fn peek(&self) -> &Token {
+        return &self.tokens[self.pos];
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.tokens[self.pos].kind;
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.tokens[idx].kind;
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.tokens[self.pos];
+        self.pos += 1;
+        return tok;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens[self.pos - 1].span.end;
+    }
+
+    fn expect(&mut self, kind: i32) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind == kind {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        let name = token_kind_name(kind);
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn fail(&self, name: String) -> Result<Token, ParseError> {
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
+        ));
+    }
+}
+
+fn scan_line(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    let gp_0 = pos;
+    sg_0: {
+        pos = gp_0;
+        sg_0_0: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_WORD { break sg_0_0; }
+            pos += 1;
+            break sg_0;
+        }
+        pos = gp_0;
+        sg_0_1: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_NUM { break sg_0_1; }
+            pos += 1;
+            break sg_0;
+        }
+        pos = gp_0;
+        sg_0_2: {
+            if pos >= tokens.len() || tokens[pos].kind != TK_SPACE { break sg_0_2; }
+            pos += 1;
+            break sg_0;
+        }
+        return -1;
+    }
+    while pos < tokens.len() && tokens[pos].kind matches { TK_WORD | TK_NUM | TK_SPACE } {
+        let sp = pos;
+        let gp_1 = pos;
+        sg_1: {
+            pos = gp_1;
+            sg_1_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_WORD { break sg_1_0; }
+                pos += 1;
+                break sg_1;
+            }
+            pos = gp_1;
+            sg_1_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_NUM { break sg_1_1; }
+                pos += 1;
+                break sg_1;
+            }
+            pos = gp_1;
+            sg_1_2: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_SPACE { break sg_1_2; }
+                pos += 1;
+                break sg_1;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn parse_line(p: &mut Parser) -> Result<LineNode, ParseError> {
+    let start = p.peek().span.start;
+    let mut word_or_num_or_space_list: Array<Token> = [];
+    let mut _plus_first = true;
+    loop {
+        if !_plus_first {
+            let mut rep_scan_pos: i32 = -1;
+            rep_scan: {
+                let tokens = &p.tokens;
+                let mut pos: i32 = p.pos;
+                let gp_2 = pos;
+                sg_2: {
+                    pos = gp_2;
+                    sg_2_0: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_WORD { break sg_2_0; }
+                        pos += 1;
+                        break sg_2;
+                    }
+                    pos = gp_2;
+                    sg_2_1: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_NUM { break sg_2_1; }
+                        pos += 1;
+                        break sg_2;
+                    }
+                    pos = gp_2;
+                    sg_2_2: {
+                        if pos >= tokens.len() || tokens[pos].kind != TK_SPACE { break sg_2_2; }
+                        pos += 1;
+                        break sg_2;
+                    }
+                    break rep_scan;
+                }
+                if pos <= p.pos { break rep_scan; }
+                rep_scan_pos = pos;
+            }
+            if rep_scan_pos < 0 { break; }
+        }
+        _plus_first = false;
+        let word_or_num_or_space = p.advance();
+        word_or_num_or_space_list.push(word_or_num_or_space);
+    }
+    let eof = p.expect(TK_EOF)?;
+    return Result::<LineNode, ParseError>::Ok(LineNode {
+        span: Span::new(start, p.last_end()),
+        word_or_num_or_space_list,
+        eof,
+    });
+}
+
+pub fn parse(input: &String) -> Result<LineNode, ParseError> {
+    let tokens = tokenize(input);
+    let mut parser = Parser::new(tokens);
+    return parse_line(&mut parser);
+}
+
+pub fn walk_line<V: Visitor>(v: &mut V, node: &LineNode) {
+    v.enter_rule(&"line", &node.span);
+    for let item of &node.word_or_num_or_space_list {
+        v.visit_token(item);
+    }
+    v.visit_token(&node.eof);
+    v.exit_rule(&"line", &node.span);
+}
+
+pub fn to_tree(node: &LineNode) -> CstNode {
+    let mut recorder = TreeRecorder::new();
+    walk_line(&mut recorder, node);
+    return recorder.build();
+}
+

--- a/package-gale/tests/grammars/ci_rule_override.g4
+++ b/package-gale/tests/grammars/ci_rule_override.g4
@@ -1,0 +1,29 @@
+// Source: Hand-authored for Gale's rule-level caseInsensitive override.
+// License: BSD-3-Clause (matches the Gale repo).
+//
+// Grammar-level `caseInsensitive = true` enables CI matching for all
+// lexer rules. Individual rules can *opt out* via a rule-level option
+// `options { caseInsensitive = false; }`. This is the inverse of
+// `ci_sql.g4` (which only tests the grammar-level true → rule-level
+// inherits true path) and exercises the override codegen in
+// `lexer_gen.wado`.
+
+grammar ci_rule_override;
+
+options { caseInsensitive = true; }
+
+line : (KEYWORD | IDENT | EXACT)+ EOF ;
+
+// Inherits grammar-level CI: matches `if`, `IF`, `If`, `iF`.
+KEYWORD : 'if' ;
+
+// Inherits grammar-level CI: matches identifiers in any case.
+IDENT : [a-z][a-z0-9_]* ;
+
+// Rule-level override: this keyword must match *exactly* `EXACT`
+// regardless of the grammar-level CI setting. Lower- or mixed-case
+// `exact` must NOT be accepted by this rule (it will fall through to
+// IDENT instead).
+EXACT options { caseInsensitive = false; } : 'EXACT' ;
+
+WS : [ \t\r\n]+ -> skip ;

--- a/package-gale/tests/grammars/label_gaps.g4
+++ b/package-gale/tests/grammars/label_gaps.g4
@@ -1,0 +1,54 @@
+// Source: Hand-authored for Gale's parser-label coverage.
+// License: BSD-3-Clause (matches the Gale repo).
+//
+// Minimal grammar that exercises scalar (single-valued) element labels at
+// parser level. The list form `items += ITEM` is covered by parser_gaps.g4
+// (A2); this fixture targets the distinct `name = TOK` and `name = rule`
+// codegen path (LabelElement with `list = false`).
+//
+// Layout:
+//   - `assign_stmt` uses a scalar TOKEN label (`key = ID`) and a scalar
+//     literal label (`value = STRING`).
+//   - `pair_stmt` uses a scalar rule-reference label (`k = key_rule`), mixed
+//     with an unlabeled token.
+//   - `mix_stmt` uses both a list label and a scalar label in the same
+//     alternative, to verify that the generator does not confuse the two
+//     when they appear together.
+
+grammar label_gaps;
+
+program
+    : stmt* EOF
+    ;
+
+stmt
+    : assign_stmt
+    | pair_stmt
+    | mix_stmt
+    ;
+
+assign_stmt
+    : key = ID EQ value = STRING SEMI
+    ;
+
+pair_stmt
+    : PAIR k = key_rule COLON ID SEMI
+    ;
+
+key_rule
+    : ID
+    ;
+
+mix_stmt
+    : LIST head = ID (COMMA rest += ID)* SEMI
+    ;
+
+PAIR   : 'pair' ;
+LIST   : 'list' ;
+EQ     : '=' ;
+COLON  : ':' ;
+COMMA  : ',' ;
+SEMI   : ';' ;
+ID     : [a-zA-Z_] [a-zA-Z_0-9]* ;
+STRING : '"' (~["\\] | '\\' .)* '"' ;
+WS     : [ \t\r\n]+ -> skip ;

--- a/package-gale/tests/grammars/lexer_command_gaps.g4
+++ b/package-gale/tests/grammars/lexer_command_gaps.g4
@@ -1,0 +1,50 @@
+// Source: Hand-authored for Gale's lexer-command coverage.
+// License: BSD-3-Clause (matches the Gale repo).
+//
+// Covers three lexer-command gaps that no existing driver grammar
+// exercises end-to-end:
+//
+//   - A `-> type(X)` command used *alone* (no pushMode, no channel).
+//     Canonical use case: two rules that match different source forms
+//     but should be emitted as the same token kind. `channels.md` and
+//     `lexer-rules.md` in `vendor/antlr4/doc/` describe the semantics.
+//   - A numeric `-> channel(N)` that routes a token to a custom channel
+//     declared via `channels { ... }`. Both the `channels` block and
+//     numeric channel arguments are ANTLR4 features that the existing
+//     `HIDDEN`-only tests do not cover.
+//   - A named reference to `DEFAULT_MODE` / `DEFAULT_TOKEN_CHANNEL` —
+//     ANTLR4 accepts these as identifiers that resolve to the implicit
+//     default mode/channel. At minimum the g4 parser must accept them.
+
+grammar lexer_command_gaps;
+
+channels { COMMENTS_CHANNEL }
+
+text : (WORD | NUMBER | PRAGMA)* EOF ;
+
+// Two different source forms, one emitted token kind: the spelled-out
+// number 'zero' is re-typed to NUMBER via `-> type(NUMBER)`.
+WORD  : [a-z]+ ;
+ZERO  : 'zero' -> type(NUMBER) ;
+NUMBER : [0-9]+ ;
+
+// Numeric channel argument: routes comments to the custom channel by
+// declared name (not HIDDEN). The parser side never sees COMMENT tokens.
+COMMENT : '//' ~[\r\n]* -> channel(COMMENTS_CHANNEL) ;
+
+// `-> mode(DEFAULT_MODE)` — exercises the parser's ability to resolve the
+// implicit default mode identifier. A `pragma` line switches to PRAGMA_MODE
+// to consume its body, then returns to the default mode by name. The
+// opening `#pragma` keyword itself is skipped so the parser sees only the
+// inner PRAGMA token.
+PRAGMA_OPEN : '#pragma' -> skip, pushMode(PRAGMA_MODE) ;
+
+WS : [ \t\r\n]+ -> skip ;
+
+mode PRAGMA_MODE;
+
+// The pragma body is a single word emitted as PRAGMA. The terminating
+// newline switches back to the default mode via `mode(DEFAULT_MODE)`.
+PRAGMA   : [a-zA-Z_]+ ;
+PRAGMA_WS : [ \t]+ -> skip ;
+PRAGMA_END : '\n' -> mode(DEFAULT_MODE), skip ;

--- a/package-gale/tests/grammars/mode_gaps.g4
+++ b/package-gale/tests/grammars/mode_gaps.g4
@@ -1,0 +1,52 @@
+// Source: Hand-authored for Gale's mode/more coverage.
+// License: BSD-3-Clause (matches the Gale repo).
+//
+// Minimal grammar that exercises lexer-command features uncovered by the
+// existing driver-test grammars — see TODO.md "Driver-level verification
+// (remaining gaps)":
+//
+//   - A3: bare `mode(X)` command (replaces top of stack, unlike pushMode).
+//   - A4: `more` semantics when the mode is entered via a lexer-command-only
+//     `pushMode` (so no action block stands between the command and the
+//     generated lexer state transition).
+//
+// The grammar models a tiny string literal with backslash escapes:
+//   - `foo` (PLAIN) is tokenized directly.
+//   - `"hello"` enters IN_STRING via `pushMode(IN_STRING)` and accumulates
+//     each character with `more` until the closing quote emits STRING.
+//   - `"hi\nthere"` switches temporarily to ESC_IN_STRING via `mode(...)`
+//     to consume the escape target, then switches back via `mode(IN_STRING)`
+//     — exercising the "replace top of stack" semantics.
+
+grammar mode_gaps;
+
+text : (PLAIN | STRING)* EOF ;
+
+PLAIN : [a-zA-Z]+ ;
+
+// A4: enter IN_STRING via pushMode from a lexer-command-only rule. The
+// opening quote itself is merged into the next emitted token via `more`
+// so the final STRING token contains the full literal.
+QUOTE : '"' -> more, pushMode(IN_STRING) ;
+
+WS : [ \t\r\n]+ -> skip ;
+
+mode IN_STRING;
+
+// A3: `mode(ESC_IN_STRING)` *replaces* the top of the mode stack, so when
+// ESC_IN_STRING finishes it returns here via another `mode(IN_STRING)`
+// rather than by popping. This is the distinguishing behavior of `mode(X)`
+// versus `pushMode(X)` / `popMode`.
+STR_ESC_BEGIN : '\\' -> more, mode(ESC_IN_STRING) ;
+
+// A4: accumulate regular string chars into the pending STRING.
+STR_CHAR : ~[\\"] -> more ;
+
+// Emit the accumulated STRING token and return to the default mode.
+STRING : '"' -> popMode ;
+
+mode ESC_IN_STRING;
+
+// Consume exactly one escape target (any char), accumulate it, and return
+// to IN_STRING via `mode(IN_STRING)` — exercising the "switch" command.
+ESC_CHAR : . -> more, mode(IN_STRING) ;

--- a/package-gale/tests/grammars/non_greedy_gaps.g4
+++ b/package-gale/tests/grammars/non_greedy_gaps.g4
@@ -1,0 +1,25 @@
+// Source: Hand-authored for Gale's parser-level non-greedy coverage.
+// License: BSD-3-Clause (matches the Gale repo).
+//
+// Minimal grammar that exercises PARSER-level non-greedy operators. The
+// canonical fuzzy-parsing idiom from `vendor/antlr4/doc/wildcard.md`:
+//
+//   file : .*? (constant .*?)+ EOF ;
+//
+// Parser non-greedy `.*?` and `TOK*?` take a distinct code path in
+// `parser_gen.wado` (`compute_non_greedy_condition`,
+// `gen_repeat_non_greedy`) that no existing driver grammar exercises
+// end-to-end — `ANTLRv4Parser.g4` uses `ARGUMENT_CONTENT*?` but the ANTLR4
+// driver test only tokenizes, never runs the parser.
+
+grammar non_greedy_gaps;
+
+file : .*? (constant .*?)+ EOF ;
+
+constant : 'public' 'static' 'final' 'int' ID ;
+
+ID : [a-zA-Z_] [a-zA-Z_0-9]* ;
+INT : [0-9]+ ;
+OP : [+\-*/=] ;
+SEMI : ';' ;
+WS : [ \t\r\n]+ -> skip ;

--- a/package-gale/tests/grammars/parser_gaps.g4
+++ b/package-gale/tests/grammars/parser_gaps.g4
@@ -1,0 +1,51 @@
+// Source: Hand-authored for Gale's parser-gaps coverage.
+// License: BSD-3-Clause (matches the Gale repo).
+//
+// A minimal combined grammar that exercises parser-level features that
+// were uncovered by the existing driver-test grammars — see TODO.md
+// "Driver-level verification (remaining gaps)":
+//
+//   - A1: parser-side `~TOK` and `~( block )` (set complement of a token).
+//   - A2: list labels `items += ITEM` (vs. single-valued labels).
+//   - A5: parser-level wildcard `.` (matches any single token).
+
+grammar parser_gaps;
+
+program
+    : stmt* EOF
+    ;
+
+stmt
+    : list_stmt
+    | not_stmt
+    | any_stmt
+    ;
+
+// A2: list labels — `items += ITEM` collects every matching token into the
+// same list label. The parser must recognize the `+=` list form without
+// confusing it with the scalar `name = ITEM` form.
+list_stmt
+    : LIST items += ITEM (COMMA items += ITEM)* SEMI
+    ;
+
+// A1: `~TOK` (token-complement) and `~( TOK | TOK )` (set-complement) at
+// parser level. Both must match exactly one token that is NOT in the set.
+not_stmt
+    : NOT ~ITEM SEMI
+    | SET ~( ITEM | NUMBER ) SEMI
+    ;
+
+// A5: parser-level wildcard `.` matches any single token.
+any_stmt
+    : ANY . SEMI
+    ;
+
+LIST   : 'list' ;
+NOT    : 'not' ;
+SET    : 'set' ;
+ANY    : 'any' ;
+ITEM   : [a-z_] [a-z_0-9]* ;
+NUMBER : [0-9]+ ;
+COMMA  : ',' ;
+SEMI   : ';' ;
+WS     : [ \t\r\n]+ -> skip ;

--- a/package-gale/tests/grammars/recursive_lexer.g4
+++ b/package-gale/tests/grammars/recursive_lexer.g4
@@ -1,0 +1,28 @@
+// Source: Hand-authored for Gale's recursive-fragment coverage.
+// License: BSD-3-Clause (matches the Gale repo).
+//
+// ANTLR4 lexer fragments may reference themselves or each other,
+// enabling lexer-time recursion. Canonical use case: matching a
+// balanced brace block as a single token — the lexer has to recurse
+// to handle arbitrary nesting depth. This is described in
+// `vendor/antlr4/doc/lexer-rules.md` (Fragments).
+//
+// Gale's `fragment_is_recursive` detection in `lexer_gen.wado`
+// promotes recursive fragments from inlined patterns to full match
+// functions; this grammar exercises that code path end-to-end.
+
+grammar recursive_lexer;
+
+file : (BLOCK | IDENT)+ EOF ;
+
+// The BLOCK token is everything from the opening `{` to the matching
+// `}`, including nested blocks. The recursive fragment BRACED handles
+// the nesting: inside the braces we can recurse into BRACED (for a
+// nested block) or consume any non-brace character.
+BLOCK : BRACED ;
+
+fragment BRACED : '{' (BRACED | ~[{}])* '}' ;
+
+IDENT : [a-zA-Z_][a-zA-Z_0-9]* ;
+
+WS : [ \t\r\n]+ -> skip ;

--- a/package-gale/tests/grammars/right_assoc_gaps.g4
+++ b/package-gale/tests/grammars/right_assoc_gaps.g4
@@ -1,0 +1,25 @@
+// Source: Hand-authored for Gale's right-associative-operator coverage.
+// License: BSD-3-Clause (matches the Gale repo).
+//
+// Minimal left-recursive grammar that uses the `<assoc=right>` rule-element
+// option on a single alternative (exponentiation `^`). ANTLR4 defaults to
+// left associativity; `<assoc=right>` flips a single alternative. The
+// distinguishing behavior:
+//   - Default (left): `2 + 3 + 4` parses as `(2 + 3) + 4`.
+//   - `<assoc=right>`: `2 ^ 3 ^ 4` parses as `2 ^ (3 ^ 4)`.
+//
+// Gale's `parser_gen.wado` has a distinct code path for right-associative
+// alternatives (lifts `min_prec` to `own_prec` rather than `own_prec + 1`
+// when recursing into the right operand), which no existing driver test
+// exercises.
+
+grammar right_assoc_gaps;
+
+expr
+    : <assoc=right> expr '^' expr  # Pow
+    | expr '+' expr                # Add
+    | INT                          # Int
+    ;
+
+INT : [0-9]+ ;
+WS  : [ \t\r\n]+ -> skip ;

--- a/package-gale/tests/grammars/unicode_props.g4
+++ b/package-gale/tests/grammars/unicode_props.g4
@@ -1,0 +1,20 @@
+// Source: Hand-authored for Gale's Unicode property coverage.
+// License: BSD-3-Clause (matches the Gale repo).
+//
+// ANTLR4 supports Unicode property escapes `\p{Name}` inside character
+// sets. Common use cases: `\p{L}` (any letter), `\p{Nd}` (decimal
+// digit), `\p{Zs}` (space separator). These expand into character
+// ranges at grammar-parse time — see `expand_unicode_property` in
+// `g4/parser.wado`.
+//
+// The existing `src/g4/parser_test.wado` verifies the ranges are
+// emitted correctly, but no driver-level test exercises the match
+// path with non-ASCII input. This grammar plugs that gap.
+
+grammar unicode_props;
+
+line : (WORD | NUM | SPACE)+ EOF ;
+
+WORD  : [\p{L}]+ ;
+NUM   : [\p{Nd}]+ ;
+SPACE : [\p{Zs}] -> skip ;


### PR DESCRIPTION
## Summary

Closes every item in `package-gale/TODO.md` **Section A** (driver-level verification) and **Section B** (negative tests), including the low-priority entries. Both sections are now fully removed from the TODO.

### Section A — Driver-level verification (A1–A14)

Added 7 new fixture grammars + golden files + driver tests covering:

- **A1/A2/A5**: parser-side `~TOK` / `~(block)`, list labels `+=`, wildcard `.` — `parser_gaps.g4`
- **A3/A4**: `mode(X)` / `more` lexer commands — `mode_gaps.g4`
- **A6**: scalar token/rule labels (`k=ID`, `k=rule_ref`) — `label_gaps.g4`
- **A7**: `<assoc=right>` alt prefix on LR alt — `right_assoc_gaps.g4`
- **A8**: non-greedy `.*?` / `TOK*?` at parser level — `non_greedy_gaps.g4`
- **A9/A11/A12**: `-> type(X)`, `channel(N)` / `channel(USER)`, `mode(DEFAULT_MODE)` — `lexer_command_gaps.g4`
- **A10**: rule-level `options { caseInsensitive = false; }` override — `ci_rule_override.g4`
- **A13**: recursive lexer fragments — `recursive_lexer.g4`
- **A14**: Unicode property escapes `\p{L}` / `\p{Nd}` / `\p{Zs}` — `unicode_props.g4`

Each fixture is wired through `mise run update-gale-golden`, `integration_test.wado`, and a dedicated `driver_*_test.wado`.

### Section B — Negative tests (B2, B6)

Implemented the two remaining slots with a principled split that mirrors ANTLR4's architecture:

- `parse()` stays **syntactic-only** (equivalent to `ANTLRParser.g`). Minimal fixtures, split-grammar halves, and `tokenVocab` imports still round-trip through it. Inline B1 duplicate-rule check is preserved.
- `check_references(&Grammar)` is the **semantic pass** (equivalent to `SymbolChecks.checkForUnresolvedRuleRefs`). Walks per-rule pending refs against the grammar's own rule tables, with lexer/parser-grammar-aware caveats.
- `parse_checked()` is the full-tool entry point — parse + check.
- **B6**: `<assoc=…>` now rejects anything other than `left` / `right` at parse time (per options.md), so LR codegen never silently falls back to left-associative.

`PendingRef { containing_rule, referenced_name, span }` lets error messages pinpoint both the bad reference and its rule context.

14 new parser tests cover the happy path, the error path (undefined parser rule, undefined token, undefined lexer rule, undefined fragment, invalid assoc), and the split-grammar caveats (`parser grammar` skips token-ref check; virtual tokens and `EOF` resolve; bare `parse` still accepts syntactically-well-formed grammars with undefined refs).

## Test plan

- [x] `package-gale/src/g4/parser_test.wado` — 118 passed, 0 failed
- [x] `package-gale/src/g4/integration_test.wado` — 27 passed, 0 failed
- [x] Full gale suite (`wado test package-gale`) — 586 passed, 0 failed
- [x] Gale source tests (`wado test package-gale/src`) — 276 passed, 0 failed
- [x] All new `.g4` fixtures round-trip through `parse()`, golden generation, and their driver tests

https://claude.ai/code/session_01HUB9MeBguN9SQ3KQBHkEBo