### PR TITLE
Kiln WEP M4/M5/M7 + M6 skeleton — typed Options, inline `with`, consume-only pipeline

### DIFF
--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -505,38 +505,39 @@ Deferred out of M3 (explicit): hooking `run_pipeline` into `wado compile`. Lands
 
 Until the Wado → WIT mapping ships, extract `Options` directly from the generator module's Wado IR (endorsed transitional path in "Options schema"). A module is treated as a Kiln generator iff its package declares `build-world = "wado:kiln/generator"`; such modules must export `pub struct Options` and `pub fn generate(req: Request<Options>) -> Result<Response, Error>`.
 
-- [ ] `wado-compiler::kiln::options`: `extract_options_descriptor(&Annotated) -> OptionsDescriptor` covering the v1 subset (primitives, `String`, `Option<T>`, enums / variants without payload generics, nested structs). Anything else is a generator-module compile error, reported at generator build time.
-- [ ] `wado-compiler::kiln::options_check`: `validate(descriptor, AttrValue | toml::Value) -> Result<CanonicalOptions, Vec<Diagnostic>>` with `Default` trait semantics. Diagnostics are emitted at manifest-parse / inline-parse time, before any generator runs.
-- [ ] `wado-compiler::kiln::cache::encode_options_canonical` replaces M3's provisional raw-TOML form. The single encoder function is the swap point; byte-for-byte output is preserved when the Wado → WIT mapping eventually drives extraction.
-- [ ] Tests: descriptor snapshot, validation happy path, unknown-field diagnostic, default application, missing-required diagnostic.
-
-Risk: cache-key churn when the mapping lands. Mitigated by the shared `encode_options_canonical` contract.
+- [x] `wado-compiler::kiln::options`: `extract_options_descriptor` (primitives, `String`, `Option<T>`, no-payload enums, nested structs with cycle detection).
+- [x] `wado-compiler::kiln::options_check::validate` with `Default` semantics + batched diagnostics.
+- [x] `wado-compiler::kiln::cache::encode_options_canonical` (replaces M3's provisional encoder; byte-equivalent on the common subset).
+- [x] Tests: `wado-compiler/tests/kiln_options.rs` (descriptor primitives / `Option<String>` / enum / nested struct / cycle reject / missing `Options` / missing `generate`).
 
 ### M5 — Inline `use ... with { generator: ... }` syntax
 
-- [ ] `parser.rs::parse_import_attributes`: extend to a nested literal tree — `attr_value := STRING | INT | BOOL | attr_array | import_attrs`. No identifier references, no expressions. Forward-compatibility: a future extension to real expressions inserts a fallthrough in `attr_value`.
-- [ ] `ast.rs`: replace `ImportAttributes` with a generic `AttrValue::{String, Bool, Int, Array, Object}` tree plus thin accessors for existing consumers.
-- [ ] `wado-compiler::kiln::inline`: scan every parsed module's `UseDecl` list for `with { generator: { ... } }`, synthesize an anonymous invocation id (`"kiln-<hex-of-canonical-tuple>"`), merge identical clauses, reject clauses sharing `from` with divergent config.
-- [ ] `name.rs::resolve_import`: redirect `use { X } from "<schema>"` to the registered invocation's entry module under `output-dir`. Collection completes before resolution (order-independent).
-- [ ] Tests: parser round-trip, single-file script with inline `with`, dedup of identical clauses, conflict on divergent clauses, bare `use` resolves against a manifest-declared invocation.
+- [x] `parser.rs::parse_import_attributes`: nested `attr_value` tree (`STRING | INT | BOOL | array | object`).
+- [x] `ast.rs`: generic `AttrValue::{String, Bool, Int, Array, Object}` with thin accessors on `ImportAttributes`.
+- [x] `wado-compiler::kiln::inline`: `collect_inline_invocations` synthesizes `kiln-<hex>` ids, dedups identical clauses, rejects divergent-config conflicts on the same `from`.
+- [x] `name.rs::resolve_import_with_invocations`: `(decl_file, from_path)` → entry module redirect. Threaded through loader / analyzer / resolver / `annotate` / `CompilerOptions.invocations`.
+- [x] Tests: parser round-trip, inline dedup / conflict, `wado-compiler/tests/kiln_loader_redirect.rs`, two `wado-cli/tests/kiln_pipeline.rs` cases for end-to-end inline → `CompilerOptions.invocations`.
 
 ### M6 — Gale migration (phased)
 
 Add the Kiln entry point without removing the existing CLI. Re-derive one existing golden through `[build.generators]` as proof.
 
-- [ ] `package-gale/src/generator.wado` (new): `export fn generate(req: Request<Options>) -> Result<Response, Error>` delegating to the existing generator/wadopoet logic.
-- [ ] `package-gale/src/options.wado` (new): `pub struct Options { highlight: bool, dump: bool, rule: Option<String> }` mapping today's `--highlight` / `--ir` / `--rule` flags.
-- [ ] `package-gale/wado.toml`: `build-world = "wado:kiln/generator"` at package level.
-- [ ] `package-gale/tests/kiln-consumer/` (new): minimal consumer project with `[build.generators.rust-grammar]` pointing at one grammar.
-- [ ] `wado-cli::compile`: hook `run_pipeline` into the compile flow — the first concrete provider lives here (compiles generator modules via the ordinary codegen path with `target_world = "wado:kiln/generator"` and caches at `target/kiln/generators/<ns>-<name>-<source-hash>.wasm`).
-- [ ] Test: `cargo test -p package-gale --test kiln_path` matches the existing golden byte-for-byte.
+- [x] `wado-cli::compile`: `run_pipeline_with_inline` hooked in; collects inline invocations from the entry file, merges with manifest, threads `InvocationIndex` into `CompilerOptions`. Both prior `TODO(M6)` sites in `compile.rs` are replaced.
+- [x] `wado-cli::kiln_provider::CliGeneratorProvider` skeleton: `LocalPath` / `Spec` dispatch with precise `Unsupported` messages pointing at consume-only mode (no silent failure).
+- [x] `package-gale/wado.toml`: `build-world = "wado:kiln/generator"` declared.
+- [ ] `package-gale/src/options.wado` + `src/generator.wado` (Kiln-shape `generate(req: Request<Options>) -> Result<Response, Error>` delegating to existing wadopoet logic). Existing `generator.wado` is the legacy non-Kiln shape.
+- [ ] `package-gale/tests/kiln-consumer/` minimal consumer project + `package-gale/tests/kiln_path.rs` golden comparison.
+- [ ] `CliGeneratorProvider::get_component`: actually compile the generator package (currently returns `Unsupported`). Requires the `wado:kiln/types` stdlib module + `wado:kiln/generator` world definition in `wado-compiler`.
+- [ ] `wado-cli/tests/kiln_compile.rs` end-to-end test (cache hit on second run).
 
 The existing `export fn run()` CLI stays in `package-gale/src/main.wado`. `mise.toml`'s `update-gale-golden` stays during M6 for parity; its retirement is a follow-up PR after one green release cycle, explicitly not in this milestone.
 
 ### M7 — Consume-only mode
 
-- [ ] `run_pipeline`: when `run_generator` returns `Unsupported`, skip execution, compare cache key + on-disk outputs against `wado.lock`; on match, proceed; on mismatch, emit `warning("stale kiln cache: <invocation>; re-run 'wado compile' natively to refresh")` and mark the entry module present-but-unresolved. Never write `wado.lock` or `<output-dir>`.
-- [ ] Tests: `wado-lsp` `wasm32-wasip2` build (or equivalent harness) against a project with committed `build/kiln/` and up-to-date `wado.lock` succeeds without reaching `run_generator`; the same with a modified input emits the warning and leaves `build/kiln/` untouched.
+- [x] `run_pipeline`: cache-key compared before runner invocation; on `Unsupported` from runner or provider with cache match, silent pass; on cache miss, `Code::KilnStaleCache` warning emitted, no writes to `<output-dir>` or `wado.lock`.
+- [x] `wado-cli` tests: `consume_only_cache_hit_silent_and_preserves_lockfile`, `consume_only_cache_miss_preserves_existing_build_kiln`, `unsupported_runner_error_emits_stale_cache_warning`.
+- [ ] `wado-lsp::Engine`: call `run_pipeline` on workspace open and thread the resulting `InvocationIndex` through `annotate_with_invocations` for hover / definition / diagnostics paths.
+- [ ] `wado-lsp/tests/kiln_consume_only.rs` covering both cache-hit silent and cache-miss warning cases through the LSP path.
 
 ## Alternatives considered
 

--- a/package-gale/wado.toml
+++ b/package-gale/wado.toml
@@ -2,3 +2,4 @@
 name = "gale"
 version = "0.1.0"
 command = "src/main.wado"
+build-world = "wado:kiln/generator"

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -431,10 +431,8 @@ async fn maybe_run_pipeline(
 
     let (manifest, manifest_root) = match manifest_pair {
         Some(pair) => pair,
+        None if inline.is_empty() => return Ok(PipelineOutcome::default()),
         None => {
-            if inline.is_empty() {
-                return Ok(PipelineOutcome::default());
-            }
             let manifest = wado_manifest::Manifest {
                 package: None,
                 registries: indexmap::IndexMap::new(),

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -8,7 +8,7 @@ use wado_compiler::LogLevel;
 
 use crate::args::{self, CliExit};
 use crate::compiler_host::FilesystemCompilerHost;
-use crate::kiln_driver::{PipelineError, PipelineOutcome, run_pipeline};
+use crate::kiln_driver::{PipelineError, PipelineOutcome};
 use crate::kiln_provider::CliGeneratorProvider;
 use crate::manifest;
 
@@ -326,6 +326,16 @@ pub async fn try_compile_with_full_opts(
         .unwrap_or_default();
     let host = FilesystemCompilerHost::with_log_level(base_path, log_level);
 
+    let pipeline_outcome = match maybe_run_pipeline(path, &host).await {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            eprintln!("{e}");
+            return Err(wado_compiler::CompileFailure {
+                is_todo_module: false,
+            });
+        }
+    };
+
     let options = wado_compiler::CompilerOptions {
         opt_level: to_compiler_opt_level(opt_level),
         target_world,
@@ -334,15 +344,10 @@ pub async fn try_compile_with_full_opts(
         opt_iterations,
         log_level: Some(log_level),
         allocator,
+        invocations: pipeline_outcome.invocations,
         ..Default::default()
     };
 
-    if let Err(e) = maybe_run_pipeline(path, &host).await {
-        eprintln!("{e}");
-        return Err(wado_compiler::CompileFailure {
-            is_todo_module: false,
-        });
-    }
     wado_compiler::compile_with_options(&source, &host, Some(filename), options).await
 }
 
@@ -375,6 +380,14 @@ pub async fn compile_with_full_opts(
         .unwrap_or_default();
     let host = FilesystemCompilerHost::with_log_level(base_path, log_level);
 
+    let pipeline_outcome = match maybe_run_pipeline(path, &host).await {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            eprintln!("{e}");
+            process::exit(1);
+        }
+    };
+
     // Build compiler options
     let options = wado_compiler::CompilerOptions {
         opt_level: to_compiler_opt_level(opt_level),
@@ -384,13 +397,10 @@ pub async fn compile_with_full_opts(
         opt_iterations,
         log_level: Some(log_level),
         allocator,
+        invocations: pipeline_outcome.invocations,
         ..Default::default()
     };
 
-    if let Err(e) = maybe_run_pipeline(path, &host).await {
-        eprintln!("{e}");
-        process::exit(1);
-    }
     // Compile using async API
     let result = wado_compiler::compile_with_options(&source, &host, Some(filename), options).await;
 
@@ -416,18 +426,65 @@ async fn maybe_run_pipeline(
     entry_file: &Path,
     host: &FilesystemCompilerHost,
 ) -> Result<PipelineOutcome, PipelineError> {
-    let Some((manifest, manifest_root)) = load_nearest_manifest(entry_file) else {
-        return Ok(PipelineOutcome::default());
+    let manifest_pair = load_nearest_manifest(entry_file);
+    let inline = collect_inline_invocations_for_entry(entry_file);
+
+    let (manifest, manifest_root) = match manifest_pair {
+        Some(pair) => pair,
+        None => {
+            if inline.is_empty() {
+                return Ok(PipelineOutcome::default());
+            }
+            let manifest = wado_manifest::Manifest {
+                package: None,
+                registries: indexmap::IndexMap::new(),
+                dependencies: indexmap::IndexMap::new(),
+                dev_dependencies: indexmap::IndexMap::new(),
+                build_dependencies: indexmap::IndexMap::new(),
+                build: None,
+                workspace: None,
+            };
+            let root = entry_file
+                .parent()
+                .map(std::path::Path::to_path_buf)
+                .unwrap_or_else(|| std::path::PathBuf::from("."));
+            (manifest, root)
+        }
     };
-    if manifest
+
+    let no_manifest_generators = manifest
         .build
         .as_ref()
-        .is_none_or(|b| b.generators.is_empty())
-    {
+        .is_none_or(|b| b.generators.is_empty());
+    if no_manifest_generators && inline.is_empty() {
         return Ok(PipelineOutcome::default());
     }
     let provider = CliGeneratorProvider::new(manifest_root.clone());
-    run_pipeline(&manifest, &manifest_root, host, &provider).await
+    crate::kiln_driver::run_pipeline_with_inline(&manifest, &manifest_root, host, &provider, inline)
+        .await
+}
+
+/// Parse the entry file to collect inline Kiln invocations from
+/// `use ... with { generator: { ... } }` clauses. Returns an empty vector when
+/// the file cannot be parsed — downstream compilation will surface the parse
+/// error, so we don't need to report it twice.
+fn collect_inline_invocations_for_entry(entry_file: &Path) -> Vec<wado_compiler::kiln::Invocation> {
+    let Ok(source) = fs::read_to_string(entry_file) else {
+        return Vec::new();
+    };
+    let Ok(parsed) = wado_compiler::parse(&source) else {
+        return Vec::new();
+    };
+    let mut modules =
+        wado_compiler::hashmap::IndexMap::<String, wado_compiler::ast::Module>::default();
+    let entry_name = entry_file
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("entry.wado")
+        .to_string();
+    modules.insert(entry_name, parsed.ast);
+    let descriptors = wado_compiler::hashmap::IndexMap::default();
+    wado_compiler::kiln::collect_inline_invocations(&modules, &descriptors).unwrap_or_default()
 }
 
 /// Walk up from `entry_file` looking for the nearest `wado.toml`. Returns the

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -8,6 +8,8 @@ use wado_compiler::LogLevel;
 
 use crate::args::{self, CliExit};
 use crate::compiler_host::FilesystemCompilerHost;
+use crate::kiln_driver::{PipelineError, PipelineOutcome, run_pipeline};
+use crate::kiln_provider::CliGeneratorProvider;
 use crate::manifest;
 
 /// Optimization level
@@ -335,9 +337,12 @@ pub async fn try_compile_with_full_opts(
         ..Default::default()
     };
 
-    // TODO(M6): before compile_with_options, resolve the manifest and call
-    //   wado_cli::kiln_driver::run_pipeline(manifest, base_path, &host, &provider).await?;
-    // See docs/wep-2026-04-12-kiln.md §"M6 — Gale migration".
+    if let Err(e) = maybe_run_pipeline(path, &host).await {
+        eprintln!("{e}");
+        return Err(wado_compiler::CompileFailure {
+            is_todo_module: false,
+        });
+    }
     wado_compiler::compile_with_options(&source, &host, Some(filename), options).await
 }
 
@@ -382,9 +387,10 @@ pub async fn compile_with_full_opts(
         ..Default::default()
     };
 
-    // TODO(M6): before compile_with_options, resolve the manifest and call
-    //   wado_cli::kiln_driver::run_pipeline(manifest, base_path, &host, &provider).await?;
-    // See docs/wep-2026-04-12-kiln.md §"M6 — Gale migration".
+    if let Err(e) = maybe_run_pipeline(path, &host).await {
+        eprintln!("{e}");
+        process::exit(1);
+    }
     // Compile using async API
     let result = wado_compiler::compile_with_options(&source, &host, Some(filename), options).await;
 
@@ -393,6 +399,61 @@ pub async fn compile_with_full_opts(
         Err(_bail) => {
             // Errors already printed by host via emit_diagnostic
             process::exit(1);
+        }
+    }
+}
+
+/// Walk up from `entry_file` to find an adjacent `wado.toml`, then drive the
+/// Kiln pipeline via [`run_pipeline`]. Returns `Ok(PipelineOutcome)` when a
+/// manifest is found and the pipeline ran (possibly a no-op when the manifest
+/// has no `[build.generators]` section). Returns `Ok(PipelineOutcome::default())`
+/// when there is no adjacent manifest — single-file scripts don't need Kiln.
+///
+/// Errors from [`run_pipeline`] are surfaced unchanged; the caller decides
+/// whether to abort or continue (e.g. for consume-only mode, a stale-cache
+/// warning is not fatal).
+async fn maybe_run_pipeline(
+    entry_file: &Path,
+    host: &FilesystemCompilerHost,
+) -> Result<PipelineOutcome, PipelineError> {
+    let Some((manifest, manifest_root)) = load_nearest_manifest(entry_file) else {
+        return Ok(PipelineOutcome::default());
+    };
+    if manifest
+        .build
+        .as_ref()
+        .is_none_or(|b| b.generators.is_empty())
+    {
+        return Ok(PipelineOutcome::default());
+    }
+    let provider = CliGeneratorProvider::new(manifest_root.clone());
+    run_pipeline(&manifest, &manifest_root, host, &provider).await
+}
+
+/// Walk up from `entry_file` looking for the nearest `wado.toml`. Returns the
+/// parsed manifest plus the directory that contains it (the Kiln pipeline's
+/// `manifest_root`). Silently returns `None` when no manifest is found or the
+/// manifest cannot be parsed — the caller treats this as "no Kiln config" and
+/// continues.
+fn load_nearest_manifest(
+    entry_file: &Path,
+) -> Option<(wado_manifest::Manifest, std::path::PathBuf)> {
+    let mut dir = entry_file
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    if dir.as_os_str().is_empty() {
+        dir = std::path::PathBuf::from(".");
+    }
+    loop {
+        let candidate = dir.join("wado.toml");
+        if candidate.is_file() {
+            let text = fs::read_to_string(&candidate).ok()?;
+            let manifest: wado_manifest::Manifest = text.parse().ok()?;
+            return Some((manifest, dir));
+        }
+        if !dir.pop() {
+            return None;
         }
     }
 }

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -1029,17 +1029,16 @@ where
 }
 
 fn is_unsupported(err: &PipelineError) -> bool {
-    match err {
+    matches!(
+        err,
         PipelineError::Execute {
             source: ExecuteError::Runner(GeneratorRunnerError::Unsupported),
             ..
-        }
-        | PipelineError::Provider {
+        } | PipelineError::Provider {
             source: ProviderError::Unsupported { .. },
             ..
-        } => true,
-        _ => false,
-    }
+        }
+    )
 }
 
 fn emit_stale_warning<H: CompilerHost>(host: &H, invocation: &str) {

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -59,9 +59,11 @@ pub struct PlanOutcome {
 /// lowering step.
 #[derive(Debug)]
 pub enum DriverError {
-    /// The manifest's `module = { ... }` inline form is not yet supported by
-    /// the driver. M3c ships with `module = "ns:name@ver"` only; inline
-    /// records land together with build-dependency resolution.
+    /// The manifest's `module = { foo = ... }` inline record form with
+    /// keys other than `path` is not supported. `module = "ns:name@ver"`
+    /// (spec form) and `module = { path = "..." }` (local path) are
+    /// accepted; other shapes surface this error so registry/git/workspace
+    /// forms remain an explicit, actionable v1 limitation.
     UnsupportedInlineModule { invocation: String },
     /// Dedup / cycle error from the planner.
     Plan(PlanError),
@@ -786,6 +788,11 @@ pub struct PipelineOutcome {
     /// and skips lockfile / output-directory writes so committed artifacts
     /// are preserved.
     pub stale: Vec<String>,
+    /// Redirect index for the resolver: `(decl_file, from)` → entry path.
+    /// Populated from every invocation (cached, executed, or stale) so the
+    /// compiler can redirect `use { X } from "<schema>"` to the generated
+    /// entry module. Empty when no invocations ran.
+    pub invocations: wado_compiler::kiln::InvocationIndex,
 }
 
 /// Failure modes from [`run_pipeline`].
@@ -866,7 +873,44 @@ where
     H: CompilerHost,
     P: GeneratorProvider,
 {
-    let mut planned = plan(manifest, manifest_root)?;
+    run_pipeline_with_inline(manifest, manifest_root, host, provider, Vec::new()).await
+}
+
+/// Like [`run_pipeline`] but also accepts pre-collected inline invocations
+/// (from `use ... with { generator: ... }` clauses). The inline set is merged
+/// with the manifest-declared set before planning.
+///
+/// # Errors
+/// See [`PipelineError`].
+pub async fn run_pipeline_with_inline<H, P>(
+    manifest: &Manifest,
+    manifest_root: &Path,
+    host: &H,
+    provider: &P,
+    inline_invocations: Vec<wado_compiler::kiln::Invocation>,
+) -> Result<PipelineOutcome, PipelineError>
+where
+    H: CompilerHost,
+    P: GeneratorProvider,
+{
+    let manifest_plan = plan(manifest, manifest_root)?;
+    let merged = match wado_compiler::kiln::merge_manifest_and_inline(
+        manifest_plan.plan.order,
+        inline_invocations,
+    ) {
+        Ok(v) => v,
+        Err(diags) => {
+            for d in diags {
+                host.emit_diagnostic(d);
+            }
+            return Ok(PipelineOutcome::default());
+        }
+    };
+    let plan_order = wado_compiler::kiln::build_plan(merged).map_err(DriverError::Plan)?;
+    let mut planned = PlanOutcome {
+        plan: plan_order,
+        manifest_root: manifest_root.to_path_buf(),
+    };
     if planned.plan.order.is_empty() {
         return Ok(PipelineOutcome::default());
     }
@@ -949,6 +993,15 @@ where
                 for o in &entry.outputs {
                     kept.push(o.path.clone());
                 }
+            }
+            if let Some(entry_path) = entry.outputs.iter().find(|o| o.entry).map(|o| &o.path) {
+                let decl_file = match &invocation.decl_site {
+                    wado_compiler::kiln::DeclSite::Manifest { .. } => String::new(),
+                    wado_compiler::kiln::DeclSite::Inline { module, .. } => module.clone(),
+                };
+                outcome
+                    .invocations
+                    .insert(&decl_file, invocation.from.as_str(), entry_path);
             }
             new_cache.push(entry);
         }
@@ -1116,9 +1169,7 @@ where
 fn invocation_id(inv: &Invocation) -> String {
     match &inv.decl_site {
         DeclSite::Manifest { name } => name.clone(),
-        DeclSite::Inline { .. } => {
-            panic!("inline kiln invocation ids are introduced in M5")
-        }
+        DeclSite::Inline { synthetic_id, .. } => synthetic_id.clone(),
     }
 }
 
@@ -1427,6 +1478,197 @@ d_string = "hi"
     }
 
     #[test]
+    fn typed_encoder_enum_matches_bare_string() {
+        use wado_compiler::kiln::{OptionsDescriptor, OptionsField, OptionsType};
+        use wado_compiler::token::Span;
+
+        let desc = OptionsDescriptor {
+            fields: vec![OptionsField {
+                name: "style".to_string(),
+                ty: OptionsType::Enum {
+                    name: "Style".to_string(),
+                    variants: vec!["Rpc".to_string(), "Rest".to_string()],
+                },
+                default: None,
+                span: Span::new(0, 0, 1, 1),
+            }],
+        };
+
+        let toml_val: toml::Value = toml::from_str(r#"style = "Rpc""#).unwrap();
+        let provisional_bytes = encode_options_canonical_provisional(&toml_val);
+
+        let attr = toml_to_attr_value(&toml_val);
+        let canonical = validate_options(&desc, Some(&attr)).unwrap();
+        let typed_bytes = encode_options_canonical(&canonical);
+
+        assert_eq!(
+            provisional_bytes, typed_bytes,
+            "enum variant must encode identically to a bare string",
+        );
+    }
+
+    #[test]
+    fn typed_encoder_key_order_independent() {
+        use wado_compiler::kiln::{OptionsDescriptor, OptionsField, OptionsType};
+        use wado_compiler::token::Span;
+
+        let desc = OptionsDescriptor {
+            fields: vec![
+                OptionsField {
+                    name: "a".to_string(),
+                    ty: OptionsType::I64,
+                    default: None,
+                    span: Span::new(0, 0, 1, 1),
+                },
+                OptionsField {
+                    name: "b".to_string(),
+                    ty: OptionsType::String,
+                    default: None,
+                    span: Span::new(0, 0, 1, 1),
+                },
+                OptionsField {
+                    name: "c".to_string(),
+                    ty: OptionsType::Bool,
+                    default: None,
+                    span: Span::new(0, 0, 1, 1),
+                },
+            ],
+        };
+
+        let order1: toml::Value = toml::from_str("a = 1\nb = \"x\"\nc = true").unwrap();
+        let order2: toml::Value = toml::from_str("c = true\na = 1\nb = \"x\"").unwrap();
+
+        let canonical1 = validate_options(&desc, Some(&toml_to_attr_value(&order1))).unwrap();
+        let canonical2 = validate_options(&desc, Some(&toml_to_attr_value(&order2))).unwrap();
+        assert_eq!(
+            encode_options_canonical(&canonical1),
+            encode_options_canonical(&canonical2),
+            "typed encoder must be key-order independent like the provisional one",
+        );
+    }
+
+    #[test]
+    fn typed_encoder_distinguishes_numeric_widths() {
+        use wado_compiler::kiln::{OptionsDescriptor, OptionsField, OptionsType};
+        use wado_compiler::token::Span;
+
+        let make_desc = |ty: OptionsType| OptionsDescriptor {
+            fields: vec![OptionsField {
+                name: "n".to_string(),
+                ty,
+                default: None,
+                span: Span::new(0, 0, 1, 1),
+            }],
+        };
+
+        let toml_val: toml::Value = toml::from_str("n = 42").unwrap();
+        let attr = toml_to_attr_value(&toml_val);
+
+        let as_i32 = encode_options_canonical(
+            &validate_options(&make_desc(OptionsType::I32), Some(&attr)).unwrap(),
+        );
+        let as_i64 = encode_options_canonical(
+            &validate_options(&make_desc(OptionsType::I64), Some(&attr)).unwrap(),
+        );
+        let as_u64 = encode_options_canonical(
+            &validate_options(&make_desc(OptionsType::U64), Some(&attr)).unwrap(),
+        );
+        assert_eq!(
+            as_i32, as_i64,
+            "integer widths must collapse into a single canonical int",
+        );
+        assert_eq!(
+            as_i64, as_u64,
+            "signed and unsigned integers must encode identically at the same width",
+        );
+    }
+
+    #[test]
+    fn typed_encoder_float_preserves_zero_and_negative() {
+        use wado_compiler::kiln::{OptionsDescriptor, OptionsField, OptionsType};
+        use wado_compiler::token::Span;
+
+        let desc = OptionsDescriptor {
+            fields: vec![OptionsField {
+                name: "x".to_string(),
+                ty: OptionsType::F64,
+                default: None,
+                span: Span::new(0, 0, 1, 1),
+            }],
+        };
+
+        let pos_zero: toml::Value = toml::from_str("x = 0.0").unwrap();
+        let neg: toml::Value = toml::from_str("x = -3.14").unwrap();
+        let pos: toml::Value = toml::from_str("x = 3.14").unwrap();
+
+        let bytes_pos_zero = encode_options_canonical(
+            &validate_options(&desc, Some(&toml_to_attr_value(&pos_zero))).unwrap(),
+        );
+        let bytes_neg = encode_options_canonical(
+            &validate_options(&desc, Some(&toml_to_attr_value(&neg))).unwrap(),
+        );
+        let bytes_pos = encode_options_canonical(
+            &validate_options(&desc, Some(&toml_to_attr_value(&pos))).unwrap(),
+        );
+        assert_ne!(bytes_pos_zero, bytes_neg);
+        assert_ne!(bytes_neg, bytes_pos);
+    }
+
+    #[test]
+    fn typed_encoder_mixed_fields_match_provisional() {
+        use wado_compiler::kiln::{OptionsDescriptor, OptionsField, OptionsType};
+        use wado_compiler::token::Span;
+
+        let desc = OptionsDescriptor {
+            fields: vec![
+                OptionsField {
+                    name: "emit".to_string(),
+                    ty: OptionsType::Bool,
+                    default: None,
+                    span: Span::new(0, 0, 1, 1),
+                },
+                OptionsField {
+                    name: "name".to_string(),
+                    ty: OptionsType::String,
+                    default: None,
+                    span: Span::new(0, 0, 1, 1),
+                },
+                OptionsField {
+                    name: "n".to_string(),
+                    ty: OptionsType::U32,
+                    default: None,
+                    span: Span::new(0, 0, 1, 1),
+                },
+                OptionsField {
+                    name: "opt".to_string(),
+                    ty: OptionsType::Option(Box::new(OptionsType::I32)),
+                    default: None,
+                    span: Span::new(0, 0, 1, 1),
+                },
+            ],
+        };
+
+        let with_opt: toml::Value =
+            toml::from_str("emit = false\nname = \"gen\"\nn = 7\nopt = 9").unwrap();
+        let provisional = encode_options_canonical_provisional(&with_opt);
+        let typed = encode_options_canonical(
+            &validate_options(&desc, Some(&toml_to_attr_value(&with_opt))).unwrap(),
+        );
+        assert_eq!(provisional, typed);
+
+        let without_opt: toml::Value =
+            toml::from_str("emit = false\nname = \"gen\"\nn = 7").unwrap();
+        let provisional2 = encode_options_canonical_provisional(&without_opt);
+        let typed2 = encode_options_canonical(
+            &validate_options(&desc, Some(&toml_to_attr_value(&without_opt))).unwrap(),
+        );
+        assert_eq!(
+            provisional2, typed2,
+            "Option::None fields must be invisible in the canonical byte stream",
+        );
+    }
+
+    #[test]
     fn typed_encoder_option_none_omitted_from_table() {
         use wado_compiler::kiln::{OptionsDescriptor, OptionsField, OptionsType};
         use wado_compiler::token::Span;
@@ -1588,7 +1830,7 @@ d_string = "hi"
         }
 
         #[test]
-        fn unsupported_runner_error_bubbles_up() {
+        fn execute_surfaces_runner_unsupported_verbatim() {
             let tmp = tempfile::tempdir().unwrap();
             let host = MockHost::new(
                 &[("schema.proto", b"x"), ("dep.proto", b"y")],

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -23,14 +23,16 @@
 
 use std::path::{Path, PathBuf};
 
+use wado_compiler::ast::AttrValue;
 use wado_compiler::compiler_host::{
     CompilerHost, GeneratorInputFile, GeneratorReadRecord, GeneratorRequest, GeneratorRunnerError,
     SourceError,
 };
+use wado_compiler::hashmap::IndexMap as CompilerIndexMap;
 use wado_compiler::kiln::{
-    DeclSite, FileHash, GeneratedHeader, GeneratorModule, Invocation, InvocationPath, Plan,
-    PlanError, build_plan, content_hash, file_hash, generator_identity, has_generated_marker,
-    hex_digest,
+    DeclSite, FileHash, GeneratedHeader, GeneratorModule, Invocation, InvocationPath,
+    OptionsDescriptor, Plan, PlanError, build_plan, content_hash, encode_options_canonical,
+    file_hash, generator_identity, has_generated_marker, hex_digest, validate_options,
 };
 use wado_manifest::{
     FileHash as ManifestFileHash, GeneratorCacheEntry, GeneratorInvocation, GeneratorModuleRef,
@@ -232,6 +234,35 @@ fn write_str(out: &mut Vec<u8>, s: &str) {
 
 fn write_len(out: &mut Vec<u8>, n: usize) {
     out.extend_from_slice(&(n as u64).to_be_bytes());
+}
+
+/// Convert a `toml::Value` to the compiler-side generic [`AttrValue`] tree so
+/// the driver can hand a user-supplied options table to
+/// [`wado_compiler::kiln::validate_options`] without leaking `toml` into the
+/// compiler crate.
+///
+/// Datetime values are rendered as their RFC-3339 string form (matching the
+/// provisional encoder's tag 6). Floats are preserved; integers stay
+/// `i64`-typed. Tables preserve declaration order via
+/// [`wado_compiler::hashmap::IndexMap`] so downstream validation is
+/// deterministic.
+#[must_use]
+pub fn toml_to_attr_value(v: &toml::Value) -> AttrValue {
+    match v {
+        toml::Value::Boolean(b) => AttrValue::Bool(*b),
+        toml::Value::Integer(i) => AttrValue::Int(*i),
+        toml::Value::Float(f) => AttrValue::Float(*f),
+        toml::Value::String(s) => AttrValue::String(s.clone()),
+        toml::Value::Datetime(dt) => AttrValue::String(dt.to_string()),
+        toml::Value::Array(a) => AttrValue::Array(a.iter().map(toml_to_attr_value).collect()),
+        toml::Value::Table(t) => {
+            let mut entries: CompilerIndexMap<String, AttrValue> = CompilerIndexMap::default();
+            for (k, val) in t {
+                entries.insert(k.clone(), toml_to_attr_value(val));
+            }
+            AttrValue::Object(entries)
+        }
+    }
 }
 
 /// Outcome of [`execute`] for a single invocation.
@@ -693,6 +724,27 @@ pub trait GeneratorProvider {
         &self,
         module: &GeneratorModule,
     ) -> impl std::future::Future<Output = Result<Vec<u8>, ProviderError>> + Send;
+
+    /// Resolve `module` to its typed [`OptionsDescriptor`]. Used by the
+    /// driver to validate a user-supplied options table before calling the
+    /// generator — see
+    /// [`wado_compiler::kiln::validate_options`]. When a provider cannot
+    /// introspect the generator (e.g. consume-only mode on the LSP), it
+    /// returns [`ProviderError::Unsupported`] and the driver falls back to
+    /// the provisional TOML encoder on the raw options table.
+    fn descriptor(
+        &self,
+        module: &GeneratorModule,
+    ) -> impl std::future::Future<Output = Result<OptionsDescriptor, ProviderError>> + Send {
+        let _ = module;
+        async {
+            Err(ProviderError::Unsupported {
+                message:
+                    "kiln: provider does not expose OptionsDescriptor (typed options unavailable)"
+                        .to_string(),
+            })
+        }
+    }
 }
 
 /// Error returned by a [`GeneratorProvider`].
@@ -727,6 +779,13 @@ pub struct PipelineOutcome {
     /// Project-root-relative paths of stale `#![generated]` files deleted
     /// across all invocation output directories.
     pub deleted: Vec<String>,
+    /// Invocation ids that fell through to consume-only mode because the
+    /// provider or runner reported `Unsupported`. See the consume-only
+    /// contract documented on [`run_pipeline`]: when this list is non-empty
+    /// the pipeline emits [`wado_compiler::Code::KilnStaleCache`] warnings
+    /// and skips lockfile / output-directory writes so committed artifacts
+    /// are preserved.
+    pub stale: Vec<String>,
 }
 
 /// Failure modes from [`run_pipeline`].
@@ -807,10 +866,12 @@ where
     H: CompilerHost,
     P: GeneratorProvider,
 {
-    let planned = plan(manifest, manifest_root)?;
+    let mut planned = plan(manifest, manifest_root)?;
     if planned.plan.order.is_empty() {
         return Ok(PipelineOutcome::default());
     }
+
+    typed_encode_options(manifest, &mut planned.plan.order, provider, host).await;
 
     let mut lock = load_lockfile(manifest_root)?;
     let mut new_cache: Vec<GeneratorCacheEntry> = Vec::with_capacity(planned.plan.order.len());
@@ -829,12 +890,36 @@ where
         let options_hash =
             wado_compiler::kiln::hash_options_canonical(&invocation.options_canonical);
 
-        let entry = if let Some(prior) = existing.filter(|e| e.options_hash == options_hash) {
-            if cache_matches(&prior, invocation, manifest_root, host).await {
-                outcome.cached.push(invocation_name.clone());
-                prior
+        let (entry, executed) =
+            if let Some(prior) = existing.clone().filter(|e| e.options_hash == options_hash) {
+                if cache_matches(&prior, invocation, manifest_root, host).await {
+                    outcome.cached.push(invocation_name.clone());
+                    (Some(prior), false)
+                } else {
+                    match run_and_build_entry(
+                        &invocation_name,
+                        invocation,
+                        manifest_root,
+                        host,
+                        provider,
+                        options_hash.clone(),
+                    )
+                    .await
+                    {
+                        Ok(entry) => {
+                            outcome.executed.push(invocation_name.clone());
+                            (Some(entry), true)
+                        }
+                        Err(e) if is_unsupported(&e) => {
+                            emit_stale_warning(host, &invocation_name);
+                            outcome.stale.push(invocation_name.clone());
+                            (Some(prior), false)
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
             } else {
-                run_and_build_entry(
+                match run_and_build_entry(
                     &invocation_name,
                     invocation,
                     manifest_root,
@@ -843,31 +928,34 @@ where
                     options_hash,
                 )
                 .await
-                .inspect(|_| {
-                    outcome.executed.push(invocation_name.clone());
-                })?
-            }
-        } else {
-            run_and_build_entry(
-                &invocation_name,
-                invocation,
-                manifest_root,
-                host,
-                provider,
-                options_hash,
-            )
-            .await
-            .inspect(|_| {
-                outcome.executed.push(invocation_name.clone());
-            })?
-        };
+                {
+                    Ok(entry) => {
+                        outcome.executed.push(invocation_name.clone());
+                        (Some(entry), true)
+                    }
+                    Err(e) if is_unsupported(&e) => {
+                        emit_stale_warning(host, &invocation_name);
+                        outcome.stale.push(invocation_name.clone());
+                        (existing, false)
+                    }
+                    Err(e) => return Err(e),
+                }
+            };
 
-        let dir = invocation.output_dir.as_str().to_string();
-        let kept = kept_by_dir.entry(dir).or_default();
-        for o in &entry.outputs {
-            kept.push(o.path.clone());
+        if let Some(entry) = entry {
+            if executed {
+                let dir = invocation.output_dir.as_str().to_string();
+                let kept = kept_by_dir.entry(dir).or_default();
+                for o in &entry.outputs {
+                    kept.push(o.path.clone());
+                }
+            }
+            new_cache.push(entry);
         }
-        new_cache.push(entry);
+    }
+
+    if !outcome.stale.is_empty() {
+        return Ok(outcome);
     }
 
     for (dir, kept) in &kept_by_dir {
@@ -885,6 +973,111 @@ where
 
     save_lockfile(manifest_root, &lock)?;
     Ok(outcome)
+}
+
+fn is_unsupported(err: &PipelineError) -> bool {
+    match err {
+        PipelineError::Execute {
+            source: ExecuteError::Runner(GeneratorRunnerError::Unsupported),
+            ..
+        }
+        | PipelineError::Provider {
+            source: ProviderError::Unsupported { .. },
+            ..
+        } => true,
+        _ => false,
+    }
+}
+
+fn emit_stale_warning<H: CompilerHost>(host: &H, invocation: &str) {
+    use wado_compiler::{Code, Diagnostic, Severity};
+    host.emit_diagnostic(Diagnostic {
+        severity: Severity::Warning,
+        code: Code::KilnStaleCache,
+        message: format!(
+            "kiln[{invocation}]: generator execution is not available in this host; \
+             re-run `wado compile` natively to refresh `build/kiln/` and `wado.lock`",
+        ),
+        span: None,
+    });
+}
+
+/// Re-encode each invocation's `options_canonical` bytes using the typed
+/// pipeline from [`wado_compiler::kiln::encode_options_canonical`] when the
+/// provider exposes a descriptor. Falls back silently to the provisional
+/// bytes already produced by [`lower`] when:
+///
+/// - the invocation is anonymous (inline `use ... with`) — M5 clauses already
+///   encode via the typed path when they are built, so this code path skips
+///   them;
+/// - the provider returns [`ProviderError::Unsupported`] (e.g. consume-only
+///   LSP mode);
+/// - the provider returns [`ProviderError::Internal`] — a warning diagnostic
+///   is surfaced through `host.emit_diagnostic`, but the pipeline continues.
+///
+/// Validation failures (unknown / missing / type-mismatched fields) surface
+/// as error diagnostics on `host`; the provisional bytes remain in place so
+/// downstream layers still see a consistent invocation. The caller's next
+/// step — `run_and_build_entry` — will fail fast when the generator rejects
+/// the options blob, so the user sees both the compiler-side validation
+/// error and the generator-side trap in the same run.
+async fn typed_encode_options<H, P>(
+    manifest: &Manifest,
+    invocations: &mut [Invocation],
+    provider: &P,
+    host: &H,
+) where
+    H: CompilerHost,
+    P: GeneratorProvider,
+{
+    use wado_compiler::{Code, Diagnostic, Severity};
+
+    let Some(build) = manifest.build.as_ref() else {
+        return;
+    };
+
+    for inv in invocations.iter_mut() {
+        let name = match &inv.decl_site {
+            DeclSite::Manifest { name } => name.clone(),
+            DeclSite::Inline { .. } => continue,
+        };
+        let Some(gi) = build.generators.get(&name) else {
+            continue;
+        };
+
+        let descriptor = match provider.descriptor(&inv.module).await {
+            Ok(d) => d,
+            Err(ProviderError::Unsupported { .. }) => continue,
+            Err(ProviderError::Internal { message }) => {
+                host.emit_diagnostic(Diagnostic {
+                    severity: Severity::Warning,
+                    code: Code::Log,
+                    message: format!(
+                        "kiln[{name}]: failed to introspect generator options schema ({message}); \
+                         falling back to raw TOML encoding",
+                    ),
+                    span: None,
+                });
+                continue;
+            }
+        };
+
+        let attr = toml_to_attr_value(&gi.options);
+        let supplied: Option<&AttrValue> = match &attr {
+            AttrValue::Object(obj) if obj.is_empty() => None,
+            other => Some(other),
+        };
+        match validate_options(&descriptor, supplied) {
+            Ok(canonical) => {
+                inv.options_canonical = encode_options_canonical(&canonical);
+            }
+            Err(diagnostics) => {
+                for d in diagnostics {
+                    host.emit_diagnostic(d);
+                }
+            }
+        }
+    }
 }
 
 async fn run_and_build_entry<H, P>(
@@ -1147,6 +1340,124 @@ output-dir = "build/kiln/second"
         assert_ne!(
             encode_options_canonical_provisional(&a),
             encode_options_canonical_provisional(&b),
+        );
+    }
+
+    #[test]
+    fn typed_encoder_byte_identical_to_provisional_on_common_subset() {
+        use wado_compiler::kiln::{CanonicalValue, OptionsDescriptor, OptionsField, OptionsType};
+        use wado_compiler::token::Span;
+
+        let desc = OptionsDescriptor {
+            fields: vec![
+                OptionsField {
+                    name: "a_bool".to_string(),
+                    ty: OptionsType::Bool,
+                    default: None,
+                    span: Span::new(0, 0, 1, 1),
+                },
+                OptionsField {
+                    name: "b_int".to_string(),
+                    ty: OptionsType::I64,
+                    default: None,
+                    span: Span::new(0, 0, 1, 1),
+                },
+                OptionsField {
+                    name: "c_float".to_string(),
+                    ty: OptionsType::F64,
+                    default: None,
+                    span: Span::new(0, 0, 1, 1),
+                },
+                OptionsField {
+                    name: "d_string".to_string(),
+                    ty: OptionsType::String,
+                    default: None,
+                    span: Span::new(0, 0, 1, 1),
+                },
+            ],
+        };
+
+        let toml_val: toml::Value = toml::from_str(
+            r#"
+a_bool = true
+b_int = 42
+c_float = 3.14
+d_string = "hi"
+"#,
+        )
+        .unwrap();
+        let provisional_bytes = encode_options_canonical_provisional(&toml_val);
+
+        let attr = toml_to_attr_value(&toml_val);
+        let canonical = validate_options(&desc, Some(&attr)).unwrap();
+        let typed_bytes = encode_options_canonical(&canonical);
+
+        assert_eq!(
+            provisional_bytes, typed_bytes,
+            "typed encoder must produce byte-identical output to provisional on the common subset"
+        );
+        let _ = CanonicalValue::Bool(true);
+    }
+
+    #[test]
+    fn typed_encoder_option_some_transparent_to_provisional() {
+        use wado_compiler::kiln::{OptionsDescriptor, OptionsField, OptionsType};
+        use wado_compiler::token::Span;
+
+        let desc = OptionsDescriptor {
+            fields: vec![OptionsField {
+                name: "rule".to_string(),
+                ty: OptionsType::Option(Box::new(OptionsType::String)),
+                default: None,
+                span: Span::new(0, 0, 1, 1),
+            }],
+        };
+
+        let toml_val: toml::Value = toml::from_str(r#"rule = "expr""#).unwrap();
+        let provisional_bytes = encode_options_canonical_provisional(&toml_val);
+
+        let attr = toml_to_attr_value(&toml_val);
+        let canonical = validate_options(&desc, Some(&attr)).unwrap();
+        let typed_bytes = encode_options_canonical(&canonical);
+
+        assert_eq!(
+            provisional_bytes, typed_bytes,
+            "Option::Some(x) must encode identically to a bare x field"
+        );
+    }
+
+    #[test]
+    fn typed_encoder_option_none_omitted_from_table() {
+        use wado_compiler::kiln::{OptionsDescriptor, OptionsField, OptionsType};
+        use wado_compiler::token::Span;
+
+        let desc = OptionsDescriptor {
+            fields: vec![
+                OptionsField {
+                    name: "name".to_string(),
+                    ty: OptionsType::String,
+                    default: None,
+                    span: Span::new(0, 0, 1, 1),
+                },
+                OptionsField {
+                    name: "rule".to_string(),
+                    ty: OptionsType::Option(Box::new(OptionsType::String)),
+                    default: None,
+                    span: Span::new(0, 0, 1, 1),
+                },
+            ],
+        };
+
+        let toml_with_none: toml::Value = toml::from_str(r#"name = "x""#).unwrap();
+        let provisional_bytes = encode_options_canonical_provisional(&toml_with_none);
+
+        let attr = toml_to_attr_value(&toml_with_none);
+        let canonical = validate_options(&desc, Some(&attr)).unwrap();
+        let typed_bytes = encode_options_canonical(&canonical);
+
+        assert_eq!(
+            provisional_bytes, typed_bytes,
+            "Option::None must be omitted from the enclosing table to match TOML omission"
         );
     }
 
@@ -1740,8 +2051,18 @@ output-dir = "build/kiln/second"
 
         impl GeneratorProvider for FailingProvider {
             async fn get_component(&self, _: &GeneratorModule) -> Result<Vec<u8>, ProviderError> {
-                Err(ProviderError::Unsupported {
+                Err(ProviderError::Internal {
                     message: "nope".to_string(),
+                })
+            }
+        }
+
+        struct UnsupportedProvider;
+
+        impl GeneratorProvider for UnsupportedProvider {
+            async fn get_component(&self, _: &GeneratorModule) -> Result<Vec<u8>, ProviderError> {
+                Err(ProviderError::Unsupported {
+                    message: "consume-only".to_string(),
                 })
             }
         }
@@ -1749,6 +2070,7 @@ output-dir = "build/kiln/second"
         struct PipelineHost {
             sources: IndexMap<String, Vec<u8>>,
             response: Mutex<Vec<Result<GeneratorResponse, GeneratorRunnerError>>>,
+            diagnostics: Mutex<Vec<Diagnostic>>,
         }
 
         impl PipelineHost {
@@ -1762,6 +2084,7 @@ output-dir = "build/kiln/second"
                         .map(|(k, v)| ((*k).to_string(), (*v).to_vec()))
                         .collect(),
                     response: Mutex::new(responses),
+                    diagnostics: Mutex::new(Vec::new()),
                 }
             }
         }
@@ -1775,7 +2098,9 @@ output-dir = "build/kiln/second"
                         path: path.to_string(),
                     })
             }
-            fn emit_diagnostic(&self, _d: Diagnostic) {}
+            fn emit_diagnostic(&self, d: Diagnostic) {
+                self.diagnostics.lock().unwrap().push(d);
+            }
             async fn run_generator(
                 &self,
                 _wasm: &[u8],
@@ -1964,6 +2289,126 @@ from = "./schema.proto"
                 PipelineError::Provider { invocation, .. } => assert_eq!(invocation, "greeter"),
                 other => panic!("expected Provider, got {other:?}"),
             }
+        }
+
+        #[test]
+        fn consume_only_cache_miss_warns_and_skips_writes() {
+            let tmp = tempfile::tempdir().unwrap();
+            let m = manifest_with_one_generator();
+            let host = PipelineHost::new(&[("schema.proto", b"s")], vec![]);
+            let outcome = runtime()
+                .block_on(async { run_pipeline(&m, tmp.path(), &host, &UnsupportedProvider).await })
+                .unwrap();
+            assert_eq!(outcome.stale, vec!["greeter".to_string()]);
+            assert!(outcome.executed.is_empty());
+            assert!(outcome.cached.is_empty());
+            assert!(!tmp.path().join("wado.lock").exists());
+            assert!(!tmp.path().join("build/kiln/greeter").exists());
+            let diags = host.diagnostics.lock().unwrap();
+            assert_eq!(diags.len(), 1);
+            assert_eq!(diags[0].code, wado_compiler::Code::KilnStaleCache);
+            assert_eq!(diags[0].severity, wado_compiler::Severity::Warning);
+        }
+
+        #[test]
+        fn consume_only_cache_hit_silent_and_preserves_lockfile() {
+            let tmp = tempfile::tempdir().unwrap();
+            let m = manifest_with_one_generator();
+            let response = GeneratorResponse {
+                files: vec![GeneratorOutputFile {
+                    path: "greeter.wado".to_string(),
+                    content: "pub fn greet() {}\n".to_string(),
+                    is_entry: true,
+                }],
+                reads: vec![],
+            };
+            let host = PipelineHost::new(&[("schema.proto", b"schema")], vec![Ok(response)]);
+            let provider = StaticProvider::new(b"component-bytes".to_vec());
+            runtime()
+                .block_on(async { run_pipeline(&m, tmp.path(), &host, &provider).await })
+                .unwrap();
+
+            let lock_path = tmp.path().join("wado.lock");
+            let original_lock = std::fs::read(&lock_path).unwrap();
+            let original_output =
+                std::fs::read(tmp.path().join("build/kiln/greeter/greeter.wado")).unwrap();
+
+            let host2 = PipelineHost::new(&[("schema.proto", b"schema")], vec![]);
+            let outcome = runtime()
+                .block_on(async {
+                    run_pipeline(&m, tmp.path(), &host2, &UnsupportedProvider).await
+                })
+                .unwrap();
+            assert_eq!(outcome.cached, vec!["greeter".to_string()]);
+            assert!(outcome.stale.is_empty());
+            assert!(outcome.executed.is_empty());
+            assert!(host2.diagnostics.lock().unwrap().is_empty());
+            assert_eq!(std::fs::read(&lock_path).unwrap(), original_lock);
+            assert_eq!(
+                std::fs::read(tmp.path().join("build/kiln/greeter/greeter.wado")).unwrap(),
+                original_output,
+            );
+        }
+
+        #[test]
+        fn consume_only_cache_miss_preserves_existing_build_kiln() {
+            let tmp = tempfile::tempdir().unwrap();
+            let m = manifest_with_one_generator();
+            let response = GeneratorResponse {
+                files: vec![GeneratorOutputFile {
+                    path: "greeter.wado".to_string(),
+                    content: "pub fn greet() {}\n".to_string(),
+                    is_entry: true,
+                }],
+                reads: vec![],
+            };
+            let host = PipelineHost::new(&[("schema.proto", b"original")], vec![Ok(response)]);
+            let provider = StaticProvider::new(b"c".to_vec());
+            runtime()
+                .block_on(async { run_pipeline(&m, tmp.path(), &host, &provider).await })
+                .unwrap();
+
+            let lock_path = tmp.path().join("wado.lock");
+            let original_lock = std::fs::read(&lock_path).unwrap();
+            let original_output =
+                std::fs::read(tmp.path().join("build/kiln/greeter/greeter.wado")).unwrap();
+
+            let host2 = PipelineHost::new(&[("schema.proto", b"mutated")], vec![]);
+            let outcome = runtime()
+                .block_on(async {
+                    run_pipeline(&m, tmp.path(), &host2, &UnsupportedProvider).await
+                })
+                .unwrap();
+            assert_eq!(outcome.stale, vec!["greeter".to_string()]);
+            assert!(outcome.cached.is_empty());
+            assert!(outcome.executed.is_empty());
+            let diags = host2.diagnostics.lock().unwrap();
+            assert_eq!(diags.len(), 1);
+            assert_eq!(diags[0].code, wado_compiler::Code::KilnStaleCache);
+            assert_eq!(std::fs::read(&lock_path).unwrap(), original_lock);
+            assert_eq!(
+                std::fs::read(tmp.path().join("build/kiln/greeter/greeter.wado")).unwrap(),
+                original_output,
+            );
+        }
+
+        #[test]
+        fn consume_only_runner_unsupported_on_cache_miss_warns() {
+            let tmp = tempfile::tempdir().unwrap();
+            let m = manifest_with_one_generator();
+            let host = PipelineHost::new(
+                &[("schema.proto", b"s")],
+                vec![Err(GeneratorRunnerError::Unsupported)],
+            );
+            let provider = StaticProvider::new(b"c".to_vec());
+            let outcome = runtime()
+                .block_on(async { run_pipeline(&m, tmp.path(), &host, &provider).await })
+                .unwrap();
+            assert_eq!(outcome.stale, vec!["greeter".to_string()]);
+            assert!(!tmp.path().join("wado.lock").exists());
+            let diags = host.diagnostics.lock().unwrap();
+            assert_eq!(diags.len(), 1);
+            assert_eq!(diags[0].code, wado_compiler::Code::KilnStaleCache);
         }
     }
 }

--- a/wado-cli/src/kiln_provider.rs
+++ b/wado-cli/src/kiln_provider.rs
@@ -94,7 +94,7 @@ impl GeneratorProvider for CliGeneratorProvider {
                 let abs = self.resolve_path(path.as_str());
                 if !abs.exists() {
                     return Err(ProviderError::Internal {
-                        message: format!("kiln: generator path `{}` does not exist", path.as_str(),),
+                        message: format!("kiln: generator path `{}` does not exist", path.as_str()),
                     });
                 }
                 Err(ProviderError::Unsupported {

--- a/wado-cli/src/kiln_provider.rs
+++ b/wado-cli/src/kiln_provider.rs
@@ -1,0 +1,182 @@
+//! CLI-side [`GeneratorProvider`] implementation.
+//!
+//! Resolves a [`GeneratorModule`] into component bytes and an
+//! [`OptionsDescriptor`] for the Kiln driver. v1 supports
+//! [`GeneratorModule::LocalPath`] (`module = { path = "..." }`) resolution.
+//! Spec-form generators (`module = "ns:name@ver"`) surface
+//! [`ProviderError::Unsupported`] with a clear message, matching WEP open-q
+//! #4 — registry/git module sources are deferred to a follow-up.
+//!
+//! Actual component compilation (`path -> .wasm`) depends on compiler-side
+//! work that is not yet landed (the `wado:kiln/generator` world, WIT type
+//! surface, and stdlib additions). Until those land,
+//! [`CliGeneratorProvider::get_component`] returns
+//! [`ProviderError::Unsupported`] with an actionable message.
+//! [`CliGeneratorProvider::descriptor`] is wired and returns an empty
+//! descriptor for paths that exist on disk, letting the driver fall through
+//! to the provisional TOML encoder for options.
+
+use std::path::{Path, PathBuf};
+
+use wado_compiler::kiln::{GeneratorModule, OptionsDescriptor};
+
+use crate::kiln_driver::{GeneratorProvider, ProviderError};
+
+/// Cache directory under the project root where resolved generator
+/// components are stored: `target/kiln/generators/`.
+pub const CACHE_DIR: &str = "target/kiln/generators";
+
+/// CLI-side generator provider.
+///
+/// Holds the project-root directory so it can resolve `LocalPath` modules
+/// relative to the manifest.
+#[derive(Debug, Clone)]
+pub struct CliGeneratorProvider {
+    manifest_root: PathBuf,
+}
+
+impl CliGeneratorProvider {
+    /// Construct a provider rooted at `manifest_root` — typically the
+    /// directory containing `wado.toml`.
+    #[must_use]
+    pub fn new(manifest_root: PathBuf) -> Self {
+        Self { manifest_root }
+    }
+
+    fn resolve_path(&self, rel: &str) -> PathBuf {
+        self.manifest_root.join(Path::new(rel))
+    }
+}
+
+impl GeneratorProvider for CliGeneratorProvider {
+    async fn get_component(&self, module: &GeneratorModule) -> Result<Vec<u8>, ProviderError> {
+        match module {
+            GeneratorModule::Spec(spec) => Err(ProviderError::Unsupported {
+                message: format!(
+                    "kiln: generator module `{spec}` is declared as a package spec; \
+                     registry/workspace build-dependency resolution is not yet supported in v1. \
+                     Use `module = {{ path = \"...\" }}` to point at a local generator package."
+                ),
+            }),
+            GeneratorModule::LocalPath(path) => {
+                let abs = self.resolve_path(path.as_str());
+                if !abs.exists() {
+                    return Err(ProviderError::Internal {
+                        message: format!(
+                            "kiln: generator path `{}` does not exist (relative to manifest root {})",
+                            path.as_str(),
+                            self.manifest_root.display(),
+                        ),
+                    });
+                }
+                Err(ProviderError::Unsupported {
+                    message: format!(
+                        "kiln: local generator at `{}` cannot be compiled yet — \
+                         the `wado:kiln/generator` world is scheduled for a follow-up PR. \
+                         Commit `build/kiln/` and `wado.lock` to use consume-only mode.",
+                        path.as_str(),
+                    ),
+                })
+            }
+        }
+    }
+
+    async fn descriptor(
+        &self,
+        module: &GeneratorModule,
+    ) -> Result<OptionsDescriptor, ProviderError> {
+        match module {
+            GeneratorModule::Spec(_) => Err(ProviderError::Unsupported {
+                message: "kiln: cannot introspect options for spec-form generators in v1"
+                    .to_string(),
+            }),
+            GeneratorModule::LocalPath(path) => {
+                let abs = self.resolve_path(path.as_str());
+                if !abs.exists() {
+                    return Err(ProviderError::Internal {
+                        message: format!("kiln: generator path `{}` does not exist", path.as_str(),),
+                    });
+                }
+                Err(ProviderError::Unsupported {
+                    message: format!(
+                        "kiln: typed options descriptor for local generator `{}` is not yet \
+                         available — falling back to provisional TOML encoding",
+                        path.as_str(),
+                    ),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wado_compiler::kiln::InvocationPath;
+
+    fn runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn spec_module_surfaces_unsupported() {
+        let provider = CliGeneratorProvider::new(PathBuf::from("/tmp"));
+        let err = runtime().block_on(async {
+            provider
+                .get_component(&GeneratorModule::Spec("ns:x@1.0.0".to_string()))
+                .await
+                .unwrap_err()
+        });
+        match err {
+            ProviderError::Unsupported { message } => {
+                assert!(message.contains("registry") || message.contains("not yet supported"));
+            }
+            _ => panic!("expected Unsupported"),
+        }
+    }
+
+    #[test]
+    fn missing_local_path_surfaces_internal() {
+        let provider = CliGeneratorProvider::new(PathBuf::from("/nonexistent"));
+        let err = runtime().block_on(async {
+            provider
+                .get_component(&GeneratorModule::LocalPath(InvocationPath::normalize(
+                    "./does-not-exist",
+                )))
+                .await
+                .unwrap_err()
+        });
+        match err {
+            ProviderError::Internal { message } => {
+                assert!(message.contains("does not exist"));
+            }
+            _ => panic!("expected Internal, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn existing_local_path_surfaces_unsupported_for_now() {
+        let tmp = std::env::temp_dir().join("wado-kiln-provider-test");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let sub = tmp.join("gen");
+        std::fs::create_dir_all(&sub).unwrap();
+        let provider = CliGeneratorProvider::new(tmp);
+        let err = runtime().block_on(async {
+            provider
+                .get_component(&GeneratorModule::LocalPath(InvocationPath::normalize(
+                    "gen",
+                )))
+                .await
+                .unwrap_err()
+        });
+        match err {
+            ProviderError::Unsupported { message } => {
+                assert!(message.contains("follow-up") || message.contains("consume-only"));
+            }
+            _ => panic!("expected Unsupported, got {err:?}"),
+        }
+    }
+}

--- a/wado-cli/src/lib.rs
+++ b/wado-cli/src/lib.rs
@@ -20,6 +20,7 @@ pub mod dump;
 pub mod format;
 pub mod init;
 pub mod kiln_driver;
+pub mod kiln_provider;
 pub mod kiln_runtime;
 pub mod lsp;
 pub mod manifest;

--- a/wado-cli/tests/kiln_pipeline.rs
+++ b/wado-cli/tests/kiln_pipeline.rs
@@ -9,7 +9,9 @@ use std::path::Path;
 use std::sync::Mutex;
 
 use indexmap::IndexMap;
-use wado_cli::kiln_driver::{GeneratorProvider, PipelineOutcome, ProviderError, run_pipeline};
+use wado_cli::kiln_driver::{
+    GeneratorProvider, PipelineOutcome, ProviderError, run_pipeline, run_pipeline_with_inline,
+};
 use wado_compiler::compiler_host::{
     CompilerHost, Diagnostic, GeneratorOutputFile, GeneratorReadRecord, GeneratorRequest,
     GeneratorResponse, GeneratorRunnerError, SourceError,
@@ -336,4 +338,113 @@ fn cache_miss_on_output_io_error_emits_warning() {
             && d.message.contains("alpha.wado")
     });
     assert!(saw_warning, "expected warning diagnostic, got: {diags:?}");
+}
+
+#[test]
+fn pipeline_invocations_feed_compiler_options_for_use_redirect() {
+    use wado_compiler::CompilerOptions;
+    use wado_compiler::kiln::{DeclSite, GeneratorModule, Invocation, InvocationPath};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let toml_str = r#"
+[package]
+name = "redirect-test"
+version = "0.1.0"
+"#;
+    let m: Manifest = toml_str.parse().unwrap();
+
+    let inline_inv = Invocation {
+        decl_site: DeclSite::Inline {
+            module: "entry.wado".to_string(),
+            synthetic_id: "kiln-abc12345".to_string(),
+        },
+        module: GeneratorModule::LocalPath(InvocationPath::normalize("../gen")),
+        from: InvocationPath::normalize("./schema.proto"),
+        inputs: vec![],
+        output_dir: InvocationPath::normalize("build/kiln/kiln-abc12345"),
+        options_canonical: Vec::new(),
+    };
+
+    let generated_content = "pub fn greet() {}\n";
+    let host = StubHost::new(
+        &[("schema.proto", b"schema-content")],
+        vec![(
+            "schema.proto",
+            GeneratorResponse {
+                files: vec![GeneratorOutputFile {
+                    path: "schema.wado".to_string(),
+                    content: generated_content.to_string(),
+                    is_entry: true,
+                }],
+                reads: Vec::<GeneratorReadRecord>::new(),
+            },
+        )],
+    );
+    let provider = StubProvider::new(b"component-bytes".to_vec());
+
+    let outcome = runtime()
+        .block_on(async {
+            run_pipeline_with_inline(&m, tmp.path(), &host, &provider, vec![inline_inv]).await
+        })
+        .unwrap();
+
+    assert!(!outcome.invocations.is_empty());
+
+    let options = CompilerOptions {
+        invocations: outcome.invocations,
+        ..CompilerOptions::default()
+    };
+    assert!(!options.invocations.is_empty());
+    assert_eq!(
+        options.invocations.redirect("entry.wado", "./schema.proto"),
+        Some("build/kiln/kiln-abc12345/schema.wado"),
+    );
+}
+
+#[test]
+fn inline_invocation_populates_invocation_index_for_redirect() {
+    use wado_compiler::kiln::{DeclSite, GeneratorModule, Invocation, InvocationPath};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let toml_str = r#"
+[package]
+name = "inline-consumer"
+version = "0.1.0"
+"#;
+    let m: Manifest = toml_str.parse().unwrap();
+
+    let inline_inv = Invocation {
+        decl_site: DeclSite::Inline {
+            module: "entry.wado".to_string(),
+            synthetic_id: "kiln-deadbeef".to_string(),
+        },
+        module: GeneratorModule::LocalPath(InvocationPath::normalize("../gen")),
+        from: InvocationPath::normalize("./sample.proto"),
+        inputs: vec![],
+        output_dir: InvocationPath::normalize("build/kiln/kiln-deadbeef"),
+        options_canonical: Vec::new(),
+    };
+
+    let host = StubHost::new(
+        &[("sample.proto", b"inline-schema")],
+        vec![("sample.proto", simple_response("sample.wado"))],
+    );
+    let provider = StubProvider::new(b"component-bytes".to_vec());
+
+    let outcome = runtime()
+        .block_on(async {
+            run_pipeline_with_inline(&m, tmp.path(), &host, &provider, vec![inline_inv]).await
+        })
+        .unwrap();
+
+    assert_eq!(outcome.executed.len(), 1, "inline should have executed");
+    assert!(
+        !outcome.invocations.is_empty(),
+        "inline outcome must populate InvocationIndex"
+    );
+    assert_eq!(
+        outcome.invocations.redirect("entry.wado", "./sample.proto"),
+        Some("build/kiln/kiln-deadbeef/sample.wado"),
+        "inline decl_file + from should redirect to the generated entry path"
+    );
 }

--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -8,7 +8,7 @@
 use crate::ast::{Item, Module, UseItem};
 use crate::compiler_host::CompilerHost;
 use crate::logger::{Bail, Logger};
-use crate::name::{ModuleSource, resolve_import, validate_module_path};
+use crate::name::{ModuleSource, validate_module_path};
 use crate::symbol::{
     EffectSymbol, EnumSymbol, FlagsSymbol, FunctionSymbol, GlobalSymbol, NewtypeSymbol,
     ResourceSymbol, StructSymbol, Symbol, SymbolKey, SymbolKind, SymbolTable, TraitSymbol,
@@ -182,6 +182,10 @@ pub struct Analyzer<'a, H: CompilerHost> {
     /// Modules loaded implicitly by the compiler (not by user imports)
     implicit_modules: crate::hashmap::IndexSet<ModuleSource>,
     entry_module_source: ModuleSource,
+    /// Kiln invocation redirects consulted by the import-resolution paths
+    /// (`validate_imports`, re-export registration). Empty when the
+    /// compilation did not run the Kiln pipeline.
+    invocations: crate::kiln::InvocationIndex,
 }
 
 impl<'a, H: CompilerHost> Analyzer<'a, H> {
@@ -192,7 +196,17 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
             logger,
             implicit_modules: crate::hashmap::IndexSet::default(),
             entry_module_source: ModuleSource::entry_point_with_filename("<uninitialized>"),
+            invocations: crate::kiln::InvocationIndex::new(),
         }
+    }
+
+    /// Seed the analyzer with a Kiln invocation index. Call before
+    /// [`Self::analyze_loaded_modules`] so import-site redirects line up
+    /// with the loader's redirects.
+    #[must_use]
+    pub fn with_invocations(mut self, invocations: crate::kiln::InvocationIndex) -> Self {
+        self.invocations = invocations;
+        self
     }
 
     /// Define a top-level symbol, emitting a `DuplicateDefinition` diagnostic
@@ -587,8 +601,14 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                     continue; // Error already collected in validate_imports
                 }
 
-                // Resolve the source path to ModuleSource
-                let source_module = resolve_import(module_source, &use_decl.source);
+                // Resolve the source path to ModuleSource, honoring any
+                // Kiln invocation redirects before the plain name lookup.
+                let source_module = crate::name::resolve_import_with_invocations(
+                    module_source,
+                    &use_decl.source,
+                    Some(&self.entry_module_source),
+                    &self.invocations,
+                );
 
                 // Check the module exists
                 if !all_modules.contains_key(&source_module) {
@@ -651,11 +671,13 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                     continue;
                 }
 
-                // Resolve the import path to ModuleSource
-                let module_source = crate::name::resolve_import_with_entry(
+                // Resolve the import path to ModuleSource, honoring any
+                // Kiln invocation redirects before the plain name lookup.
+                let module_source = crate::name::resolve_import_with_invocations(
                     from_module_source,
                     &use_decl.source,
                     Some(&self.entry_module_source),
+                    &self.invocations,
                 );
 
                 // Check the module exists in pre-loaded modules

--- a/wado-compiler/src/annotate.rs
+++ b/wado-compiler/src/annotate.rs
@@ -667,25 +667,35 @@ pub async fn annotate<H: CompilerHost>(
     host: &H,
     filename: Option<&str>,
 ) -> Result<Annotated, Bail> {
+    annotate_with_invocations(source, host, filename, crate::kiln::InvocationIndex::new()).await
+}
+
+/// Variant of [`annotate`] that seeds the loader with a Kiln
+/// [`crate::kiln::InvocationIndex`] so bare `use { X } from "<schema>"`
+/// clauses can pick up generator-produced entry modules.
+pub async fn annotate_with_invocations<H: CompilerHost>(
+    source: &str,
+    host: &H,
+    filename: Option<&str>,
+    invocations: crate::kiln::InvocationIndex,
+) -> Result<Annotated, Bail> {
     let logger = Logger::new(host, LogLevel::default());
     if let Some(f) = filename {
         logger.set_file(f);
     }
-    annotate_with_logger(source, host, filename, &logger).await
+    annotate_with_logger_invocations(source, host, filename, &logger, invocations).await
 }
 
-/// Internal variant of [`annotate`] that reuses an existing [`Logger`].
-///
-/// `compile_with_options` uses this to run annotate + lower under a single
-/// logger session so diagnostics stay contextualized.
-pub(crate) async fn annotate_with_logger<H: CompilerHost>(
+async fn annotate_with_logger_invocations<H: CompilerHost>(
     source: &str,
     host: &H,
     filename: Option<&str>,
     logger: &Logger<'_, H>,
+    invocations: crate::kiln::InvocationIndex,
 ) -> Result<Annotated, Bail> {
     let load_result = {
-        let module_loader = loader::ModuleLoader::new(host, LogLevel::default());
+        let module_loader =
+            loader::ModuleLoader::new(host, LogLevel::default()).with_invocations(invocations);
         module_loader
             .load_all(source, filename)
             .await
@@ -707,7 +717,7 @@ pub(crate) fn annotate_loaded<H: CompilerHost>(
 ) -> Result<Annotated, Bail> {
     let symbols = {
         let _span = logger.span("analyze");
-        let mut analyzer = Analyzer::new(logger);
+        let mut analyzer = Analyzer::new(logger).with_invocations(load_result.invocations.clone());
         analyzer.analyze_loaded_modules(
             &load_result.modules,
             &load_result.entry_module_source,
@@ -723,6 +733,7 @@ pub(crate) fn annotate_loaded<H: CompilerHost>(
             &load_result.modules,
             &load_result.entry_module_source,
             logger,
+            load_result.invocations.clone(),
         )?
     };
 

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -1,6 +1,6 @@
 // AST definitions for Wado
 
-use crate::hashmap::IndexSet;
+use crate::hashmap::{IndexMap, IndexSet};
 use crate::token::Span;
 
 /// Module-local, parse-stable identifier for AST nodes that bear semantic
@@ -1126,12 +1126,97 @@ pub struct UseItemSimple {
     pub alias: Option<String>,
 }
 
-/// Import attributes for `with { ... }` clause
+/// Generic attribute-value tree produced by `with { ... }` clauses.
+///
+/// Scalars and containers only — no identifier references or expressions,
+/// per WEP 2026-04-12 (Kiln) §M5. Deterministic insertion order via
+/// [`IndexMap`] keeps round-tripping and cache-key encoding stable.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AttrValue {
+    String(String),
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    Array(Vec<AttrValue>),
+    Object(IndexMap<String, AttrValue>),
+}
+
+impl AttrValue {
+    /// Borrow the inner string, if this is a [`AttrValue::String`].
+    #[must_use]
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            AttrValue::String(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Borrow the inner object, if this is a [`AttrValue::Object`].
+    #[must_use]
+    pub fn as_object(&self) -> Option<&IndexMap<String, AttrValue>> {
+        match self {
+            AttrValue::Object(o) => Some(o),
+            _ => None,
+        }
+    }
+
+    /// Borrow the inner array, if this is a [`AttrValue::Array`].
+    #[must_use]
+    pub fn as_array(&self) -> Option<&[AttrValue]> {
+        match self {
+            AttrValue::Array(a) => Some(a.as_slice()),
+            _ => None,
+        }
+    }
+}
+
+/// Import attributes for `with { ... }` clause.
+///
+/// Stores every key/value pair as a generic [`AttrValue`] tree. The three
+/// historical keys (`version`, `integrity`, `type_hint`) are still accessed
+/// via thin accessor methods so older call sites compile unchanged. New
+/// consumers (e.g. Kiln inline generators) read raw entries via
+/// [`ImportAttributes::get`] and [`ImportAttributes::generator`].
 #[derive(Debug, Clone, Default)]
 pub struct ImportAttributes {
-    pub version: Option<String>,
-    pub integrity: Option<String>,
-    pub type_hint: Option<String>,
+    /// Top-level key/value entries, in parse order.
+    pub entries: IndexMap<String, AttrValue>,
+}
+
+impl ImportAttributes {
+    fn get_str(&self, key: &str) -> Option<String> {
+        self.entries
+            .get(key)
+            .and_then(AttrValue::as_str)
+            .map(str::to_string)
+    }
+
+    #[must_use]
+    pub fn version(&self) -> Option<String> {
+        self.get_str("version")
+    }
+
+    #[must_use]
+    pub fn integrity(&self) -> Option<String> {
+        self.get_str("integrity")
+    }
+
+    #[must_use]
+    pub fn type_hint(&self) -> Option<String> {
+        self.get_str("type")
+    }
+
+    /// Inline Kiln generator configuration (`with { generator: { ... } }`).
+    #[must_use]
+    pub fn generator(&self) -> Option<&IndexMap<String, AttrValue>> {
+        self.entries.get("generator").and_then(AttrValue::as_object)
+    }
+
+    /// Raw lookup for any top-level attribute.
+    #[must_use]
+    pub fn get(&self, key: &str) -> Option<&AttrValue> {
+        self.entries.get(key)
+    }
 }
 
 /// Use declaration with ESM-like syntax:

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -128,6 +128,14 @@ pub enum Code {
     // General logging
     /// Generic log message (info, debug, etc.)
     Log,
+
+    // Kiln errors
+    /// A generator's `Options` struct uses a shape not supported by Kiln.
+    GeneratorOptionsUnsupported,
+    /// A generator invocation's options value failed typed validation.
+    GeneratorOptionsInvalid,
+    /// Generator cache is stale and host cannot re-run generators (consume-only mode).
+    KilnStaleCache,
 }
 
 impl std::fmt::Display for Code {
@@ -157,6 +165,9 @@ impl std::fmt::Display for Code {
             Code::SpanStart => "SPAN_START",
             Code::SpanEnd => "SPAN_END",
             Code::Log => "LOG",
+            Code::GeneratorOptionsUnsupported => "GENERATOR_OPTIONS_UNSUPPORTED",
+            Code::GeneratorOptionsInvalid => "GENERATOR_OPTIONS_INVALID",
+            Code::KilnStaleCache => "KILN_STALE_CACHE",
         };
         write!(f, "{name}")
     }

--- a/wado-compiler/src/kiln.rs
+++ b/wado-compiler/src/kiln.rs
@@ -13,13 +13,21 @@
 
 pub mod cache;
 pub mod header;
+pub mod inline;
 pub mod invocation;
+pub mod options;
+pub mod options_check;
 pub mod plan;
 
 pub use cache::{
-    CacheKeyInputs, FileHash, compose_cache_key, content_hash, file_hash, gather_file_hashes,
-    generator_identity, hash_options_canonical, hex_digest,
+    CacheKeyInputs, FileHash, compose_cache_key, content_hash, encode_options_canonical, file_hash,
+    gather_file_hashes, generator_identity, hash_options_canonical, hex_digest,
 };
 pub use header::{GeneratedHeader, has_generated_marker, parse_header};
+pub use inline::{InvocationIndex, collect_inline_invocations, merge_manifest_and_inline};
 pub use invocation::{DeclSite, GeneratorModule, Invocation, InvocationPath};
+pub use options::{
+    CanonicalValue, OptionsDescriptor, OptionsField, OptionsType, extract_options_descriptor,
+};
+pub use options_check::{CanonicalOptions, validate as validate_options};
 pub use plan::{Plan, PlanError, build_plan, depends_on};

--- a/wado-compiler/src/kiln/cache.rs
+++ b/wado-compiler/src/kiln/cache.rs
@@ -19,6 +19,8 @@
 use sha2::{Digest, Sha256};
 
 use super::invocation::{GeneratorModule, Invocation, InvocationPath};
+use super::options::CanonicalValue;
+use super::options_check::CanonicalOptions;
 
 fn digest(bytes: &[u8]) -> [u8; 32] {
     let mut h = Sha256::new();
@@ -101,6 +103,89 @@ pub fn compose_cache_key(inputs: &CacheKeyInputs<'_>) -> [u8; 32] {
 #[must_use]
 pub fn hex_digest(digest: &[u8; 32]) -> String {
     hex(digest)
+}
+
+/// Encode a [`CanonicalOptions`] to the canonical cache-key byte string.
+///
+/// Format is a direct superset of the provisional TOML encoder's layout so
+/// cache keys for inputs expressible in both encoders stay byte-identical:
+///
+/// - `0` bool, 1 byte (0 / 1)
+/// - `1` integer, 8 BE bytes (signed)
+/// - `2` float, 8 BE bytes (IEEE-754 bits)
+/// - `3` string, u64 BE length-prefix + UTF-8 bytes
+/// - `5` table, u64 BE count + each (key string + value), keys sorted
+///
+/// `Option<T>` is encoded transparently: `Some(x)` emits exactly what `x`
+/// alone would emit; `None` is omitted from the enclosing table (and the
+/// table's entry count is reduced accordingly). This matches the provisional
+/// encoder's behavior where a missing field in TOML simply does not appear.
+/// Enums map to strings (tag 3). Unsigned integers are cast to signed before
+/// the big-endian write, matching TOML's single integer tag.
+#[must_use]
+pub fn encode_options_canonical(options: &CanonicalOptions) -> Vec<u8> {
+    let mut out = Vec::new();
+    encode_options_table(&mut out, &options.values);
+    out
+}
+
+fn encode_options_table(out: &mut Vec<u8>, entries: &[(String, CanonicalValue)]) {
+    out.push(5);
+    let mut indices: Vec<usize> = (0..entries.len())
+        .filter(|i| !matches!(entries[*i].1, CanonicalValue::None))
+        .collect();
+    indices.sort_by(|a, b| entries[*a].0.cmp(&entries[*b].0));
+    write_u64(out, indices.len() as u64);
+    for i in indices {
+        let (k, v) = &entries[i];
+        write_vec_str(out, k);
+        encode_canonical_value(out, v);
+    }
+}
+
+fn encode_canonical_value(out: &mut Vec<u8>, v: &CanonicalValue) {
+    match v {
+        CanonicalValue::Bool(b) => {
+            out.push(0);
+            out.push(u8::from(*b));
+        }
+        CanonicalValue::I64(n) => {
+            out.push(1);
+            out.extend_from_slice(&n.to_be_bytes());
+        }
+        CanonicalValue::U64(n) => {
+            out.push(1);
+            out.extend_from_slice(&(*n as i64).to_be_bytes());
+        }
+        CanonicalValue::F64(f) => {
+            out.push(2);
+            out.extend_from_slice(&f.to_bits().to_be_bytes());
+        }
+        CanonicalValue::String(s) | CanonicalValue::Enum(s) => {
+            out.push(3);
+            write_vec_str(out, s);
+        }
+        CanonicalValue::None => {
+            // Caller must suppress the enclosing entry; reaching here
+            // indicates a bug in the options walker.
+            panic!("kiln: encode_options_canonical reached bare None value");
+        }
+        CanonicalValue::Some(inner) => {
+            encode_canonical_value(out, inner);
+        }
+        CanonicalValue::Struct(fields) => {
+            encode_options_table(out, fields);
+        }
+    }
+}
+
+fn write_u64(out: &mut Vec<u8>, n: u64) {
+    out.extend_from_slice(&n.to_be_bytes());
+}
+
+fn write_vec_str(out: &mut Vec<u8>, s: &str) {
+    write_u64(out, s.len() as u64);
+    out.extend_from_slice(s.as_bytes());
 }
 
 /// Hex SHA-256 of the canonical options encoding.

--- a/wado-compiler/src/kiln/inline.rs
+++ b/wado-compiler/src/kiln/inline.rs
@@ -131,22 +131,22 @@ pub fn collect_inline_invocations(
                         continue;
                     }
                     let from_key = invocation.from.as_str().to_string();
-                    if let Some((prior, prior_mod)) = by_from.get(&from_key) {
-                        if identity_key(prior) != tuple_key {
-                            diagnostics.push(Diagnostic {
-                                severity: Severity::Error,
-                                code: Code::GeneratorOptionsInvalid,
-                                message: format!(
-                                    "kiln: two inline generator clauses disagree for `from = \"{}\"` \
+                    if let Some((prior, prior_mod)) = by_from.get(&from_key)
+                        && identity_key(prior) != tuple_key
+                    {
+                        diagnostics.push(Diagnostic {
+                            severity: Severity::Error,
+                            code: Code::GeneratorOptionsInvalid,
+                            message: format!(
+                                "kiln: two inline generator clauses disagree for `from = \"{}\"` \
                                      (first in {}, second in {})",
-                                    invocation.from.as_str(),
-                                    prior_mod,
-                                    module_path,
-                                ),
-                                span: Some(span_of(module_path, use_decl)),
-                            });
-                            continue;
-                        }
+                                invocation.from.as_str(),
+                                prior_mod,
+                                module_path,
+                            ),
+                            span: Some(span_of(module_path, use_decl)),
+                        });
+                        continue;
                     }
                     by_tuple.insert(tuple_key.clone(), invocation.clone());
                     by_from.insert(from_key, (invocation, module_path.clone()));

--- a/wado-compiler/src/kiln/inline.rs
+++ b/wado-compiler/src/kiln/inline.rs
@@ -1,0 +1,613 @@
+//! Inline-invocation collection for `use ... with { generator: { ... } }`.
+//!
+//! An inline clause declares a Kiln invocation directly at the import site
+//! instead of inside `wado.toml`. This module walks the parsed [`UseDecl`]s,
+//! extracts the `generator: {...}` object from
+//! [`crate::ast::ImportAttributes`], and builds matching
+//! [`crate::kiln::Invocation`]s. The result can be merged with manifest-lowered
+//! invocations before [`crate::kiln::plan::build_plan`] runs.
+//!
+//! Two clauses with identical `(module, from, inputs, output_dir,
+//! options_canonical)` tuples are merged into a single invocation; this is the
+//! same dedup contract as the manifest path. Two clauses that share `from` but
+//! disagree on any other field produce a diagnostic citing both spans.
+
+use sha2::{Digest, Sha256};
+
+use crate::ast::{AttrValue, Module, UseDecl};
+use crate::compiler_host::{Code, Diagnostic, DiagnosticSpan, Severity};
+use crate::hashmap::IndexMap;
+
+use super::cache::{encode_options_canonical, hex_digest};
+use super::invocation::{DeclSite, GeneratorModule, Invocation, InvocationPath};
+use super::options::OptionsDescriptor;
+use super::options_check::{CanonicalOptions, validate};
+
+/// Default output-directory prefix for inline invocations: each clause lands
+/// under `build/kiln/<synthetic_id>` unless it declares its own `output_dir`.
+pub const DEFAULT_INLINE_OUTPUT_DIR_PREFIX: &str = "build/kiln";
+
+/// Resolver-side lookup table that redirects a `use ... from "<from>"` whose
+/// `<from>` path matches a Kiln invocation's primary source to the
+/// invocation's generated entry module.
+///
+/// Built once per compilation unit from the merged manifest + inline
+/// invocation set, after the pipeline has populated `build/kiln/…` so the
+/// entry module's on-disk location is known. For consume-only mode (no
+/// pipeline run), the index is built from the last recorded lockfile entry's
+/// `output.entry = true` path — that path lives on disk already or the
+/// cache check failed.
+///
+/// Lookups are keyed by `(declaring_file_normalized, from_path_normalized)`.
+/// Two clauses declared in different files can redirect to the same entry
+/// iff the manifest + inline merge keeps them under a single invocation.
+#[derive(Debug, Default, Clone)]
+pub struct InvocationIndex {
+    /// Entries mapping `(decl_file, from_path)` → entry module path (relative
+    /// to the project root, forward-slash normalized).
+    entries: IndexMap<(String, String), String>,
+}
+
+impl InvocationIndex {
+    /// Create an empty index.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            entries: IndexMap::default(),
+        }
+    }
+
+    /// Record that a `use ... from "<from>"` inside `decl_file` should
+    /// redirect to `entry_path` (project-root-relative). Paths are
+    /// normalized before insertion so callers may pass raw user input.
+    ///
+    /// Silently overwrites a prior entry with the same key. The caller is
+    /// responsible for ensuring the set of recorded invocations is
+    /// conflict-free (see [`merge_manifest_and_inline`]).
+    pub fn insert(&mut self, decl_file: &str, from: &str, entry_path: &str) {
+        let decl = InvocationPath::normalize(decl_file).as_str().to_string();
+        let from = InvocationPath::normalize(from).as_str().to_string();
+        let entry = InvocationPath::normalize(entry_path).as_str().to_string();
+        self.entries.insert((decl, from), entry);
+    }
+
+    /// Look up the entry module path for a `(decl_file, from)` pair. Returns
+    /// the project-root-relative path of the entry module, or `None` if no
+    /// invocation matches.
+    #[must_use]
+    pub fn redirect(&self, decl_file: &str, from: &str) -> Option<&str> {
+        let decl = InvocationPath::normalize(decl_file).as_str().to_string();
+        let from = InvocationPath::normalize(from).as_str().to_string();
+        self.entries.get(&(decl, from)).map(String::as_str)
+    }
+
+    /// Returns `true` when no invocations have been recorded. Consumers
+    /// (e.g. the resolver) can short-circuit the redirect check.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// Scan every `UseDecl` in `modules` for an inline
+/// `with { generator: { ... } }` clause and lower it to a canonical
+/// [`Invocation`].
+///
+/// `descriptors` is a per-module-spec lookup — when present, the inline
+/// clause's `options` object is validated and encoded through the typed
+/// pipeline. Missing descriptors fall through to an empty canonical options
+/// blob (matching the behavior for a generator without a declared
+/// `Options` struct).
+///
+/// Diagnostics are batched: a single malformed clause does not prevent the
+/// rest of the tree from being collected. Returns `Err` only when at least
+/// one `Severity::Error` diagnostic was emitted.
+///
+/// # Errors
+/// Every shape mismatch, options-validation error, and dedup conflict is
+/// reported through the returned `Vec<Diagnostic>`.
+pub fn collect_inline_invocations(
+    modules: &IndexMap<String, Module>,
+    descriptors: &IndexMap<String, OptionsDescriptor>,
+) -> Result<Vec<Invocation>, Vec<Diagnostic>> {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    let mut by_tuple: IndexMap<String, Invocation> = IndexMap::default();
+    let mut by_from: IndexMap<String, (Invocation, String)> = IndexMap::default();
+
+    for (module_path, module) in modules {
+        for use_decl in use_decls_of(module) {
+            let Some(attrs) = use_decl.attributes.as_ref() else {
+                continue;
+            };
+            let Some(gen_cfg) = attrs.generator() else {
+                continue;
+            };
+
+            match lower_inline(module_path, use_decl, gen_cfg, descriptors) {
+                Ok(invocation) => {
+                    let tuple_key = identity_key(&invocation);
+                    if let Some(existing) = by_tuple.get(&tuple_key) {
+                        let _ = existing;
+                        continue;
+                    }
+                    let from_key = invocation.from.as_str().to_string();
+                    if let Some((prior, prior_mod)) = by_from.get(&from_key) {
+                        if identity_key(prior) != tuple_key {
+                            diagnostics.push(Diagnostic {
+                                severity: Severity::Error,
+                                code: Code::GeneratorOptionsInvalid,
+                                message: format!(
+                                    "kiln: two inline generator clauses disagree for `from = \"{}\"` \
+                                     (first in {}, second in {})",
+                                    invocation.from.as_str(),
+                                    prior_mod,
+                                    module_path,
+                                ),
+                                span: Some(span_of(module_path, use_decl)),
+                            });
+                            continue;
+                        }
+                    }
+                    by_tuple.insert(tuple_key.clone(), invocation.clone());
+                    by_from.insert(from_key, (invocation, module_path.clone()));
+                }
+                Err(mut errs) => diagnostics.append(&mut errs),
+            }
+        }
+    }
+
+    if diagnostics.iter().any(|d| d.severity == Severity::Error) {
+        return Err(diagnostics);
+    }
+    Ok(by_tuple.into_iter().map(|(_, v)| v).collect())
+}
+
+/// Merge manifest-declared invocations with inline-collected ones.
+///
+/// Cross-source `from` conflicts — a manifest invocation and an inline
+/// clause both targeting the same primary source with different
+/// `(module, inputs, output_dir, options_canonical)` — surface as error
+/// diagnostics. Identical tuples are deduplicated.
+///
+/// # Errors
+/// Every cross-source conflict is reported. Returns `Err` when any error
+/// diagnostic is emitted.
+pub fn merge_manifest_and_inline(
+    manifest: Vec<Invocation>,
+    inline: Vec<Invocation>,
+) -> Result<Vec<Invocation>, Vec<Diagnostic>> {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    let mut out: Vec<Invocation> = Vec::with_capacity(manifest.len() + inline.len());
+    let mut by_tuple: IndexMap<String, usize> = IndexMap::default();
+    let mut by_from: IndexMap<String, usize> = IndexMap::default();
+
+    for inv in manifest.into_iter().chain(inline) {
+        let tuple_key = identity_key(&inv);
+        if by_tuple.contains_key(&tuple_key) {
+            continue;
+        }
+        let from_key = inv.from.as_str().to_string();
+        if let Some(&idx) = by_from.get(&from_key) {
+            let prior = &out[idx];
+            diagnostics.push(Diagnostic {
+                severity: Severity::Error,
+                code: Code::GeneratorOptionsInvalid,
+                message: format!(
+                    "kiln: generator invocations for `from = \"{}\"` disagree between {} and {}",
+                    inv.from.as_str(),
+                    prior.decl_site,
+                    inv.decl_site,
+                ),
+                span: None,
+            });
+            continue;
+        }
+        by_tuple.insert(tuple_key, out.len());
+        by_from.insert(from_key, out.len());
+        out.push(inv);
+    }
+
+    if diagnostics.iter().any(|d| d.severity == Severity::Error) {
+        return Err(diagnostics);
+    }
+    Ok(out)
+}
+
+fn use_decls_of(module: &Module) -> impl Iterator<Item = &UseDecl> {
+    module.items.iter().filter_map(|it| match it {
+        crate::ast::Item::Use(u) => Some(u),
+        _ => None,
+    })
+}
+
+fn lower_inline(
+    module_path: &str,
+    use_decl: &UseDecl,
+    cfg: &IndexMap<String, AttrValue>,
+    descriptors: &IndexMap<String, OptionsDescriptor>,
+) -> Result<Invocation, Vec<Diagnostic>> {
+    let mut errors: Vec<Diagnostic> = Vec::new();
+
+    let module = match cfg.get("module") {
+        Some(AttrValue::String(s)) => Some(GeneratorModule::Spec(s.clone())),
+        Some(AttrValue::Object(obj)) => {
+            lower_module_object(module_path, use_decl, obj, &mut errors)
+        }
+        Some(other) => {
+            errors.push(Diagnostic {
+                severity: Severity::Error,
+                code: Code::GeneratorOptionsInvalid,
+                message: format!(
+                    "kiln: `generator.module` must be a string (\"ns:name@ver\") or an object with \
+                     a `path` field, got {}",
+                    attr_kind(other),
+                ),
+                span: Some(span_of(module_path, use_decl)),
+            });
+            None
+        }
+        None => {
+            errors.push(Diagnostic {
+                severity: Severity::Error,
+                code: Code::GeneratorOptionsInvalid,
+                message: "kiln: inline `with { generator: {...} }` requires a `module` field"
+                    .to_string(),
+                span: Some(span_of(module_path, use_decl)),
+            });
+            None
+        }
+    };
+
+    let from = InvocationPath::normalize(&use_decl.source);
+    let inputs = match cfg.get("inputs") {
+        None => Vec::new(),
+        Some(AttrValue::Array(items)) => items
+            .iter()
+            .enumerate()
+            .filter_map(|(i, v)| match v {
+                AttrValue::String(s) => Some(InvocationPath::normalize(s)),
+                other => {
+                    errors.push(Diagnostic {
+                        severity: Severity::Error,
+                        code: Code::GeneratorOptionsInvalid,
+                        message: format!(
+                            "kiln: `generator.inputs[{i}]` must be a string, got {}",
+                            attr_kind(other),
+                        ),
+                        span: Some(span_of(module_path, use_decl)),
+                    });
+                    None
+                }
+            })
+            .collect(),
+        Some(other) => {
+            errors.push(Diagnostic {
+                severity: Severity::Error,
+                code: Code::GeneratorOptionsInvalid,
+                message: format!(
+                    "kiln: `generator.inputs` must be an array of strings, got {}",
+                    attr_kind(other),
+                ),
+                span: Some(span_of(module_path, use_decl)),
+            });
+            Vec::new()
+        }
+    };
+
+    let options_canonical = if let Some(module) = module.as_ref() {
+        encode_options(
+            module,
+            cfg.get("options"),
+            use_decl,
+            module_path,
+            descriptors,
+            &mut errors,
+        )
+    } else {
+        Vec::new()
+    };
+
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+    let module = module.expect("module was validated above");
+
+    let synthetic_id = {
+        let mut h = Sha256::new();
+        h.update(module_key(&module).as_bytes());
+        h.update(from.as_str().as_bytes());
+        for p in &inputs {
+            h.update(p.as_str().as_bytes());
+            h.update([0u8]);
+        }
+        h.update(&options_canonical);
+        let digest: [u8; 32] = h.finalize().into();
+        format!("kiln-{}", &hex_digest(&digest)[..16])
+    };
+
+    let output_dir = InvocationPath::normalize(&format!(
+        "{DEFAULT_INLINE_OUTPUT_DIR_PREFIX}/{synthetic_id}"
+    ));
+
+    Ok(Invocation {
+        decl_site: DeclSite::Inline {
+            module: module_path.to_string(),
+            synthetic_id,
+        },
+        module,
+        from,
+        inputs,
+        output_dir,
+        options_canonical,
+    })
+}
+
+fn lower_module_object(
+    module_path: &str,
+    use_decl: &UseDecl,
+    obj: &IndexMap<String, AttrValue>,
+    errors: &mut Vec<Diagnostic>,
+) -> Option<GeneratorModule> {
+    if let Some(AttrValue::String(p)) = obj.get("path") {
+        return Some(GeneratorModule::LocalPath(InvocationPath::normalize(p)));
+    }
+    errors.push(Diagnostic {
+        severity: Severity::Error,
+        code: Code::GeneratorOptionsInvalid,
+        message: "kiln: object-form `generator.module` must carry a `path: \"...\"` field \
+                  (registry/git forms are not yet supported in v1)"
+            .to_string(),
+        span: Some(span_of(module_path, use_decl)),
+    });
+    None
+}
+
+fn encode_options(
+    module: &GeneratorModule,
+    options_value: Option<&AttrValue>,
+    use_decl: &UseDecl,
+    module_path: &str,
+    descriptors: &IndexMap<String, OptionsDescriptor>,
+    errors: &mut Vec<Diagnostic>,
+) -> Vec<u8> {
+    let key = module_key(module);
+    let Some(descriptor) = descriptors.get(&key) else {
+        return Vec::new();
+    };
+
+    let canonical: CanonicalOptions = match validate(descriptor, options_value) {
+        Ok(c) => c,
+        Err(mut errs) => {
+            for d in &mut errs {
+                if d.span.is_none() {
+                    d.span = Some(span_of(module_path, use_decl));
+                }
+            }
+            errors.append(&mut errs);
+            return Vec::new();
+        }
+    };
+    encode_options_canonical(&canonical)
+}
+
+fn module_key(module: &GeneratorModule) -> String {
+    match module {
+        GeneratorModule::Spec(s) => format!("spec:{s}"),
+        GeneratorModule::LocalPath(p) => format!("path:{}", p.as_str()),
+    }
+}
+
+fn identity_key(inv: &Invocation) -> String {
+    let mut h = Sha256::new();
+    h.update(module_key(&inv.module).as_bytes());
+    h.update(inv.from.as_str().as_bytes());
+    for p in &inv.inputs {
+        h.update(p.as_str().as_bytes());
+        h.update([0u8]);
+    }
+    h.update(inv.output_dir.as_str().as_bytes());
+    h.update(&inv.options_canonical);
+    let digest: [u8; 32] = h.finalize().into();
+    hex_digest(&digest)
+}
+
+fn span_of(module_path: &str, use_decl: &UseDecl) -> DiagnosticSpan {
+    DiagnosticSpan::from_span(&use_decl.span, Some(module_path))
+}
+
+fn attr_kind(v: &AttrValue) -> &'static str {
+    match v {
+        AttrValue::String(_) => "string",
+        AttrValue::Int(_) => "integer",
+        AttrValue::Float(_) => "float",
+        AttrValue::Bool(_) => "bool",
+        AttrValue::Array(_) => "array",
+        AttrValue::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{AstId, ImportAttributes, Item, UseDecl, UseItem};
+    use crate::token::Span;
+
+    fn span() -> Span {
+        Span::new(0, 0, 1, 1)
+    }
+
+    fn module_with_use(source: &str, attrs: ImportAttributes) -> Module {
+        let use_decl = UseDecl {
+            id: AstId(0),
+            is_pub: false,
+            source: source.to_string(),
+            source_span: span(),
+            source_id: AstId(1),
+            items: vec![UseItem::Wildcard],
+            attributes: Some(attrs),
+            span: span(),
+        };
+        Module::new(vec![Item::Use(use_decl)])
+    }
+
+    fn attr_with_generator(entries: &[(&str, AttrValue)]) -> ImportAttributes {
+        let mut gen_obj: IndexMap<String, AttrValue> = IndexMap::default();
+        for (k, v) in entries {
+            gen_obj.insert((*k).to_string(), v.clone());
+        }
+        let mut entries_map: IndexMap<String, AttrValue> = IndexMap::default();
+        entries_map.insert("generator".to_string(), AttrValue::Object(gen_obj));
+        ImportAttributes {
+            entries: entries_map,
+        }
+    }
+
+    #[test]
+    fn extracts_invocation_from_inline_clause() {
+        let attrs =
+            attr_with_generator(&[("module", AttrValue::String("ns:gen@1.0.0".to_string()))]);
+        let module = module_with_use("./schema.proto", attrs);
+        let mut mods: IndexMap<String, Module> = IndexMap::default();
+        mods.insert("src/main.wado".to_string(), module);
+
+        let result = collect_inline_invocations(&mods, &IndexMap::default()).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].from.as_str(), "schema.proto");
+        assert!(matches!(&result[0].module, GeneratorModule::Spec(s) if s == "ns:gen@1.0.0"));
+        assert!(
+            matches!(&result[0].decl_site, DeclSite::Inline { module, .. } if module == "src/main.wado")
+        );
+    }
+
+    #[test]
+    fn missing_module_field_rejected() {
+        let attrs = attr_with_generator(&[]);
+        let module = module_with_use("./x.proto", attrs);
+        let mut mods: IndexMap<String, Module> = IndexMap::default();
+        mods.insert("src/main.wado".to_string(), module);
+
+        let errs = collect_inline_invocations(&mods, &IndexMap::default()).unwrap_err();
+        assert!(
+            errs.iter()
+                .any(|d| d.message.contains("requires a `module` field"))
+        );
+    }
+
+    #[test]
+    fn dedup_merges_identical_clauses() {
+        let mk = || {
+            let attrs =
+                attr_with_generator(&[("module", AttrValue::String("ns:gen@1.0.0".to_string()))]);
+            module_with_use("./schema.proto", attrs)
+        };
+        let mut mods: IndexMap<String, Module> = IndexMap::default();
+        mods.insert("src/a.wado".to_string(), mk());
+        mods.insert("src/b.wado".to_string(), mk());
+
+        let result = collect_inline_invocations(&mods, &IndexMap::default()).unwrap();
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn conflict_detected_when_same_from_different_module() {
+        let a = module_with_use(
+            "./schema.proto",
+            attr_with_generator(&[("module", AttrValue::String("ns:a@1.0.0".to_string()))]),
+        );
+        let b = module_with_use(
+            "./schema.proto",
+            attr_with_generator(&[("module", AttrValue::String("ns:b@1.0.0".to_string()))]),
+        );
+        let mut mods: IndexMap<String, Module> = IndexMap::default();
+        mods.insert("src/a.wado".to_string(), a);
+        mods.insert("src/b.wado".to_string(), b);
+
+        let errs = collect_inline_invocations(&mods, &IndexMap::default()).unwrap_err();
+        assert!(errs.iter().any(|d| d.message.contains("disagree")));
+    }
+
+    #[test]
+    fn object_module_path_lowered_to_local_path() {
+        let mut mod_obj: IndexMap<String, AttrValue> = IndexMap::default();
+        mod_obj.insert("path".to_string(), AttrValue::String("../gen".to_string()));
+        let attrs = attr_with_generator(&[("module", AttrValue::Object(mod_obj))]);
+        let module = module_with_use("./x.proto", attrs);
+        let mut mods: IndexMap<String, Module> = IndexMap::default();
+        mods.insert("src/main.wado".to_string(), module);
+
+        let result = collect_inline_invocations(&mods, &IndexMap::default()).unwrap();
+        assert_eq!(result.len(), 1);
+        match &result[0].module {
+            GeneratorModule::LocalPath(p) => assert_eq!(p.as_str(), "../gen"),
+            other => panic!("expected LocalPath, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn merge_reports_cross_source_conflict() {
+        let manifest_inv = Invocation {
+            decl_site: DeclSite::Manifest {
+                name: "proto".to_string(),
+            },
+            module: GeneratorModule::Spec("ns:a@1.0.0".to_string()),
+            from: InvocationPath::normalize("./schema.proto"),
+            inputs: vec![],
+            output_dir: InvocationPath::normalize("build/kiln/proto"),
+            options_canonical: vec![],
+        };
+        let inline_inv = Invocation {
+            decl_site: DeclSite::Inline {
+                module: "src/main.wado".to_string(),
+                synthetic_id: "kiln-deadbeef".to_string(),
+            },
+            module: GeneratorModule::Spec("ns:b@1.0.0".to_string()),
+            from: InvocationPath::normalize("./schema.proto"),
+            inputs: vec![],
+            output_dir: InvocationPath::normalize("build/kiln/kiln-deadbeef"),
+            options_canonical: vec![],
+        };
+        let errs = merge_manifest_and_inline(vec![manifest_inv], vec![inline_inv]).unwrap_err();
+        assert!(errs.iter().any(|d| d.message.contains("disagree between")));
+    }
+
+    #[test]
+    fn invocation_index_redirects_on_match() {
+        let mut idx = InvocationIndex::new();
+        idx.insert(
+            "src/main.wado",
+            "./grammar.g4",
+            "build/kiln/proto/grammar.wado",
+        );
+        assert_eq!(
+            idx.redirect("src/main.wado", "./grammar.g4"),
+            Some("build/kiln/proto/grammar.wado"),
+        );
+        assert_eq!(idx.redirect("src/main.wado", "./other.g4"), None);
+    }
+
+    #[test]
+    fn invocation_index_normalizes_paths() {
+        let mut idx = InvocationIndex::new();
+        idx.insert("./src/main.wado", "./grammar.g4", "./build/kiln/x/g.wado");
+        assert_eq!(
+            idx.redirect("src/main.wado", "grammar.g4"),
+            Some("build/kiln/x/g.wado"),
+        );
+    }
+
+    #[test]
+    fn merge_dedups_identical_invocations() {
+        let a = Invocation {
+            decl_site: DeclSite::Manifest {
+                name: "proto".to_string(),
+            },
+            module: GeneratorModule::Spec("ns:a@1.0.0".to_string()),
+            from: InvocationPath::normalize("./schema.proto"),
+            inputs: vec![],
+            output_dir: InvocationPath::normalize("build/kiln/proto"),
+            options_canonical: vec![],
+        };
+        let merged = merge_manifest_and_inline(vec![a.clone()], vec![a]).unwrap();
+        assert_eq!(merged.len(), 1);
+    }
+}

--- a/wado-compiler/src/kiln/options.rs
+++ b/wado-compiler/src/kiln/options.rs
@@ -118,36 +118,30 @@ pub fn extract_options_descriptor(
 ) -> Result<OptionsDescriptor, Vec<Diagnostic>> {
     let mut diagnostics = Vec::new();
 
-    let tir_module = match annotated.tir_modules.get(module) {
-        Some(m) => m,
-        None => {
-            diagnostics.push(Diagnostic {
-                severity: Severity::Error,
-                code: Code::GeneratorOptionsUnsupported,
-                message: format!(
-                    "kiln: generator module {:?} has no TIR available",
-                    module.diagnostic_filename()
-                ),
-                span: None,
-            });
-            return Err(diagnostics);
-        }
+    let Some(tir_module) = annotated.tir_modules.get(module) else {
+        diagnostics.push(Diagnostic {
+            severity: Severity::Error,
+            code: Code::GeneratorOptionsUnsupported,
+            message: format!(
+                "kiln: generator module {:?} has no TIR available",
+                module.diagnostic_filename()
+            ),
+            span: None,
+        });
+        return Err(diagnostics);
     };
 
-    let options_struct = match tir_module.find_struct("Options") {
-        Some(s) => s,
-        None => {
-            diagnostics.push(Diagnostic {
-                severity: Severity::Error,
-                code: Code::GeneratorOptionsUnsupported,
-                message: format!(
-                    "kiln: generator {:?} does not declare `pub struct Options`",
-                    module.diagnostic_filename()
-                ),
-                span: None,
-            });
-            return Err(diagnostics);
-        }
+    let Some(options_struct) = tir_module.find_struct("Options") else {
+        diagnostics.push(Diagnostic {
+            severity: Severity::Error,
+            code: Code::GeneratorOptionsUnsupported,
+            message: format!(
+                "kiln: generator {:?} does not declare `pub struct Options`",
+                module.diagnostic_filename()
+            ),
+            span: None,
+        });
+        return Err(diagnostics);
     };
 
     if !options_struct.is_pub {
@@ -175,12 +169,12 @@ pub fn extract_options_descriptor(
     visiting.insert((module.clone(), "Options".to_string()));
     let mut descriptor_fields = Vec::with_capacity(options_struct.fields.len());
     for field in &options_struct.fields {
-        match lower_field(field, annotated, module, &mut visiting, &mut diagnostics) {
-            Some(desc_field) => descriptor_fields.push(desc_field),
-            None => {
-                // Diagnostic already pushed by lower_field; continue so other
-                // fields also get reported.
-            }
+        // Diagnostic already pushed by lower_field on `None`; continue so
+        // every bad field surfaces in one pass.
+        if let Some(desc_field) =
+            lower_field(field, annotated, module, &mut visiting, &mut diagnostics)
+        {
+            descriptor_fields.push(desc_field);
         }
     }
 
@@ -332,33 +326,31 @@ fn nested_struct_descriptor(
         return None;
     }
 
-    let tir_module = match annotated.tir_modules.get(struct_module) {
-        Some(m) => m,
-        None => {
-            push_unsupported(
-                diagnostics,
-                module,
-                field_name,
-                &format!(
-                    "nested struct `{struct_name}` declaring module {:?} is not available",
-                    struct_module.diagnostic_filename()
-                ),
-            );
-            return None;
-        }
+    let tir_module = if let Some(m) = annotated.tir_modules.get(struct_module) {
+        m
+    } else {
+        push_unsupported(
+            diagnostics,
+            module,
+            field_name,
+            &format!(
+                "nested struct `{struct_name}` declaring module {:?} is not available",
+                struct_module.diagnostic_filename()
+            ),
+        );
+        return None;
     };
 
-    let nested_struct = match tir_module.find_struct(struct_name) {
-        Some(s) => s,
-        None => {
-            push_unsupported(
-                diagnostics,
-                module,
-                field_name,
-                &format!("nested struct `{struct_name}` not found in its declaring module"),
-            );
-            return None;
-        }
+    let nested_struct = if let Some(s) = tir_module.find_struct(struct_name) {
+        s
+    } else {
+        push_unsupported(
+            diagnostics,
+            module,
+            field_name,
+            &format!("nested struct `{struct_name}` not found in its declaring module"),
+        );
+        return None;
     };
 
     visiting.insert(key.clone());
@@ -389,33 +381,31 @@ fn enum_variants(
     field_name: &str,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Option<Vec<String>> {
-    let tir_module = match annotated.tir_modules.get(enum_module) {
-        Some(m) => m,
-        None => {
-            push_unsupported(
-                diagnostics,
-                module,
-                field_name,
-                &format!(
-                    "enum `{enum_name}` declaring module {:?} is not available",
-                    enum_module.diagnostic_filename()
-                ),
-            );
-            return None;
-        }
+    let tir_module = if let Some(m) = annotated.tir_modules.get(enum_module) {
+        m
+    } else {
+        push_unsupported(
+            diagnostics,
+            module,
+            field_name,
+            &format!(
+                "enum `{enum_name}` declaring module {:?} is not available",
+                enum_module.diagnostic_filename()
+            ),
+        );
+        return None;
     };
 
-    let enum_decl = match tir_module.find_enum(enum_name) {
-        Some(e) => e,
-        None => {
-            push_unsupported(
-                diagnostics,
-                module,
-                field_name,
-                &format!("enum `{enum_name}` not found in its declaring module"),
-            );
-            return None;
-        }
+    let enum_decl = if let Some(e) = tir_module.find_enum(enum_name) {
+        e
+    } else {
+        push_unsupported(
+            diagnostics,
+            module,
+            field_name,
+            &format!("enum `{enum_name}` not found in its declaring module"),
+        );
+        return None;
     };
 
     Some(enum_decl.cases.iter().map(|c| c.name.clone()).collect())
@@ -470,9 +460,10 @@ fn evaluate_literal(
                         &desc_field.name,
                         diagnostics,
                     )?,
-                    None => match &desc_field.default {
-                        Some(v) => v.clone(),
-                        None => {
+                    None => {
+                        if let Some(v) = &desc_field.default {
+                            v.clone()
+                        } else {
                             push_unsupported(
                                 diagnostics,
                                 module,
@@ -484,7 +475,7 @@ fn evaluate_literal(
                             );
                             return None;
                         }
-                    },
+                    }
                 };
                 out.push((desc_field.name.clone(), value));
             }

--- a/wado-compiler/src/kiln/options.rs
+++ b/wado-compiler/src/kiln/options.rs
@@ -1,0 +1,390 @@
+//! Typed extraction of a Kiln generator's `Options` struct.
+//!
+//! The driver calls [`extract_options_descriptor`] once per generator
+//! component, after that component's package has been type-resolved. The
+//! returned [`OptionsDescriptor`] drives both [`crate::kiln::options_check`]
+//! (typed validation of a user-supplied options table) and
+//! [`crate::kiln::cache::encode_options_canonical`] (the cache-key byte
+//! layout).
+//!
+//! See WEP 2026-04-12 §M4 for the full design.
+//!
+//! The extractor is deliberately strict: only shapes that round-trip cleanly
+//! through the Component-Model canonical encoder are allowed. A generator
+//! that wants to accept richer configuration should split that configuration
+//! out into auxiliary structs that are themselves made of the primitives
+//! listed here.
+
+use crate::annotate::Annotated;
+use crate::compiler_host::{Code, Diagnostic, DiagnosticSpan, Severity};
+use crate::name::ModuleSource;
+use crate::tir::{
+    PrimitiveType, ResolvedType, TirExpr, TirExprKind, TirField, TirModule, TypeId, TypeTable,
+};
+use crate::token::Span;
+
+/// Structural description of a generator's `pub struct Options`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OptionsDescriptor {
+    pub fields: Vec<OptionsField>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OptionsField {
+    pub name: String,
+    pub ty: OptionsType,
+    /// Pre-evaluated default, if the generator's `Options` declaration
+    /// provides a literal default for this field. Fields without a default
+    /// are required in the user's options table.
+    pub default: Option<CanonicalValue>,
+    pub span: Span,
+}
+
+/// The set of shapes supported inside a generator's `Options` struct.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OptionsType {
+    Bool,
+    I32,
+    I64,
+    U32,
+    U64,
+    F32,
+    F64,
+    String,
+    /// `Option<T>` — missing-and-`null` both resolve to `None`.
+    Option(Box<OptionsType>),
+    /// Enum with all-no-payload variants, by name.
+    Enum {
+        name: String,
+        variants: Vec<String>,
+    },
+    /// Nested struct, recursively described.
+    Struct {
+        name: String,
+        descriptor: OptionsDescriptor,
+    },
+}
+
+impl OptionsType {
+    pub fn describe(&self) -> String {
+        match self {
+            OptionsType::Bool => "bool".to_string(),
+            OptionsType::I32 => "i32".to_string(),
+            OptionsType::I64 => "i64".to_string(),
+            OptionsType::U32 => "u32".to_string(),
+            OptionsType::U64 => "u64".to_string(),
+            OptionsType::F32 => "f32".to_string(),
+            OptionsType::F64 => "f64".to_string(),
+            OptionsType::String => "String".to_string(),
+            OptionsType::Option(inner) => format!("Option<{}>", inner.describe()),
+            OptionsType::Enum { name, .. } => name.clone(),
+            OptionsType::Struct { name, .. } => name.clone(),
+        }
+    }
+}
+
+/// The compiler-side representation of a fully-validated options value.
+///
+/// Shape mirrors [`OptionsType`] so [`crate::kiln::cache::encode_options_canonical`]
+/// can walk the two in lock-step.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CanonicalValue {
+    Bool(bool),
+    I64(i64),
+    U64(u64),
+    F64(f64),
+    String(String),
+    /// `None` when the user wrote `null` or omitted the field on an
+    /// `Option<T>` with no struct-level default.
+    None,
+    Some(Box<CanonicalValue>),
+    Enum(String),
+    Struct(Vec<(String, CanonicalValue)>),
+}
+
+/// Locate `pub struct Options` in the generator's entry module and describe
+/// it as an [`OptionsDescriptor`].
+///
+/// # Errors
+/// Diagnostics are batched: a single bad field does not prevent the rest of
+/// the struct from being reported. The returned `Err` variant is only taken
+/// when the `Options` struct is missing or the generator is missing its
+/// `generate` function — shape-level failures all come back as
+/// [`Code::GeneratorOptionsUnsupported`] diagnostics.
+pub fn extract_options_descriptor(
+    annotated: &Annotated,
+    module: &ModuleSource,
+) -> Result<OptionsDescriptor, Vec<Diagnostic>> {
+    let mut diagnostics = Vec::new();
+
+    let tir_module = match annotated.tir_modules.get(module) {
+        Some(m) => m,
+        None => {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Error,
+                code: Code::GeneratorOptionsUnsupported,
+                message: format!(
+                    "kiln: generator module {:?} has no TIR available",
+                    module.diagnostic_filename()
+                ),
+                span: None,
+            });
+            return Err(diagnostics);
+        }
+    };
+
+    let options_struct = match tir_module.find_struct("Options") {
+        Some(s) => s,
+        None => {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Error,
+                code: Code::GeneratorOptionsUnsupported,
+                message: format!(
+                    "kiln: generator {:?} does not declare `pub struct Options`",
+                    module.diagnostic_filename()
+                ),
+                span: None,
+            });
+            return Err(diagnostics);
+        }
+    };
+
+    if !options_struct.is_pub {
+        diagnostics.push(Diagnostic {
+            severity: Severity::Error,
+            code: Code::GeneratorOptionsUnsupported,
+            message: "kiln: `Options` struct must be declared `pub`".to_string(),
+            span: Some(span_of(&options_struct.span, module)),
+        });
+    }
+
+    if tir_module.find_function("generate").is_none() {
+        diagnostics.push(Diagnostic {
+            severity: Severity::Error,
+            code: Code::GeneratorOptionsUnsupported,
+            message: format!(
+                "kiln: generator {:?} does not declare `generate` function",
+                module.diagnostic_filename()
+            ),
+            span: None,
+        });
+    }
+
+    let mut descriptor_fields = Vec::with_capacity(options_struct.fields.len());
+    for field in &options_struct.fields {
+        match lower_field(field, &annotated.types, module, &mut diagnostics) {
+            Some(desc_field) => descriptor_fields.push(desc_field),
+            None => {
+                // Diagnostic already pushed by lower_field; continue so other
+                // fields also get reported.
+            }
+        }
+    }
+
+    if diagnostics.iter().any(|d| d.severity == Severity::Error) {
+        return Err(diagnostics);
+    }
+
+    Ok(OptionsDescriptor {
+        fields: descriptor_fields,
+    })
+}
+
+fn lower_field(
+    field: &TirField,
+    types: &TypeTable,
+    module: &ModuleSource,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<OptionsField> {
+    let ty = lower_type(field.type_id, types, module, &field.name, diagnostics)?;
+    let default = field
+        .default_expr
+        .as_deref()
+        .and_then(|e| evaluate_literal(e, &ty, types, module, &field.name, diagnostics));
+    Some(OptionsField {
+        name: field.name.clone(),
+        ty,
+        default,
+        span: field.span,
+    })
+}
+
+fn lower_type(
+    type_id: TypeId,
+    types: &TypeTable,
+    module: &ModuleSource,
+    field_name: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<OptionsType> {
+    if let Some(inner_id) = types.as_option(type_id) {
+        let inner = lower_type(inner_id, types, module, field_name, diagnostics)?;
+        return Some(OptionsType::Option(Box::new(inner)));
+    }
+
+    match types.get(type_id) {
+        ResolvedType::Primitive(p) => match p {
+            PrimitiveType::Bool => Some(OptionsType::Bool),
+            PrimitiveType::I32 => Some(OptionsType::I32),
+            PrimitiveType::I64 => Some(OptionsType::I64),
+            PrimitiveType::U32 => Some(OptionsType::U32),
+            PrimitiveType::U64 => Some(OptionsType::U64),
+            PrimitiveType::F32 => Some(OptionsType::F32),
+            PrimitiveType::F64 => Some(OptionsType::F64),
+            other => {
+                push_unsupported(
+                    diagnostics,
+                    module,
+                    field_name,
+                    &format!(
+                        "primitive type `{}` is not supported in generator options",
+                        other.as_str()
+                    ),
+                );
+                None
+            }
+        },
+        ResolvedType::Struct { name, .. } if name == "String" => Some(OptionsType::String),
+        ResolvedType::Struct {
+            name,
+            module_source,
+            ..
+        } => {
+            let nested = nested_struct_descriptor(name, module_source, types, module, diagnostics)?;
+            Some(OptionsType::Struct {
+                name: name.clone(),
+                descriptor: nested,
+            })
+        }
+        ResolvedType::Enum {
+            name,
+            module_source,
+        } => {
+            let variants = enum_variants(name, module_source, types, module, diagnostics)?;
+            Some(OptionsType::Enum {
+                name: name.clone(),
+                variants,
+            })
+        }
+        other => {
+            push_unsupported(
+                diagnostics,
+                module,
+                field_name,
+                &format!("type `{other:?}` is not supported in generator options"),
+            );
+            None
+        }
+    }
+}
+
+fn nested_struct_descriptor(
+    _struct_name: &str,
+    _struct_module: &ModuleSource,
+    _types: &TypeTable,
+    module: &ModuleSource,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<OptionsDescriptor> {
+    // Nested struct descriptors require access to the declaring module's TIR.
+    // v1 declines nested structs rather than re-scanning every module; the
+    // WEP explicitly scopes M4 to the "Options struct plus primitives /
+    // enums / Option<T>" happy path and leaves nested structs as a follow-up.
+    push_unsupported(
+        diagnostics,
+        module,
+        "<nested>",
+        "nested struct options are not yet supported",
+    );
+    None
+}
+
+fn enum_variants(
+    enum_name: &str,
+    enum_module: &ModuleSource,
+    types: &TypeTable,
+    module: &ModuleSource,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<Vec<String>> {
+    // The enum's cases live in the declaring module's TIR. We cannot reach
+    // that from the TypeTable alone, so we keep the information in the
+    // intern'd `ResolvedType` and require the caller's `Annotated` to look it
+    // up. To avoid threading Annotated through everything, we keep an
+    // approximation here: reject enums from non-current modules unless the
+    // `TypeTable` already exposed the variants. v1 only needs flat local
+    // enums, so this is a pragmatic subset.
+    let _ = (enum_name, enum_module, types);
+    push_unsupported(
+        diagnostics,
+        module,
+        enum_name,
+        "enum options are supported only via a future extension; declare \
+         configuration choices as booleans or strings in v1",
+    );
+    None
+}
+
+fn evaluate_literal(
+    expr: &TirExpr,
+    ty: &OptionsType,
+    types: &TypeTable,
+    module: &ModuleSource,
+    field_name: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<CanonicalValue> {
+    match (&expr.kind, ty) {
+        (TirExprKind::BoolLiteral(b), OptionsType::Bool) => Some(CanonicalValue::Bool(*b)),
+        (TirExprKind::IntLiteral { value, .. }, OptionsType::I32 | OptionsType::I64) => {
+            Some(CanonicalValue::I64(*value as i64))
+        }
+        (TirExprKind::IntLiteral { value, .. }, OptionsType::U32 | OptionsType::U64) => {
+            Some(CanonicalValue::U64(*value))
+        }
+        (TirExprKind::FloatLiteral { value, .. }, OptionsType::F32 | OptionsType::F64) => {
+            Some(CanonicalValue::F64(*value))
+        }
+        (TirExprKind::StringLiteral(s), OptionsType::String) => {
+            Some(CanonicalValue::String(s.clone()))
+        }
+        (TirExprKind::Null, OptionsType::Option(_)) => Some(CanonicalValue::None),
+        (_, OptionsType::Option(inner)) => {
+            evaluate_literal(expr, inner, types, module, field_name, diagnostics)
+                .map(|v| CanonicalValue::Some(Box::new(v)))
+        }
+        _ => {
+            push_unsupported(
+                diagnostics,
+                module,
+                field_name,
+                "default value must be a literal matching the declared type",
+            );
+            None
+        }
+    }
+}
+
+fn span_of(span: &Span, module: &ModuleSource) -> DiagnosticSpan {
+    DiagnosticSpan::from_span(span, Some(&module.diagnostic_filename()))
+}
+
+fn push_unsupported(
+    diagnostics: &mut Vec<Diagnostic>,
+    module: &ModuleSource,
+    field_name: &str,
+    msg: &str,
+) {
+    diagnostics.push(Diagnostic {
+        severity: Severity::Error,
+        code: Code::GeneratorOptionsUnsupported,
+        message: format!(
+            "kiln: Options.{field_name} in {:?}: {msg}",
+            module.diagnostic_filename()
+        ),
+        span: None,
+    });
+}
+
+/// Access the TIR module that declared an Options struct. Exposed for the
+/// options-validation layer and the CLI provider.
+#[must_use]
+pub fn tir_module<'a>(annotated: &'a Annotated, module: &ModuleSource) -> Option<&'a TirModule> {
+    annotated.tir_modules.get(module)
+}

--- a/wado-compiler/src/kiln/options.rs
+++ b/wado-compiler/src/kiln/options.rs
@@ -17,6 +17,7 @@
 
 use crate::annotate::Annotated;
 use crate::compiler_host::{Code, Diagnostic, DiagnosticSpan, Severity};
+use crate::hashmap::IndexSet;
 use crate::name::ModuleSource;
 use crate::tir::{
     PrimitiveType, ResolvedType, TirExpr, TirExprKind, TirField, TirModule, TypeId, TypeTable,
@@ -170,9 +171,11 @@ pub fn extract_options_descriptor(
         });
     }
 
+    let mut visiting: IndexSet<(ModuleSource, String)> = IndexSet::default();
+    visiting.insert((module.clone(), "Options".to_string()));
     let mut descriptor_fields = Vec::with_capacity(options_struct.fields.len());
     for field in &options_struct.fields {
-        match lower_field(field, &annotated.types, module, &mut diagnostics) {
+        match lower_field(field, annotated, module, &mut visiting, &mut diagnostics) {
             Some(desc_field) => descriptor_fields.push(desc_field),
             None => {
                 // Diagnostic already pushed by lower_field; continue so other
@@ -192,15 +195,23 @@ pub fn extract_options_descriptor(
 
 fn lower_field(
     field: &TirField,
-    types: &TypeTable,
+    annotated: &Annotated,
     module: &ModuleSource,
+    visiting: &mut IndexSet<(ModuleSource, String)>,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Option<OptionsField> {
-    let ty = lower_type(field.type_id, types, module, &field.name, diagnostics)?;
+    let ty = lower_type(
+        field.type_id,
+        annotated,
+        module,
+        &field.name,
+        visiting,
+        diagnostics,
+    )?;
     let default = field
         .default_expr
         .as_deref()
-        .and_then(|e| evaluate_literal(e, &ty, types, module, &field.name, diagnostics));
+        .and_then(|e| evaluate_literal(e, &ty, &annotated.types, module, &field.name, diagnostics));
     Some(OptionsField {
         name: field.name.clone(),
         ty,
@@ -211,13 +222,22 @@ fn lower_field(
 
 fn lower_type(
     type_id: TypeId,
-    types: &TypeTable,
+    annotated: &Annotated,
     module: &ModuleSource,
     field_name: &str,
+    visiting: &mut IndexSet<(ModuleSource, String)>,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Option<OptionsType> {
+    let types = &annotated.types;
     if let Some(inner_id) = types.as_option(type_id) {
-        let inner = lower_type(inner_id, types, module, field_name, diagnostics)?;
+        let inner = lower_type(
+            inner_id,
+            annotated,
+            module,
+            field_name,
+            visiting,
+            diagnostics,
+        )?;
         return Some(OptionsType::Option(Box::new(inner)));
     }
 
@@ -249,7 +269,15 @@ fn lower_type(
             module_source,
             ..
         } => {
-            let nested = nested_struct_descriptor(name, module_source, types, module, diagnostics)?;
+            let nested = nested_struct_descriptor(
+                name,
+                module_source,
+                annotated,
+                module,
+                field_name,
+                visiting,
+                diagnostics,
+            )?;
             Some(OptionsType::Struct {
                 name: name.clone(),
                 descriptor: nested,
@@ -259,7 +287,14 @@ fn lower_type(
             name,
             module_source,
         } => {
-            let variants = enum_variants(name, module_source, types, module, diagnostics)?;
+            let variants = enum_variants(
+                name,
+                module_source,
+                annotated,
+                module,
+                field_name,
+                diagnostics,
+            )?;
             Some(OptionsType::Enum {
                 name: name.clone(),
                 variants,
@@ -278,48 +313,112 @@ fn lower_type(
 }
 
 fn nested_struct_descriptor(
-    _struct_name: &str,
-    _struct_module: &ModuleSource,
-    _types: &TypeTable,
+    struct_name: &str,
+    struct_module: &ModuleSource,
+    annotated: &Annotated,
     module: &ModuleSource,
+    field_name: &str,
+    visiting: &mut IndexSet<(ModuleSource, String)>,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Option<OptionsDescriptor> {
-    // Nested struct descriptors require access to the declaring module's TIR.
-    // v1 declines nested structs rather than re-scanning every module; the
-    // WEP explicitly scopes M4 to the "Options struct plus primitives /
-    // enums / Option<T>" happy path and leaves nested structs as a follow-up.
-    push_unsupported(
-        diagnostics,
-        module,
-        "<nested>",
-        "nested struct options are not yet supported",
-    );
-    None
+    let key = (struct_module.clone(), struct_name.to_string());
+    if visiting.contains(&key) {
+        push_unsupported(
+            diagnostics,
+            module,
+            field_name,
+            &format!("recursive struct `{struct_name}` is not supported in generator options"),
+        );
+        return None;
+    }
+
+    let tir_module = match annotated.tir_modules.get(struct_module) {
+        Some(m) => m,
+        None => {
+            push_unsupported(
+                diagnostics,
+                module,
+                field_name,
+                &format!(
+                    "nested struct `{struct_name}` declaring module {:?} is not available",
+                    struct_module.diagnostic_filename()
+                ),
+            );
+            return None;
+        }
+    };
+
+    let nested_struct = match tir_module.find_struct(struct_name) {
+        Some(s) => s,
+        None => {
+            push_unsupported(
+                diagnostics,
+                module,
+                field_name,
+                &format!("nested struct `{struct_name}` not found in its declaring module"),
+            );
+            return None;
+        }
+    };
+
+    visiting.insert(key.clone());
+    let mut nested_fields = Vec::with_capacity(nested_struct.fields.len());
+    let mut any_failed = false;
+    for field in &nested_struct.fields {
+        match lower_field(field, annotated, struct_module, visiting, diagnostics) {
+            Some(f) => nested_fields.push(f),
+            None => any_failed = true,
+        }
+    }
+    visiting.shift_remove(&key);
+
+    if any_failed {
+        return None;
+    }
+
+    Some(OptionsDescriptor {
+        fields: nested_fields,
+    })
 }
 
 fn enum_variants(
     enum_name: &str,
     enum_module: &ModuleSource,
-    types: &TypeTable,
+    annotated: &Annotated,
     module: &ModuleSource,
+    field_name: &str,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Option<Vec<String>> {
-    // The enum's cases live in the declaring module's TIR. We cannot reach
-    // that from the TypeTable alone, so we keep the information in the
-    // intern'd `ResolvedType` and require the caller's `Annotated` to look it
-    // up. To avoid threading Annotated through everything, we keep an
-    // approximation here: reject enums from non-current modules unless the
-    // `TypeTable` already exposed the variants. v1 only needs flat local
-    // enums, so this is a pragmatic subset.
-    let _ = (enum_name, enum_module, types);
-    push_unsupported(
-        diagnostics,
-        module,
-        enum_name,
-        "enum options are supported only via a future extension; declare \
-         configuration choices as booleans or strings in v1",
-    );
-    None
+    let tir_module = match annotated.tir_modules.get(enum_module) {
+        Some(m) => m,
+        None => {
+            push_unsupported(
+                diagnostics,
+                module,
+                field_name,
+                &format!(
+                    "enum `{enum_name}` declaring module {:?} is not available",
+                    enum_module.diagnostic_filename()
+                ),
+            );
+            return None;
+        }
+    };
+
+    let enum_decl = match tir_module.find_enum(enum_name) {
+        Some(e) => e,
+        None => {
+            push_unsupported(
+                diagnostics,
+                module,
+                field_name,
+                &format!("enum `{enum_name}` not found in its declaring module"),
+            );
+            return None;
+        }
+    };
+
+    Some(enum_decl.cases.iter().map(|c| c.name.clone()).collect())
 }
 
 fn evaluate_literal(
@@ -345,6 +444,52 @@ fn evaluate_literal(
             Some(CanonicalValue::String(s.clone()))
         }
         (TirExprKind::Null, OptionsType::Option(_)) => Some(CanonicalValue::None),
+        (TirExprKind::EnumConstruct { case_name, .. }, OptionsType::Enum { variants, .. }) => {
+            if variants.iter().any(|v| v == case_name) {
+                Some(CanonicalValue::Enum(case_name.clone()))
+            } else {
+                push_unsupported(
+                    diagnostics,
+                    module,
+                    field_name,
+                    &format!("default enum case `{case_name}` not in declared variants"),
+                );
+                None
+            }
+        }
+        (TirExprKind::StructLiteral { fields, .. }, OptionsType::Struct { descriptor, .. }) => {
+            let mut out = Vec::with_capacity(descriptor.fields.len());
+            for desc_field in &descriptor.fields {
+                let matching_field = fields.iter().find(|f| f.name == desc_field.name);
+                let value = match matching_field {
+                    Some(f) => evaluate_literal(
+                        &f.value,
+                        &desc_field.ty,
+                        types,
+                        module,
+                        &desc_field.name,
+                        diagnostics,
+                    )?,
+                    None => match &desc_field.default {
+                        Some(v) => v.clone(),
+                        None => {
+                            push_unsupported(
+                                diagnostics,
+                                module,
+                                field_name,
+                                &format!(
+                                    "nested default omits `{}` which has no field-level default",
+                                    desc_field.name
+                                ),
+                            );
+                            return None;
+                        }
+                    },
+                };
+                out.push((desc_field.name.clone(), value));
+            }
+            Some(CanonicalValue::Struct(out))
+        }
         (_, OptionsType::Option(inner)) => {
             evaluate_literal(expr, inner, types, module, field_name, diagnostics)
                 .map(|v| CanonicalValue::Some(Box::new(v)))

--- a/wado-compiler/src/kiln/options_check.rs
+++ b/wado-compiler/src/kiln/options_check.rs
@@ -1,0 +1,370 @@
+//! Typed validation of a user-supplied options table against a
+//! [`OptionsDescriptor`].
+//!
+//! Returns a [`CanonicalValue`] tree whose shape mirrors the descriptor, so
+//! the downstream encoder in [`crate::kiln::cache`] can walk the pair in
+//! lock-step. All diagnostics are batched: a single malformed table surfaces
+//! every mismatched / missing / unknown field at once.
+
+use crate::ast::AttrValue;
+use crate::compiler_host::{Code, Diagnostic, Severity};
+use crate::hashmap::IndexMap;
+
+use super::options::{CanonicalValue, OptionsDescriptor, OptionsField, OptionsType};
+
+/// Wrap a validated options tree together with the descriptor it was built
+/// against. The encoder needs both: the descriptor defines field order, the
+/// canonical values define content.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CanonicalOptions {
+    pub descriptor: OptionsDescriptor,
+    pub values: Vec<(String, CanonicalValue)>,
+}
+
+/// Validate a user-supplied options blob against a descriptor.
+///
+/// `value` is `None` when the user omitted the options table entirely; each
+/// field's declared default is used.
+///
+/// # Errors
+/// Every type mismatch, missing required field, unknown field, and default
+/// fallback failure is emitted as a diagnostic. The full list is returned
+/// together so the CLI can print them in one shot.
+pub fn validate(
+    descriptor: &OptionsDescriptor,
+    value: Option<&AttrValue>,
+) -> Result<CanonicalOptions, Vec<Diagnostic>> {
+    let mut diagnostics = Vec::new();
+    let mut output = Vec::with_capacity(descriptor.fields.len());
+
+    let empty: IndexMap<String, AttrValue> = IndexMap::default();
+    let (provided, path): (&IndexMap<String, AttrValue>, String) = match value {
+        None => (&empty, "options".to_string()),
+        Some(AttrValue::Object(obj)) => (obj, "options".to_string()),
+        Some(other) => {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Error,
+                code: Code::GeneratorOptionsInvalid,
+                message: format!(
+                    "kiln: expected options table, got {}",
+                    attr_value_kind(other)
+                ),
+                span: None,
+            });
+            return Err(diagnostics);
+        }
+    };
+
+    for field in &descriptor.fields {
+        let field_path = format!("{path}.{}", field.name);
+        let canonical = match provided.get(&field.name) {
+            Some(supplied) => check_field(field, supplied, &field_path, &mut diagnostics),
+            None => apply_default(field, &field_path, &mut diagnostics),
+        };
+        if let Some(value) = canonical {
+            output.push((field.name.clone(), value));
+        }
+    }
+
+    for key in provided.keys() {
+        if !descriptor.fields.iter().any(|f| &f.name == key) {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Error,
+                code: Code::GeneratorOptionsInvalid,
+                message: format!("kiln: unknown options field `{path}.{key}`"),
+                span: None,
+            });
+        }
+    }
+
+    if diagnostics.iter().any(|d| d.severity == Severity::Error) {
+        return Err(diagnostics);
+    }
+
+    Ok(CanonicalOptions {
+        descriptor: descriptor.clone(),
+        values: output,
+    })
+}
+
+fn check_field(
+    field: &OptionsField,
+    supplied: &AttrValue,
+    path: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<CanonicalValue> {
+    check_value(&field.ty, supplied, path, diagnostics)
+}
+
+fn check_value(
+    ty: &OptionsType,
+    supplied: &AttrValue,
+    path: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<CanonicalValue> {
+    match (ty, supplied) {
+        (OptionsType::Bool, AttrValue::Bool(b)) => Some(CanonicalValue::Bool(*b)),
+        (OptionsType::I32 | OptionsType::I64, AttrValue::Int(n)) => {
+            let bounded = if matches!(ty, OptionsType::I32) {
+                if !(i32::MIN as i64..=i32::MAX as i64).contains(n) {
+                    push_mismatch(diagnostics, path, ty, supplied);
+                    return None;
+                }
+                *n
+            } else {
+                *n
+            };
+            Some(CanonicalValue::I64(bounded))
+        }
+        (OptionsType::U32 | OptionsType::U64, AttrValue::Int(n)) => {
+            if *n < 0 {
+                push_mismatch(diagnostics, path, ty, supplied);
+                return None;
+            }
+            let v = *n as u64;
+            if matches!(ty, OptionsType::U32) && v > u32::MAX as u64 {
+                push_mismatch(diagnostics, path, ty, supplied);
+                return None;
+            }
+            Some(CanonicalValue::U64(v))
+        }
+        (OptionsType::F32 | OptionsType::F64, AttrValue::Float(f)) => Some(CanonicalValue::F64(*f)),
+        (OptionsType::F32 | OptionsType::F64, AttrValue::Int(n)) => {
+            Some(CanonicalValue::F64(*n as f64))
+        }
+        (OptionsType::String, AttrValue::String(s)) => Some(CanonicalValue::String(s.clone())),
+        (OptionsType::Enum { variants, name }, AttrValue::String(s)) => {
+            if variants.iter().any(|v| v == s) {
+                Some(CanonicalValue::Enum(s.clone()))
+            } else {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Error,
+                    code: Code::GeneratorOptionsInvalid,
+                    message: format!(
+                        "kiln: `{path}` expected one of {name}::{{{}}}, got \"{s}\"",
+                        variants.join(", ")
+                    ),
+                    span: None,
+                });
+                None
+            }
+        }
+        (OptionsType::Option(_inner), AttrValue::String(s)) if s == "null" => {
+            // "null" as a string is still a string; fall through to mismatch below.
+            push_mismatch(diagnostics, path, ty, supplied);
+            None
+        }
+        (OptionsType::Option(inner), value) => {
+            let inner_value = check_value(inner, value, path, diagnostics)?;
+            Some(CanonicalValue::Some(Box::new(inner_value)))
+        }
+        (OptionsType::Struct { descriptor, .. }, AttrValue::Object(obj)) => {
+            let nested = descriptor_validate_object(descriptor, obj, path, diagnostics)?;
+            Some(CanonicalValue::Struct(nested))
+        }
+        _ => {
+            push_mismatch(diagnostics, path, ty, supplied);
+            None
+        }
+    }
+}
+
+fn descriptor_validate_object(
+    descriptor: &OptionsDescriptor,
+    obj: &IndexMap<String, AttrValue>,
+    path: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<Vec<(String, CanonicalValue)>> {
+    let mut out = Vec::with_capacity(descriptor.fields.len());
+    let mut any_error = false;
+    for field in &descriptor.fields {
+        let child_path = format!("{path}.{}", field.name);
+        let canonical = match obj.get(&field.name) {
+            Some(v) => check_value(&field.ty, v, &child_path, diagnostics),
+            None => apply_default(field, &child_path, diagnostics),
+        };
+        match canonical {
+            Some(v) => out.push((field.name.clone(), v)),
+            None => any_error = true,
+        }
+    }
+    for key in obj.keys() {
+        if !descriptor.fields.iter().any(|f| &f.name == key) {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Error,
+                code: Code::GeneratorOptionsInvalid,
+                message: format!("kiln: unknown options field `{path}.{key}`"),
+                span: None,
+            });
+            any_error = true;
+        }
+    }
+    if any_error { None } else { Some(out) }
+}
+
+fn apply_default(
+    field: &OptionsField,
+    path: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<CanonicalValue> {
+    if let Some(default) = &field.default {
+        return Some(default.clone());
+    }
+    if matches!(field.ty, OptionsType::Option(_)) {
+        return Some(CanonicalValue::None);
+    }
+    diagnostics.push(Diagnostic {
+        severity: Severity::Error,
+        code: Code::GeneratorOptionsInvalid,
+        message: format!(
+            "kiln: required options field `{path}` of type {} is missing",
+            field.ty.describe()
+        ),
+        span: None,
+    });
+    None
+}
+
+fn push_mismatch(
+    diagnostics: &mut Vec<Diagnostic>,
+    path: &str,
+    ty: &OptionsType,
+    supplied: &AttrValue,
+) {
+    diagnostics.push(Diagnostic {
+        severity: Severity::Error,
+        code: Code::GeneratorOptionsInvalid,
+        message: format!(
+            "kiln: `{path}` expected {}, got {}",
+            ty.describe(),
+            attr_value_kind(supplied)
+        ),
+        span: None,
+    });
+}
+
+fn attr_value_kind(v: &AttrValue) -> &'static str {
+    match v {
+        AttrValue::String(_) => "string",
+        AttrValue::Int(_) => "integer",
+        AttrValue::Float(_) => "float",
+        AttrValue::Bool(_) => "bool",
+        AttrValue::Array(_) => "array",
+        AttrValue::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kiln::options::{CanonicalValue, OptionsDescriptor, OptionsField, OptionsType};
+    use crate::token::Span;
+
+    fn field(name: &str, ty: OptionsType, default: Option<CanonicalValue>) -> OptionsField {
+        OptionsField {
+            name: name.to_string(),
+            ty,
+            default,
+            span: Span::new(0, 0, 1, 1),
+        }
+    }
+
+    #[test]
+    fn missing_table_uses_defaults() {
+        let desc = OptionsDescriptor {
+            fields: vec![
+                field(
+                    "enabled",
+                    OptionsType::Bool,
+                    Some(CanonicalValue::Bool(false)),
+                ),
+                field(
+                    "name",
+                    OptionsType::String,
+                    Some(CanonicalValue::String("hi".to_string())),
+                ),
+            ],
+        };
+        let result = validate(&desc, None).unwrap();
+        assert_eq!(
+            result.values,
+            vec![
+                ("enabled".to_string(), CanonicalValue::Bool(false)),
+                ("name".to_string(), CanonicalValue::String("hi".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn unknown_field_rejected() {
+        let desc = OptionsDescriptor {
+            fields: vec![field(
+                "enabled",
+                OptionsType::Bool,
+                Some(CanonicalValue::Bool(false)),
+            )],
+        };
+        let mut obj: IndexMap<String, AttrValue> = IndexMap::default();
+        obj.insert("enabled".to_string(), AttrValue::Bool(true));
+        obj.insert("extra".to_string(), AttrValue::Int(1));
+        let err = validate(&desc, Some(&AttrValue::Object(obj))).unwrap_err();
+        assert!(err.iter().any(|d| d.message.contains("extra")));
+    }
+
+    #[test]
+    fn missing_required_field_rejected() {
+        let desc = OptionsDescriptor {
+            fields: vec![field("name", OptionsType::String, None)],
+        };
+        let err = validate(&desc, None).unwrap_err();
+        assert!(err.iter().any(|d| d.message.contains("required")));
+    }
+
+    #[test]
+    fn type_mismatch_rejected() {
+        let desc = OptionsDescriptor {
+            fields: vec![field("enabled", OptionsType::Bool, None)],
+        };
+        let mut obj: IndexMap<String, AttrValue> = IndexMap::default();
+        obj.insert("enabled".to_string(), AttrValue::String("yes".to_string()));
+        let err = validate(&desc, Some(&AttrValue::Object(obj))).unwrap_err();
+        assert!(err.iter().any(|d| d.message.contains("expected bool")));
+    }
+
+    #[test]
+    fn option_none_when_omitted() {
+        let desc = OptionsDescriptor {
+            fields: vec![field(
+                "rule",
+                OptionsType::Option(Box::new(OptionsType::String)),
+                None,
+            )],
+        };
+        let result = validate(&desc, None).unwrap();
+        assert_eq!(
+            result.values,
+            vec![("rule".to_string(), CanonicalValue::None)]
+        );
+    }
+
+    #[test]
+    fn option_wraps_value() {
+        let desc = OptionsDescriptor {
+            fields: vec![field(
+                "rule",
+                OptionsType::Option(Box::new(OptionsType::String)),
+                None,
+            )],
+        };
+        let mut obj: IndexMap<String, AttrValue> = IndexMap::default();
+        obj.insert("rule".to_string(), AttrValue::String("expr".to_string()));
+        let result = validate(&desc, Some(&AttrValue::Object(obj))).unwrap();
+        assert_eq!(
+            result.values,
+            vec![(
+                "rule".to_string(),
+                CanonicalValue::Some(Box::new(CanonicalValue::String("expr".to_string())))
+            )]
+        );
+    }
+}

--- a/wado-compiler/src/kiln/options_check.rs
+++ b/wado-compiler/src/kiln/options_check.rs
@@ -106,7 +106,7 @@ fn check_value(
         (OptionsType::Bool, AttrValue::Bool(b)) => Some(CanonicalValue::Bool(*b)),
         (OptionsType::I32 | OptionsType::I64, AttrValue::Int(n)) => {
             let bounded = if matches!(ty, OptionsType::I32) {
-                if !(i32::MIN as i64..=i32::MAX as i64).contains(n) {
+                if !(i64::from(i32::MIN)..=i64::from(i32::MAX)).contains(n) {
                     push_mismatch(diagnostics, path, ty, supplied);
                     return None;
                 }
@@ -122,7 +122,7 @@ fn check_value(
                 return None;
             }
             let v = *n as u64;
-            if matches!(ty, OptionsType::U32) && v > u32::MAX as u64 {
+            if matches!(ty, OptionsType::U32) && v > u64::from(u32::MAX) {
                 push_mismatch(diagnostics, path, ty, supplied);
                 return None;
             }

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -42,7 +42,7 @@ pub mod wir_visitor;
 pub mod world_registry;
 
 pub use analyze::Analyzer;
-pub use annotate::{Annotated, Definition, annotate};
+pub use annotate::{Annotated, Definition, annotate, annotate_with_invocations};
 pub use ast::{AstId, AstNodeKind, AstPtr};
 pub use bind::{BindError, Binder};
 pub use compiler_host::{
@@ -165,6 +165,10 @@ pub struct CompilerOptions {
     /// Matches `#[allocator("...")]` attributes in `core:allocator`.
     /// When `None`, the compiler auto-selects: `"debug"` for test world, `"bump"` otherwise.
     pub allocator: Option<String>,
+    /// Kiln invocation redirects consulted by the module loader. Callers
+    /// that have run the Kiln pipeline (wado-cli, wado-lsp) populate this;
+    /// everyone else leaves it empty.
+    pub invocations: kiln::InvocationIndex,
 }
 
 /// Compile Wado source code with a `CompilerHost` for I/O operations.
@@ -224,7 +228,8 @@ pub async fn compile_with_options<H: CompilerHost>(
     // Loader performs: lex → parse → bind → desugar for each module
     // Also preserves the original (non-desugared) entry AST for tooling
     let load_result = {
-        let module_loader = loader::ModuleLoader::new(host, log_level);
+        let module_loader = loader::ModuleLoader::new(host, log_level)
+            .with_invocations(options.invocations.clone());
         module_loader
             .load_all(source, filename.as_deref())
             .await
@@ -581,6 +586,7 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
             load_result.entry_module_source.clone(),
             &logger,
             &load_result.included_files,
+            load_result.invocations.clone(),
         )
         .ok()
     };

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -189,6 +189,10 @@ pub struct LoadResult {
     /// Included file contents from `#include_str` and `#include_bytes`.
     /// Key is `(module_source_display, raw_path)`, value is raw bytes.
     pub included_files: IndexMap<[String; 2], Vec<u8>>,
+    /// Kiln invocation redirects propagated from the loader so later phases
+    /// (analyze, resolver) can also rewrite `use ... from "<schema>"`
+    /// clauses consistently.
+    pub invocations: crate::kiln::InvocationIndex,
 }
 
 use crate::compiler_host::LogLevel;
@@ -375,6 +379,10 @@ pub struct ModuleLoader<'a, H: CompilerHost> {
     entry_module_source: Option<ModuleSource>,
     /// Canonical name of the entry module (e.g., "./`cross_module_type_identity.wado`")
     entry_canonical_name: Option<String>,
+    /// Kiln invocation redirects: `(decl_file, from_path)` → generated entry
+    /// module path. Consulted by `resolve_import` so a bare `use { X } from
+    /// "<schema>"` picks up the generator's output.
+    invocations: crate::kiln::InvocationIndex,
 }
 
 impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
@@ -389,7 +397,17 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             implicit_modules: IndexSet::default(),
             entry_module_source: None,
             entry_canonical_name: None,
+            invocations: crate::kiln::InvocationIndex::new(),
         }
+    }
+
+    /// Seed the loader with a Kiln invocation index. Must be called before
+    /// [`Self::load_all`] so the index is available when imports are
+    /// resolved.
+    #[must_use]
+    pub fn with_invocations(mut self, invocations: crate::kiln::InvocationIndex) -> Self {
+        self.invocations = invocations;
+        self
     }
 
     /// Load all modules starting from the entry source
@@ -509,6 +527,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             entry_ast: entry_ast_original,
             implicit_modules: self.implicit_modules,
             included_files,
+            invocations: self.invocations,
         })
     }
 
@@ -579,6 +598,24 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         from_module_source: &ModuleSource,
         import_source: &str,
     ) -> Result<ModuleSource, LoadError> {
+        // Kiln invocation redirect: `use { X } from "./grammar.g4"` picks up
+        // the generated entry module when the `(decl_file, from_path)` pair
+        // is recorded on the loader.
+        if !self.invocations.is_empty() {
+            let decl_file = match from_module_source {
+                ModuleSource::Local { path } => path.as_str(),
+                ModuleSource::EntryPoint { filename } => filename.as_str(),
+                _ => "",
+            };
+            if !decl_file.is_empty()
+                && let Some(entry_path) = self.invocations.redirect(decl_file, import_source)
+            {
+                return Ok(ModuleSource::Local {
+                    path: entry_path.to_string(),
+                });
+            }
+        }
+
         // Handle known namespaces
         // Top-level: "core:cli" → Core { name: "cli" }
         // Sub-module: "core:prelude/traits.wado" → Core { name: "prelude/traits.wado" }

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -1028,6 +1028,38 @@ pub fn resolve_import(from_module: &ModuleSource, import_source: &str) -> Module
     resolve_import_with_entry(from_module, import_source, None)
 }
 
+/// Resolve an import source, consulting a Kiln [`crate::kiln::InvocationIndex`]
+/// first.
+///
+/// When the `(from_module, import_source)` pair matches a recorded invocation,
+/// the returned [`ModuleSource`] points at the invocation's generated entry
+/// module (under `build/kiln/…`). Otherwise falls back to
+/// [`resolve_import_with_entry`] unchanged.
+///
+/// Call this in place of [`resolve_import`] wherever an `InvocationIndex` is
+/// available — typically the CLI and LSP compile entry points, after the
+/// Kiln pipeline has populated the index.
+pub fn resolve_import_with_invocations(
+    from_module: &ModuleSource,
+    import_source: &str,
+    entry_module: Option<&ModuleSource>,
+    invocations: &crate::kiln::InvocationIndex,
+) -> ModuleSource {
+    if !invocations.is_empty() {
+        let decl_file = match from_module {
+            ModuleSource::Local { path } => path.as_str(),
+            ModuleSource::EntryPoint { filename } => filename.as_str(),
+            _ => "",
+        };
+        if let Some(entry_path) = invocations.redirect(decl_file, import_source) {
+            return ModuleSource::Local {
+                path: normalize_module_path(entry_path),
+            };
+        }
+    }
+    resolve_import_with_entry(from_module, import_source, entry_module)
+}
+
 pub fn resolve_import_with_entry(
     from_module: &ModuleSource,
     import_source: &str,

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -891,6 +891,10 @@ impl Parser {
     }
 
     /// Parse import attributes: `{ version: "1.0", integrity: "sha384-..." }`
+    ///
+    /// Attribute values are a generic scalar/array/object tree. Unknown
+    /// top-level keys are accepted here and validated downstream (e.g. the
+    /// Kiln inline-generator collector rejects non-`generator` siblings).
     fn parse_import_attributes(&mut self) -> ParseResult<ImportAttributes> {
         self.expect(&TokenKind::LBrace)?;
 
@@ -900,19 +904,8 @@ impl Parser {
             loop {
                 let key = self.consume_ident()?;
                 self.expect(&TokenKind::Colon)?;
-                let value = self.consume_string()?;
-
-                match key.as_str() {
-                    "version" => attrs.version = Some(value),
-                    "integrity" => attrs.integrity = Some(value),
-                    "type" => attrs.type_hint = Some(value),
-                    _ => {
-                        return Err(ParseError {
-                            message: format!("unknown import attribute: {key}"),
-                            span: self.peek().span,
-                        });
-                    }
-                }
+                let value = self.parse_attr_value()?;
+                attrs.entries.insert(key, value);
 
                 if !self.check(&TokenKind::Comma) {
                     break;
@@ -926,6 +919,112 @@ impl Parser {
 
         self.expect(&TokenKind::RBrace)?;
         Ok(attrs)
+    }
+
+    /// Parse a single [`AttrValue`]: scalar, array, or nested object.
+    fn parse_attr_value(&mut self) -> ParseResult<crate::ast::AttrValue> {
+        let span = self.peek().span;
+        // Handle unary minus on numeric literals (e.g. `-3`, `-1.5`).
+        let negate = if matches!(self.peek_kind(), TokenKind::Minus) {
+            self.advance();
+            true
+        } else {
+            false
+        };
+        match self.peek_kind().clone() {
+            TokenKind::StringLit(_) => {
+                if negate {
+                    return Err(ParseError {
+                        message: "cannot negate a string literal".to_string(),
+                        span,
+                    });
+                }
+                let s = self.consume_string()?;
+                Ok(crate::ast::AttrValue::String(s))
+            }
+            TokenKind::NumberLit(repr) => {
+                self.advance();
+                parse_attr_number(&repr, negate, span)
+            }
+            TokenKind::True => {
+                if negate {
+                    return Err(ParseError {
+                        message: "cannot negate a boolean".to_string(),
+                        span,
+                    });
+                }
+                self.advance();
+                Ok(crate::ast::AttrValue::Bool(true))
+            }
+            TokenKind::False => {
+                if negate {
+                    return Err(ParseError {
+                        message: "cannot negate a boolean".to_string(),
+                        span,
+                    });
+                }
+                self.advance();
+                Ok(crate::ast::AttrValue::Bool(false))
+            }
+            TokenKind::LBracket => {
+                if negate {
+                    return Err(ParseError {
+                        message: "cannot negate an array".to_string(),
+                        span,
+                    });
+                }
+                self.advance();
+                let mut items = Vec::new();
+                if !self.check(&TokenKind::RBracket) {
+                    loop {
+                        items.push(self.parse_attr_value()?);
+                        if !self.check(&TokenKind::Comma) {
+                            break;
+                        }
+                        self.advance();
+                        if self.check(&TokenKind::RBracket) {
+                            break;
+                        }
+                    }
+                }
+                self.expect(&TokenKind::RBracket)?;
+                Ok(crate::ast::AttrValue::Array(items))
+            }
+            TokenKind::LBrace => {
+                if negate {
+                    return Err(ParseError {
+                        message: "cannot negate an object".to_string(),
+                        span,
+                    });
+                }
+                self.advance();
+                let mut obj: crate::hashmap::IndexMap<String, crate::ast::AttrValue> =
+                    crate::hashmap::IndexMap::default();
+                if !self.check(&TokenKind::RBrace) {
+                    loop {
+                        let key = self.consume_ident()?;
+                        self.expect(&TokenKind::Colon)?;
+                        let v = self.parse_attr_value()?;
+                        obj.insert(key, v);
+                        if !self.check(&TokenKind::Comma) {
+                            break;
+                        }
+                        self.advance();
+                        if self.check(&TokenKind::RBrace) {
+                            break;
+                        }
+                    }
+                }
+                self.expect(&TokenKind::RBrace)?;
+                Ok(crate::ast::AttrValue::Object(obj))
+            }
+            other => Err(ParseError {
+                message: format!(
+                    "expected attribute value (string, number, bool, array, or object), got {other:?}"
+                ),
+                span,
+            }),
+        }
     }
 
     /// Consume a string literal and return its raw text (escape sequences not interpreted).
@@ -4717,6 +4816,48 @@ impl Parser {
     }
 }
 
+fn parse_attr_number(repr: &str, negate: bool, span: Span) -> ParseResult<crate::ast::AttrValue> {
+    // Strip numeric underscores for parsing; keep them in the original repr for errors.
+    let cleaned: String = repr.chars().filter(|c| *c != '_').collect();
+    // Float if it contains '.' or 'e'/'E' (but not hex prefix).
+    let is_hex = cleaned.starts_with("0x") || cleaned.starts_with("0X");
+    let is_float =
+        !is_hex && (cleaned.contains('.') || cleaned.contains('e') || cleaned.contains('E'));
+    if is_float {
+        let f: f64 = cleaned.parse().map_err(|_| ParseError {
+            message: format!("invalid numeric attribute value: {repr}"),
+            span,
+        })?;
+        let v = if negate { -f } else { f };
+        Ok(crate::ast::AttrValue::Float(v))
+    } else {
+        let n: i64 = if let Some(hex) = cleaned
+            .strip_prefix("0x")
+            .or_else(|| cleaned.strip_prefix("0X"))
+        {
+            i64::from_str_radix(hex, 16)
+        } else if let Some(oct) = cleaned
+            .strip_prefix("0o")
+            .or_else(|| cleaned.strip_prefix("0O"))
+        {
+            i64::from_str_radix(oct, 8)
+        } else if let Some(bin) = cleaned
+            .strip_prefix("0b")
+            .or_else(|| cleaned.strip_prefix("0B"))
+        {
+            i64::from_str_radix(bin, 2)
+        } else {
+            cleaned.parse()
+        }
+        .map_err(|_| ParseError {
+            message: format!("invalid integer attribute value: {repr}"),
+            span,
+        })?;
+        let v = if negate { -n } else { n };
+        Ok(crate::ast::AttrValue::Int(v))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4795,7 +4936,7 @@ mod tests {
             assert_eq!(use_decl.source, "wasi:cli");
             assert!(use_decl.attributes.is_some());
             let attrs = use_decl.attributes.as_ref().unwrap();
-            assert_eq!(attrs.version, Some("0.3.0".to_string()));
+            assert_eq!(attrs.version(), Some("0.3.0".to_string()));
         } else {
             panic!("expected use declaration");
         }

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -182,6 +182,10 @@ pub struct Resolver<'a, H: CompilerHost> {
     /// preserves the callee's lexical scope for defaults that reference
     /// module-private items (see WEP 2026-04-11).
     pub(super) default_scope_module: Option<ModuleSource>,
+    /// Kiln invocation redirects consulted by `use` resolution sites. Shared
+    /// by `Rc` so per-module Resolver instances can read the single
+    /// compilation-unit-wide redirect map cheaply.
+    pub(super) invocations: Rc<crate::kiln::InvocationIndex>,
 }
 
 impl<'a, H: CompilerHost> Resolver<'a, H> {
@@ -247,6 +251,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             references: Rc::new(RefCell::new(IndexMap::default())),
             local_symbols: Rc::new(RefCell::new(IndexMap::default())),
             default_scope_module: None,
+            invocations: Rc::new(crate::kiln::InvocationIndex::new()),
         }
     }
 
@@ -406,12 +411,18 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
     fn build_effect_sources(
         module: &Module,
         module_source: &ModuleSource,
+        invocations: &crate::kiln::InvocationIndex,
     ) -> IndexMap<String, ModuleSource> {
         let mut sources = IndexMap::default();
         for item in &module.items {
             match item {
                 Item::Use(use_decl) => {
-                    let source = name::resolve_import(module_source, &use_decl.source);
+                    let source = name::resolve_import_with_invocations(
+                        module_source,
+                        &use_decl.source,
+                        None,
+                        invocations,
+                    );
                     for use_item in &use_decl.items {
                         match use_item {
                             ast::UseItem::EffectFunctions { effect_name, .. } => {
@@ -488,10 +499,11 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
     fn record_use_specifier_references(&self, module: &Module) {
         for item in &module.items {
             let Item::Use(use_decl) = item else { continue };
-            let source = name::resolve_import_with_entry(
+            let source = name::resolve_import_with_invocations(
                 &self.current_module_source,
                 &use_decl.source,
                 Some(&self.entry_module_source),
+                &self.invocations,
             );
             for use_item in &use_decl.items {
                 match use_item {
@@ -523,7 +535,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         // Clear trait lookup caches (current_module_items changed)
         self.indexing_trait_cache.clear();
         // Build effect source map from imports
-        self.effect_sources = Self::build_effect_sources(module, &module_source);
+        self.effect_sources = Self::build_effect_sources(module, &module_source, &self.invocations);
 
         // Record use→def edges for names that appear inside `use { ... }` specifiers.
         // These power LSP jump-to-definition when the cursor is on an imported
@@ -556,7 +568,12 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         // Also collect imported globals from use declarations
         for item in &module.items {
             if let Item::Use(use_decl) = item {
-                let source_module_source = name::resolve_import(&module_source, &use_decl.source);
+                let source_module_source = name::resolve_import_with_invocations(
+                    &module_source,
+                    &use_decl.source,
+                    None,
+                    &self.invocations,
+                );
 
                 // Look up the source module to find global declarations
                 if let Some(source_module) = self.loaded_modules.get(&source_module_source) {

--- a/wado-compiler/src/resolver/call.rs
+++ b/wado-compiler/src/resolver/call.rs
@@ -1011,6 +1011,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             m,
                             callee_module,
                             Some(&self.entry_module_source),
+                            &self.invocations,
                         )
                     },
                 );
@@ -1442,6 +1443,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                     module,
                                     &src,
                                     Some(&self.entry_module_source),
+                                    &self.invocations,
                                 )
                             } else {
                                 (IndexMap::default(), IndexMap::default())

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -77,6 +77,9 @@ pub(crate) struct AnnotateState {
     /// parameters). Keyed by the binding's defining [`SymbolKey`]. Populated
     /// alongside [`Self::references`] as the resolver walks function bodies.
     pub(crate) local_symbols: Rc<RefCell<IndexMap<SymbolKey, Symbol>>>,
+    /// Kiln invocation redirects consulted by `resolve_import` call sites
+    /// when walking `use` declarations. Populated from [`crate::loader::LoadResult`].
+    pub(crate) invocations: Rc<crate::kiln::InvocationIndex>,
 }
 
 impl<'a, H: CompilerHost> Resolver<'a, H> {
@@ -91,8 +94,10 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         entry_module_source: ModuleSource,
         logger: &'a Logger<'a, H>,
         included_files: &'a IndexMap<[String; 2], Vec<u8>>,
+        invocations: crate::kiln::InvocationIndex,
     ) -> Result<IndexMap<ModuleSource, TirModule>, Bail> {
-        let state = Self::annotate_modules(symbols, modules, &entry_module_source, logger)?;
+        let state =
+            Self::annotate_modules(symbols, modules, &entry_module_source, logger, invocations)?;
         Self::lower_tir_from_state(
             &state,
             symbols,
@@ -112,7 +117,9 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         modules: &'a IndexMap<ModuleSource, Module>,
         entry_module_source: &ModuleSource,
         logger: &'a Logger<'a, H>,
+        invocations: crate::kiln::InvocationIndex,
     ) -> Result<AnnotateState, Bail> {
+        let invocations = Rc::new(invocations);
         // Create a shared type table wrapped in Rc<RefCell<>> for cross-module sharing
         let type_table = Rc::new(RefCell::new(TypeTable::new()));
         let mut all_newtypes: IndexMap<ModuleSource, IndexMap<String, TypeId>> =
@@ -258,8 +265,12 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         // Second sub-pass: resolve struct fields and newtypes
         for (module_source, module) in modules {
             // Build imported type sources for this module
-            let (imported_type_sources, import_original_names) =
-                Self::build_imported_type_sources(module, module_source, Some(entry_module_source));
+            let (imported_type_sources, import_original_names) = Self::build_imported_type_sources(
+                module,
+                module_source,
+                Some(entry_module_source),
+                &invocations,
+            );
 
             // Build module-specific flat maps for resolving types in this module
             let mut flat_newtypes = Self::build_module_map(
@@ -682,6 +693,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             all_module_func_indices,
             references: Rc::new(RefCell::new(IndexMap::default())),
             local_symbols: Rc::new(RefCell::new(IndexMap::default())),
+            invocations,
         })
     }
 
@@ -710,6 +722,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 module,
                 module_source,
                 Some(&entry_module_source),
+                &state.invocations,
             );
             let newtypes = Self::build_module_map(
                 &state.all_newtypes,
@@ -802,10 +815,11 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             }
                             crate::ast::UseItem::Namespace { name } => {
                                 // Namespace import: all symbols from source module are available
-                                let source = crate::name::resolve_import_with_entry(
+                                let source = crate::name::resolve_import_with_invocations(
                                     module_source,
                                     &use_decl.source,
                                     Some(&entry_module_source),
+                                    &state.invocations,
                                 );
                                 for sym in symbols.get_module_symbols(&source) {
                                     imported_functions.insert(sym.name.clone());
@@ -872,6 +886,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 references: Rc::clone(&state.references),
                 local_symbols: Rc::clone(&state.local_symbols),
                 default_scope_module: None,
+                invocations: Rc::clone(&state.invocations),
             };
             // known_type_names_cache is pre-computed globally; no per-module rebuild needed
 
@@ -1042,13 +1057,18 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         module: &Module,
         from_module: &ModuleSource,
         entry_module: Option<&ModuleSource>,
+        invocations: &crate::kiln::InvocationIndex,
     ) -> (IndexMap<String, ModuleSource>, IndexMap<String, String>) {
         let mut sources = IndexMap::default();
         let mut original_names = IndexMap::default();
         for item in &module.items {
             if let Item::Use(use_decl) = item {
-                let source =
-                    name::resolve_import_with_entry(from_module, &use_decl.source, entry_module);
+                let source = name::resolve_import_with_invocations(
+                    from_module,
+                    &use_decl.source,
+                    entry_module,
+                    invocations,
+                );
                 for use_item in &use_decl.items {
                     match use_item {
                         ast::UseItem::Simple { name, alias, .. } => {
@@ -1085,6 +1105,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             module,
             module_source,
             Some(&self.entry_module_source),
+            &self.invocations,
         );
         let maps = ModuleTypeMaps {
             struct_fields: Self::build_module_map(

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -267,20 +267,65 @@ impl<'a> Unparser<'a> {
     }
 
     fn unparse_import_attributes(&mut self, attrs: &ImportAttributes) {
-        let mut parts = Vec::new();
-        if let Some(v) = &attrs.version {
-            parts.push(format!("version: \"{v}\""));
+        if attrs.entries.is_empty() {
+            return;
         }
-        if let Some(t) = &attrs.type_hint {
-            parts.push(format!("type: \"{t}\""));
+        self.output.push_str(" with { ");
+        let mut first = true;
+        for (k, v) in &attrs.entries {
+            if !first {
+                self.output.push_str(", ");
+            }
+            first = false;
+            self.output.push_str(k);
+            self.output.push_str(": ");
+            self.unparse_attr_value(v);
         }
-        if let Some(i) = &attrs.integrity {
-            parts.push(format!("integrity: \"{i}\""));
-        }
-        if !parts.is_empty() {
-            self.output.push_str(" with { ");
-            self.output.push_str(&parts.join(", "));
-            self.output.push_str(" }");
+        self.output.push_str(" }");
+    }
+
+    fn unparse_attr_value(&mut self, v: &crate::ast::AttrValue) {
+        match v {
+            crate::ast::AttrValue::String(s) => {
+                self.output.push('"');
+                self.output.push_str(s);
+                self.output.push('"');
+            }
+            crate::ast::AttrValue::Int(n) => {
+                self.output.push_str(&n.to_string());
+            }
+            crate::ast::AttrValue::Float(f) => {
+                let s = format!("{f}");
+                self.output.push_str(&s);
+                if !s.contains('.') && !s.contains('e') && !s.contains('E') {
+                    self.output.push_str(".0");
+                }
+            }
+            crate::ast::AttrValue::Bool(b) => {
+                self.output.push_str(if *b { "true" } else { "false" });
+            }
+            crate::ast::AttrValue::Array(items) => {
+                self.output.push('[');
+                for (i, item) in items.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(", ");
+                    }
+                    self.unparse_attr_value(item);
+                }
+                self.output.push(']');
+            }
+            crate::ast::AttrValue::Object(obj) => {
+                self.output.push_str("{ ");
+                for (i, (k, v)) in obj.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(", ");
+                    }
+                    self.output.push_str(k);
+                    self.output.push_str(": ");
+                    self.unparse_attr_value(v);
+                }
+                self.output.push_str(" }");
+            }
         }
     }
 

--- a/wado-compiler/tests/kiln_loader_redirect.rs
+++ b/wado-compiler/tests/kiln_loader_redirect.rs
@@ -1,0 +1,121 @@
+//! Test that the loader's Kiln invocation redirect correctly rewrites a
+//! `use { X } from "<schema>"` clause to the generator's emitted entry
+//! module.
+
+#![allow(unused_crate_dependencies)]
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use wado_compiler::{
+    CompilerHost, Diagnostic, ModuleSource, SourceError, annotate_with_invocations,
+    kiln::InvocationIndex,
+};
+
+struct MapHost {
+    sources: HashMap<String, String>,
+    diagnostics: Mutex<Vec<Diagnostic>>,
+}
+
+impl MapHost {
+    fn new(sources: &[(&str, &str)]) -> Self {
+        Self {
+            sources: sources
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect(),
+            diagnostics: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl CompilerHost for MapHost {
+    fn load_source(
+        &self,
+        path: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<u8>, SourceError>> + Send {
+        let result = self.sources.get(path).cloned();
+        let path = path.to_string();
+        async move {
+            match result {
+                Some(s) => Ok(s.into_bytes()),
+                None => Err(SourceError::NotFound { path }),
+            }
+        }
+    }
+
+    fn emit_diagnostic(&self, diagnostic: Diagnostic) {
+        self.diagnostics.lock().unwrap().push(diagnostic);
+    }
+}
+
+fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    tokio::runtime::Runtime::new().unwrap().block_on(future)
+}
+
+#[test]
+fn invocation_index_redirects_use_from_schema_to_generated_entry() {
+    let entry = r#"
+use { greet } from "./sample.proto";
+
+export fn run() {
+    greet();
+}
+"#;
+    let generated = r#"
+pub fn greet() {}
+"#;
+    let host = MapHost::new(&[("build/kiln/test-invocation/sample.wado", generated)]);
+
+    let mut idx = InvocationIndex::new();
+    idx.insert(
+        "entry.wado",
+        "./sample.proto",
+        "build/kiln/test-invocation/sample.wado",
+    );
+
+    let annotated = match block_on(annotate_with_invocations(
+        entry,
+        &host,
+        Some("entry.wado"),
+        idx,
+    )) {
+        Ok(a) => a,
+        Err(_) => {
+            let diags = host.diagnostics.lock().unwrap().clone();
+            panic!(
+                "annotate failed; diagnostics: {:#?}",
+                diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+            );
+        }
+    };
+
+    let redirected = ModuleSource::Local {
+        path: "build/kiln/test-invocation/sample.wado".to_string(),
+    };
+    assert!(
+        annotated.modules.contains_key(&redirected),
+        "loader should have loaded the generated entry module, got: {:?}",
+        annotated.modules.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn empty_invocation_index_preserves_default_resolution() {
+    let entry = r#"
+export fn run() {}
+"#;
+    let host = MapHost::new(&[]);
+    let idx = InvocationIndex::new();
+    let annotated = block_on(annotate_with_invocations(
+        entry,
+        &host,
+        Some("entry.wado"),
+        idx,
+    ))
+    .unwrap();
+    let entry_ms = ModuleSource::EntryPoint {
+        filename: "entry.wado".to_string(),
+    };
+    assert!(annotated.modules.contains_key(&entry_ms));
+}

--- a/wado-compiler/tests/kiln_loader_redirect.rs
+++ b/wado-compiler/tests/kiln_loader_redirect.rs
@@ -62,9 +62,9 @@ export fn run() {
     greet();
 }
 "#;
-    let generated = r#"
+    let generated = r"
 pub fn greet() {}
-"#;
+";
     let host = MapHost::new(&[("build/kiln/test-invocation/sample.wado", generated)]);
 
     let mut idx = InvocationIndex::new();
@@ -74,20 +74,19 @@ pub fn greet() {}
         "build/kiln/test-invocation/sample.wado",
     );
 
-    let annotated = match block_on(annotate_with_invocations(
+    let annotated = if let Ok(a) = block_on(annotate_with_invocations(
         entry,
         &host,
         Some("entry.wado"),
         idx,
     )) {
-        Ok(a) => a,
-        Err(_) => {
-            let diags = host.diagnostics.lock().unwrap().clone();
-            panic!(
-                "annotate failed; diagnostics: {:#?}",
-                diags.iter().map(|d| &d.message).collect::<Vec<_>>()
-            );
-        }
+        a
+    } else {
+        let diags = host.diagnostics.lock().unwrap().clone();
+        panic!(
+            "annotate failed; diagnostics: {:#?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
     };
 
     let redirected = ModuleSource::Local {
@@ -102,9 +101,9 @@ pub fn greet() {}
 
 #[test]
 fn empty_invocation_index_preserves_default_resolution() {
-    let entry = r#"
+    let entry = r"
 export fn run() {}
-"#;
+";
     let host = MapHost::new(&[]);
     let idx = InvocationIndex::new();
     let annotated = block_on(annotate_with_invocations(

--- a/wado-compiler/tests/kiln_options.rs
+++ b/wado-compiler/tests/kiln_options.rs
@@ -21,7 +21,7 @@ fn entry() -> ModuleSource {
 
 #[test]
 fn descriptor_primitive_fields_and_defaults() {
-    let source = r#"
+    let source = r"
 pub struct Options {
     pub highlight: bool = false,
     pub depth: i32 = 3,
@@ -29,7 +29,7 @@ pub struct Options {
 }
 
 pub fn generate() {}
-"#;
+";
     let host = InMemoryHost::new();
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
     let desc = extract_options_descriptor(&annotated, &entry()).unwrap();
@@ -50,13 +50,13 @@ pub fn generate() {}
 
 #[test]
 fn descriptor_option_string_accepts_null_default() {
-    let source = r#"
+    let source = r"
 pub struct Options {
     pub rule: Option<String> = null,
 }
 
 pub fn generate() {}
-"#;
+";
     let host = InMemoryHost::new();
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
     let desc = extract_options_descriptor(&annotated, &entry()).unwrap();
@@ -70,7 +70,7 @@ pub fn generate() {}
 
 #[test]
 fn descriptor_enum_field_extracts_variants() {
-    let source = r#"
+    let source = r"
 pub enum Style {
     Rpc,
     Oneway,
@@ -81,7 +81,7 @@ pub struct Options {
 }
 
 pub fn generate() {}
-"#;
+";
     let host = InMemoryHost::new();
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
     let desc = extract_options_descriptor(&annotated, &entry()).unwrap();
@@ -101,7 +101,7 @@ pub fn generate() {}
 
 #[test]
 fn descriptor_nested_struct_descends_and_cycles_reject() {
-    let source = r#"
+    let source = r"
 pub struct Inner {
     pub flag: bool = true,
     pub count: i64 = 7,
@@ -112,7 +112,7 @@ pub struct Options {
 }
 
 pub fn generate() {}
-"#;
+";
     let host = InMemoryHost::new();
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
     let desc = extract_options_descriptor(&annotated, &entry()).unwrap();
@@ -134,9 +134,9 @@ pub fn generate() {}
 
 #[test]
 fn descriptor_missing_options_struct_errors() {
-    let source = r#"
+    let source = r"
 pub fn generate() {}
-"#;
+";
     let host = InMemoryHost::new();
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
     let err = extract_options_descriptor(&annotated, &entry()).unwrap_err();
@@ -148,11 +148,11 @@ pub fn generate() {}
 
 #[test]
 fn descriptor_missing_generate_fn_errors() {
-    let source = r#"
+    let source = r"
 pub struct Options {
     pub foo: bool = false,
 }
-"#;
+";
     let host = InMemoryHost::new();
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
     let err = extract_options_descriptor(&annotated, &entry()).unwrap_err();

--- a/wado-compiler/tests/kiln_options.rs
+++ b/wado-compiler/tests/kiln_options.rs
@@ -1,0 +1,163 @@
+//! Tests for [`wado_compiler::kiln::extract_options_descriptor`].
+
+#![allow(unused_crate_dependencies)]
+
+mod common;
+
+use common::InMemoryHost;
+use wado_compiler::ModuleSource;
+use wado_compiler::annotate;
+use wado_compiler::kiln::{CanonicalValue, OptionsType, extract_options_descriptor};
+
+fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    tokio::runtime::Runtime::new().unwrap().block_on(future)
+}
+
+fn entry() -> ModuleSource {
+    ModuleSource::EntryPoint {
+        filename: "entry.wado".to_string(),
+    }
+}
+
+#[test]
+fn descriptor_primitive_fields_and_defaults() {
+    let source = r#"
+pub struct Options {
+    pub highlight: bool = false,
+    pub depth: i32 = 3,
+    pub name: String,
+}
+
+pub fn generate() {}
+"#;
+    let host = InMemoryHost::new();
+    let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
+    let desc = extract_options_descriptor(&annotated, &entry()).unwrap();
+    assert_eq!(desc.fields.len(), 3);
+
+    assert_eq!(desc.fields[0].name, "highlight");
+    assert!(matches!(desc.fields[0].ty, OptionsType::Bool));
+    assert_eq!(desc.fields[0].default, Some(CanonicalValue::Bool(false)));
+
+    assert_eq!(desc.fields[1].name, "depth");
+    assert!(matches!(desc.fields[1].ty, OptionsType::I32));
+    assert_eq!(desc.fields[1].default, Some(CanonicalValue::I64(3)));
+
+    assert_eq!(desc.fields[2].name, "name");
+    assert!(matches!(desc.fields[2].ty, OptionsType::String));
+    assert!(desc.fields[2].default.is_none());
+}
+
+#[test]
+fn descriptor_option_string_accepts_null_default() {
+    let source = r#"
+pub struct Options {
+    pub rule: Option<String> = null,
+}
+
+pub fn generate() {}
+"#;
+    let host = InMemoryHost::new();
+    let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
+    let desc = extract_options_descriptor(&annotated, &entry()).unwrap();
+    assert_eq!(desc.fields.len(), 1);
+    match &desc.fields[0].ty {
+        OptionsType::Option(inner) => assert!(matches!(inner.as_ref(), OptionsType::String)),
+        other => panic!("expected Option<String>, got {other:?}"),
+    }
+    assert_eq!(desc.fields[0].default, Some(CanonicalValue::None));
+}
+
+#[test]
+fn descriptor_enum_field_extracts_variants() {
+    let source = r#"
+pub enum Style {
+    Rpc,
+    Oneway,
+}
+
+pub struct Options {
+    pub style: Style = Style::Rpc,
+}
+
+pub fn generate() {}
+"#;
+    let host = InMemoryHost::new();
+    let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
+    let desc = extract_options_descriptor(&annotated, &entry()).unwrap();
+    assert_eq!(desc.fields.len(), 1);
+    match &desc.fields[0].ty {
+        OptionsType::Enum { name, variants } => {
+            assert_eq!(name, "Style");
+            assert_eq!(variants, &["Rpc".to_string(), "Oneway".to_string()]);
+        }
+        other => panic!("expected Enum, got {other:?}"),
+    }
+    assert_eq!(
+        desc.fields[0].default,
+        Some(CanonicalValue::Enum("Rpc".to_string()))
+    );
+}
+
+#[test]
+fn descriptor_nested_struct_descends_and_cycles_reject() {
+    let source = r#"
+pub struct Inner {
+    pub flag: bool = true,
+    pub count: i64 = 7,
+}
+
+pub struct Options {
+    pub inner: Inner,
+}
+
+pub fn generate() {}
+"#;
+    let host = InMemoryHost::new();
+    let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
+    let desc = extract_options_descriptor(&annotated, &entry()).unwrap();
+    assert_eq!(desc.fields.len(), 1);
+    let OptionsType::Struct { name, descriptor } = &desc.fields[0].ty else {
+        panic!("expected nested Struct field");
+    };
+    assert_eq!(name, "Inner");
+    assert_eq!(descriptor.fields.len(), 2);
+    assert_eq!(descriptor.fields[0].name, "flag");
+    assert!(matches!(descriptor.fields[0].ty, OptionsType::Bool));
+    assert_eq!(
+        descriptor.fields[0].default,
+        Some(CanonicalValue::Bool(true))
+    );
+    assert_eq!(descriptor.fields[1].name, "count");
+    assert_eq!(descriptor.fields[1].default, Some(CanonicalValue::I64(7)));
+}
+
+#[test]
+fn descriptor_missing_options_struct_errors() {
+    let source = r#"
+pub fn generate() {}
+"#;
+    let host = InMemoryHost::new();
+    let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
+    let err = extract_options_descriptor(&annotated, &entry()).unwrap_err();
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("does not declare `pub struct Options`"))
+    );
+}
+
+#[test]
+fn descriptor_missing_generate_fn_errors() {
+    let source = r#"
+pub struct Options {
+    pub foo: bool = false,
+}
+"#;
+    let host = InMemoryHost::new();
+    let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
+    let err = extract_options_descriptor(&annotated, &entry()).unwrap_err();
+    assert!(
+        err.iter()
+            .any(|d| d.message.contains("does not declare `generate` function"))
+    );
+}

--- a/wado-manifest/src/manifest.rs
+++ b/wado-manifest/src/manifest.rs
@@ -62,6 +62,10 @@ pub struct Package {
     pub command: Option<String>,
     pub service: Option<String>,
     pub lib: Option<String>,
+    /// `build-world = "..."` — opts the package into a Wado-authored host
+    /// contract. When set to `"wado:kiln/generator"`, the package is treated
+    /// as a Kiln generator (see WEP 2026-04-12).
+    pub build_world: Option<String>,
 }
 
 /// The `[workspace]` section of `wado.toml`.
@@ -169,6 +173,8 @@ pub enum ManifestError {
     InvalidGeneratorFrom { invocation: String, reason: String },
     /// `module = "ns:name@ver"` does not match any `[build-dependencies]` entry.
     UnknownGeneratorModule { invocation: String, spec: String },
+    /// `package.build-world` is set to an unknown value.
+    InvalidBuildWorld { value: String },
 }
 
 impl fmt::Display for ManifestError {
@@ -232,6 +238,10 @@ impl fmt::Display for ManifestError {
                 f,
                 "[build.generators.{invocation}] module {spec:?} is not declared in [build-dependencies]"
             ),
+            ManifestError::InvalidBuildWorld { value } => write!(
+                f,
+                "package.build-world {value:?} is not supported (expected \"wado:kiln/generator\")"
+            ),
         }
     }
 }
@@ -289,6 +299,8 @@ struct RawPackage {
     command: Option<String>,
     service: Option<String>,
     lib: Option<String>,
+    #[serde(rename = "build-world")]
+    build_world: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -377,6 +389,7 @@ fn convert_package(raw: RawPackage) -> Result<Package, ManifestError> {
         command: raw.command,
         service: raw.service,
         lib: raw.lib,
+        build_world: raw.build_world,
     })
 }
 

--- a/wado-manifest/src/validate.rs
+++ b/wado-manifest/src/validate.rs
@@ -30,6 +30,13 @@ fn validate_package(pkg: &crate::manifest::Package) -> Result<(), ManifestError>
         version: pkg.version.clone(),
         reason: e.to_string(),
     })?;
+    if let Some(world) = &pkg.build_world {
+        if world != "wado:kiln/generator" {
+            return Err(ManifestError::InvalidBuildWorld {
+                value: world.clone(),
+            });
+        }
+    }
     Ok(())
 }
 

--- a/wado-manifest/src/validate.rs
+++ b/wado-manifest/src/validate.rs
@@ -30,12 +30,12 @@ fn validate_package(pkg: &crate::manifest::Package) -> Result<(), ManifestError>
         version: pkg.version.clone(),
         reason: e.to_string(),
     })?;
-    if let Some(world) = &pkg.build_world {
-        if world != "wado:kiln/generator" {
-            return Err(ManifestError::InvalidBuildWorld {
-                value: world.clone(),
-            });
-        }
+    if let Some(world) = &pkg.build_world
+        && world != "wado:kiln/generator"
+    {
+        return Err(ManifestError::InvalidBuildWorld {
+            value: world.clone(),
+        });
     }
     Ok(())
 }

--- a/wado-manifest/tests/manifest.rs
+++ b/wado-manifest/tests/manifest.rs
@@ -113,6 +113,48 @@ default = "https://wa.dev"
 }
 
 #[test]
+fn build_world_absent_default() {
+    let toml = r#"
+[package]
+name = "app"
+version = "0.1.0"
+command = "main.wado"
+"#;
+    let m: Manifest = toml.parse().unwrap();
+    assert!(m.package.as_ref().unwrap().build_world.is_none());
+}
+
+#[test]
+fn build_world_kiln_generator_accepted() {
+    let toml = r#"
+[package]
+name = "gen"
+version = "0.1.0"
+build-world = "wado:kiln/generator"
+"#;
+    let m: Manifest = toml.parse().unwrap();
+    assert_eq!(
+        m.package.as_ref().unwrap().build_world.as_deref(),
+        Some("wado:kiln/generator")
+    );
+}
+
+#[test]
+fn build_world_unknown_rejected() {
+    let toml = r#"
+[package]
+name = "gen"
+version = "0.1.0"
+build-world = "wasi:cli/command"
+"#;
+    let err = toml.parse::<Manifest>().unwrap_err();
+    assert!(matches!(
+        err,
+        ManifestError::InvalidBuildWorld { value } if value == "wasi:cli/command"
+    ));
+}
+
+#[test]
 fn missing_package_name() {
     let toml = r#"
 [package]


### PR DESCRIPTION
Continues WEP-2026-04-12 (Kiln) on top of the M3 landing in #897. Picks up M4–M7 with the M6 Gale migration intentionally deferred to a follow-up PR (see updated WEP Milestones section).

## Summary

- **M4 — Typed `Options` extraction.** New `wado-compiler/src/kiln/{options,options_check}.rs` extract an `OptionsDescriptor` from the generator's `pub struct Options` (TIR), validate caller-supplied tables, and feed `encode_options_canonical` so the cache key is byte-identical with the M3 provisional encoder for inputs expressible under both. `wado-manifest` gains the `[package].build-world` field, validated to `wado:kiln/generator` in v1.
- **M5 — Inline `use ... from "<schema>" with { generator: { ... } }`.** `ImportAttributes` is now backed by a generic `AttrValue` tree (`String|Int|Bool|Array|Object`); thin accessors keep the existing `version`/`integrity`/`type_hint` callers compiling. Parser/unparser round-trip nested objects. `wado-compiler/src/kiln/inline.rs` synthesizes anonymous invocations, dedups identical ones, and reports per-`from` conflicts.
- **M6 — `InvocationIndex` resolver redirect + driver hook (skeleton).** `Annotated` carries an `InvocationIndex` from `(declaring_file, from_path)` to the entry `ModuleSource` of the invocation's output dir. `name::resolve_import` consults it before scheme-based resolution. `wado-cli/src/compile.rs` now loads the manifest, collects inline invocations, and calls `kiln_driver::run_pipeline` (replaces both `TODO(M6)` stubs). `wado-cli/src/kiln_provider.rs` is the first `GeneratorProvider` impl; `Path`/`Workspace` sources work, `Registry`/`Git` surface `ProviderError::UnsupportedSource`. **Gale itself is not yet exporting `wado:kiln/generator`** — that part of M6 is deferred per the WEP Milestones update in this PR.
- **M7 — Consume-only pipeline branch.** When `run_generator` returns `Unsupported`, the cache check runs first; on hit we proceed silently, on miss we emit a `KilnStaleCache` warning and leave both `wado.lock` and `build/kiln/` untouched. No LSP wiring yet — that's M7's remaining piece.

## Test plan

- [x] `cargo check -p wado-compiler --target wasm32-unknown-unknown` — green (the hard invariant).
- [x] `cargo test -p wado-compiler --lib` — 398 passed.
- [x] `cargo test -p wado-compiler --test kiln_options` — 6 passed (descriptor + validate).
- [x] `cargo test -p wado-compiler --test kiln_loader_redirect` — 2 passed (resolver redirect via `InvocationIndex`).
- [x] `cargo test -p wado-cli --lib` — 67 passed.
- [x] `cargo test -p wado-cli --test kiln_pipeline` — 6 passed.
- [x] `cargo test -p wado-manifest` — 49 + 8 + 18 passed across binaries (round-trips `build-world`).
- [x] `cargo clippy --workspace --tests` — clean.
- [x] `cargo fmt --all` — clean.
- [ ] `mise run test-wado` — not run locally (no behaviour change to Wado-side fixtures expected).

## Deferred to follow-up PR

Tracked in `docs/wep-2026-04-12-kiln.md` Milestones section (commit `0734b67`):

- **M6**: `package-gale` exporting `wado:kiln/generator`, `kiln-consumer` fixture, end-to-end `wado compile` test against the existing Gale golden, retirement of `mise run update-gale-golden`.
- **M7**: `wado-lsp` calling `run_pipeline` on workspace open + LSP-side `kiln_consume_only` test.