### PR TITLE
perf(dev-tools): speed up update-golden-fixtures ~5.5x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ sha2 = { version = "0.10", default-features = false }
 [profile.dev.package.wado-compiler]
 opt-level = 1
 
+[profile.dev.package.wado-dev-tools]
+opt-level = 1
+
 # Optimize Cranelift in dev/test builds for faster E2E tests.
 # Cranelift compiles Wasm→native for every test; without this it runs in debug mode.
 [profile.dev.package.cranelift-codegen]

--- a/wado-dev-tools/src/pipeline.rs
+++ b/wado-dev-tools/src/pipeline.rs
@@ -12,16 +12,21 @@ use crate::template::Template;
 
 const COMPILER_STACK_SIZE: usize = 16 * 1024 * 1024;
 
-/// Default worker count: one third of the logical CPUs (min 1). Each worker
-/// owns a 16 MB stack and runs the full compiler plus wasmtime, so saturating
-/// every core is wasteful and, on constrained sandboxes, has empirically led
-/// to SIGSEGV from resource exhaustion during golden-dump. Halving the CPU
-/// count still segfaulted in practice, so we go to one third.
+/// Default worker count: one per logical CPU. Each worker owns a 16 MB stack
+/// and runs the full compiler plus wasmtime. On constrained sandboxes this has
+/// empirically caused SIGSEGV from resource exhaustion; set `WADO_GOLDEN_WORKERS`
+/// to cap the parallelism in that case.
 fn default_num_workers() -> usize {
-    let logical = std::thread::available_parallelism()
+    if let Some(n) = std::env::var("WADO_GOLDEN_WORKERS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+    {
+        return n;
+    }
+    std::thread::available_parallelism()
         .map(std::num::NonZero::get)
-        .unwrap_or(4);
-    (logical / 3).max(1)
+        .unwrap_or(4)
 }
 
 /// Per-worker slot tracking which file is currently being compiled.


### PR DESCRIPTION
## Summary

`update-golden-fixtures` was taking 7 min (424s) on a 4-core machine, blocking day-to-day iteration on the compiler. Profiling with `perf` + `samply` pointed at two design choices in `wado-dev-tools/src/pipeline.rs`:

1. **Default worker count is `logical / 3`** — on a 4-core machine this rounds to **1 worker**, so the pipeline was effectively serial even though the per-file work is embarrassingly parallel.
2. **`wado-dev-tools` is built at `opt-level=0`** — `wado-compiler` itself already has `opt-level=1` for dev builds, but the thin wrapper (tokio/wasmtime glue) did not, and it shows up in profiles.

### Changes

- `Cargo.toml`: add `[profile.dev.package.wado-dev-tools]` with `opt-level=1`, matching `wado-compiler`. No change to the `cargo build` flow — still a dev build, no separate release artifact needed.
- `wado-dev-tools/src/pipeline.rs`: `default_num_workers()` now returns `available_parallelism()` (one worker per logical CPU) with `WADO_GOLDEN_WORKERS` as an environment override for sandboxes that previously SIGSEGV'd under full parallelism (16 MB per-worker stack × N workers can exhaust constrained RLIMITs).

### Measurements (4-core / 16 GB Linux)

| | Before | After |
|---|---|---|
| `update-golden-fixtures` full run | **424s** | **77s** (5.5×) |
| Workers | 1 | 4 |
| Per-file compile avg | 0.526s | 0.426s |
| Slowest file | 1.02s | 0.88s |

Scaling matrix on a 50-file subset, `release` build for reference:

| Build | W=1 | W=2 | W=3 | W=4 |
|---|---|---|---|---|
| debug (opt-level=0)    | 28.95s | 14.59s | 9.71s | 7.41s |
| release (opt-level=3)  | 10.95s | 5.54s | 3.77s | 2.92s |

Clean linear scaling up to the core count, with diminishing returns past that (tested W=6, W=8 on 4 cores — same as W=4).

### Profiler observations (reference, not addressed here)

Even with these changes, `malloc` / `_int_free` / `memmove` / `realloc` account for ~52% of CPU in a release build. The bulk of the rest is `Clone` on `ast::Expr`, `ast::Type`, `tir::ResolvedType`, and `String`. Reducing allocation in the compiler (arena, string interning) is the next lever but is a compiler-wide refactor, not a dev-tools change.

Another follow-up I considered and did **not** include: incremental regeneration (content-hash manifest so editing one fixture doesn't rebuild 806). It needs inter-fixture dependency tracking (100 fixtures do `use … from "./sub/…"`). Happy to do it in a follow-up if this isn't fast enough for the 1-file-edit case.

## Test plan

- [x] `mise run update-golden-fixtures` → completes in 77s, output bit-identical to HEAD (`git diff wado-compiler/tests/fixtures.golden/` empty).
- [x] `mise run on-task-done` started before commit: build, clippy, `update-golden-fixtures`, `update-golden-format-fixtures`, `update-gale-golden`, `doc-stdlib`, `format`, and the unit/integration test phases up to e2e O0 all passed. e2e was in progress at commit time (reduce-parallelism tip from the skill is still available if it hits the known flake).
- [ ] Reviewer on a different core count should see proportional scaling — please sanity-check on a higher-core box.

https://claude.ai/code/session_011m5UrW92bWy4tN3vvc6xrP

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5UrW92bWy4tN3vvc6xrP)_