### PR TITLE
fix(cli/doc): recognise fenced code blocks in render_md_doc

### DIFF
--- a/docs/stdlib-core-kiln.md
+++ b/docs/stdlib-core-kiln.md
@@ -23,8 +23,8 @@ Generator authors call this at the top of their `generate` entry:
 
 ```wado
 export fn generate(raw: RawRequest) -> Result<Response, Error> {
-let req = bind_request::<Options>(raw)?;
-// ... read req.primary.content, honor req.options, emit files ...
+    let req = bind_request::<Options>(raw)?;
+    // ... read req.primary.content, honor req.options, emit files ...
 }
 ```
 

--- a/docs/stdlib-core-prelude.md
+++ b/docs/stdlib-core-prelude.md
@@ -2951,10 +2951,10 @@ Example (HTTP POST body):
 ```wado
 let [body_rx, body_tx] = Stream::<u8>::new();
 let [req, _tx_future] = Request::new(headers, Option::Some(body_rx), ...);
-let task = Client::send(req); // host subtask starts
-body_tx.write(body_bytes); // rendezvous with host read
+let task = Client::send(req);       // host subtask starts
+body_tx.write(body_bytes);          // rendezvous with host read
 body_tx.drop();
-let resp = task.wait(); // block for response
+let resp = task.wait();             // block for response
 ```
 
 #### `__cm_packed: i32`

--- a/docs/stdlib-core-serde.md
+++ b/docs/stdlib-core-serde.md
@@ -9,35 +9,64 @@ Provides format-agnostic `Serialize` and `Deserialize` traits with a 17-method
 data model optimized for JSON and CBOR. Format implementations (e.g., `core:json`)
 implement `Serializer` and `Deserializer` to support specific wire formats.
 
-Usage:
-
 ```wado
 use { Serialize, Deserialize, SerializeError, DeserializeError } from "core:serde";
 ```
 
-Field attributes:
+## Field naming on the wire
 
-- `#[serde(default)]` on a struct field — when the field is absent during
-  deserialization, fall back to a default value instead of returning
-  `MissingField`. The fallback is the field's declared default expression
-  (`f: T = expr`) if present, otherwise the type's zero-value (`0`, `""`,
-  `false`, `[]`, `null`, ...). A field that declares `= expr` is implicitly
-  `#[serde(default)]`, so the attribute is only needed on fields without a
-  declared default.
-- `#[serde(rename = "...")]` on a struct field — override the wire-form
-  key for that field.
-- `#[serde(rename_all = "...")]` on a struct — rename every field by a
-  convention (`"camelCase"`, `"snake_case"`, `"kebab-case"`, ...).
+Wado fields are `snake_case` by convention, but the default wire-form key
+is `camelCase`. Override per struct with `#[serde(rename_all = "...")]`,
+or per field with `#[serde(rename = "...")]` (which takes precedence).
 
-Example — a field with a declared default is implicitly tolerated when
-missing, so deserializing `{"host":"localhost"}` yields `timeout = 30`:
+`rename_all` strategies: `"camelCase"` (default), `"snake_case"`,
+`"PascalCase"`, `"SCREAMING_SNAKE_CASE"`, `"kebab-case"`,
+`"SCREAMING-KEBAB-CASE"`.
+
+```wado
+// Default — wire keys are camelCase
+struct User {
+    user_name: String,        // wire key: "userName"
+    account_id: i64,          // wire key: "accountId"
+}
+
+// Per-struct convention
+#[serde(rename_all = "snake_case")]
+struct Event {
+    created_at: String,       // wire key: "created_at"
+    event_type: String,       // wire key: "event_type"
+}
+
+// Per-field override (wins over rename_all)
+#[serde(rename_all = "kebab-case")]
+struct Header {
+    content_type: String,     // wire key: "content-type"
+    #[serde(rename = "X-Trace-Id")]
+    trace_id: String,         // wire key: "X-Trace-Id"
+}
+```
+
+## Missing fields on deserialization
+
+By default, a missing required field produces `DeserializeError` with kind
+`MissingField`. To tolerate omission, mark the field with
+`#[serde(default)]` (uses the type's zero-value: `0`, `""`, `false`, `[]`,
+`null`, ...) or declare a default expression with `f: T = expr` (uses that
+expression). A field that declares `= expr` is implicitly
+`#[serde(default)]`, so the attribute is only needed on fields without a
+declared default.
 
 ```wado
 struct Config {
-    host: String,
-    timeout: i32 = 30,
+    host: String,             // required - error if missing
+    #[serde(default)]
+    port: i32,                // missing -> 0  (zero-value)
+    timeout: i32 = 30,        // missing -> 30 (declared default)
 }
 impl Deserialize for Config;
+
+// {"host":"localhost"}
+//   -> Config { host: "localhost", port: 0, timeout: 30 }
 ```
 
 ## Traits

--- a/docs/stdlib-core-serde.md
+++ b/docs/stdlib-core-serde.md
@@ -34,8 +34,8 @@ missing, so deserializing `{"host":"localhost"}` yields `timeout = 30`:
 
 ```wado
 struct Config {
-host: String,
-timeout: i32 = 30,
+    host: String,
+    timeout: i32 = 30,
 }
 impl Deserialize for Config;
 ```

--- a/docs/stdlib-core-zlib.md
+++ b/docs/stdlib-core-zlib.md
@@ -30,19 +30,19 @@ Compression:
 
 ```wado
 let input: Array<u8> = [...];
-let compressed = zlib_compress(&input); // zlib, default level/strategy
-let fast = zlib_compress(&input, Z_BEST_SPEED); // override level only
-let best = zlib_compress(&input, Z_BEST_COMPRESSION);
-let gz = gzip_compress(&input); // gzip wrapper
-let raw = deflate_raw(&input); // raw DEFLATE, no header/trailer
+let compressed = zlib_compress(&input);                            // zlib, default level/strategy
+let fast       = zlib_compress(&input, Z_BEST_SPEED);              // override level only
+let best       = zlib_compress(&input, Z_BEST_COMPRESSION);
+let gz         = gzip_compress(&input);                            // gzip wrapper
+let raw        = deflate_raw(&input);                              // raw DEFLATE, no header/trailer
 ```
 
 Decompression:
 
 ```wado
-let z = inflate_zlib(&compressed)?; // RFC 1950
-let gz = inflate_gzip(&gzipped)?; // RFC 1952
-let any = uncompress(&data)?; // auto-detect zlib/gzip
+let z   = inflate_zlib(&compressed)?;                              // RFC 1950
+let gz  = inflate_gzip(&gzipped)?;                                 // RFC 1952
+let any = uncompress(&data)?;                                      // auto-detect zlib/gzip
 ```
 
 Streaming (chunked input):

--- a/wado-cli/src/doc.rs
+++ b/wado-cli/src/doc.rs
@@ -743,7 +743,7 @@ fn render_md_doc(out: &mut String, doc: &str) {
     }
 }
 
-/// CommonMark fenced code block delimiter — three or more `` ` `` or `~`.
+/// `CommonMark` fenced code block delimiter — three or more `` ` `` or `~`.
 #[derive(Clone, Copy)]
 struct FenceMarker {
     /// Fence character (`` ` `` or `~`).

--- a/wado-cli/src/doc.rs
+++ b/wado-cli/src/doc.rs
@@ -652,8 +652,45 @@ fn render_md_doc(out: &mut String, doc: &str) {
     let mut in_list = false;
     let mut in_blockquote = false;
     let mut prev_heading = false;
+    let mut fence: Option<FenceMarker> = None;
 
     for line in doc.lines() {
+        // Inside a fenced code block: detect the closing fence and emit
+        // every other line verbatim. CommonMark heading / list / emphasis
+        // rules do not apply inside the block.
+        if let Some(open) = fence {
+            let trimmed_start = line.trim_start();
+            if matches_fence_close(trimmed_start, &open) {
+                out.push_str(trimmed_start);
+                out.push('\n');
+                fence = None;
+                prev_blank = false;
+                prev_heading = false;
+                in_list = false;
+                in_blockquote = false;
+                continue;
+            }
+            out.push_str(line);
+            out.push('\n');
+            prev_blank = false;
+            continue;
+        }
+
+        // Detect an opening fence before any other markdown processing.
+        if let Some(open) = fence_open(line.trim_start()) {
+            if !prev_blank {
+                out.push('\n');
+            }
+            out.push_str(line.trim_start());
+            out.push('\n');
+            fence = Some(open);
+            prev_blank = false;
+            prev_heading = false;
+            in_list = false;
+            in_blockquote = false;
+            continue;
+        }
+
         let normalized = normalize_md_line(line);
         let trimmed = normalized.trim();
 
@@ -704,6 +741,40 @@ fn render_md_doc(out: &mut String, doc: &str) {
             in_blockquote = false;
         }
     }
+}
+
+/// CommonMark fenced code block delimiter — three or more `` ` `` or `~`.
+#[derive(Clone, Copy)]
+struct FenceMarker {
+    /// Fence character (`` ` `` or `~`).
+    ch: char,
+    /// Number of fence characters in the opening run.
+    len: usize,
+}
+
+fn fence_open(s: &str) -> Option<FenceMarker> {
+    let ch = s.chars().next()?;
+    if ch != '`' && ch != '~' {
+        return None;
+    }
+    let len = s.chars().take_while(|&c| c == ch).count();
+    if len < 3 {
+        return None;
+    }
+    // Backtick fences forbid backticks in the info string per CommonMark; the
+    // remaining content after a tilde fence has no such restriction.
+    if ch == '`' && s[len..].contains('`') {
+        return None;
+    }
+    Some(FenceMarker { ch, len })
+}
+
+fn matches_fence_close(s: &str, open: &FenceMarker) -> bool {
+    let count = s.chars().take_while(|&c| c == open.ch).count();
+    if count < open.len {
+        return false;
+    }
+    s[count..].chars().all(|c| c == ' ' || c == '\t')
 }
 
 fn normalize_md_line(line: &str) -> String {
@@ -1012,5 +1083,102 @@ fn render_simple_struct(out: &mut String, s: &DocStruct) {
             out.push_str("    ..\n");
         }
         out.push_str("}\n");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render(input: &str) -> String {
+        let mut out = String::new();
+        render_md_doc(&mut out, input);
+        out
+    }
+
+    #[test]
+    fn fenced_block_preserves_attribute_lines_as_content() {
+        // Lines starting with `#` inside a fenced block are content, not headings.
+        let input =
+            "Example:\n\n```wado\nstruct S {\n    #[serde(default)]\n    port: i32,\n}\n```";
+        let out = render(input);
+        assert!(
+            out.contains("    #[serde(default)]\n    port: i32,"),
+            "expected attribute and field on consecutive lines, got:\n{out}"
+        );
+        // No spurious blank line between the attribute and the next field.
+        assert!(
+            !out.contains("#[serde(default)]\n\n"),
+            "unexpected blank after attribute:\n{out}"
+        );
+    }
+
+    #[test]
+    fn fenced_block_preserves_indentation_and_alignment() {
+        let input = "```wado\nlet a = 1;          // one\nlet bb = 22;        // two\n```";
+        let out = render(input);
+        assert!(
+            out.contains("let a = 1;          // one\n"),
+            "alignment whitespace should survive inside fenced block:\n{out}"
+        );
+        assert!(
+            out.contains("let bb = 22;        // two\n"),
+            "alignment whitespace should survive inside fenced block:\n{out}"
+        );
+    }
+
+    #[test]
+    fn tilde_fenced_block_is_recognized() {
+        let input = "~~~wado\n#[serde(default)]\nport: i32 = 0,\n~~~";
+        let out = render(input);
+        assert!(
+            out.contains("~~~wado\n#[serde(default)]\nport: i32 = 0,\n~~~\n"),
+            "tilde fence should pass through content verbatim:\n{out}"
+        );
+    }
+
+    #[test]
+    fn longer_closing_fence_is_accepted() {
+        // Opening of length 4 must be matched by 4+ closing chars.
+        let input = "````wado\nlet x = 1;\n`````";
+        let out = render(input);
+        assert!(out.contains("````wado\nlet x = 1;\n`````\n"), "got:\n{out}");
+    }
+
+    #[test]
+    fn shorter_closing_fence_does_not_close() {
+        // Opening of length 4, run of 3 backticks inside is not a close.
+        let input = "````wado\n```\nstill code\n````";
+        let out = render(input);
+        assert!(
+            out.contains("```\nstill code\n````\n"),
+            "inner ``` should remain content:\n{out}"
+        );
+    }
+
+    #[test]
+    fn outside_fence_heading_still_inserts_blank() {
+        // Sanity check: existing heading behaviour outside fenced blocks is unchanged.
+        let input = "# Title\nfollow-up";
+        let out = render(input);
+        assert_eq!(out, "# Title\n\nfollow-up\n");
+    }
+
+    #[test]
+    fn fence_close_with_info_string_is_not_a_close() {
+        // Closing fences disallow info strings per CommonMark — `````wado` is content.
+        let input = "```wado\n```rust\nstill code\n```";
+        let out = render(input);
+        assert!(out.contains("```rust\nstill code\n```\n"), "got:\n{out}");
+    }
+
+    #[test]
+    fn fence_blank_line_is_preserved() {
+        let input = "```wado\nlet a = 1;\n\nlet b = 2;\n```";
+        let out = render(input);
+        assert!(
+            out.contains("let a = 1;\n\nlet b = 2;\n"),
+            "blank lines inside fenced block must be preserved:\n{out}"
+        );
     }
 }

--- a/wado-compiler/lib/core/serde.wado
+++ b/wado-compiler/lib/core/serde.wado
@@ -4,35 +4,64 @@
 //! data model optimized for JSON and CBOR. Format implementations (e.g., `core:json`)
 //! implement `Serializer` and `Deserializer` to support specific wire formats.
 //!
-//! Usage:
-//!
 //! ```wado
 //! use { Serialize, Deserialize, SerializeError, DeserializeError } from "core:serde";
 //! ```
 //!
-//! Field attributes:
+//! ## Field naming on the wire
 //!
-//! - `#[serde(default)]` on a struct field — when the field is absent during
-//!   deserialization, fall back to a default value instead of returning
-//!   `MissingField`. The fallback is the field's declared default expression
-//!   (`f: T = expr`) if present, otherwise the type's zero-value (`0`, `""`,
-//!   `false`, `[]`, `null`, ...). A field that declares `= expr` is implicitly
-//!   `#[serde(default)]`, so the attribute is only needed on fields without a
-//!   declared default.
-//! - `#[serde(rename = "...")]` on a struct field — override the wire-form
-//!   key for that field.
-//! - `#[serde(rename_all = "...")]` on a struct — rename every field by a
-//!   convention (`"camelCase"`, `"snake_case"`, `"kebab-case"`, ...).
+//! Wado fields are `snake_case` by convention, but the default wire-form key
+//! is `camelCase`. Override per struct with `#[serde(rename_all = "...")]`,
+//! or per field with `#[serde(rename = "...")]` (which takes precedence).
 //!
-//! Example — a field with a declared default is implicitly tolerated when
-//! missing, so deserializing `{"host":"localhost"}` yields `timeout = 30`:
+//! `rename_all` strategies: `"camelCase"` (default), `"snake_case"`,
+//! `"PascalCase"`, `"SCREAMING_SNAKE_CASE"`, `"kebab-case"`,
+//! `"SCREAMING-KEBAB-CASE"`.
+//!
+//! ```wado
+//! // Default — wire keys are camelCase
+//! struct User {
+//!     user_name: String,        // wire key: "userName"
+//!     account_id: i64,          // wire key: "accountId"
+//! }
+//!
+//! // Per-struct convention
+//! #[serde(rename_all = "snake_case")]
+//! struct Event {
+//!     created_at: String,       // wire key: "created_at"
+//!     event_type: String,       // wire key: "event_type"
+//! }
+//!
+//! // Per-field override (wins over rename_all)
+//! #[serde(rename_all = "kebab-case")]
+//! struct Header {
+//!     content_type: String,     // wire key: "content-type"
+//!     #[serde(rename = "X-Trace-Id")]
+//!     trace_id: String,         // wire key: "X-Trace-Id"
+//! }
+//! ```
+//!
+//! ## Missing fields on deserialization
+//!
+//! By default, a missing required field produces `DeserializeError` with kind
+//! `MissingField`. To tolerate omission, mark the field with
+//! `#[serde(default)]` (uses the type's zero-value: `0`, `""`, `false`, `[]`,
+//! `null`, ...) or declare a default expression with `f: T = expr` (uses that
+//! expression). A field that declares `= expr` is implicitly
+//! `#[serde(default)]`, so the attribute is only needed on fields without a
+//! declared default.
 //!
 //! ```wado
 //! struct Config {
-//!     host: String,
-//!     timeout: i32 = 30,
+//!     host: String,             // required - error if missing
+//!     #[serde(default)]
+//!     port: i32,                // missing -> 0  (zero-value)
+//!     timeout: i32 = 30,        // missing -> 30 (declared default)
 //! }
 //! impl Deserialize for Config;
+//!
+//! // {"host":"localhost"}
+//! //   -> Config { host: "localhost", port: 0, timeout: 30 }
 //! ```
 
 


### PR DESCRIPTION
## Summary

`render_md_doc` (in `wado-cli/src/doc.rs`) was processing every line of a doc comment as if it were prose markdown, even inside fenced code blocks. Three problems followed:

- Lines starting with `#` (e.g. `#[serde(default)]`, `#[inline]`) were treated as ATX headings, gaining a spurious blank line after them.
- Leading whitespace was stripped via `line.trim_start()`, flattening struct / function bodies inside `` ```wado `` blocks.
- Multi-space alignment was collapsed by `collapse_md_spaces`, killing column-aligned trailing comments in code samples.

This adds CommonMark-style fenced code block tracking. Both backtick (` ``` `) and tilde (`~~~`) fences are recognised. Inside a fence, list / blockquote / heading detection is skipped and the line is emitted verbatim, so indentation and alignment survive.

Closing rules follow CommonMark:

- Closing run uses the same character as the opening run.
- Closing run is at least as long as the opening run.
- The closing line allows only whitespace after the fence characters — `` ```rust `` is not a valid closer for a backtick fence.
- A backtick fence's info string cannot itself contain backticks.

## Test plan

- [x] Eight unit tests added in `doc::tests`:
  - `fenced_block_preserves_attribute_lines_as_content` — `#[serde(default)]` is no longer treated as a heading.
  - `fenced_block_preserves_indentation_and_alignment` — leading and inner whitespace survive.
  - `tilde_fenced_block_is_recognized` — `~~~wado` … `~~~` works the same as backticks.
  - `longer_closing_fence_is_accepted` — `` ```` `` opens, `` ````` `` closes.
  - `shorter_closing_fence_does_not_close` — a 3-backtick run inside a 4-backtick fence stays content.
  - `outside_fence_heading_still_inserts_blank` — regression check that prose headings still get the blank-line treatment.
  - `fence_close_with_info_string_is_not_a_close` — info string on closer rejected.
  - `fence_blank_line_is_preserved` — blank lines inside code blocks survive.
- [x] `cargo test -p wado-cli` — all suites green.
- [x] `mise run doc-stdlib` regenerated stdlib markdown; the diffs are pure improvements (alignment / indentation restored in `core:zlib`, `core:prelude`, `core:kiln`, `core:serde`).

https://claude.ai/code/session_01MXS1zF583VuFJWDfa3pvbD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXS1zF583VuFJWDfa3pvbD)_