### PR TITLE
feat(cli): load extra CA certs from SSL_CERT_FILE for guest HTTPS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,6 +2213,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2908,6 +2917,7 @@ dependencies = [
  "futures",
  "glob",
  "http",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -2915,11 +2925,14 @@ dependencies = [
  "jsonschema",
  "lexopt",
  "predicates",
+ "rustls 0.22.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2",
  "tempfile",
  "tokio",
+ "tokio-rustls 0.25.0",
  "toml 1.1.2+spec-1.1.0",
  "wado-compiler",
  "wado-lsp",
@@ -2928,6 +2941,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,11 @@ http = { version = "1" }
 http-body-util = { version = "0.1" }
 hyper = { version = "1", features = ["http1", "http2", "server"] }
 hyper-util = { version = "0.1", features = ["tokio", "http1", "http2", "server", "server-auto"] }
+rustls = { version = "0.22", default-features = false, features = ["ring", "tls12", "logging"] }
+tokio-rustls = { version = "0.25", default-features = false, features = ["ring", "tls12", "logging"] }
+webpki-roots = { version = "0.26" }
+rustls-pemfile = { version = "2" }
+http-body = { version = "1" }
 assert_cmd = { version = "2" }
 heck = { version = "0.5" }
 lexopt = { version = "0.3.1" }

--- a/wado-cli/Cargo.toml
+++ b/wado-cli/Cargo.toml
@@ -23,9 +23,14 @@ futures = { workspace = true }
 glob = { workspace = true }
 indexmap = { workspace = true }
 http = { workspace = true }
+http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
+rustls = { workspace = true }
+tokio-rustls = { workspace = true }
+webpki-roots = { workspace = true }
+rustls-pemfile = { workspace = true }
 lexopt = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/wado-cli/src/http_hooks.rs
+++ b/wado-cli/src/http_hooks.rs
@@ -56,16 +56,16 @@ impl Default for WadoHttpHooks {
 
 fn load_extra_ca_certs(roots: &mut RootCertStore) {
     for var in ["WADO_CA_BUNDLE", "SSL_CERT_FILE"] {
-        if let Ok(path) = std::env::var(var) {
-            if !path.is_empty() {
-                load_pem_bundle(roots, Path::new(&path));
-            }
+        if let Ok(path) = std::env::var(var)
+            && !path.is_empty()
+        {
+            load_pem_bundle(roots, Path::new(&path));
         }
     }
-    if let Ok(dir) = std::env::var("SSL_CERT_DIR") {
-        if !dir.is_empty() {
-            load_pem_dir(roots, Path::new(&dir));
-        }
+    if let Ok(dir) = std::env::var("SSL_CERT_DIR")
+        && !dir.is_empty()
+    {
+        load_pem_dir(roots, Path::new(&dir));
     }
 }
 
@@ -158,15 +158,15 @@ async fn send_request(
     let connect_timeout = options
         .as_ref()
         .and_then(|o| o.connect_timeout)
-        .unwrap_or(Duration::from_secs(600));
+        .unwrap_or(Duration::from_mins(10));
     let first_byte_timeout = options
         .as_ref()
         .and_then(|o| o.first_byte_timeout)
-        .unwrap_or(Duration::from_secs(600));
+        .unwrap_or(Duration::from_mins(10));
     let between_bytes_timeout = options
         .as_ref()
         .and_then(|o| o.between_bytes_timeout)
-        .unwrap_or(Duration::from_secs(600));
+        .unwrap_or(Duration::from_mins(10));
 
     let tcp = match tokio::time::timeout(connect_timeout, TcpStream::connect(&connect_addr)).await {
         Ok(Ok(s)) => s,
@@ -271,10 +271,10 @@ fn from_hyper_response_error(err: hyper::Error) -> ErrorCode {
     if err.is_timeout() {
         return ErrorCode::HttpResponseTimeout;
     }
-    if let Some(cause) = err.source() {
-        if let Some(err) = cause.downcast_ref::<ErrorCode>() {
-            return err.clone();
-        }
+    if let Some(cause) = err.source()
+        && let Some(err) = cause.downcast_ref::<ErrorCode>()
+    {
+        return err.clone();
     }
     warn_log!("hyper response error: {err:?}");
     ErrorCode::HttpProtocolError

--- a/wado-cli/src/http_hooks.rs
+++ b/wado-cli/src/http_hooks.rs
@@ -1,0 +1,325 @@
+//! Custom `WasiHttpHooks` that extends wasmtime's default TLS trust store with
+//! certificates loaded from the `SSL_CERT_FILE` / `SSL_CERT_DIR` /
+//! `WADO_CA_BUNDLE` environment variables.
+//!
+//! wasmtime's stock `default_send_request` hardcodes `webpki-roots`, which is
+//! not sufficient when the host sits behind a TLS-inspecting proxy that signs
+//! outgoing HTTPS with a private CA (e.g. a sandboxed dev environment).
+
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use http::uri::Scheme;
+use http_body_util::BodyExt;
+use http_body_util::combinators::UnsyncBoxBody;
+use rustls::RootCertStore;
+use rustls::pki_types::{CertificateDer, ServerName};
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
+use wasmtime_wasi::TrappableError;
+use wasmtime_wasi_http::p3::bindings::http::types::{DnsErrorPayload, ErrorCode};
+use wasmtime_wasi_http::p3::{RequestOptions, WasiHttpHooks};
+
+macro_rules! warn_log {
+    ($($arg:tt)*) => { eprintln!("warning: {}", format_args!($($arg)*)) };
+}
+
+pub struct WadoHttpHooks {
+    client_config: Arc<rustls::ClientConfig>,
+}
+
+impl WadoHttpHooks {
+    pub fn new() -> Self {
+        let mut roots = RootCertStore {
+            roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+        };
+        load_extra_ca_certs(&mut roots);
+        let client_config = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        Self {
+            client_config: Arc::new(client_config),
+        }
+    }
+}
+
+impl Default for WadoHttpHooks {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn load_extra_ca_certs(roots: &mut RootCertStore) {
+    for var in ["WADO_CA_BUNDLE", "SSL_CERT_FILE"] {
+        if let Ok(path) = std::env::var(var) {
+            if !path.is_empty() {
+                load_pem_bundle(roots, Path::new(&path));
+            }
+        }
+    }
+    if let Ok(dir) = std::env::var("SSL_CERT_DIR") {
+        if !dir.is_empty() {
+            load_pem_dir(roots, Path::new(&dir));
+        }
+    }
+}
+
+fn load_pem_bundle(roots: &mut RootCertStore, path: &Path) {
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(err) => {
+            warn_log!("failed to open CA bundle {}: {err}", path.display());
+            return;
+        }
+    };
+    let mut reader = BufReader::new(file);
+    let mut certs: Vec<CertificateDer<'static>> = Vec::new();
+    for item in rustls_pemfile::certs(&mut reader) {
+        match item {
+            Ok(cert) => certs.push(cert),
+            Err(err) => warn_log!("failed to parse cert in {}: {err}", path.display()),
+        }
+    }
+    let (_added, ignored) = roots.add_parsable_certificates(certs);
+    if ignored > 0 {
+        warn_log!("ignored {ignored} invalid certs in {}", path.display());
+    }
+}
+
+fn load_pem_dir(roots: &mut RootCertStore, dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        warn_log!("failed to read SSL_CERT_DIR {}", dir.display());
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() {
+            load_pem_bundle(roots, &path);
+        }
+    }
+}
+
+impl WasiHttpHooks for WadoHttpHooks {
+    fn send_request(
+        &mut self,
+        request: http::Request<UnsyncBoxBody<Bytes, ErrorCode>>,
+        options: Option<RequestOptions>,
+        _fut: Box<dyn core::future::Future<Output = Result<(), ErrorCode>> + Send>,
+    ) -> Box<
+        dyn core::future::Future<
+                Output = Result<
+                    (
+                        http::Response<UnsyncBoxBody<Bytes, ErrorCode>>,
+                        Box<dyn core::future::Future<Output = Result<(), ErrorCode>> + Send>,
+                    ),
+                    TrappableError<ErrorCode>,
+                >,
+            > + Send,
+    > {
+        let config = Arc::clone(&self.client_config);
+        Box::new(async move {
+            let (res, driver) = send_request(config, request, options)
+                .await
+                .map_err(TrappableError::from)?;
+            let driver: Box<dyn core::future::Future<Output = Result<(), ErrorCode>> + Send> =
+                Box::new(driver);
+            Ok((res.map(BodyExt::boxed_unsync), driver))
+        })
+    }
+}
+
+async fn send_request(
+    client_config: Arc<rustls::ClientConfig>,
+    mut req: http::Request<UnsyncBoxBody<Bytes, ErrorCode>>,
+    options: Option<RequestOptions>,
+) -> Result<
+    (
+        http::Response<impl http_body::Body<Data = Bytes, Error = ErrorCode>>,
+        BoxFuture<'static, Result<(), ErrorCode>>,
+    ),
+    ErrorCode,
+> {
+    let uri = req.uri();
+    let authority = uri.authority().ok_or(ErrorCode::HttpRequestUriInvalid)?;
+    let use_tls = uri.scheme() == Some(&Scheme::HTTPS);
+    let host = authority.host().to_string();
+    let connect_addr = if authority.port().is_some() {
+        authority.to_string()
+    } else {
+        let port = if use_tls { 443 } else { 80 };
+        format!("{authority}:{port}")
+    };
+
+    let connect_timeout = options
+        .as_ref()
+        .and_then(|o| o.connect_timeout)
+        .unwrap_or(Duration::from_secs(600));
+    let first_byte_timeout = options
+        .as_ref()
+        .and_then(|o| o.first_byte_timeout)
+        .unwrap_or(Duration::from_secs(600));
+    let between_bytes_timeout = options
+        .as_ref()
+        .and_then(|o| o.between_bytes_timeout)
+        .unwrap_or(Duration::from_secs(600));
+
+    let tcp = match tokio::time::timeout(connect_timeout, TcpStream::connect(&connect_addr)).await {
+        Ok(Ok(s)) => s,
+        Ok(Err(err)) if err.kind() == std::io::ErrorKind::AddrNotAvailable => {
+            return Err(dns_error("address not available".to_string(), 0));
+        }
+        Ok(Err(err))
+            if err
+                .to_string()
+                .starts_with("failed to lookup address information") =>
+        {
+            return Err(dns_error("address not available".to_string(), 0));
+        }
+        Ok(Err(err)) => {
+            warn_log!("connection refused: {err:?}");
+            return Err(ErrorCode::ConnectionRefused);
+        }
+        Err(_) => return Err(ErrorCode::ConnectionTimeout),
+    };
+
+    let (mut sender, conn_driver) = if use_tls {
+        let domain = ServerName::try_from(host.as_str())
+            .map_err(|e| {
+                warn_log!("dns lookup error: {e:?}");
+                dns_error("invalid dns name".to_string(), 0)
+            })?
+            .to_owned();
+        let connector = TlsConnector::from(client_config);
+        let tls = connector.connect(domain, tcp).await.map_err(|e| {
+            warn_log!("tls protocol error: {e:?}");
+            ErrorCode::TlsProtocolError
+        })?;
+        handshake(tls, connect_timeout).await?
+    } else {
+        handshake(tcp, connect_timeout).await?
+    };
+
+    *req.uri_mut() = http::Uri::builder()
+        .path_and_query(
+            req.uri()
+                .path_and_query()
+                .map(http::uri::PathAndQuery::as_str)
+                .unwrap_or("/"),
+        )
+        .build()
+        .expect("comes from valid request");
+
+    let res = tokio::time::timeout(first_byte_timeout, sender.send_request(req))
+        .await
+        .map_err(|_| ErrorCode::ConnectionReadTimeout)?
+        .map_err(ErrorCode::from_hyper_request_error)?;
+
+    let res = res.map(|incoming| IncomingResponseBody {
+        incoming,
+        timeout: {
+            let mut t = tokio::time::interval(between_bytes_timeout);
+            t.reset();
+            t
+        },
+    });
+
+    Ok((res, conn_driver))
+}
+
+async fn handshake<S>(
+    stream: S,
+    connect_timeout: Duration,
+) -> Result<
+    (
+        hyper::client::conn::http1::SendRequest<UnsyncBoxBody<Bytes, ErrorCode>>,
+        BoxFuture<'static, Result<(), ErrorCode>>,
+    ),
+    ErrorCode,
+>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin + 'static,
+{
+    let (sender, conn) = tokio::time::timeout(
+        connect_timeout,
+        hyper::client::conn::http1::Builder::new().handshake(hyper_util::rt::TokioIo::new(stream)),
+    )
+    .await
+    .map_err(|_| ErrorCode::ConnectionTimeout)?
+    .map_err(ErrorCode::from_hyper_request_error)?;
+
+    // The hyper connection must be driven concurrently with `sender.send_request`,
+    // otherwise the request never reaches the wire. Spawn the connection on the
+    // tokio runtime now, and forward its result via a channel so the caller can
+    // still observe completion / errors.
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let res = conn.await.map_err(from_hyper_response_error);
+        let _ = tx.send(res);
+    });
+    let driver: BoxFuture<'static, Result<(), ErrorCode>> =
+        Box::pin(async move { rx.await.unwrap_or(Ok(())) });
+    Ok((sender, driver))
+}
+
+fn from_hyper_response_error(err: hyper::Error) -> ErrorCode {
+    use core::error::Error as _;
+    if err.is_timeout() {
+        return ErrorCode::HttpResponseTimeout;
+    }
+    if let Some(cause) = err.source() {
+        if let Some(err) = cause.downcast_ref::<ErrorCode>() {
+            return err.clone();
+        }
+    }
+    warn_log!("hyper response error: {err:?}");
+    ErrorCode::HttpProtocolError
+}
+
+fn dns_error(rcode: String, info_code: u16) -> ErrorCode {
+    ErrorCode::DnsError(DnsErrorPayload {
+        rcode: Some(rcode),
+        info_code: Some(info_code),
+    })
+}
+
+struct IncomingResponseBody {
+    incoming: hyper::body::Incoming,
+    timeout: tokio::time::Interval,
+}
+
+impl http_body::Body for IncomingResponseBody {
+    type Data = <hyper::body::Incoming as http_body::Body>::Data;
+    type Error = ErrorCode;
+
+    fn poll_frame(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        use core::task::Poll;
+        match std::pin::Pin::new(&mut self.as_mut().incoming).poll_frame(cx) {
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(from_hyper_response_error(err)))),
+            Poll::Ready(Some(Ok(frame))) => {
+                self.timeout.reset();
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Poll::Pending => match self.timeout.poll_tick(cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(_) => Poll::Ready(Some(Err(ErrorCode::ConnectionReadTimeout))),
+            },
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.incoming.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.incoming.size_hint()
+    }
+}

--- a/wado-cli/src/lib.rs
+++ b/wado-cli/src/lib.rs
@@ -18,6 +18,7 @@ pub mod compiler_host;
 pub mod doc;
 pub mod dump;
 pub mod format;
+pub mod http_hooks;
 pub mod init;
 pub mod kiln_driver;
 pub mod kiln_provider;

--- a/wado-cli/src/runtime.rs
+++ b/wado-cli/src/runtime.rs
@@ -5,10 +5,13 @@ use wasmtime_wasi::{DirPerms, FilePerms, WasiCtx, WasiCtxView, WasiView};
 use wasmtime_wasi_http::WasiHttpCtx;
 use wasmtime_wasi_http::p3::{WasiHttpCtxView, WasiHttpView};
 
+use crate::http_hooks::WadoHttpHooks;
+
 pub struct WasiState {
     ctx: WasiCtx,
     table: ResourceTable,
     http: WasiHttpCtx,
+    http_hooks: WadoHttpHooks,
 }
 
 impl WasiState {
@@ -30,7 +33,13 @@ impl WasiState {
         let ctx = builder.build();
         let table = ResourceTable::new();
         let http = WasiHttpCtx::new();
-        Ok(Self { ctx, table, http })
+        let http_hooks = WadoHttpHooks::new();
+        Ok(Self {
+            ctx,
+            table,
+            http,
+            http_hooks,
+        })
     }
 }
 
@@ -48,7 +57,7 @@ impl WasiHttpView for WasiState {
         WasiHttpCtxView {
             ctx: &mut self.http,
             table: &mut self.table,
-            hooks: Default::default(),
+            hooks: &mut self.http_hooks,
         }
     }
 }

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -165,6 +165,7 @@ struct HttpWasiState {
     table: ResourceTable,
     wasi: WasiCtx,
     http: WasiHttpCtx,
+    http_hooks: crate::http_hooks::WadoHttpHooks,
 }
 
 impl WasiView for HttpWasiState {
@@ -181,7 +182,7 @@ impl WasiHttpView for HttpWasiState {
         WasiHttpCtxView {
             ctx: &mut self.http,
             table: &mut self.table,
-            hooks: Default::default(),
+            hooks: &mut self.http_hooks,
         }
     }
 }
@@ -198,6 +199,7 @@ fn create_http_state() -> HttpWasiState {
         table: ResourceTable::new(),
         wasi: WasiCtxBuilder::new().inherit_stdio().build(),
         http: WasiHttpCtx::new(),
+        http_hooks: crate::http_hooks::WadoHttpHooks::new(),
     }
 }
 


### PR DESCRIPTION
## Summary

wasmtime 43's stock `default_send_request` hardcodes `webpki-roots` as the only TLS trust store, so outgoing HTTPS from a guest component fails with `ErrorCode::TlsProtocolError` whenever the host sits behind a TLS-inspecting proxy (the sandboxed Claude Code dev environment, corporate MITM proxies, etc.). `example/llm.wado` against OpenRouter hit exactly this.

This PR adds a custom `WasiHttpHooks` implementation (`wado-cli/src/http_hooks.rs`) that overrides `send_request` with a minimal hyper-based HTTPS client whose rustls `RootCertStore` is seeded with `webpki-roots` **plus** any PEM certificates referenced by:

- `WADO_CA_BUNDLE` (wado-specific, checked first)
- `SSL_CERT_FILE`  (OpenSSL-style single-PEM bundle)
- `SSL_CERT_DIR`   (directory of PEM files)

The hooks are wired into both `wado run` (`runtime.rs::WasiState`) and `wado serve` (`serve.rs::HttpWasiState`). With `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt` (already set in the sandbox), `example/llm.wado` and `example/http-get.wado` now complete successfully.

### Why a custom hook instead of patching wasmtime?

`default_send_request` hardcodes the root store, and `[patch.crates-io] wasmtime-wasi-http = { path = "vendor/wasmtime/crates/wasi-http" }` led to duplicate-crate conflicts because the vendored workspace resolves `wasmtime = { workspace = true }` against its own path, giving us two distinct `wasmtime 43.0.1`s. Implementing `WasiHttpHooks::send_request` is the supported extension point.

### Implementation notes

- The hyper H1 connection future is spawned on the tokio runtime and forwarded to the caller via a oneshot channel — the trait's returned `io` future is only polled *after* `send_request` awaits the response, so running it inline would deadlock.
- Timeouts (`connect_timeout`, `first_byte_timeout`, `between_bytes_timeout`) and `IncomingResponseBody::poll_frame` reproduce the behavior of `default_send_request` so body-streaming semantics are preserved.

## Test plan

- [x] `example/http-get.wado` → `Status: 200` against httpbin.org
- [x] `example/llm.wado` with `OPENROUTER_API_KEY` set → returns a completion from OpenRouter
- [x] `mise run on-task-done` (full: build, clippy-fix, update-golden-\*, doc-stdlib, format, test, test-wado) passes

https://claude.ai/code/session_01R2YEjmGu6QzErkQ7ihHDJc

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2YEjmGu6QzErkQ7ihHDJc)_