### PR TITLE
fix(compiler): key WASI type lookups by (source_interface, name) to eliminate bare-name collisions

### DIFF
--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -288,10 +288,7 @@ pub struct WasiRegistry {
     /// `(cm_name, fields with CM names, fields with Wado names)`.
     /// Fields: Vec<(`cm_field_name`, `field_type`)>
     /// Wado fields: Vec<(`wado_field_name`, `cm_field_name`, `field_type`)>
-    structs: IndexMap<
-        (String, String),
-        (String, Vec<(String, Type)>, Vec<(String, String, Type)>),
-    >,
+    structs: IndexMap<(String, String), (String, Vec<(String, Type)>, Vec<(String, String, Type)>)>,
 }
 
 /// Insert into a `(source_interface, name)`-keyed map, panicking on duplicate
@@ -306,13 +303,13 @@ fn register_unique<V>(
     value: V,
 ) {
     let key = (source_interface, name);
-    if map.contains_key(&key) {
-        panic!(
-            "WasiRegistry: duplicate {kind} registration for `{}` in interface `{}`. \
-             Each (interface, name) pair must be registered exactly once.",
-            key.1, key.0,
-        );
-    }
+    assert!(
+        !map.contains_key(&key),
+        "WasiRegistry: duplicate {kind} registration for `{}` in interface `{}`. \
+         Each (interface, name) pair must be registered exactly once.",
+        key.1,
+        key.0,
+    );
     map.insert(key, value);
 }
 
@@ -1011,8 +1008,7 @@ impl WasiRegistry {
             .chain(self.flags.keys())
             .map(|(_, n)| n.as_str())
             .collect();
-        let resources: IndexSet<&str> =
-            self.resources.keys().map(|(_, n)| n.as_str()).collect();
+        let resources: IndexSet<&str> = self.resources.keys().map(|(_, n)| n.as_str()).collect();
         let structs: IndexSet<&str> = self.structs.keys().map(|(_, n)| n.as_str()).collect();
 
         // Check all parameter types

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -365,6 +365,18 @@ impl WasiRegistry {
         Collision::Accept
     }
 
+    /// Return the canonical source interface that first registered
+    /// `(kind, name)`, e.g. `"wasi:filesystem/types@0.3.0-rc-2026-03-15"`.
+    ///
+    /// `kind` is one of `"variants"`, `"enums"`, `"resources"`, `"structs"`,
+    /// `"flags"`, or `"newtypes"`. Returns `None` when the pair was never
+    /// registered or when it was registered without a `#[cm(...)]` attribute.
+    pub fn bare_name_owner(&self, kind: &str, name: &str) -> Option<&str> {
+        self.name_owner
+            .get(&(kind.to_string(), name.to_string()))
+            .map(String::as_str)
+    }
+
     /// Extract the source interface (the part before the `#` fragment,
     /// e.g. `"wasi:cli/stdout@0.3.0-rc-2026-03-15"`) from the
     /// first `#[cm("...")]` attribute on a stdlib item. Returns an

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -258,64 +258,107 @@ pub struct WasiRegistry {
     /// Track which WASI function names are used to detect collisions
     used_names: BTreeSet<String>,
 
-    /// Newtypes collected from WASI modules (e.g., Instant -> u64)
-    newtypes: IndexMap<String, Type>,
+    /// Newtypes collected from WASI modules (e.g., Instant -> u64).
+    /// Key: `(source_interface, wado_name)` where `source_interface` is the
+    /// `#[cm("...")]` fragment before the `#` (e.g.
+    /// `"wasi:clocks/types@0.3.0-rc-2026-03-15"`). Keying by interface makes
+    /// same-named types from distinct interfaces structurally distinct.
+    newtypes: IndexMap<(String, String), Type>,
 
-    /// Resource types collected from WASI modules (e.g., `TerminalInput`, `TerminalOutput`)
-    /// Maps resource name -> (CM resource name kebab-case, source interface path)
-    /// e.g., "`TerminalInput`" -> ("terminal-input", "wasi:cli/terminal-input@0.3.0-rc-2026-01-06")
-    resources: IndexMap<String, (String, String)>,
+    /// Resource types collected from WASI modules (e.g., `TerminalInput`).
+    /// Key: `(source_interface, wado_name)`. Value: CM kebab-case name.
+    resources: IndexMap<(String, String), String>,
 
-    /// Flags types collected from WASI modules (e.g., `PathFlags`, `OpenFlags`)
-    /// Maps Wado flags name -> (CM flags name kebab-case, member names in kebab-case)
-    flags: IndexMap<String, (String, Vec<String>)>,
+    /// Flags types collected from WASI modules (e.g., `PathFlags`, `OpenFlags`).
+    /// Key: `(source_interface, wado_name)`. Value:
+    /// `(cm_name, member names in kebab-case)`.
+    flags: IndexMap<(String, String), (String, Vec<String>)>,
 
-    /// Enum types collected from WASI modules (e.g., `ErrorCode`, `IpAddressFamily`)
-    /// Maps Wado enum name -> (CM enum name kebab-case, variant names in kebab-case)
-    enums: IndexMap<String, (String, Vec<String>)>,
+    /// Enum types collected from WASI modules (e.g., `ErrorCode`, `IpAddressFamily`).
+    /// Key: `(source_interface, wado_name)`. Value:
+    /// `(cm_name, variant names in kebab-case)`.
+    enums: IndexMap<(String, String), (String, Vec<String>)>,
 
-    /// Variant types collected from WASI modules (e.g., `HeaderError`)
-    /// Maps Wado variant name -> (CM variant name, cases)
-    variants: IndexMap<String, (String, Vec<CmVariantCase>)>,
+    /// Variant types collected from WASI modules (e.g., `HeaderError`).
+    /// Key: `(source_interface, wado_name)`. Value: `(cm_name, cases)`.
+    variants: IndexMap<(String, String), (String, Vec<CmVariantCase>)>,
 
-    /// Struct types collected from WASI modules (e.g., `DnsErrorPayload`)
-    /// Maps Wado struct name -> (CM record name kebab-case, source interface path, fields with CM names, fields with Wado names)
+    /// Struct types collected from WASI modules (e.g., `DnsErrorPayload`).
+    /// Key: `(source_interface, wado_name)`. Value:
+    /// `(cm_name, fields with CM names, fields with Wado names)`.
     /// Fields: Vec<(`cm_field_name`, `field_type`)>
     /// Wado fields: Vec<(`wado_field_name`, `cm_field_name`, `field_type`)>
-    /// Tracks which `(type_kind, bare_name)` was first registered from
-    /// which source interface. Used by `register_module` to panic on
-    /// silent overwrites between same-named types from different
-    /// modules. Without this, a second registration would shadow the
-    /// first (e.g. registering `core:kiln/types::Response` after
-    /// `wasi:http/types::Response` would corrupt CM codegen for HTTP
-    /// types). The proper fix — making every map source-aware and
-    /// migrating the ~128 lookup callers — is tracked separately;
-    /// this assertion converts the silent corruption into a loud
-    /// build failure at the moment of collision.
-    /// See `tests/fixtures/cross_module_same_name_*` for regression
-    /// fixtures.
-    name_owner: IndexMap<(String, String), String>,
     structs: IndexMap<
-        String,
-        (
-            String,
-            String,
-            Vec<(String, Type)>,
-            Vec<(String, String, Type)>,
-        ),
+        (String, String),
+        (String, Vec<(String, Type)>, Vec<(String, String, Type)>),
     >,
 }
 
-/// Outcome of a `WasiRegistry::check_collision` probe.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Collision {
-    /// First registration for this `(kind, name)`, or a re-registration
-    /// from the same source — caller should perform the bare-name insert.
-    Accept,
-    /// Different source already registered — caller should skip the bare-name
-    /// insert to preserve the first registrant. The duplicate is still
-    /// reachable via the dual-storage source-disambiguated key.
-    Reject,
+/// Insert into a `(source_interface, name)`-keyed map, panicking on duplicate
+/// registration. Two registrations of the same `(interface, name)` pair
+/// indicate a stdlib bug (the same declaration emitted twice) — we want a
+/// loud failure instead of a silent overwrite.
+fn register_unique<V>(
+    map: &mut IndexMap<(String, String), V>,
+    kind: &str,
+    source_interface: String,
+    name: String,
+    value: V,
+) {
+    let key = (source_interface, name);
+    if map.contains_key(&key) {
+        panic!(
+            "WasiRegistry: duplicate {kind} registration for `{}` in interface `{}`. \
+             Each (interface, name) pair must be registered exactly once.",
+            key.1, key.0,
+        );
+    }
+    map.insert(key, value);
+}
+
+/// Return the value for `name` in a `(source_interface, name)`-keyed map
+/// when exactly one interface defines it. Returns `None` for zero or multiple
+/// matches — ambiguous same-named types must be disambiguated via an
+/// interface- or package-scoped accessor.
+fn find_unique_in<'a, V>(map: &'a IndexMap<(String, String), V>, name: &str) -> Option<&'a V> {
+    let mut found: Option<&V> = None;
+    for ((_, n), v) in map {
+        if n != name {
+            continue;
+        }
+        if found.is_some() {
+            return None;
+        }
+        found = Some(v);
+    }
+    found
+}
+
+/// Return true if any interface registers `name` in a
+/// `(source_interface, name)`-keyed map.
+fn has_any_in<V>(map: &IndexMap<(String, String), V>, name: &str) -> bool {
+    map.keys().any(|(_, n)| n == name)
+}
+
+/// Return the `source_interface` when `name` has exactly one registrant,
+/// ignoring empty source strings.
+fn find_unique_source_in<'a, V>(
+    map: &'a IndexMap<(String, String), V>,
+    name: &str,
+) -> Option<&'a str> {
+    let mut found: Option<&str> = None;
+    for ((src, n), _) in map {
+        if n != name {
+            continue;
+        }
+        if found.is_some() {
+            return None;
+        }
+        if !src.is_empty() {
+            found = Some(src.as_str());
+        }
+    }
+    found
 }
 
 impl WasiRegistry {
@@ -324,57 +367,56 @@ impl WasiRegistry {
         Self::default()
     }
 
-    /// Detect bare-name collisions across modules during stdlib
-    /// registration. The registry's per-kind maps are keyed by the
-    /// bare type name without the owning interface, so two modules
-    /// declaring the same name would silently overwrite each other.
-    /// `name_owner` records the first source interface to register a
-    /// given `(kind, name)` pair; a subsequent registration from a
-    /// different source returns `Reject` so the caller can skip the
-    /// insert (preserving the first registrant under the bare name)
-    /// rather than corrupting the map.
+    /// Return the canonical source interface that owns `(kind, name)` — i.e.
+    /// the `#[cm("...")]` fragment before the `#` (e.g.
+    /// `"wasi:filesystem/types@0.3.0-rc-2026-03-15"`). `kind` is one of
+    /// `"variants"`, `"enums"`, `"resources"`, `"structs"`, `"flags"`, or
+    /// `"newtypes"`.
     ///
-    /// Callers that need a specific module's type must use the
-    /// dual-storage `format!("{interface}#{name}")` key (currently
-    /// only `enums` and `variants` populate that side) or a future
-    /// source-aware accessor. The dual-storage path is the safe one
-    /// for collisions; the bare-name path serves the common case
-    /// where a type is unique across stdlib.
-    ///
-    /// See `tests/fixtures/cross_module_same_name_*` regression
-    /// fixtures and the WEP 2026-04-12 (Kiln) blocker discussion.
-    fn check_collision(&mut self, kind: &str, name: &str, source: &str) -> Collision {
-        if source.is_empty() {
-            return Collision::Accept;
-        }
-        let key = (kind.to_string(), name.to_string());
-        if let Some(prev) = self.name_owner.get(&key) {
-            if prev != source {
-                eprintln!(
-                    "WasiRegistry: bare-name collision in `{kind}` for `{name}`: \
-                     first registered from `{prev}`, ignoring duplicate from `{source}`. \
-                     The bare-name slot keeps the first registrant; callers that need \
-                     `{name}` from `{source}` must use the source-disambiguated key \
-                     (`{source}#{name}`). See WEP 2026-04-12 (Kiln).",
-                );
-                return Collision::Reject;
-            }
-            return Collision::Accept;
-        }
-        self.name_owner.insert(key, source.to_string());
-        Collision::Accept
-    }
-
-    /// Return the canonical source interface that first registered
-    /// `(kind, name)`, e.g. `"wasi:filesystem/types@0.3.0-rc-2026-03-15"`.
-    ///
-    /// `kind` is one of `"variants"`, `"enums"`, `"resources"`, `"structs"`,
-    /// `"flags"`, or `"newtypes"`. Returns `None` when the pair was never
-    /// registered or when it was registered without a `#[cm(...)]` attribute.
+    /// Returns `Some` only when exactly one WASI interface declares the bare
+    /// name. Same-named types from multiple interfaces (e.g. `ErrorCode` in
+    /// `wasi:filesystem/types` vs `wasi:http/types`) return `None` — callers
+    /// must then disambiguate with the package-scoped accessor (e.g.
+    /// `get_variant_cases_by_package`).
     pub fn bare_name_owner(&self, kind: &str, name: &str) -> Option<&str> {
-        self.name_owner
-            .get(&(kind.to_string(), name.to_string()))
-            .map(String::as_str)
+        let candidates: Vec<&str> = match kind {
+            "variants" => self
+                .variants
+                .keys()
+                .filter_map(|(src, n)| (n == name && !src.is_empty()).then_some(src.as_str()))
+                .collect(),
+            "enums" => self
+                .enums
+                .keys()
+                .filter_map(|(src, n)| (n == name && !src.is_empty()).then_some(src.as_str()))
+                .collect(),
+            "resources" => self
+                .resources
+                .keys()
+                .filter_map(|(src, n)| (n == name && !src.is_empty()).then_some(src.as_str()))
+                .collect(),
+            "structs" => self
+                .structs
+                .keys()
+                .filter_map(|(src, n)| (n == name && !src.is_empty()).then_some(src.as_str()))
+                .collect(),
+            "flags" => self
+                .flags
+                .keys()
+                .filter_map(|(src, n)| (n == name && !src.is_empty()).then_some(src.as_str()))
+                .collect(),
+            "newtypes" => self
+                .newtypes
+                .keys()
+                .filter_map(|(src, n)| (n == name && !src.is_empty()).then_some(src.as_str()))
+                .collect(),
+            _ => return None,
+        };
+        if candidates.len() == 1 {
+            Some(candidates[0])
+        } else {
+            None
+        }
     }
 
     /// Extract the source interface (the part before the `#` fragment,
@@ -459,12 +501,13 @@ impl WasiRegistry {
         for item in &module.items {
             if let Item::Newtype(alias) = item {
                 let source_interface = Self::cm_source_interface(&alias.attrs);
-                if self.check_collision("newtypes", &alias.name, &source_interface)
-                    == Collision::Reject
-                {
-                    continue;
-                }
-                self.newtypes.insert(alias.name.clone(), alias.ty.clone());
+                register_unique(
+                    &mut self.newtypes,
+                    "newtype",
+                    source_interface,
+                    alias.name.clone(),
+                    alias.ty.clone(),
+                );
             }
         }
 
@@ -476,13 +519,13 @@ impl WasiRegistry {
                 // Extract source interface path from #[cm] attribute
                 // Format: #[cm("wasi:cli/terminal-input@0.3.0-rc-2026-01-06#terminal-input")]
                 let source_interface = Self::cm_source_interface(&resource.attrs);
-                if self.check_collision("resources", &resource.name, &source_interface)
-                    == Collision::Reject
-                {
-                    continue;
-                }
-                self.resources
-                    .insert(resource.name.clone(), (cm_name, source_interface));
+                register_unique(
+                    &mut self.resources,
+                    "resource",
+                    source_interface,
+                    resource.name.clone(),
+                    cm_name,
+                );
             }
         }
 
@@ -508,14 +551,12 @@ impl WasiRegistry {
                         )
                     })
                     .collect();
-                if self.check_collision("structs", &struct_def.name, &source_interface)
-                    == Collision::Reject
-                {
-                    continue;
-                }
-                self.structs.insert(
+                register_unique(
+                    &mut self.structs,
+                    "struct",
+                    source_interface,
                     struct_def.name.clone(),
-                    (cm_name, source_interface, fields, wado_fields),
+                    (cm_name, fields, wado_fields),
                 );
             }
         }
@@ -527,24 +568,23 @@ impl WasiRegistry {
                 // Use the #[cm] fragment as the CM name (preserves acronym casing)
                 let cm_name = cm_attr_cm_name(attrs, &flags_def.name);
                 let source_interface = Self::cm_source_interface(attrs);
-                if self.check_collision("flags", &flags_def.name, &source_interface)
-                    == Collision::Reject
-                {
-                    continue;
-                }
                 // Use per-member #[cm] attr for CM name
                 let member_names: Vec<String> = flags_def
                     .flags
                     .iter()
                     .map(|m| cm_attr_cm_name(&m.attrs, &m.name))
                     .collect();
-                self.flags
-                    .insert(flags_def.name.clone(), (cm_name, member_names));
+                register_unique(
+                    &mut self.flags,
+                    "flags",
+                    source_interface,
+                    flags_def.name.clone(),
+                    (cm_name, member_names),
+                );
             }
         }
 
         // Collect enum types from this module
-        // Use interface path from #[cm] attribute as key to distinguish same-named enums
         for item in &module.items {
             if let Item::Enum(enum_def) = item {
                 // Use the #[cm] fragment as the CM name (preserves acronym casing)
@@ -559,22 +599,13 @@ impl WasiRegistry {
                 // Extract interface path from #[cm] attribute if present
                 // Format: #[cm("wasi:sockets/types@0.3.0-rc-2025-09-16#error-code")]
                 let source_interface = Self::cm_source_interface(&enum_def.attrs);
-                let bare_outcome = self.check_collision("enums", &enum_def.name, &source_interface);
-                // Store by Wado name only when this source wins the bare-name
-                // slot; subsequent collisions are still reachable via the
-                // disambiguated key below.
-                if bare_outcome == Collision::Accept {
-                    self.enums.insert(
-                        enum_def.name.clone(),
-                        (cm_name.clone(), variant_names.clone()),
-                    );
-                }
-
-                // Always also store by interface path + name for disambiguation
-                if !source_interface.is_empty() {
-                    let full_key = format!("{source_interface}#{}", enum_def.name);
-                    self.enums.insert(full_key, (cm_name, variant_names));
-                }
+                register_unique(
+                    &mut self.enums,
+                    "enum",
+                    source_interface,
+                    enum_def.name.clone(),
+                    (cm_name, variant_names),
+                );
             }
         }
 
@@ -584,8 +615,6 @@ impl WasiRegistry {
                 // Use the #[cm] fragment as the CM name (preserves acronym casing)
                 let cm_name = cm_attr_cm_name(&variant_def.attrs, &variant_def.name);
                 let source_interface = Self::cm_source_interface(&variant_def.attrs);
-                let bare_outcome =
-                    self.check_collision("variants", &variant_def.name, &source_interface);
                 // Store both CM and Wado names for each case
                 let cases: Vec<CmVariantCase> = variant_def
                     .cases
@@ -597,27 +626,23 @@ impl WasiRegistry {
                     })
                     .collect();
 
-                // Store by Wado name only when this source wins the bare-name
-                // slot; subsequent collisions are still reachable via the
-                // disambiguated key below.
-                if bare_outcome == Collision::Accept {
-                    self.variants
-                        .insert(variant_def.name.clone(), (cm_name.clone(), cases.clone()));
-                }
-
-                // Always also store by interface path + name for disambiguation
-                if !source_interface.is_empty() {
-                    let full_key = format!("{source_interface}#{}", variant_def.name);
-                    self.variants.insert(full_key, (cm_name, cases));
-                }
+                register_unique(
+                    &mut self.variants,
+                    "variant",
+                    source_interface,
+                    variant_def.name.clone(),
+                    (cm_name, cases),
+                );
             }
         }
 
-        // Helper closure to resolve types through aliases
-        let resolve_type = |ty: &Type, aliases: &IndexMap<String, Type>| -> Type {
+        // Helper closure to resolve types through aliases (scan the
+        // `(source_interface, name)`-keyed newtypes map by name; skip
+        // resolution when the name is ambiguous across interfaces).
+        let resolve_type = |ty: &Type, aliases: &IndexMap<(String, String), Type>| -> Type {
             match ty {
                 Type::Named(named) => {
-                    if let Some(resolved) = aliases.get(&named.name) {
+                    if let Some(resolved) = find_unique_in(aliases, &named.name) {
                         resolved.clone()
                     } else {
                         ty.clone()
@@ -719,189 +744,170 @@ impl WasiRegistry {
         }
     }
 
-    /// Get a newtype by name
+    /// Get a newtype by name, when unambiguous across interfaces.
     pub fn get_newtype(&self, name: &str) -> Option<&Type> {
-        self.newtypes.get(name)
+        find_unique_in(&self.newtypes, name)
     }
 
-    /// Get all newtypes
-    pub fn newtypes(&self) -> &IndexMap<String, Type> {
+    /// Iterate all newtypes as `((source_interface, name), type)`.
+    pub fn newtypes(&self) -> &IndexMap<(String, String), Type> {
         &self.newtypes
     }
 
-    /// Check if a type name is a registered resource
+    /// Check if a type name is a registered resource (in any interface).
     pub fn is_resource(&self, name: &str) -> bool {
-        self.resources.contains_key(name)
+        has_any_in(&self.resources, name)
     }
 
-    /// Get the CM kebab-case name for a resource
+    /// Get the CM kebab-case name for a resource, when unambiguous.
     pub fn get_resource_cm_name(&self, name: &str) -> Option<&str> {
-        self.resources
-            .get(name)
-            .map(|(cm_name, _)| cm_name.as_str())
+        find_unique_in(&self.resources, name).map(String::as_str)
     }
 
-    /// Get the source interface path for a resource
-    /// e.g., "`TerminalInput`" -> "wasi:cli/terminal-input@0.3.0-rc-2026-01-06"
+    /// Get the source interface path for a resource, when unambiguous.
+    /// e.g., `TerminalInput` -> `"wasi:cli/terminal-input@0.3.0-rc-2026-01-06"`.
     pub fn get_resource_source_interface(&self, name: &str) -> Option<&str> {
-        self.resources
-            .get(name)
-            .map(|(_, path)| path.as_str())
-            .filter(|p| !p.is_empty())
+        find_unique_source_in(&self.resources, name)
     }
 
-    /// Check if a type name is a registered enum
+    /// Check if a type name is a registered enum (in any interface).
     pub fn is_enum(&self, name: &str) -> bool {
-        self.enums.contains_key(name)
+        has_any_in(&self.enums, name)
     }
 
-    /// Get the CM kebab-case name for an enum
+    /// Get the CM kebab-case name for an enum, when unambiguous.
     pub fn get_enum_cm_name(&self, name: &str) -> Option<&str> {
-        self.enums.get(name).map(|(cm_name, _)| cm_name.as_str())
+        find_unique_in(&self.enums, name).map(|(cm_name, _)| cm_name.as_str())
     }
 
-    /// Get the CM enum variant names (in kebab-case)
+    /// Get the CM enum variant names (in kebab-case), when unambiguous.
     pub fn get_enum_variants(&self, name: &str) -> Option<&[String]> {
-        self.enums
-            .get(name)
-            .map(|(_, variants)| variants.as_slice())
+        find_unique_in(&self.enums, name).map(|(_, variants)| variants.as_slice())
     }
 
-    /// Get the CM enum variant names by interface path + name
-    /// This is used to disambiguate enums with the same Wado name but different interfaces
-    /// (e.g., wasi:cli/types#ErrorCode vs wasi:sockets/types#ErrorCode)
+    /// Get the CM enum variant names scoped to a specific source interface
+    /// (e.g. `"wasi:cli/types@0.3.0-rc-2026-03-15"`). Disambiguates enums
+    /// sharing a Wado name across interfaces. Falls back to the unscoped
+    /// lookup when only one interface defines the name.
     pub fn get_enum_variants_by_interface(
         &self,
         interface_path: &str,
         name: &str,
     ) -> Option<&[String]> {
-        let full_key = format!("{interface_path}#{name}");
         self.enums
-            .get(&full_key)
-            .or_else(|| self.enums.get(name))
+            .get(&(interface_path.to_string(), name.to_string()))
             .map(|(_, variants)| variants.as_slice())
+            .or_else(|| self.get_enum_variants(name))
     }
 
-    /// Get the CM enum name by interface path + name
+    /// Get the CM enum name scoped to a specific source interface.
     pub fn get_enum_cm_name_by_interface(&self, interface_path: &str, name: &str) -> Option<&str> {
-        let full_key = format!("{interface_path}#{name}");
         self.enums
-            .get(&full_key)
-            .or_else(|| self.enums.get(name))
+            .get(&(interface_path.to_string(), name.to_string()))
             .map(|(cm_name, _)| cm_name.as_str())
+            .or_else(|| self.get_enum_cm_name(name))
     }
 
-    /// Check if an interface defines its own enum type (exact interface path match, no fallback)
+    /// Check if a specific interface defines its own enum type (exact match, no fallback).
     pub fn has_enum_in_interface(&self, interface_path: &str, name: &str) -> bool {
-        let full_key = format!("{interface_path}#{name}");
-        self.enums.contains_key(&full_key)
+        self.enums
+            .contains_key(&(interface_path.to_string(), name.to_string()))
     }
 
-    /// Check if a type name is a registered flags type
+    /// Check if a type name is a registered flags type (in any interface).
     pub fn is_flags(&self, name: &str) -> bool {
-        self.flags.contains_key(name)
+        has_any_in(&self.flags, name)
     }
 
-    /// Get the CM kebab-case name for a flags type
+    /// Get the CM kebab-case name for a flags type, when unambiguous.
     pub fn get_flags_cm_name(&self, name: &str) -> Option<&str> {
-        self.flags.get(name).map(|(cm_name, _)| cm_name.as_str())
+        find_unique_in(&self.flags, name).map(|(cm_name, _)| cm_name.as_str())
     }
 
-    /// Get the CM member names (in kebab-case) for a flags type
+    /// Get the CM member names (in kebab-case) for a flags type, when unambiguous.
     pub fn get_flags_members(&self, name: &str) -> Option<&[String]> {
-        self.flags.get(name).map(|(_, members)| members.as_slice())
+        find_unique_in(&self.flags, name).map(|(_, members)| members.as_slice())
     }
 
-    /// Check if a type name is a registered variant
+    /// Check if a type name is a registered variant (in any interface).
     pub fn is_variant(&self, name: &str) -> bool {
-        self.variants.contains_key(name)
+        has_any_in(&self.variants, name)
     }
 
-    /// Get the CM kebab-case name for a variant
+    /// Get the CM kebab-case name for a variant, when unambiguous.
     pub fn get_variant_cm_name(&self, name: &str) -> Option<&str> {
-        self.variants.get(name).map(|(cm_name, _)| cm_name.as_str())
+        find_unique_in(&self.variants, name).map(|(cm_name, _)| cm_name.as_str())
     }
 
-    /// Get the variant cases (CM kebab-case name, payload type if any)
+    /// Get the variant cases, when unambiguous.
     pub fn get_variant_cases(&self, name: &str) -> Option<&[CmVariantCase]> {
-        self.variants.get(name).map(|(_, cases)| cases.as_slice())
+        find_unique_in(&self.variants, name).map(|(_, cases)| cases.as_slice())
     }
 
-    /// Get the variant cases by WASI package name (e.g., "http") for disambiguation.
-    /// Searches for a full-key entry matching `wasi:{package}/...#{name}`.
-    /// Falls back to unqualified name lookup if no scoped entry is found.
+    /// Get the variant cases scoped to a WASI package (e.g., `"http"`).
+    /// Prefers an interface whose source starts with `"wasi:{package}/"`.
     pub fn get_variant_cases_by_package(
         &self,
         package: &str,
         name: &str,
     ) -> Option<&[CmVariantCase]> {
         let prefix = format!("wasi:{package}/");
-        let suffix = format!("#{name}");
         self.variants
             .iter()
-            .find(|(key, _)| key.starts_with(&prefix) && key.ends_with(&suffix))
+            .find(|((src, n), _)| n == name && src.starts_with(&prefix))
             .map(|(_, (_, cases))| cases.as_slice())
             .or_else(|| self.get_variant_cases(name))
     }
 
-    /// Get the variant cases by interface path + name for disambiguation.
-    /// Tries interface-qualified key first, falls back to unqualified name.
+    /// Get the variant cases scoped to a specific source interface.
     pub fn get_variant_cases_by_interface(
         &self,
         interface_path: &str,
         name: &str,
     ) -> Option<&[CmVariantCase]> {
-        let full_key = format!("{interface_path}#{name}");
         self.variants
-            .get(&full_key)
-            .or_else(|| self.variants.get(name))
+            .get(&(interface_path.to_string(), name.to_string()))
             .map(|(_, cases)| cases.as_slice())
+            .or_else(|| self.get_variant_cases(name))
     }
 
-    /// Get the CM variant name by interface path + name for disambiguation.
+    /// Get the CM variant name scoped to a specific source interface.
     pub fn get_variant_cm_name_by_interface(
         &self,
         interface_path: &str,
         name: &str,
     ) -> Option<&str> {
-        let full_key = format!("{interface_path}#{name}");
         self.variants
-            .get(&full_key)
-            .or_else(|| self.variants.get(name))
+            .get(&(interface_path.to_string(), name.to_string()))
             .map(|(cm_name, _)| cm_name.as_str())
+            .or_else(|| self.get_variant_cm_name(name))
     }
 
-    /// Check if a type name is a registered struct (WIT record)
+    /// Check if a type name is a registered struct (WIT record, in any interface).
     pub fn is_struct(&self, name: &str) -> bool {
-        self.structs.contains_key(name)
+        has_any_in(&self.structs, name)
     }
 
-    /// Get the CM kebab-case name for a struct (WIT record)
+    /// Get the CM kebab-case name for a struct, when unambiguous.
     pub fn get_struct_cm_name(&self, name: &str) -> Option<&str> {
-        self.structs
-            .get(name)
-            .map(|(cm_name, _, _, _)| cm_name.as_str())
+        find_unique_in(&self.structs, name).map(|(cm_name, _, _)| cm_name.as_str())
     }
 
-    /// Get the fields of a struct (CM kebab-case field name, field type)
+    /// Get the fields of a struct (CM kebab-case field name, field type), when unambiguous.
     pub fn get_struct_fields(&self, name: &str) -> Option<&[(String, Type)]> {
-        self.structs
-            .get(name)
-            .map(|(_, _, fields, _)| fields.as_slice())
+        find_unique_in(&self.structs, name).map(|(_, fields, _)| fields.as_slice())
     }
 
-    /// Get the source interface path for a struct
+    /// Get the source interface path for a struct, when unambiguous.
     pub fn get_struct_source_interface(&self, name: &str) -> Option<&str> {
-        self.structs
-            .get(name)
-            .map(|(_, source, _, _)| source.as_str())
+        find_unique_source_in(&self.structs, name)
     }
 
-    /// Find the interface name (e.g., "types") for a struct given its CM name
-    /// (e.g., "directory-entry"). Used by the component builder to alias types
-    /// from WASI interface imports.
+    /// Find the interface name (e.g., `"types"`) for a struct given its CM name
+    /// (e.g., `"directory-entry"`). Used by the component builder to alias
+    /// types from WASI interface imports.
     pub fn find_interface_for_struct_cm_name(&self, cm_name: &str) -> Option<String> {
-        for (wado_name, (struct_cm_name, source_path, _, _)) in &self.structs {
+        for ((source_path, wado_name), (struct_cm_name, _, _)) in &self.structs {
             if struct_cm_name == cm_name || wado_name == cm_name {
                 let wasi = CmImport::parse(source_path)?;
                 return Some(wasi.interface);
@@ -910,17 +916,15 @@ impl WasiRegistry {
         None
     }
 
-    /// Get the fields with Wado names (`wado_name`, `cm_name`, `field_type`)
+    /// Get the fields with Wado names, when unambiguous.
     pub fn get_struct_fields_with_wado_names(
         &self,
         name: &str,
     ) -> Option<&[(String, String, Type)]> {
-        self.structs
-            .get(name)
-            .map(|(_, _, _, wado_fields)| wado_fields.as_slice())
+        find_unique_in(&self.structs, name).map(|(_, _, wado_fields)| wado_fields.as_slice())
     }
 
-    /// Iterate over all structs from a specific interface (matched by prefix)
+    /// Iterate over all structs from a specific interface (matched by prefix).
     /// Returns (`wado_name`, `cm_name`, fields) in insertion order.
     pub fn structs_for_interface(
         &self,
@@ -928,7 +932,7 @@ impl WasiRegistry {
     ) -> impl Iterator<Item = (&str, &str, &[(String, Type)])> {
         self.structs
             .iter()
-            .filter_map(move |(name, (cm_name, source, fields, _))| {
+            .filter_map(move |((source, name), (cm_name, fields, _))| {
                 if source.starts_with(interface_prefix) {
                     Some((name.as_str(), cm_name.as_str(), fields.as_slice()))
                 } else {
@@ -937,21 +941,18 @@ impl WasiRegistry {
             })
     }
 
-    /// Iterate over variants from a specific interface using full-key entries.
-    /// Full-key format: `"interface_path#WadoName"` (inserted by `register_module`).
-    /// Returns (`wado_name`, `cm_name`, cases) in insertion order.
+    /// Iterate over variants from a specific interface (matched by prefix on
+    /// the source interface). Returns (`wado_name`, `cm_name`, cases) in
+    /// insertion order.
     pub fn variants_for_interface(
         &self,
         interface_prefix: &str,
     ) -> impl Iterator<Item = (&str, &str, &[CmVariantCase])> {
-        let prefix = format!("{interface_prefix}#");
         self.variants
             .iter()
-            .filter_map(move |(key, (cm_name, cases))| {
-                if key.starts_with(&prefix) {
-                    // key = "interface_path#WadoName"
-                    let wado_name = key.split('#').nth(1).unwrap_or(key.as_str());
-                    Some((wado_name, cm_name.as_str(), cases.as_slice()))
+            .filter_map(move |((source, name), (cm_name, cases))| {
+                if source.starts_with(interface_prefix) {
+                    Some((name.as_str(), cm_name.as_str(), cases.as_slice()))
                 } else {
                     None
                 }
@@ -966,7 +967,7 @@ impl WasiRegistry {
     ) -> impl Iterator<Item = (&str, &str)> {
         self.resources
             .iter()
-            .filter_map(move |(name, (cm_name, source))| {
+            .filter_map(move |((source, name), cm_name)| {
                 if source.starts_with(interface_prefix) {
                     Some((name.as_str(), cm_name.as_str()))
                 } else {
@@ -988,7 +989,7 @@ impl WasiRegistry {
             && g.name == "Option"
             && g.args.len() == 1
             && let Type::Named(inner) = &g.args[0]
-            && let Some((cm_name, _)) = self.resources.get(&inner.name)
+            && let Some(cm_name) = find_unique_in(&self.resources, &inner.name)
         {
             return Some((inner.name.clone(), cm_name.clone()));
         }
@@ -1002,15 +1003,17 @@ impl WasiRegistry {
     /// all types in the function signature are supported.
     pub fn is_function_supported(&self, func: &WasiFunctionInfo) -> bool {
         // Build sets of known enum, variant, flags, and resource names
+        // (bare name is enough here — the sets are only used as a membership check).
         let enums: IndexSet<&str> = self
             .enums
             .keys()
             .chain(self.variants.keys())
             .chain(self.flags.keys())
-            .map(String::as_str)
+            .map(|(_, n)| n.as_str())
             .collect();
-        let resources: IndexSet<&str> = self.resources.keys().map(String::as_str).collect();
-        let structs: IndexSet<&str> = self.structs.keys().map(String::as_str).collect();
+        let resources: IndexSet<&str> =
+            self.resources.keys().map(|(_, n)| n.as_str()).collect();
+        let structs: IndexSet<&str> = self.structs.keys().map(|(_, n)| n.as_str()).collect();
 
         // Check all parameter types
         for (_, _, ty) in &func.params {

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -109,20 +109,16 @@ pub fn wasi_type_to_type_id(
                 type_table.make_option(inner_type)
             }
             "Result" if g.args.len() == 2 => {
-                let ok_type =
-                    wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
-                let err_type =
-                    wasi_type_to_type_id(&g.args[1], type_table, registry, wasi_package);
+                let ok_type = wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
+                let err_type = wasi_type_to_type_id(&g.args[1], type_table, registry, wasi_package);
                 type_table.make_result(ok_type, err_type)
             }
             "Stream" if g.args.len() == 1 => {
-                let inner =
-                    wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
+                let inner = wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
                 type_table.make_stream(inner)
             }
             "Future" if g.args.len() == 1 => {
-                let inner =
-                    wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
+                let inner = wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
                 type_table.make_future(inner)
             }
             // Own/Borrow are handle types represented as i32
@@ -156,7 +152,14 @@ fn wasi_package_from_cm_source(source: &str) -> Option<&str> {
 /// package (e.g. `ErrorCode` is owned by `filesystem` but referenced from
 /// `http` bindings).
 fn canonical_wasi_package<'a>(registry: &'a WasiRegistry, name: &str) -> Option<&'a str> {
-    for kind in ["variants", "enums", "resources", "structs", "flags", "newtypes"] {
+    for kind in [
+        "variants",
+        "enums",
+        "resources",
+        "structs",
+        "flags",
+        "newtypes",
+    ] {
         if let Some(source) = registry.bare_name_owner(kind, name)
             && let Some(pkg) = wasi_package_from_cm_source(source)
         {
@@ -790,8 +793,7 @@ fn synthesize_lift_list(
     // These are needed by the monomorphizer to instantiate Array::with_capacity and .push().
     let (elem_type_id, array_type_id) = if let Some(ctx) = ctx {
         let mut tt = ctx.type_table.borrow_mut();
-        let elem_tid =
-            wasi_type_to_type_id(elem_ty, &mut tt, ctx.wasi_registry, ctx.wasi_package);
+        let elem_tid = wasi_type_to_type_id(elem_ty, &mut tt, ctx.wasi_registry, ctx.wasi_package);
         let array_tid = tt.make_array(elem_tid);
         (elem_tid, array_tid)
     } else {
@@ -946,11 +948,7 @@ fn synthesize_lift_option_inner(
     ctx: Option<&LiftContext<'_>>,
 ) -> TirExpr {
     let layout = if let Some(c) = ctx {
-        cm_abi::layout_option_with_registry_scoped(
-            inner_ty,
-            c.wasi_registry,
-            Some(c.wasi_package),
-        )
+        cm_abi::layout_option_with_registry_scoped(inner_ty, c.wasi_registry, Some(c.wasi_package))
     } else {
         cm_abi::layout_option(inner_ty)
     };
@@ -1053,8 +1051,7 @@ fn synthesize_lift_result_inner(
     // i32 but initialized with `ref.null none` (a reference type).
     let result_type_id = if let Some(ctx) = ctx {
         let mut tt = ctx.type_table.borrow_mut();
-        let ok_type_id =
-            wasi_type_to_type_id(ok_ty, &mut tt, ctx.wasi_registry, ctx.wasi_package);
+        let ok_type_id = wasi_type_to_type_id(ok_ty, &mut tt, ctx.wasi_registry, ctx.wasi_package);
         let err_type_id =
             wasi_type_to_type_id(err_ty, &mut tt, ctx.wasi_registry, ctx.wasi_package);
         tt.make_result(ok_type_id, err_type_id)
@@ -1900,12 +1897,7 @@ fn synthesize_flatten_value_to_flat_args(
                     if let Some(payload_ty) = &case.payload {
                         let payload_type_id = {
                             let mut tt = type_table.borrow_mut();
-                            wasi_type_to_type_id(
-                                payload_ty,
-                                &mut tt,
-                                wasi_registry,
-                                wasi_package,
-                            )
+                            wasi_type_to_type_id(payload_ty, &mut tt, wasi_registry, wasi_package)
                         };
                         let payload_expr = variant_payload(
                             local_ref(val_local, &format!("{prefix}_val"), vt),
@@ -2557,12 +2549,7 @@ fn synthesize_adapter(
             Type::Named(n) if wasi_registry.is_struct(&n.name) => {
                 let struct_type_id = {
                     let mut tt = type_table.borrow_mut();
-                    wasi_type_to_type_id(
-                        param_type,
-                        &mut tt,
-                        wasi_registry,
-                        &func_info.package,
-                    )
+                    wasi_type_to_type_id(param_type, &mut tt, wasi_registry, &func_info.package)
                 };
                 params.push(TirParam {
                     name: param_name.clone(),
@@ -2580,12 +2567,7 @@ fn synthesize_adapter(
             Type::Named(n) if wasi_registry.is_variant(&n.name) => {
                 let variant_type_id = {
                     let mut tt = type_table.borrow_mut();
-                    wasi_type_to_type_id(
-                        param_type,
-                        &mut tt,
-                        wasi_registry,
-                        &func_info.package,
-                    )
+                    wasi_type_to_type_id(param_type, &mut tt, wasi_registry, &func_info.package)
                 };
                 params.push(TirParam {
                     name: param_name.clone(),
@@ -2603,12 +2585,7 @@ fn synthesize_adapter(
             Type::Generic(g) if g.name == "Option" && g.args.len() == 1 => {
                 let option_type_id = {
                     let mut tt = type_table.borrow_mut();
-                    wasi_type_to_type_id(
-                        param_type,
-                        &mut tt,
-                        wasi_registry,
-                        &func_info.package,
-                    )
+                    wasi_type_to_type_id(param_type, &mut tt, wasi_registry, &func_info.package)
                 };
                 params.push(TirParam {
                     name: param_name.clone(),
@@ -2757,12 +2734,8 @@ fn synthesize_adapter(
                 // Resolve proper TypeIds for the element and array types
                 let (elem_type_id, array_type_id) = {
                     let mut tt = type_table.borrow_mut();
-                    let elem_tid = wasi_type_to_type_id(
-                        elem_type,
-                        &mut tt,
-                        wasi_registry,
-                        &func_info.package,
-                    );
+                    let elem_tid =
+                        wasi_type_to_type_id(elem_type, &mut tt, wasi_registry, &func_info.package);
                     let array_tid = tt.make_array(elem_tid);
                     (elem_tid, array_tid)
                 };
@@ -2939,12 +2912,7 @@ fn synthesize_adapter(
                 for (field_idx, (wado_name, _, field_ty)) in wado_fields.iter().enumerate() {
                     let field_type_id = {
                         let mut tt = type_table.borrow_mut();
-                        wasi_type_to_type_id(
-                            field_ty,
-                            &mut tt,
-                            wasi_registry,
-                            &func_info.package,
-                        )
+                        wasi_type_to_type_id(field_ty, &mut tt, wasi_registry, &func_info.package)
                     };
                     flat_args.push(TirExpr {
                         kind: crate::tir::TirExprKind::FieldAccess {
@@ -5770,12 +5738,9 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                 let func_info = func_info.clone();
                 let binding_name =
                     binding_func_name(&func_info.effect_name, &func_info.method_name);
-                let owner_module = lookup_effect_owner(
-                    &owner_sources,
-                    &func_info.effect_name,
-                    &func_info.package,
-                )
-                .unwrap_or_else(|| ModuleSource::wasi(&func_info.package));
+                let owner_module =
+                    lookup_effect_owner(&owner_sources, &func_info.effect_name, &func_info.package)
+                        .unwrap_or_else(|| ModuleSource::wasi(&func_info.package));
                 let adapter = synthesize_adapter(
                     &func_info,
                     project.wasi_registry,
@@ -7032,14 +6997,28 @@ fn replace_wasi_derived_type_recursive(
             {
                 let new_elem = new_elem_args[0];
                 drop(tt);
-                replace_wasi_derived_type_recursive(adapter, &g.args[0], new_elem, wasi_registry, wasi_package, type_table);
+                replace_wasi_derived_type_recursive(
+                    adapter,
+                    &g.args[0],
+                    new_elem,
+                    wasi_registry,
+                    wasi_package,
+                    type_table,
+                );
             }
         }
         Type::Tuple(elems) => {
             // Get the user's tuple field types
             if let Some(user_elems) = type_table.borrow().as_tuple(user_type) {
                 for (wasi_elem, &user_elem) in elems.iter().zip(user_elems.iter()) {
-                    replace_wasi_derived_type_recursive(adapter, wasi_elem, user_elem, wasi_registry, wasi_package, type_table);
+                    replace_wasi_derived_type_recursive(
+                        adapter,
+                        wasi_elem,
+                        user_elem,
+                        wasi_registry,
+                        wasi_package,
+                        type_table,
+                    );
                 }
             }
         }
@@ -7050,7 +7029,14 @@ fn replace_wasi_derived_type_recursive(
             {
                 let new_inner = new_args[0];
                 drop(tt);
-                replace_wasi_derived_type_recursive(adapter, &g.args[0], new_inner, wasi_registry, wasi_package, type_table);
+                replace_wasi_derived_type_recursive(
+                    adapter,
+                    &g.args[0],
+                    new_inner,
+                    wasi_registry,
+                    wasi_package,
+                    type_table,
+                );
             }
         }
         Type::Generic(g) if g.name == "Result" && g.args.len() == 2 => {
@@ -7061,8 +7047,22 @@ fn replace_wasi_derived_type_recursive(
                 let new_ok = new_args[0];
                 let new_err = new_args[1];
                 drop(tt);
-                replace_wasi_derived_type_recursive(adapter, &g.args[0], new_ok, wasi_registry, wasi_package, type_table);
-                replace_wasi_derived_type_recursive(adapter, &g.args[1], new_err, wasi_registry, wasi_package, type_table);
+                replace_wasi_derived_type_recursive(
+                    adapter,
+                    &g.args[0],
+                    new_ok,
+                    wasi_registry,
+                    wasi_package,
+                    type_table,
+                );
+                replace_wasi_derived_type_recursive(
+                    adapter,
+                    &g.args[1],
+                    new_err,
+                    wasi_registry,
+                    wasi_package,
+                    type_table,
+                );
             }
         }
         _ => {}
@@ -7096,7 +7096,14 @@ fn fixup_wasi_derived_types_in_adapter(
         let new_type = call_args[i].type_id;
         // Resolve newtypes (e.g., FieldName → String) before computing WASI-derived TypeId
         let resolved = wasi_registry.resolve_type(param_type);
-        replace_wasi_derived_type_recursive(adapter, &resolved, new_type, wasi_registry, wasi_package, type_table);
+        replace_wasi_derived_type_recursive(
+            adapter,
+            &resolved,
+            new_type,
+            wasi_registry,
+            wasi_package,
+            type_table,
+        );
     }
     // Also fix up return type's WASI-derived sub-types — but skip for CM bindings
     // that return non-flat types (tuples, variants). Their return TypeId was set
@@ -7107,7 +7114,14 @@ fn fixup_wasi_derived_types_in_adapter(
         && let Some(return_type) = &func_info.return_type
     {
         let resolved = wasi_registry.resolve_type(return_type);
-        replace_wasi_derived_type_recursive(adapter, &resolved, user_return_type, wasi_registry, wasi_package, type_table);
+        replace_wasi_derived_type_recursive(
+            adapter,
+            &resolved,
+            user_return_type,
+            wasi_registry,
+            wasi_package,
+            type_table,
+        );
     }
 }
 

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -92,24 +92,39 @@ pub fn wasi_type_to_type_id_scoped(
             "()" => TypeTable::UNIT,
             "String" => type_table.make_struct("String".to_string(), ModuleSource::string()),
             // Resource/enum/variant types - look up the already-resolved TypeId if available.
-            // When a WASI package hint is available, try scoped lookup first to avoid
-            // name collisions (e.g. wasi:cli/ErrorCode vs wasi:http/ErrorCode).
+            // Primary lookup is scoped by `(name, wasi_package)`; only the WASI binding
+            // synthesizer may still fall back to the unscoped by-name scan, because
+            // WASI types can be interned under multiple package contexts (the resolver
+            // registers each declaring module independently). Cross-module name
+            // collisions with user-declared types are prevented because the fallback
+            // is only ever hit inside the WASI binding synthesizer.
             _ => wasi_package
                 .and_then(|pkg| {
                     type_table.find_named_type_by_wasi_package(named.name.as_str(), pkg)
                 })
+                .or_else(|| {
+                    registry
+                        .and_then(|reg| canonical_wasi_package(reg, named.name.as_str()))
+                        .and_then(|pkg| {
+                            type_table.find_named_type_by_wasi_package(named.name.as_str(), pkg)
+                        })
+                })
                 .or_else(|| type_table.find_resource_type_by_name(named.name.as_str()))
                 .or_else(|| type_table.find_variant_type_by_name(named.name.as_str()))
                 .or_else(|| {
-                    // Create variant from WASI registry when it exists in a
-                    // different module but not yet in this type_table.
-                    // Checked BEFORE find_enum_type_by_name to prevent a
-                    // same-named enum (e.g. cli ErrorCode) from shadowing
-                    // a package-scoped variant (e.g. filesystem ErrorCode).
+                    // Create variant from WASI registry when it exists but is
+                    // not yet in this type_table. Prefer the registry's
+                    // canonical owning package so we don't mint a duplicate
+                    // TypeId when the same variant was (or will be) created by
+                    // another scope. Checked BEFORE the enum fallback to
+                    // prevent a same-named enum (e.g. cli ErrorCode) from
+                    // shadowing a package-scoped variant (e.g. filesystem
+                    // ErrorCode).
                     if let Some(reg) = registry
-                        && let Some(pkg) = wasi_package
                         && reg.is_variant(&named.name)
                     {
+                        let pkg = canonical_wasi_package(reg, named.name.as_str())
+                            .or(wasi_package)?;
                         Some(type_table.make_variant(
                             named.name.clone(),
                             ModuleSource::Wasi {
@@ -179,6 +194,31 @@ pub fn wasi_type_to_type_id_scoped(
         }
         _ => TypeTable::UNIT,
     }
+}
+
+/// Extract the WASI package (e.g. `"filesystem"`) from a CM source string like
+/// `"wasi:filesystem/types@0.3.0-rc-2026-03-15"`. Returns `None` for
+/// non-`wasi:` sources or malformed strings.
+fn wasi_package_from_cm_source(source: &str) -> Option<&str> {
+    let after_colon = source.strip_prefix("wasi:")?;
+    let without_version = after_colon.split('@').next().unwrap_or(after_colon);
+    without_version.split('/').next()
+}
+
+/// Given a bare type name, ask the registry for its canonical owner and return
+/// the WASI package (e.g. `"filesystem"`). Used to disambiguate name lookups
+/// for types whose canonical owner differs from the currently-processed WASI
+/// package (e.g. `ErrorCode` is owned by `filesystem` but referenced from
+/// `http` bindings).
+fn canonical_wasi_package<'a>(registry: &'a WasiRegistry, name: &str) -> Option<&'a str> {
+    for kind in ["variants", "enums", "resources", "structs", "flags", "newtypes"] {
+        if let Some(source) = registry.bare_name_owner(kind, name)
+            && let Some(pkg) = wasi_package_from_cm_source(source)
+        {
+            return Some(pkg);
+        }
+    }
+    None
 }
 
 /// Extract the WASI sub-module interface path for a struct from the registry.
@@ -426,6 +466,10 @@ fn try_lift_wasi_variant_or_enum(
         let variant_type = ctx
             .wasi_package
             .and_then(|pkg| tt.find_named_type_by_wasi_package(name, pkg))
+            .or_else(|| {
+                canonical_wasi_package(ctx.wasi_registry, name)
+                    .and_then(|pkg| tt.find_named_type_by_wasi_package(name, pkg))
+            })
             .or_else(|| tt.find_variant_type_by_name(name))?;
         drop(tt);
         return Some(synthesize_lift_wasi_variant(
@@ -446,6 +490,10 @@ fn try_lift_wasi_variant_or_enum(
         let enum_type = ctx
             .wasi_package
             .and_then(|pkg| tt.find_named_type_by_wasi_package(name, pkg))
+            .or_else(|| {
+                canonical_wasi_package(ctx.wasi_registry, name)
+                    .and_then(|pkg| tt.find_named_type_by_wasi_package(name, pkg))
+            })
             .or_else(|| tt.find_enum_type_by_name(name))?;
         drop(tt);
         return Some(synthesize_lift_wasi_enum(
@@ -3413,25 +3461,56 @@ fn synthesize_adapter(
     binding
 }
 
-/// Build a name → module source map for every effect/resource declared in the
-/// loaded TIR modules. The CM binding synthesizer uses this to attach the
+/// Build a `(module_source, name)` set for every effect/resource declared in
+/// the loaded TIR modules. The CM binding synthesizer uses this to attach the
 /// owning effect to each generated binding using the same `module_source` the
 /// resolver assigns to user-written `with E` clauses.
+///
+/// Keying by `(module_source, name)` (rather than name alone) prevents
+/// collisions when two modules declare an effect or resource with the same
+/// name — `lookup_effect_owner` selects the canonical WASI module.
 fn effect_owner_module_sources(
     modules: &IndexMap<ModuleSource, crate::tir::TirModule>,
-) -> IndexMap<String, ModuleSource> {
-    let mut out: IndexMap<String, ModuleSource> = IndexMap::default();
+) -> IndexMap<(ModuleSource, String), ()> {
+    let mut out: IndexMap<(ModuleSource, String), ()> = IndexMap::default();
     for (module_source, module) in modules {
         for effect in &module.effects {
-            out.entry(effect.name.clone())
-                .or_insert_with(|| module_source.clone());
+            out.insert((module_source.clone(), effect.name.clone()), ());
         }
         for resource in &module.resources {
-            out.entry(resource.name.clone())
-                .or_insert_with(|| module_source.clone());
+            out.insert((module_source.clone(), resource.name.clone()), ());
         }
     }
     out
+}
+
+/// Look up the canonical owning module for an effect/resource named `name`
+/// whose binding targets WASI `package` (e.g. `"cli"`).
+///
+/// Preferred match: a `ModuleSource::Wasi { interface }` whose interface starts
+/// with `"{package}/"` (e.g. `wasi:cli/stdio.wado` for package `"cli"`).
+/// Falls back to any other owner with the same name if no WASI match exists.
+fn lookup_effect_owner(
+    owners: &IndexMap<(ModuleSource, String), ()>,
+    name: &str,
+    package: &str,
+) -> Option<ModuleSource> {
+    let wasi_prefix = format!("{package}/");
+    let mut fallback: Option<ModuleSource> = None;
+    for ((ms, n), ()) in owners {
+        if n != name {
+            continue;
+        }
+        if let ModuleSource::Wasi { interface } = ms
+            && interface.starts_with(&wasi_prefix)
+        {
+            return Some(ms.clone());
+        }
+        if fallback.is_none() {
+            fallback = Some(ms.clone());
+        }
+    }
+    fallback
 }
 
 /// Compute flat CM ABI types for an export return type, resolving variant and
@@ -5696,10 +5775,12 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                 let func_info = func_info.clone();
                 let binding_name =
                     binding_func_name(&func_info.effect_name, &func_info.method_name);
-                let owner_module = owner_sources
-                    .get(&func_info.effect_name)
-                    .cloned()
-                    .unwrap_or_else(|| ModuleSource::wasi(&func_info.package));
+                let owner_module = lookup_effect_owner(
+                    &owner_sources,
+                    &func_info.effect_name,
+                    &func_info.package,
+                )
+                .unwrap_or_else(|| ModuleSource::wasi(&func_info.package));
                 let adapter = synthesize_adapter(
                     &func_info,
                     project.wasi_registry,

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -423,7 +423,10 @@ fn try_lift_wasi_variant_or_enum(
     };
     if let Some(cases) = cases_opt {
         let cases = cases.to_vec();
-        let variant_type = tt.find_variant_type_by_name(name)?;
+        let variant_type = ctx
+            .wasi_package
+            .and_then(|pkg| tt.find_named_type_by_wasi_package(name, pkg))
+            .or_else(|| tt.find_variant_type_by_name(name))?;
         drop(tt);
         return Some(synthesize_lift_wasi_variant(
             name,
@@ -440,7 +443,10 @@ fn try_lift_wasi_variant_or_enum(
     // Check WASI enums (e.g., ErrorCode)
     if let Some(case_names) = ctx.wasi_registry.get_enum_variants(name) {
         let case_names = case_names.to_vec();
-        let enum_type = tt.find_enum_type_by_name(name)?;
+        let enum_type = ctx
+            .wasi_package
+            .and_then(|pkg| tt.find_named_type_by_wasi_package(name, pkg))
+            .or_else(|| tt.find_enum_type_by_name(name))?;
         drop(tt);
         return Some(synthesize_lift_wasi_enum(
             name,

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -38,41 +38,32 @@ use super::common::{
 pub struct LiftContext<'a> {
     pub wasi_registry: &'a WasiRegistry,
     pub type_table: &'a RefCell<TypeTable>,
-    /// WASI package hint for scoped type resolution (e.g., "http").
-    /// When set, named types are first looked up within this package to avoid
-    /// name collisions (e.g., wasi:cli/ErrorCode vs wasi:http/ErrorCode).
-    pub wasi_package: Option<&'a str>,
+    /// WASI package owning the binding being synthesized (e.g., `"http"`).
+    /// Required: every WASI binding is emitted inside a known package, and
+    /// named-type lookups are always scoped by `(name, wasi_package)` to
+    /// prevent collisions such as `wasi:cli/ErrorCode` vs. `wasi:http/ErrorCode`.
+    pub wasi_package: &'a str,
 }
 
 /// Convert a WASI AST `Type` to a `TypeId` in the type table.
 ///
+/// Every WASI binding is emitted inside a known package (e.g. `"http"`), so
+/// both the registry and the owning package are required — there is no
+/// unscoped variant. Named types are resolved by `(name, wasi_package)`; if
+/// the primary scope misses we consult the registry for the canonical owner
+/// of the bare name (e.g. `ErrorCode` is declared in `filesystem/types.wado`
+/// but referenced from `http` bindings). Same-named types from distinct
+/// interfaces are always distinct `TypeId`s.
+///
 /// This is needed for synthesized binding code that calls generic methods
 /// (e.g., `Array::<String>::with_capacity()`). The monomorphizer requires
-/// concrete `TypeId`s in `MonomorphInfo::type_args` to instantiate generic methods.
-pub fn wasi_type_to_type_id(ty: &Type, type_table: &mut TypeTable) -> TypeId {
-    wasi_type_to_type_id_scoped(ty, type_table, None, None)
-}
-
-/// Convert a WASI AST `Type` to a `TypeId`, with optional registry access for struct resolution.
-pub fn wasi_type_to_type_id_with_registry(
+/// concrete `TypeId`s in `MonomorphInfo::type_args` to instantiate generic
+/// methods.
+pub fn wasi_type_to_type_id(
     ty: &Type,
     type_table: &mut TypeTable,
-    registry: Option<&WasiRegistry>,
-) -> TypeId {
-    wasi_type_to_type_id_scoped(ty, type_table, registry, None)
-}
-
-/// Convert a WASI AST `Type` to a `TypeId`, with optional WASI package scope.
-///
-/// When `wasi_package` is provided (e.g., `"http"`), named types are first
-/// looked up within that WASI package before falling back to the unscoped
-/// lookup.  This prevents name collisions such as `wasi:cli/ErrorCode` (enum)
-/// shadowing `wasi:http/ErrorCode` (variant).
-pub fn wasi_type_to_type_id_scoped(
-    ty: &Type,
-    type_table: &mut TypeTable,
-    registry: Option<&WasiRegistry>,
-    wasi_package: Option<&str>,
+    registry: &WasiRegistry,
+    wasi_package: &str,
 ) -> TypeId {
     match ty {
         Type::Named(named) => match named.name.as_str() {
@@ -91,93 +82,47 @@ pub fn wasi_type_to_type_id_scoped(
             // Unit type written as a named type "()"
             "()" => TypeTable::UNIT,
             "String" => type_table.make_struct("String".to_string(), ModuleSource::string()),
-            // Resource/enum/variant types - look up the already-resolved TypeId if available.
-            // Primary lookup is scoped by `(name, wasi_package)`; only the WASI binding
-            // synthesizer may still fall back to the unscoped by-name scan, because
-            // WASI types can be interned under multiple package contexts (the resolver
-            // registers each declaring module independently). Cross-module name
-            // collisions with user-declared types are prevented because the fallback
-            // is only ever hit inside the WASI binding synthesizer.
-            _ => wasi_package
-                .and_then(|pkg| {
-                    type_table.find_named_type_by_wasi_package(named.name.as_str(), pkg)
-                })
+            // Resource/enum/variant types - look up the already-resolved TypeId.
+            // Lookups are strictly scoped by `(name, wasi_package)`. If the
+            // primary scope misses, we consult the registry for the canonical
+            // owning package and retry — never a bare-name scan, which would
+            // conflate same-named types from distinct interfaces (e.g.
+            // `wasi:filesystem/ErrorCode` vs. `wasi:http/ErrorCode`).
+            _ => type_table
+                .find_named_type_by_wasi_package(named.name.as_str(), wasi_package)
                 .or_else(|| {
-                    registry
-                        .and_then(|reg| canonical_wasi_package(reg, named.name.as_str()))
-                        .and_then(|pkg| {
-                            type_table.find_named_type_by_wasi_package(named.name.as_str(), pkg)
-                        })
-                })
-                .or_else(|| type_table.find_resource_type_by_name(named.name.as_str()))
-                .or_else(|| type_table.find_variant_type_by_name(named.name.as_str()))
-                .or_else(|| {
-                    // Create variant from WASI registry when it exists but is
-                    // not yet in this type_table. Prefer the registry's
-                    // canonical owning package so we don't mint a duplicate
-                    // TypeId when the same variant was (or will be) created by
-                    // another scope. Checked BEFORE the enum fallback to
-                    // prevent a same-named enum (e.g. cli ErrorCode) from
-                    // shadowing a package-scoped variant (e.g. filesystem
-                    // ErrorCode).
-                    if let Some(reg) = registry
-                        && reg.is_variant(&named.name)
-                    {
-                        let pkg = canonical_wasi_package(reg, named.name.as_str())
-                            .or(wasi_package)?;
-                        Some(type_table.make_variant(
-                            named.name.clone(),
-                            ModuleSource::Wasi {
-                                interface: format!("{pkg}/types.wado"),
-                            },
-                        ))
-                    } else {
-                        None
-                    }
-                })
-                .or_else(|| type_table.find_enum_type_by_name(named.name.as_str()))
-                .or_else(|| {
-                    // Check WASI struct registry
-                    if let Some(reg) = registry
-                        && reg.is_struct(&named.name)
-                    {
-                        let package = wasi_struct_package(reg, &named.name);
-                        Some(type_table.make_struct(
-                            named.name.clone(),
-                            ModuleSource::Wasi { interface: package },
-                        ))
-                    } else {
-                        None
-                    }
+                    canonical_wasi_package(registry, named.name.as_str()).and_then(|pkg| {
+                        type_table.find_named_type_by_wasi_package(named.name.as_str(), pkg)
+                    })
                 })
                 .unwrap_or(TypeTable::I32),
         },
         Type::Generic(g) => match g.name.as_str() {
             "Array" if g.args.len() == 1 => {
                 let elem_type =
-                    wasi_type_to_type_id_scoped(&g.args[0], type_table, registry, wasi_package);
+                    wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
                 type_table.make_array(elem_type)
             }
             "Option" if g.args.len() == 1 => {
                 let inner_type =
-                    wasi_type_to_type_id_scoped(&g.args[0], type_table, registry, wasi_package);
+                    wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
                 type_table.make_option(inner_type)
             }
             "Result" if g.args.len() == 2 => {
                 let ok_type =
-                    wasi_type_to_type_id_scoped(&g.args[0], type_table, registry, wasi_package);
+                    wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
                 let err_type =
-                    wasi_type_to_type_id_scoped(&g.args[1], type_table, registry, wasi_package);
+                    wasi_type_to_type_id(&g.args[1], type_table, registry, wasi_package);
                 type_table.make_result(ok_type, err_type)
             }
             "Stream" if g.args.len() == 1 => {
                 let inner =
-                    wasi_type_to_type_id_scoped(&g.args[0], type_table, registry, wasi_package);
+                    wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
                 type_table.make_stream(inner)
             }
             "Future" if g.args.len() == 1 => {
                 let inner =
-                    wasi_type_to_type_id_scoped(&g.args[0], type_table, registry, wasi_package);
+                    wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
                 type_table.make_future(inner)
             }
             // Own/Borrow are handle types represented as i32
@@ -188,7 +133,7 @@ pub fn wasi_type_to_type_id_scoped(
         Type::Tuple(types) => {
             let resolved: Vec<TypeId> = types
                 .iter()
-                .map(|t| wasi_type_to_type_id_scoped(t, type_table, registry, wasi_package))
+                .map(|t| wasi_type_to_type_id(t, type_table, registry, wasi_package))
                 .collect();
             type_table.make_tuple(resolved)
         }
@@ -454,23 +399,19 @@ fn try_lift_wasi_variant_or_enum(
     let tt = ctx.type_table.borrow();
 
     // Check WASI variants (e.g., HeaderError with cases InvalidSyntax, Forbidden, Immutable)
-    // Use package-scoped lookup when available to avoid name collisions
+    // Use package-scoped lookup to avoid name collisions
     // (e.g., wasi:http/ErrorCode vs wasi:sockets/ErrorCode).
-    let cases_opt = if let Some(pkg) = ctx.wasi_package {
-        ctx.wasi_registry.get_variant_cases_by_package(pkg, name)
-    } else {
-        ctx.wasi_registry.get_variant_cases(name)
-    };
+    let cases_opt = ctx
+        .wasi_registry
+        .get_variant_cases_by_package(ctx.wasi_package, name);
     if let Some(cases) = cases_opt {
         let cases = cases.to_vec();
-        let variant_type = ctx
-            .wasi_package
-            .and_then(|pkg| tt.find_named_type_by_wasi_package(name, pkg))
+        let variant_type = tt
+            .find_named_type_by_wasi_package(name, ctx.wasi_package)
             .or_else(|| {
                 canonical_wasi_package(ctx.wasi_registry, name)
                     .and_then(|pkg| tt.find_named_type_by_wasi_package(name, pkg))
-            })
-            .or_else(|| tt.find_variant_type_by_name(name))?;
+            })?;
         drop(tt);
         return Some(synthesize_lift_wasi_variant(
             name,
@@ -487,14 +428,12 @@ fn try_lift_wasi_variant_or_enum(
     // Check WASI enums (e.g., ErrorCode)
     if let Some(case_names) = ctx.wasi_registry.get_enum_variants(name) {
         let case_names = case_names.to_vec();
-        let enum_type = ctx
-            .wasi_package
-            .and_then(|pkg| tt.find_named_type_by_wasi_package(name, pkg))
+        let enum_type = tt
+            .find_named_type_by_wasi_package(name, ctx.wasi_package)
             .or_else(|| {
                 canonical_wasi_package(ctx.wasi_registry, name)
                     .and_then(|pkg| tt.find_named_type_by_wasi_package(name, pkg))
-            })
-            .or_else(|| tt.find_enum_type_by_name(name))?;
+            })?;
         drop(tt);
         return Some(synthesize_lift_wasi_enum(
             name,
@@ -653,7 +592,7 @@ fn synthesize_lift_wasi_variant(
     ));
 
     // Compute max payload alignment for payload offset calculation
-    let wasi_package = ctx.and_then(|c| c.wasi_package);
+    let wasi_package = ctx.map(|c| c.wasi_package);
     let max_payload_align = cases
         .iter()
         .filter_map(|case| case.payload.as_ref())
@@ -851,7 +790,8 @@ fn synthesize_lift_list(
     // These are needed by the monomorphizer to instantiate Array::with_capacity and .push().
     let (elem_type_id, array_type_id) = if let Some(ctx) = ctx {
         let mut tt = ctx.type_table.borrow_mut();
-        let elem_tid = wasi_type_to_type_id(elem_ty, &mut tt);
+        let elem_tid =
+            wasi_type_to_type_id(elem_ty, &mut tt, ctx.wasi_registry, ctx.wasi_package);
         let array_tid = tt.make_array(elem_tid);
         (elem_tid, array_tid)
     } else {
@@ -1006,7 +946,11 @@ fn synthesize_lift_option_inner(
     ctx: Option<&LiftContext<'_>>,
 ) -> TirExpr {
     let layout = if let Some(c) = ctx {
-        cm_abi::layout_option_with_registry_scoped(inner_ty, c.wasi_registry, c.wasi_package)
+        cm_abi::layout_option_with_registry_scoped(
+            inner_ty,
+            c.wasi_registry,
+            Some(c.wasi_package),
+        )
     } else {
         cm_abi::layout_option(inner_ty)
     };
@@ -1017,7 +961,7 @@ fn synthesize_lift_option_inner(
     let option_type_id = if let Some(c) = ctx {
         let mut tt = c.type_table.borrow_mut();
         let inner_type_id =
-            wasi_type_to_type_id_scoped(inner_ty, &mut tt, Some(c.wasi_registry), c.wasi_package);
+            wasi_type_to_type_id(inner_ty, &mut tt, c.wasi_registry, c.wasi_package);
         tt.make_option(inner_type_id)
     } else {
         TypeTable::I32 // placeholder when no context
@@ -1083,7 +1027,12 @@ fn synthesize_lift_result_inner(
     ctx: Option<&LiftContext<'_>>,
 ) -> TirExpr {
     let layout = if let Some(c) = ctx {
-        cm_abi::layout_result_with_registry_scoped(ok_ty, err_ty, c.wasi_registry, c.wasi_package)
+        cm_abi::layout_result_with_registry_scoped(
+            ok_ty,
+            err_ty,
+            c.wasi_registry,
+            Some(c.wasi_package),
+        )
     } else {
         cm_abi::layout_result(ok_ty, err_ty)
     };
@@ -1104,8 +1053,10 @@ fn synthesize_lift_result_inner(
     // i32 but initialized with `ref.null none` (a reference type).
     let result_type_id = if let Some(ctx) = ctx {
         let mut tt = ctx.type_table.borrow_mut();
-        let ok_type_id = wasi_type_to_type_id_scoped(ok_ty, &mut tt, None, ctx.wasi_package);
-        let err_type_id = wasi_type_to_type_id_scoped(err_ty, &mut tt, None, ctx.wasi_package);
+        let ok_type_id =
+            wasi_type_to_type_id(ok_ty, &mut tt, ctx.wasi_registry, ctx.wasi_package);
+        let err_type_id =
+            wasi_type_to_type_id(err_ty, &mut tt, ctx.wasi_registry, ctx.wasi_package);
         tt.make_result(ok_type_id, err_type_id)
     } else {
         TypeTable::I32 // placeholder when no context
@@ -1219,9 +1170,7 @@ fn synthesize_lift_tuple(
         let mut tt = ctx.type_table.borrow_mut();
         let elem_type_ids: Vec<TypeId> = elems
             .iter()
-            .map(|t| {
-                wasi_type_to_type_id_scoped(t, &mut tt, Some(ctx.wasi_registry), ctx.wasi_package)
-            })
+            .map(|t| wasi_type_to_type_id(t, &mut tt, ctx.wasi_registry, ctx.wasi_package))
             .collect();
         tt.make_tuple(elem_type_ids)
     } else {
@@ -1473,6 +1422,8 @@ fn synthesize_lower_tuple(
     addr: TirExpr,
     next_local: &mut u32,
     local_types: &mut Vec<TypeId>,
+    wasi_registry: &WasiRegistry,
+    wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) -> Vec<TirStmt> {
     let layout = cm_abi::layout_tuple(elems);
@@ -1495,7 +1446,7 @@ fn synthesize_lower_tuple(
         // Determine the type_id for this field
         let field_type_id = {
             let mut tt = type_table.borrow_mut();
-            wasi_type_to_type_id(elem_ty, &mut tt)
+            wasi_type_to_type_id(elem_ty, &mut tt, wasi_registry, wasi_package)
         };
 
         // Extract the i-th field from the tuple using FieldAccess
@@ -1521,6 +1472,8 @@ fn synthesize_lower_tuple(
                 field_addr,
                 next_local,
                 local_types,
+                wasi_registry,
+                wasi_package,
                 type_table,
             )
         } else {
@@ -1686,6 +1639,7 @@ fn synthesize_lower_wasi_variant_to_memory(
     stmts: &mut Vec<TirStmt>,
     local_types: &mut Vec<TypeId>,
     wasi_registry: &crate::component_model::WasiRegistry,
+    wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) {
     let cases = if let Some(c) = wasi_registry.get_variant_cases(name) {
@@ -1738,7 +1692,7 @@ fn synthesize_lower_wasi_variant_to_memory(
         if let Some(payload_ty) = &case.payload {
             let payload_type_id = {
                 let mut tt = type_table.borrow_mut();
-                wasi_type_to_type_id_with_registry(payload_ty, &mut tt, Some(wasi_registry))
+                wasi_type_to_type_id(payload_ty, &mut tt, wasi_registry, wasi_package)
             };
 
             let payload_expr = variant_payload(
@@ -1755,6 +1709,7 @@ fn synthesize_lower_wasi_variant_to_memory(
                 next_local,
                 local_types,
                 wasi_registry,
+                wasi_package,
                 type_table,
             );
 
@@ -1784,6 +1739,7 @@ fn synthesize_lower_option_to_memory(
     stmts: &mut Vec<TirStmt>,
     local_types: &mut Vec<TypeId>,
     wasi_registry: &crate::component_model::WasiRegistry,
+    wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) {
     let value_type_id = value.type_id;
@@ -1821,7 +1777,7 @@ fn synthesize_lower_option_to_memory(
     // If Some: lower payload to memory
     let inner_type_id = {
         let mut tt = type_table.borrow_mut();
-        wasi_type_to_type_id_with_registry(inner_type, &mut tt, Some(wasi_registry))
+        wasi_type_to_type_id(inner_type, &mut tt, wasi_registry, wasi_package)
     };
     let payload_expr = variant_payload(
         local_ref(value_local, "__opt_val", value_type_id),
@@ -1836,6 +1792,7 @@ fn synthesize_lower_option_to_memory(
         next_local,
         local_types,
         wasi_registry,
+        wasi_package,
         type_table,
     );
 
@@ -1864,6 +1821,7 @@ fn synthesize_flatten_value_to_flat_args(
     local_types: &mut Vec<TypeId>,
     flat_args: &mut Vec<TirExpr>,
     wasi_registry: &crate::component_model::WasiRegistry,
+    wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) {
     let resolved = wasi_registry.resolve_type(ty);
@@ -1942,10 +1900,11 @@ fn synthesize_flatten_value_to_flat_args(
                     if let Some(payload_ty) = &case.payload {
                         let payload_type_id = {
                             let mut tt = type_table.borrow_mut();
-                            wasi_type_to_type_id_with_registry(
+                            wasi_type_to_type_id(
                                 payload_ty,
                                 &mut tt,
-                                Some(wasi_registry),
+                                wasi_registry,
+                                wasi_package,
                             )
                         };
                         let payload_expr = variant_payload(
@@ -1965,6 +1924,7 @@ fn synthesize_flatten_value_to_flat_args(
                             local_types,
                             &mut case_flat,
                             wasi_registry,
+                            wasi_package,
                             type_table,
                         );
                         // Assign case flat values to shared payload locals
@@ -2016,6 +1976,7 @@ fn synthesize_flatten_option_to_flat_args(
     local_types: &mut Vec<TypeId>,
     flat_args: &mut Vec<TirExpr>,
     wasi_registry: &crate::component_model::WasiRegistry,
+    wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) {
     let vt = value.type_id;
@@ -2063,7 +2024,7 @@ fn synthesize_flatten_option_to_flat_args(
     // If Some: extract payload and flatten it
     let inner_type_id = {
         let mut tt = type_table.borrow_mut();
-        wasi_type_to_type_id_with_registry(inner_type, &mut tt, Some(wasi_registry))
+        wasi_type_to_type_id(inner_type, &mut tt, wasi_registry, wasi_package)
     };
     let payload_expr = variant_payload(
         local_ref(val_local, &format!("{prefix}_optval"), vt),
@@ -2082,6 +2043,7 @@ fn synthesize_flatten_option_to_flat_args(
         local_types,
         &mut some_flat,
         wasi_registry,
+        wasi_package,
         type_table,
     );
     // Assign flattened values to the mutable locals
@@ -2118,6 +2080,7 @@ fn synthesize_lower_wasi_type_to_memory(
     next_local: &mut u32,
     local_types: &mut Vec<TypeId>,
     wasi_registry: &crate::component_model::WasiRegistry,
+    wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) -> Vec<TirStmt> {
     let resolved = wasi_registry.resolve_type(ty);
@@ -2143,7 +2106,7 @@ fn synthesize_lower_wasi_type_to_memory(
                     offset = crate::cm_abi::align_to(offset, fa);
                     let field_type_id = {
                         let mut tt = type_table.borrow_mut();
-                        wasi_type_to_type_id(field_ty, &mut tt)
+                        wasi_type_to_type_id(field_ty, &mut tt, wasi_registry, wasi_package)
                     };
                     let field_expr = TirExpr {
                         kind: crate::tir::TirExprKind::FieldAccess {
@@ -2166,6 +2129,7 @@ fn synthesize_lower_wasi_type_to_memory(
                         next_local,
                         local_types,
                         wasi_registry,
+                        wasi_package,
                         type_table,
                     ));
                     offset += fs;
@@ -2593,7 +2557,12 @@ fn synthesize_adapter(
             Type::Named(n) if wasi_registry.is_struct(&n.name) => {
                 let struct_type_id = {
                     let mut tt = type_table.borrow_mut();
-                    wasi_type_to_type_id_with_registry(param_type, &mut tt, Some(wasi_registry))
+                    wasi_type_to_type_id(
+                        param_type,
+                        &mut tt,
+                        wasi_registry,
+                        &func_info.package,
+                    )
                 };
                 params.push(TirParam {
                     name: param_name.clone(),
@@ -2611,7 +2580,12 @@ fn synthesize_adapter(
             Type::Named(n) if wasi_registry.is_variant(&n.name) => {
                 let variant_type_id = {
                     let mut tt = type_table.borrow_mut();
-                    wasi_type_to_type_id_with_registry(param_type, &mut tt, Some(wasi_registry))
+                    wasi_type_to_type_id(
+                        param_type,
+                        &mut tt,
+                        wasi_registry,
+                        &func_info.package,
+                    )
                 };
                 params.push(TirParam {
                     name: param_name.clone(),
@@ -2629,7 +2603,12 @@ fn synthesize_adapter(
             Type::Generic(g) if g.name == "Option" && g.args.len() == 1 => {
                 let option_type_id = {
                     let mut tt = type_table.borrow_mut();
-                    wasi_type_to_type_id_with_registry(param_type, &mut tt, Some(wasi_registry))
+                    wasi_type_to_type_id(
+                        param_type,
+                        &mut tt,
+                        wasi_registry,
+                        &func_info.package,
+                    )
                 };
                 params.push(TirParam {
                     name: param_name.clone(),
@@ -2778,7 +2757,12 @@ fn synthesize_adapter(
                 // Resolve proper TypeIds for the element and array types
                 let (elem_type_id, array_type_id) = {
                     let mut tt = type_table.borrow_mut();
-                    let elem_tid = wasi_type_to_type_id(elem_type, &mut tt);
+                    let elem_tid = wasi_type_to_type_id(
+                        elem_type,
+                        &mut tt,
+                        wasi_registry,
+                        &func_info.package,
+                    );
                     let array_tid = tt.make_array(elem_tid);
                     (elem_tid, array_tid)
                 };
@@ -2907,6 +2891,8 @@ fn synthesize_adapter(
                         addr_ref,
                         &mut next_local,
                         &mut local_types,
+                        wasi_registry,
+                        &func_info.package,
                         type_table,
                     )
                 } else {
@@ -2953,7 +2939,12 @@ fn synthesize_adapter(
                 for (field_idx, (wado_name, _, field_ty)) in wado_fields.iter().enumerate() {
                     let field_type_id = {
                         let mut tt = type_table.borrow_mut();
-                        wasi_type_to_type_id(field_ty, &mut tt)
+                        wasi_type_to_type_id(
+                            field_ty,
+                            &mut tt,
+                            wasi_registry,
+                            &func_info.package,
+                        )
                     };
                     flat_args.push(TirExpr {
                         kind: crate::tir::TirExprKind::FieldAccess {
@@ -2982,6 +2973,7 @@ fn synthesize_adapter(
                         &mut local_types,
                         &mut flat_args,
                         wasi_registry,
+                        &func_info.package,
                         type_table,
                     );
                 }
@@ -3002,6 +2994,7 @@ fn synthesize_adapter(
                         &mut local_types,
                         &mut flat_args,
                         wasi_registry,
+                        &func_info.package,
                         type_table,
                     );
                 }
@@ -3159,6 +3152,7 @@ fn synthesize_adapter(
                         &mut body_stmts,
                         &mut local_types,
                         wasi_registry,
+                        &func_info.package,
                         type_table,
                     );
                     continue;
@@ -3186,6 +3180,7 @@ fn synthesize_adapter(
                         &mut body_stmts,
                         &mut local_types,
                         wasi_registry,
+                        &func_info.package,
                         type_table,
                     );
                     continue;
@@ -3290,7 +3285,7 @@ fn synthesize_adapter(
                 let lift_ctx = LiftContext {
                     wasi_registry,
                     type_table,
-                    wasi_package: Some(&func_info.package),
+                    wasi_package: &func_info.package,
                 };
                 let lifted = synthesize_lift_with_context(
                     &resolved,
@@ -3352,7 +3347,7 @@ fn synthesize_adapter(
         let lift_ctx = LiftContext {
             wasi_registry,
             type_table,
-            wasi_package: Some(&func_info.package),
+            wasi_package: &func_info.package,
         };
         let lifted = synthesize_lift_with_context(
             &resolved,
@@ -3409,7 +3404,7 @@ fn synthesize_adapter(
             let lift_ctx = LiftContext {
                 wasi_registry,
                 type_table,
-                wasi_package: Some(&func_info.package),
+                wasi_package: &func_info.package,
             };
             let lifted = synthesize_lift_flat_result(
                 &resolved,
@@ -6485,7 +6480,7 @@ fn synthesize_stream_read_func(
     let lift_ctx = LiftContext {
         wasi_registry,
         type_table,
-        wasi_package: Some("filesystem"),
+        wasi_package: "filesystem",
     };
     let ast_type = crate::ast::Type::Named(crate::ast::NamedType {
         id: crate::ast::AstId::fresh(),
@@ -6998,11 +6993,13 @@ fn replace_wasi_derived_type_recursive(
     adapter: &mut TirFunction,
     wasi_type: &Type,
     user_type: TypeId,
+    wasi_registry: &WasiRegistry,
+    wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) {
     let old_type = {
         let mut tt = type_table.borrow_mut();
-        wasi_type_to_type_id(wasi_type, &mut tt)
+        wasi_type_to_type_id(wasi_type, &mut tt, wasi_registry, wasi_package)
     };
     if old_type != user_type && old_type != TypeTable::I32 && old_type != TypeTable::UNIT {
         // Skip replacement if the user type resolves to the same base type
@@ -7035,14 +7032,14 @@ fn replace_wasi_derived_type_recursive(
             {
                 let new_elem = new_elem_args[0];
                 drop(tt);
-                replace_wasi_derived_type_recursive(adapter, &g.args[0], new_elem, type_table);
+                replace_wasi_derived_type_recursive(adapter, &g.args[0], new_elem, wasi_registry, wasi_package, type_table);
             }
         }
         Type::Tuple(elems) => {
             // Get the user's tuple field types
             if let Some(user_elems) = type_table.borrow().as_tuple(user_type) {
                 for (wasi_elem, &user_elem) in elems.iter().zip(user_elems.iter()) {
-                    replace_wasi_derived_type_recursive(adapter, wasi_elem, user_elem, type_table);
+                    replace_wasi_derived_type_recursive(adapter, wasi_elem, user_elem, wasi_registry, wasi_package, type_table);
                 }
             }
         }
@@ -7053,7 +7050,7 @@ fn replace_wasi_derived_type_recursive(
             {
                 let new_inner = new_args[0];
                 drop(tt);
-                replace_wasi_derived_type_recursive(adapter, &g.args[0], new_inner, type_table);
+                replace_wasi_derived_type_recursive(adapter, &g.args[0], new_inner, wasi_registry, wasi_package, type_table);
             }
         }
         Type::Generic(g) if g.name == "Result" && g.args.len() == 2 => {
@@ -7064,8 +7061,8 @@ fn replace_wasi_derived_type_recursive(
                 let new_ok = new_args[0];
                 let new_err = new_args[1];
                 drop(tt);
-                replace_wasi_derived_type_recursive(adapter, &g.args[0], new_ok, type_table);
-                replace_wasi_derived_type_recursive(adapter, &g.args[1], new_err, type_table);
+                replace_wasi_derived_type_recursive(adapter, &g.args[0], new_ok, wasi_registry, wasi_package, type_table);
+                replace_wasi_derived_type_recursive(adapter, &g.args[1], new_err, wasi_registry, wasi_package, type_table);
             }
         }
         _ => {}
@@ -7086,6 +7083,7 @@ fn fixup_wasi_derived_types_in_adapter(
     wasi_registry: &crate::component_model::WasiRegistry,
     skip_self: bool,
 ) {
+    let wasi_package = func_info.package.as_str();
     let params_iter: Box<dyn Iterator<Item = &(String, String, Type)>> = if skip_self {
         Box::new(func_info.params.iter().skip(1))
     } else {
@@ -7098,7 +7096,7 @@ fn fixup_wasi_derived_types_in_adapter(
         let new_type = call_args[i].type_id;
         // Resolve newtypes (e.g., FieldName → String) before computing WASI-derived TypeId
         let resolved = wasi_registry.resolve_type(param_type);
-        replace_wasi_derived_type_recursive(adapter, &resolved, new_type, type_table);
+        replace_wasi_derived_type_recursive(adapter, &resolved, new_type, wasi_registry, wasi_package, type_table);
     }
     // Also fix up return type's WASI-derived sub-types — but skip for CM bindings
     // that return non-flat types (tuples, variants). Their return TypeId was set
@@ -7109,7 +7107,7 @@ fn fixup_wasi_derived_types_in_adapter(
         && let Some(return_type) = &func_info.return_type
     {
         let resolved = wasi_registry.resolve_type(return_type);
-        replace_wasi_derived_type_recursive(adapter, &resolved, user_return_type, type_table);
+        replace_wasi_derived_type_recursive(adapter, &resolved, user_return_type, wasi_registry, wasi_package, type_table);
     }
 }
 
@@ -8052,10 +8050,11 @@ fn rewrite_calls_in_expr(
                         if matches!(arg.expr.kind, TirExprKind::Null) {
                             let option_type_id = {
                                 let mut tt = type_table.borrow_mut();
-                                wasi_type_to_type_id_with_registry(
+                                wasi_type_to_type_id(
                                     param_type,
                                     &mut tt,
-                                    Some(wasi_registry),
+                                    wasi_registry,
+                                    &func_info.package,
                                 )
                             };
                             flat.push(option_none(option_type_id));
@@ -8199,10 +8198,11 @@ fn rewrite_calls_in_expr(
                         if matches!(arg.kind, TirExprKind::Null) {
                             let option_type_id = {
                                 let mut tt = type_table.borrow_mut();
-                                wasi_type_to_type_id_with_registry(
+                                wasi_type_to_type_id(
                                     param_type,
                                     &mut tt,
-                                    Some(wasi_registry),
+                                    wasi_registry,
+                                    &func_info.package,
                                 )
                             };
                             flat.push(option_none(option_type_id));

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -500,7 +500,7 @@ fn generate_struct_serialize(
     let ref_string_type = tt.make_ref(string_type);
     let ser_error_type = tt.make_struct("SerializeError".to_string(), serde_module.clone());
     let ser_error_kind_type = tt
-        .find_enum_type_by_name("SerializeErrorKind")
+        .find_enum_type("SerializeErrorKind", &serde_module)
         .unwrap_or(TypeTable::I32);
     let result_unit_err = tt.make_result(TypeTable::UNIT, ser_error_type);
     let struct_ser_type = tt.make_assoc_type_projection(
@@ -718,7 +718,7 @@ fn generate_struct_deserialize(
     let option_i32 = tt.make_option(TypeTable::I32);
     let deser_error_type = tt.make_struct("DeserializeError".to_string(), serde_module.clone());
     let deser_error_kind_type = tt
-        .find_enum_type_by_name("DeserializeErrorKind")
+        .find_enum_type("DeserializeErrorKind", &serde_module)
         .unwrap_or(TypeTable::I32);
     let result_struct_err = tt.make_result(struct_type, deser_error_type);
     let lookup_fn_type = tt.make_function(
@@ -1594,7 +1594,7 @@ fn generate_enum_deserialize(
     let ref_string_type = tt.make_ref(string_type);
     let deser_error_type = tt.make_struct("DeserializeError".to_string(), serde_module.clone());
     let deser_error_kind_type = tt
-        .find_enum_type_by_name("DeserializeErrorKind")
+        .find_enum_type("DeserializeErrorKind", &serde_module)
         .unwrap_or(TypeTable::I32);
     let result_enum_err = tt.make_result(enum_type, deser_error_type);
     let d_type_param = tt.make_type_param("D".to_string(), 0);
@@ -1971,7 +1971,7 @@ fn generate_variant_serialize(
     let ref_string_type = tt.make_ref(string_type);
     let ser_error_type = tt.make_struct("SerializeError".to_string(), serde_module.clone());
     let ser_error_kind_type = tt
-        .find_enum_type_by_name("SerializeErrorKind")
+        .find_enum_type("SerializeErrorKind", &serde_module)
         .unwrap_or(TypeTable::I32);
     let result_unit_err = tt.make_result(TypeTable::UNIT, ser_error_type);
     let variant_ser_type = tt.make_assoc_type_projection(
@@ -2248,7 +2248,7 @@ fn generate_variant_deserialize(
     let ref_string_type = tt.make_ref(string_type);
     let deser_error_type = tt.make_struct("DeserializeError".to_string(), serde_module.clone());
     let deser_error_kind_type = tt
-        .find_enum_type_by_name("DeserializeErrorKind")
+        .find_enum_type("DeserializeErrorKind", &serde_module)
         .unwrap_or(TypeTable::I32);
     let result_variant_err = tt.make_result(variant_type, deser_error_type);
     let d_type_param = tt.make_type_param("D".to_string(), 0);
@@ -2828,7 +2828,7 @@ fn generate_flags_serialize(
     let ref_string_type = tt.make_ref(string_type);
     let ser_error_type = tt.make_struct("SerializeError".to_string(), serde_module.clone());
     let ser_error_kind_type = tt
-        .find_enum_type_by_name("SerializeErrorKind")
+        .find_enum_type("SerializeErrorKind", &serde_module)
         .unwrap_or(TypeTable::I32);
     let result_unit_err = tt.make_result(TypeTable::UNIT, ser_error_type);
     let seq_ser_type = tt.make_assoc_type_projection(
@@ -3055,7 +3055,7 @@ fn generate_flags_deserialize(
     let ref_string_type = tt.make_ref(string_type);
     let deser_error_type = tt.make_struct("DeserializeError".to_string(), serde_module.clone());
     let deser_error_kind_type = tt
-        .find_enum_type_by_name("DeserializeErrorKind")
+        .find_enum_type("DeserializeErrorKind", &serde_module)
         .unwrap_or(TypeTable::I32);
     let result_flags_err = tt.make_result(flags_type, deser_error_type);
     let result_unit_err = tt.make_result(TypeTable::UNIT, deser_error_type);

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1080,11 +1080,7 @@ impl TypeTable {
 
     /// Find a variant type by (name, `module_source`) pair via `intern_map` (O(1)).
     /// Collision-safe across modules when two variant types share a name.
-    pub fn find_variant_type(
-        &self,
-        name: &str,
-        module_source: &ModuleSource,
-    ) -> Option<TypeId> {
+    pub fn find_variant_type(&self, name: &str, module_source: &ModuleSource) -> Option<TypeId> {
         let key = ResolvedType::Variant {
             name: name.to_string(),
             module_source: module_source.clone(),
@@ -1094,11 +1090,7 @@ impl TypeTable {
 
     /// Find a resource type by (name, `module_source`) pair via `intern_map` (O(1)).
     /// Collision-safe across modules when two resource types share a name.
-    pub fn find_resource_type(
-        &self,
-        name: &str,
-        module_source: &ModuleSource,
-    ) -> Option<TypeId> {
+    pub fn find_resource_type(&self, name: &str, module_source: &ModuleSource) -> Option<TypeId> {
         let key = ResolvedType::Resource {
             name: name.to_string(),
             module_source: module_source.clone(),

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1078,8 +1078,23 @@ impl TypeTable {
         self.intern_map.get(&key).copied()
     }
 
+    /// Find a variant type by (name, `module_source`) pair via `intern_map` (O(1)).
+    /// Unlike `find_variant_type_by_name`, this is collision-safe across modules.
+    pub fn find_variant_type(
+        &self,
+        name: &str,
+        module_source: &ModuleSource,
+    ) -> Option<TypeId> {
+        let key = ResolvedType::Variant {
+            name: name.to_string(),
+            module_source: module_source.clone(),
+        };
+        self.intern_map.get(&key).copied()
+    }
+
     /// Find a variant type by name (scanning all types).
     /// Returns the first matching `ResolvedType::Variant` with the given name.
+    /// Prefer `find_variant_type` when the module source is known.
     pub fn find_variant_type_by_name(&self, name: &str) -> Option<TypeId> {
         for (&type_id, resolved) in &self.types {
             if let ResolvedType::Variant { name: vname, .. } = resolved
@@ -1091,8 +1106,23 @@ impl TypeTable {
         None
     }
 
+    /// Find a resource type by (name, `module_source`) pair via `intern_map` (O(1)).
+    /// Unlike `find_resource_type_by_name`, this is collision-safe across modules.
+    pub fn find_resource_type(
+        &self,
+        name: &str,
+        module_source: &ModuleSource,
+    ) -> Option<TypeId> {
+        let key = ResolvedType::Resource {
+            name: name.to_string(),
+            module_source: module_source.clone(),
+        };
+        self.intern_map.get(&key).copied()
+    }
+
     /// Find a resource type by name (scanning all types).
     /// Returns the first matching `ResolvedType::Resource` with the given name.
+    /// Prefer `find_resource_type` when the module source is known.
     pub fn find_resource_type_by_name(&self, name: &str) -> Option<TypeId> {
         for (&type_id, resolved) in &self.types {
             if let ResolvedType::Resource { name: rname, .. } = resolved
@@ -1104,8 +1134,19 @@ impl TypeTable {
         None
     }
 
+    /// Find an enum type by (name, `module_source`) pair via `intern_map` (O(1)).
+    /// Unlike `find_enum_type_by_name`, this is collision-safe across modules.
+    pub fn find_enum_type(&self, name: &str, module_source: &ModuleSource) -> Option<TypeId> {
+        let key = ResolvedType::Enum {
+            name: name.to_string(),
+            module_source: module_source.clone(),
+        };
+        self.intern_map.get(&key).copied()
+    }
+
     /// Find an enum type by name (scanning all types).
     /// Returns the first matching `ResolvedType::Enum` with the given name.
+    /// Prefer `find_enum_type` when the module source is known.
     pub fn find_enum_type_by_name(&self, name: &str) -> Option<TypeId> {
         for (&type_id, resolved) in &self.types {
             if let ResolvedType::Enum { name: ename, .. } = resolved
@@ -1115,6 +1156,16 @@ impl TypeTable {
             }
         }
         None
+    }
+
+    /// Find a flags type by (name, `module_source`) pair via `intern_map` (O(1)).
+    /// Collision-safe across modules when two flags types share a name.
+    pub fn find_flags_type(&self, name: &str, module_source: &ModuleSource) -> Option<TypeId> {
+        let key = ResolvedType::Flags {
+            name: name.to_string(),
+            module_source: module_source.clone(),
+        };
+        self.intern_map.get(&key).copied()
     }
 
     /// Find a named type (resource, enum, or variant) scoped to a WASI package.

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1079,7 +1079,7 @@ impl TypeTable {
     }
 
     /// Find a variant type by (name, `module_source`) pair via `intern_map` (O(1)).
-    /// Unlike `find_variant_type_by_name`, this is collision-safe across modules.
+    /// Collision-safe across modules when two variant types share a name.
     pub fn find_variant_type(
         &self,
         name: &str,
@@ -1092,10 +1092,13 @@ impl TypeTable {
         self.intern_map.get(&key).copied()
     }
 
-    /// Find a variant type by name (scanning all types).
-    /// Returns the first matching `ResolvedType::Variant` with the given name.
-    /// Prefer `find_variant_type` when the module source is known.
-    pub fn find_variant_type_by_name(&self, name: &str) -> Option<TypeId> {
+    /// Find a variant type by name alone (scans all types).
+    ///
+    /// WARNING: collision-prone across modules — prefer `find_variant_type`
+    /// when the module source is known. Kept as an internal helper for the
+    /// WASI binding synthesizer, which resolves cross-WASI-package type
+    /// references where the primary `(name, wasi_package)` scope misses.
+    pub(crate) fn find_variant_type_by_name(&self, name: &str) -> Option<TypeId> {
         for (&type_id, resolved) in &self.types {
             if let ResolvedType::Variant { name: vname, .. } = resolved
                 && vname == name
@@ -1107,7 +1110,7 @@ impl TypeTable {
     }
 
     /// Find a resource type by (name, `module_source`) pair via `intern_map` (O(1)).
-    /// Unlike `find_resource_type_by_name`, this is collision-safe across modules.
+    /// Collision-safe across modules when two resource types share a name.
     pub fn find_resource_type(
         &self,
         name: &str,
@@ -1120,10 +1123,13 @@ impl TypeTable {
         self.intern_map.get(&key).copied()
     }
 
-    /// Find a resource type by name (scanning all types).
-    /// Returns the first matching `ResolvedType::Resource` with the given name.
-    /// Prefer `find_resource_type` when the module source is known.
-    pub fn find_resource_type_by_name(&self, name: &str) -> Option<TypeId> {
+    /// Find a resource type by name alone (scans all types).
+    ///
+    /// WARNING: collision-prone across modules — prefer `find_resource_type`
+    /// when the module source is known. Kept as an internal helper for the
+    /// WASI binding synthesizer, which resolves cross-WASI-package type
+    /// references where the primary `(name, wasi_package)` scope misses.
+    pub(crate) fn find_resource_type_by_name(&self, name: &str) -> Option<TypeId> {
         for (&type_id, resolved) in &self.types {
             if let ResolvedType::Resource { name: rname, .. } = resolved
                 && rname == name
@@ -1135,7 +1141,7 @@ impl TypeTable {
     }
 
     /// Find an enum type by (name, `module_source`) pair via `intern_map` (O(1)).
-    /// Unlike `find_enum_type_by_name`, this is collision-safe across modules.
+    /// Collision-safe across modules when two enum types share a name.
     pub fn find_enum_type(&self, name: &str, module_source: &ModuleSource) -> Option<TypeId> {
         let key = ResolvedType::Enum {
             name: name.to_string(),
@@ -1144,10 +1150,13 @@ impl TypeTable {
         self.intern_map.get(&key).copied()
     }
 
-    /// Find an enum type by name (scanning all types).
-    /// Returns the first matching `ResolvedType::Enum` with the given name.
-    /// Prefer `find_enum_type` when the module source is known.
-    pub fn find_enum_type_by_name(&self, name: &str) -> Option<TypeId> {
+    /// Find an enum type by name alone (scans all types).
+    ///
+    /// WARNING: collision-prone across modules — prefer `find_enum_type`
+    /// when the module source is known. Kept as an internal helper for the
+    /// WASI binding synthesizer, which resolves cross-WASI-package type
+    /// references where the primary `(name, wasi_package)` scope misses.
+    pub(crate) fn find_enum_type_by_name(&self, name: &str) -> Option<TypeId> {
         for (&type_id, resolved) in &self.types {
             if let ResolvedType::Enum { name: ename, .. } = resolved
                 && ename == name

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1092,23 +1092,6 @@ impl TypeTable {
         self.intern_map.get(&key).copied()
     }
 
-    /// Find a variant type by name alone (scans all types).
-    ///
-    /// WARNING: collision-prone across modules — prefer `find_variant_type`
-    /// when the module source is known. Kept as an internal helper for the
-    /// WASI binding synthesizer, which resolves cross-WASI-package type
-    /// references where the primary `(name, wasi_package)` scope misses.
-    pub(crate) fn find_variant_type_by_name(&self, name: &str) -> Option<TypeId> {
-        for (&type_id, resolved) in &self.types {
-            if let ResolvedType::Variant { name: vname, .. } = resolved
-                && vname == name
-            {
-                return Some(type_id);
-            }
-        }
-        None
-    }
-
     /// Find a resource type by (name, `module_source`) pair via `intern_map` (O(1)).
     /// Collision-safe across modules when two resource types share a name.
     pub fn find_resource_type(
@@ -1123,23 +1106,6 @@ impl TypeTable {
         self.intern_map.get(&key).copied()
     }
 
-    /// Find a resource type by name alone (scans all types).
-    ///
-    /// WARNING: collision-prone across modules — prefer `find_resource_type`
-    /// when the module source is known. Kept as an internal helper for the
-    /// WASI binding synthesizer, which resolves cross-WASI-package type
-    /// references where the primary `(name, wasi_package)` scope misses.
-    pub(crate) fn find_resource_type_by_name(&self, name: &str) -> Option<TypeId> {
-        for (&type_id, resolved) in &self.types {
-            if let ResolvedType::Resource { name: rname, .. } = resolved
-                && rname == name
-            {
-                return Some(type_id);
-            }
-        }
-        None
-    }
-
     /// Find an enum type by (name, `module_source`) pair via `intern_map` (O(1)).
     /// Collision-safe across modules when two enum types share a name.
     pub fn find_enum_type(&self, name: &str, module_source: &ModuleSource) -> Option<TypeId> {
@@ -1148,23 +1114,6 @@ impl TypeTable {
             module_source: module_source.clone(),
         };
         self.intern_map.get(&key).copied()
-    }
-
-    /// Find an enum type by name alone (scans all types).
-    ///
-    /// WARNING: collision-prone across modules — prefer `find_enum_type`
-    /// when the module source is known. Kept as an internal helper for the
-    /// WASI binding synthesizer, which resolves cross-WASI-package type
-    /// references where the primary `(name, wasi_package)` scope misses.
-    pub(crate) fn find_enum_type_by_name(&self, name: &str) -> Option<TypeId> {
-        for (&type_id, resolved) in &self.types {
-            if let ResolvedType::Enum { name: ename, .. } = resolved
-                && ename == name
-            {
-                return Some(type_id);
-            }
-        }
-        None
     }
 
     /// Find a flags type by (name, `module_source`) pair via `intern_map` (O(1)).

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1126,12 +1126,14 @@ impl TypeTable {
         self.intern_map.get(&key).copied()
     }
 
-    /// Find a named type (resource, enum, or variant) scoped to a WASI package.
+    /// Find any decl-backed named type (resource, enum, variant, struct,
+    /// flags, or newtype) scoped to a WASI package.
     ///
-    /// Tries resource → enum → variant in order, restricting matches to types
-    /// whose `module_source` is `Wasi { interface }` where `interface` starts
-    /// with `{wasi_package}/`.  Falls back to the unscoped lookup when no
-    /// scoped match is found.
+    /// Matches types whose `module_source` is `Wasi { interface }` where
+    /// `interface` starts with `{wasi_package}/`. The key invariant: two WIT
+    /// interfaces in distinct packages that happen to share a type name
+    /// (e.g. `wasi:cli/ErrorCode` vs `wasi:http/ErrorCode`) resolve to
+    /// distinct `TypeId`s because `module_source` is part of the intern key.
     pub fn find_named_type_by_wasi_package(
         &self,
         name: &str,
@@ -1139,22 +1141,42 @@ impl TypeTable {
     ) -> Option<TypeId> {
         let prefix = format!("{wasi_package}/");
         for (&type_id, resolved) in &self.types {
-            let matches = match resolved {
+            let (n, ms) = match resolved {
                 ResolvedType::Resource {
                     name: n,
-                    module_source: ModuleSource::Wasi { interface },
-                } => n == name && interface.starts_with(&prefix),
-                ResolvedType::Enum {
+                    module_source,
+                }
+                | ResolvedType::Enum {
                     name: n,
-                    module_source: ModuleSource::Wasi { interface },
-                } => n == name && interface.starts_with(&prefix),
-                ResolvedType::Variant {
+                    module_source,
+                }
+                | ResolvedType::Variant {
                     name: n,
-                    module_source: ModuleSource::Wasi { interface },
-                } => n == name && interface.starts_with(&prefix),
-                _ => false,
+                    module_source,
+                }
+                | ResolvedType::Struct {
+                    name: n,
+                    module_source,
+                    is_monomorphized: false,
+                    ..
+                }
+                | ResolvedType::Flags {
+                    name: n,
+                    module_source,
+                }
+                | ResolvedType::Newtype {
+                    name: n,
+                    module_source,
+                    ..
+                } => (n, module_source),
+                _ => continue,
             };
-            if matches {
+            if n != name {
+                continue;
+            }
+            if let ModuleSource::Wasi { interface } = ms
+                && interface.starts_with(&prefix)
+            {
                 return Some(type_id);
             }
         }

--- a/wado-compiler/src/world_registry.rs
+++ b/wado-compiler/src/world_registry.rs
@@ -134,8 +134,23 @@ impl WorldRegistry {
     ///
     /// The world is keyed by its fully-qualified name from the `#[cm("...")]` attribute.
     /// If no attribute is present, the `PascalCase` name is used as fallback.
+    ///
+    /// If another world is already registered under the same `fq_name`, the
+    /// first registrant is kept and this registration is skipped (with a
+    /// warning logged to stderr). Two distinct worlds sharing a fully-qualified
+    /// name is a bug in the stdlib or user input — silently overwriting would
+    /// make the earlier world invisible to the code generator.
     pub fn register(&mut self, world: &WorldDecl) {
         let fq_name = fq_name_from_attrs(&world.attrs).unwrap_or_else(|| world.name.clone());
+
+        if self.worlds.contains_key(&fq_name) {
+            eprintln!(
+                "WorldRegistry: duplicate world `{fq_name}` (also declared as `{}`). \
+                 Keeping the first registrant.",
+                world.name,
+            );
+            return;
+        }
 
         let exports = world
             .exports


### PR DESCRIPTION
## Summary

Replaces the bare-name collision workaround in `WasiRegistry` and throughout the CM binding synthesizer with a strict `(source_interface, name)` identity for every WIT-declared type. Same-named types from distinct interfaces — e.g. `wasi:cli/ErrorCode` (enum), `wasi:filesystem/ErrorCode`, `wasi:http/ErrorCode`, `wasi:sockets/ErrorCode`, `wasi:sockets/ip-name-lookup#ErrorCode` (variants) — now resolve to distinct `TypeId`s through the entire pipeline, with no silent first-wins selection anywhere.

### What changed

- **`TypeTable::find_*_by_name` deleted.** `find_variant_type` / `find_enum_type` / `find_resource_type` / `find_flags_type` require a `&ModuleSource`. `find_named_type_by_wasi_package` now covers every decl-backed kind (Resource, Enum, Variant, Struct, Flags, Newtype).
- **`wasi_type_to_type_id` consolidated** — the `_scoped` / `_with_registry` wrappers are gone; `(registry, wasi_package)` are required. `LiftContext::wasi_package` tightened from `Option<&str>` to `&str`, and `wasi_package` is threaded through every synthesizer that materializes types (`synthesize_lower_tuple`, `synthesize_lower_wasi_variant_to_memory`, `synthesize_lower_option_to_memory`, `synthesize_flatten_value_to_flat_args`, `synthesize_flatten_option_to_flat_args`, `synthesize_lower_wasi_type_to_memory`, `replace_wasi_derived_type_recursive`).
- **`WasiRegistry` internals re-keyed by `(source_interface, name)`**. `enums`, `variants`, `resources`, `structs`, `flags`, `newtypes` all keyed by a `(String, String)` pair. The `check_collision` / `Collision` / `name_owner` workaround (and its stderr warnings on every compile) is removed.
- **`register_unique` helper panics on duplicate `(interface, name)` registration** — same name defined twice in the same .wado file (or emitted twice by the stdlib) is a loud build failure, not a silent overwrite.
- **`find_unique_in` / `has_any_in` / `find_unique_source_in` helpers** — bare-name accessors now return `Some` only when exactly one interface defines the name; ambiguous same-named types must use an interface- or package-scoped accessor.
- **`effect_owner_module_sources` keyed by `(ModuleSource, name)`**, with a `lookup_effect_owner(name, package)` helper that prefers the WASI package match.
- **`WorldRegistry::register` rejects duplicate fully-qualified names** with an explicit stderr warning (keeps first registrant) instead of silently overwriting.

### Test plan

- [x] `cargo test -p wado-compiler --lib` — 401 passed, 0 failed
- [x] `cargo test -p wado-compiler --test e2e` — 5430 passed, 0 failed (covers `http_client_*`, `wasi_filesystem_*`, and existing `cross_module_same_name_{enum,variant,struct,flags,resource,effect,world}` regression fixtures)
- [x] `mise run test-wado` — 10/10 passed
- [x] `mise run on-task-done` — cargo build, clippy-fix, golden regeneration (wir, format, gale), doc-stdlib, cargo fmt, and dprint fmt all succeeded. No stdlib golden drift.
- [x] Confirmed the `WasiRegistry: bare-name collision in variants for ErrorCode: …` stderr spam on every stdlib load is gone.

https://claude.ai/code/session_01KZUqfEnrQsDyVg8P9wRgaa

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZUqfEnrQsDyVg8P9wRgaa)_