### PR TITLE
wasi: add wasi:tls@0.3.0-draft stdlib (wasmtime v44)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -385,6 +385,9 @@ cargo run -p wado-from-idl -- \
 cargo run -p wado-from-idl -- \
     --wit-dir vendor/wasmtime/crates/wasi/src/p3/wit \
     --output-dir wado-compiler/lib/wasi
+cargo run -p wado-from-idl -- \
+    --wit-dir vendor/wasmtime/crates/wasi-tls/src/p3/wit \
+    --output-dir wado-compiler/lib/wasi
 """
 
 [tasks.update-stdlib-kiln]

--- a/wado-compiler/lib/wasi/tls.wado
+++ b/wado-compiler/lib/wasi/tls.wado
@@ -1,0 +1,4 @@
+#![generated(by = "wado-from-idl")]
+
+pub use { Error } from "wasi:tls/types.wado";
+pub use { Connector } from "wasi:tls/client.wado";

--- a/wado-compiler/lib/wasi/tls/client.wado
+++ b/wado-compiler/lib/wasi/tls/client.wado
@@ -1,0 +1,29 @@
+#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/client.wit"])]
+
+use { Error } from "wasi:tls/types.wado";
+
+
+#[cm("wasi:tls/client@0.3.0-draft#connector")]
+pub resource Connector {
+    #[cm("wasi:tls/client@0.3.0-draft#[constructor]connector")]
+    fn new() -> Connector;
+    /// Set up the encryption stream transform.
+    /// This takes an unprotected `cleartext` application data stream and
+    /// returns an encrypted data stream, ready to be sent out over the network.
+    /// Closing the `cleartext` stream will cause a `close_notify` packet to be emitted on the returned output stream.
+    #[cm("wasi:tls/client@0.3.0-draft#[method]connector.send")]
+    #[cm_params("self", "cleartext")]
+    fn send(self: &Connector, cleartext: Stream<u8>) -> [Stream<u8>, Future<Result<(), Error>>];
+    /// Set up the decryption stream transform.
+    /// This takes an encrypted data stream, as received via e.g. the network,
+    /// and returns a decrypted application data stream.
+    #[cm("wasi:tls/client@0.3.0-draft#[method]connector.receive")]
+    #[cm_params("self", "ciphertext")]
+    fn receive(self: &Connector, ciphertext: Stream<u8>) -> [Stream<u8>, Future<Result<(), Error>>];
+    /// Perform the handshake.
+    /// The `send` & `receive` streams must be set up before calling this method.
+    #[cm("wasi:tls/client@0.3.0-draft#[static]connector.connect")]
+    #[cm_params("this", "server-name")]
+    async fn connect(this: Connector, server_name: String) -> AsyncCall<Result<(), Error>>;
+}
+

--- a/wado-compiler/lib/wasi/tls/client.wado
+++ b/wado-compiler/lib/wasi/tls/client.wado
@@ -26,4 +26,3 @@ pub resource Connector {
     #[cm_params("this", "server-name")]
     async fn connect(this: Connector, server_name: String) -> AsyncCall<Result<(), Error>>;
 }
-

--- a/wado-compiler/lib/wasi/tls/types.wado
+++ b/wado-compiler/lib/wasi/tls/types.wado
@@ -6,4 +6,3 @@ pub resource Error {
     #[cm_params("self")]
     fn to_debug_string(self: &Error) -> String;
 }
-

--- a/wado-compiler/lib/wasi/tls/types.wado
+++ b/wado-compiler/lib/wasi/tls/types.wado
@@ -1,0 +1,9 @@
+#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/types.wit"])]
+
+#[cm("wasi:tls/types@0.3.0-draft#error")]
+pub resource Error {
+    #[cm("wasi:tls/types@0.3.0-draft#[method]error.to-debug-string")]
+    #[cm_params("self")]
+    fn to_debug_string(self: &Error) -> String;
+}
+

--- a/wado-compiler/lib/wasi/tls/worlds.wado
+++ b/wado-compiler/lib/wasi/tls/worlds.wado
@@ -12,6 +12,4 @@ pub world Imports {
         Connector::receive,
         Connector::connect,
     }
-
 }
-

--- a/wado-compiler/lib/wasi/tls/worlds.wado
+++ b/wado-compiler/lib/wasi/tls/worlds.wado
@@ -1,0 +1,17 @@
+#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/world.wit"])]
+
+#[cm("wasi:tls/imports@0.3.0-draft")]
+pub world Imports {
+    import Types {
+        Error::to_debug_string,
+    }
+
+    import Client {
+        Connector::new,
+        Connector::send,
+        Connector::receive,
+        Connector::connect,
+    }
+
+}
+


### PR DESCRIPTION
## Summary

- wasmtime v44 に追加された P3 `wasi-tls` クレート (`wasi:tls@0.3.0-draft`) を Wado 標準ライブラリに取り込み
- `mise run update-stdlib-wasi` が `vendor/wasmtime/crates/wasi-tls/src/p3/wit` も処理するように変更
- `wado-from-idl` で生成された `wado-compiler/lib/wasi/tls/{types,client,worlds}.wado` と flat re-export `wasi/tls.wado` をコミット

生成結果:

- `wasi:tls/types` — `resource Error { to_debug_string }`
- `wasi:tls/client` — `resource Connector { new, send, receive, connect }` (`Stream<u8>` / `Future<Result<(), Error>>` / `async ... AsyncCall<...>`)
- `wasi:tls/imports` world

## Test plan

- [ ] `mise run update-stdlib-wasi` を再実行して差分が出ないこと
- [ ] `mise run on-task-done` 実行 (format / clippy / test / test-wado)
- [ ] `use { Connector } from "wasi:tls";` する最小 Wado プログラムが少なくとも parse / resolve できることを確認

なお 1 つ目のコミットで stable toolchain (1.94.1) を使ったのは `rust-toolchain.toml` の 1.95 を `static.rust-lang.org` 側 503 で取得できなかったため (環境依存の一時的事情)。`wado-from-idl` はテキスト生成のみで rustc 版差には非依存のため出力は同一です。

https://claude.ai/code/session_01RxpSgrnKEnqDmcTo36drNG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxpSgrnKEnqDmcTo36drNG)_