### PR TITLE
feat(effect-handler): use `=>` instead of `=` in `with E => h do` syntax

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1026,6 +1026,39 @@ run_both(
 );  // E = Stdout + Stderr
 ```
 
+### Effect Handlers
+
+See [WEP: Effect Handler](./wep-2026-04-11-effect-handler.md).
+
+An effect handler is an `impl Effect for Type` where the methods may call `resume value` to continue the suspended computation. The `with` block installs handlers for the duration of its `do` body. The `=>` arrow reads as "calls to E dispatch to h"; it is not an assignment.
+
+```wado
+effect Counter {
+    fn next() -> i32;
+}
+
+struct Mock { value: i32 }
+
+impl Counter for Mock {
+    fn next(&mut self) -> i32 {
+        self.value += 1;
+        resume self.value
+    }
+}
+
+fn main() {
+    let mut m = Mock { value: 0 };
+    with Counter => &mut m do {
+        let a = Counter::next();   // 1
+        let b = Counter::next();   // 2
+    }
+    // Multiple handlers — comma-separated
+    // with Stdin => &mut s, Stdout => &mut o do { ... }
+}
+```
+
+`resume value` (only valid inside a handler method) hands `value` back to the caller of the operation. Without post-resume code it lowers to `return value`.
+
 ## Entrypoints
 
 The entrypoint is defined in a World, which requires `export` keyword.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4024,7 +4024,15 @@ See `docs/wep-2026-01-12-value-semantics-and-stores.md` for detailed design rati
 
 ### Handlers
 
-See `docs/wep-2026-01-27-effect-system-design.md` for handler syntax, resource-as-effect, and effect propagation design.
+A handler is an `impl Effect for Type` whose methods may use `resume value` to deliver a value to the suspended caller. The `with E => h do { body }` block installs `h` as the handler for effect `E` for the duration of `body`. The `=>` arrow reads as a dispatch binding ("calls to `E` go to `h`"); it is not an assignment, since each `with` pushes onto a per-effect handler chain that is restored on exit.
+
+```wado
+with Stdin => &mut mock do { ... }
+with Stdin => &mut s, Stdout => &mut o do { ... }
+with &mut bundle do { ... }                       // bundled (omits effect name)
+```
+
+See `docs/wep-2026-01-27-effect-system-design.md` for resource-as-effect and effect propagation design, and `docs/wep-2026-04-11-effect-handler.md` for handler syntax, dispatch lowering, and `MockCM`.
 
 ## World System
 

--- a/docs/wep-2026-04-11-effect-handler.md
+++ b/docs/wep-2026-04-11-effect-handler.md
@@ -4,7 +4,7 @@ Status: Draft
 
 ## Implementation Status
 
-- [x] Front-end (lexer / AST / parser / unparser): `with E = h do { ... }`,
+- [x] Front-end (lexer / AST / parser / unparser): `with E => h do { ... }`,
       `resume value`, and `..` rest in `impl Effect for Type` blocks.
 - [x] Resolver / effect-check: track installed handlers in scope and skip
       handled effects when checking caller requirements.
@@ -229,9 +229,9 @@ run. Its scope:
 - New negative fixtures (already covered by Phase 2 diagnostics, just
   verify they reject):
   - `resume` outside a handler method body
-  - `with E = h do` where `h: T` does not `impl E for T`
-  - `with NotAnEffect = h do` (e.g. `with i32 = 0 do`)
-  - bundled handler form (`with &mut h do` without `Effect =`), pending
+  - `with E => h do` where `h: T` does not `impl E for T`
+  - `with NotAnEffect => h do` (e.g. `with i32 => 0 do`)
+  - bundled handler form (`with &mut h do` without `Effect =>`), pending
     full implementation
 
 ## Context
@@ -278,12 +278,12 @@ Handler implementations add `&self` or `&mut self` to access the handler's state
 
 ### Using Handlers
 
-The `with Effect = value do { ... }` block installs a handler for the scope of the `do` block:
+The `with Effect => value do { ... }` block installs a handler for the scope of the `do` block. The `=>` arrow reads as a dispatch binding ("calls to `Effect` go to `value`"); it mirrors the match-arm arrow and is deliberately not `=`, since the operation pushes a handler onto a per-effect stack rather than performing assignment.
 
 ```wado
 fn test_input() {
     let mut mock = MockStdin { responses: ["hello", "world"], index: 0 };
-    with Stdin = &mut mock do {
+    with Stdin => &mut mock do {
         let a = Stdin::read_line();  // "hello"
         let b = Stdin::read_line();  // "world"
     }
@@ -294,7 +294,7 @@ fn test_input() {
 Multiple handlers:
 
 ```wado
-with Stdin = &mut mock_stdin, Stdout = &mut mock_stdout do {
+with Stdin => &mut mock_stdin, Stdout => &mut mock_stdout do {
     // ...
 }
 ```
@@ -323,7 +323,7 @@ impl Stdin for LoggingStdin {
 // Caller must have Stdout (handler method's effect), but not Stdin (handled)
 fn test_logging() with Stdout {
     let mock = LoggingStdin { response: "mocked" };
-    with Stdin = &mock do {
+    with Stdin => &mock do {
         let line = Stdin::read_line();
     }
 }
@@ -392,7 +392,7 @@ Handlers only handle the effects they declare. All other effects forward to the 
 
 ```wado
 let mock = MockClient;
-with Client = &mock do {
+with Client => &mock do {
     let headers = Fields::new();    // Fields is not handled → forwards to outer scope
     let req = Request::new(...);    // Request is not handled → forwards to outer scope
     let resp = Client::send(req);   // Client IS handled → goes to MockClient
@@ -424,7 +424,7 @@ impl Client for CachingClient {
 
 export fn run() with Stdout, Client {
     let mut cache = TreeMap::<String, Response>::new();
-    with Client = &mut CachingClient { cache: &mut cache } do {
+    with Client => &mut CachingClient { cache: &mut cache } do {
         app();
     }
 }
@@ -437,8 +437,8 @@ Handlers nest naturally. Inner handlers override specific effects; unhandled eff
 ```wado
 let mut mock_stdout = MockStdout { captured: [] };
 let mock_client = MockClient;
-with Stdout = &mut mock_stdout do {
-    with Client = &mock_client do {
+with Stdout => &mut mock_stdout do {
+    with Client => &mock_client do {
         println("sending...");   // Stdout → MockStdout (outer handler)
         Client::send(req);       // Client → MockClient (inner handler)
     }
@@ -605,8 +605,8 @@ When a type implements multiple effects, listing each one in `with` is verbose. 
 
 ```wado
 // Explicit: list each effect separately
-with Stream<u8> = &mut cm, StreamWritable<u8> = &mut cm,
-     Future<T> = &mut cm, FutureWritable<T> = &mut cm do { ... }
+with Stream<u8> => &mut cm, StreamWritable<u8> => &mut cm,
+     Future<T> => &mut cm, FutureWritable<T> => &mut cm do { ... }
 
 // Bundled: handle all effects MockCM implements
 with &mut cm do { ... }
@@ -615,7 +615,7 @@ with &mut cm do { ... }
 Multiple handlers compose naturally:
 
 ```wado
-with &mut cm, Stdout = &mut stdout, Client = &mut client do {
+with &mut cm, Stdout => &mut stdout, Client => &mut client do {
     run();
 }
 ```
@@ -664,7 +664,7 @@ impl MockStdout {
 test "println captures output" {
     let mut cm = MockCM::new();
     let mut stdout = MockStdout { streams: [] };
-    with &mut cm, Stdout = &mut stdout do {
+    with &mut cm, Stdout => &mut stdout do {
         println("hello");
         println("world");
         // drain() must be called inside MockCM scope (fake handles are only valid here)
@@ -731,7 +731,7 @@ test "http-get fetches and prints" {
         response_body: `{"origin": "127.0.0.1"}`,
         status: 200,
     };
-    with &mut cm, Stdout = &mut stdout, Client = &mut client do {
+    with &mut cm, Stdout => &mut stdout, Client => &mut client do {
         run();  // example/http-get.wado's export fn run()
         assert client.requests[0] == "/get";
         let output = stdout.drain();
@@ -794,8 +794,8 @@ test "timing middleware records elapsed time" {
     let downstream = MockHandler { status: 200, body: "ok" };
     let mut timing = TimingMiddleware { log: [] };
     with &mut cm do {
-        with Handler = &downstream do {
-            with Handler = &mut timing do {
+        with Handler => &downstream do {
+            with Handler => &mut timing do {
                 let req = create_test_request("/api");
                 let resp = Handler::handle(req);
                 assert resp matches { Ok(_) };
@@ -831,7 +831,7 @@ for a TypeScript token of that name).
 
 #### Handler expressions are restricted to unary expressions
 
-Inside `with E1 = handler do { ... }`, the `handler` slot is parsed
+Inside `with E1 => handler do { ... }`, the `handler` slot is parsed
 with `parse_unary_expr`, which covers references (`&h`, `&mut h`),
 prefix-`*` deref, `!`/`~`/`-`, identifiers, calls, method calls, and
 field/index access. It deliberately stops short of:
@@ -844,7 +844,7 @@ This keeps the grammar unambiguous: stopping at unary level prevents the
 handler expression from greedily eating the trailing `,` or `do` token
 that closes the binding list. Cases that need the excluded forms must
 wrap the handler in parentheses, e.g.
-`with E = (h as &mut MockE) do { ... }`.
+`with E => (h as &mut MockE) do { ... }`.
 
 ### Dispatch Mechanism: funcref vtable + Wasm Global
 
@@ -895,7 +895,7 @@ The outer-scope restoration before `call_ref` ensures that handler method bodies
 ### Compilation of `with ... do`
 
 ```wado
-with Stdout = &mut mock do { body }
+with Stdout => &mut mock do { body }
 ```
 
 Compiles to:

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -1588,7 +1588,7 @@ pub enum Expr {
     Spread(Box<Expr>, Span),
     /// Range expression: `a..<b` (exclusive) or `a..=b` (inclusive)
     Range(Box<RangeExpr>),
-    /// Effect handler installation block: `with E1 = h1, E2 = h2 do { body }`.
+    /// Effect handler installation block: `with E1 => h1, E2 => h2 do { body }`.
     /// See `docs/wep-2026-04-11-effect-handler.md`.
     WithHandler(Box<WithHandlerExpr>),
     /// `resume value` — control-flow expression valid only inside an effect
@@ -1597,7 +1597,7 @@ pub enum Expr {
     Resume(Box<ResumeExpr>),
 }
 
-/// `with E1 = h1, E2 = h2 do { body }` — installs effect handlers for the
+/// `with E1 => h1, E2 => h2 do { body }` — installs effect handlers for the
 /// duration of `body`. The block's value is the value of `body`.
 #[derive(Debug, Clone)]
 pub struct WithHandlerExpr {
@@ -1607,7 +1607,7 @@ pub struct WithHandlerExpr {
     pub span: Span,
 }
 
-/// A single `Effect = handler` binding inside `with ... do`.
+/// A single `Effect => handler` binding inside `with ... do`.
 ///
 /// `effect` is `None` for handler bundling: `with &mut value do { ... }`
 /// installs the value as a handler for every effect it implements.
@@ -1618,7 +1618,7 @@ pub struct WithHandlerExpr {
 #[derive(Debug, Clone)]
 pub struct EffectHandlerBinding {
     pub id: AstId,
-    /// Effect type on the LHS of `=` (e.g., `Stdout`, `Stream<u8>`). `None`
+    /// Effect type on the LHS of `=>` (e.g., `Stdout`, `Stream<u8>`). `None`
     /// for bundled handlers (`with &mut value do { ... }`).
     pub effect: Option<Type>,
     /// Handler expression, e.g., `&mut mock`.

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -1409,7 +1409,7 @@ impl Parser {
         Ok(Stmt::Match(m))
     }
 
-    /// Parse a `with E = h do { ... }` statement.
+    /// Parse a `with E => h do { ... }` statement.
     ///
     /// The trailing `}` of the do-block makes the statement boundary
     /// unambiguous, so the trailing semicolon is optional — same as
@@ -3360,11 +3360,13 @@ impl Parser {
     }
 
     /// Parse an effect handler installation expression:
-    /// `with E1 = h1, E2 = h2 do { body }` or `with &mut h do { body }` (bundled).
+    /// `with E1 => h1, E2 => h2 do { body }` or `with &mut h do { body }` (bundled).
     ///
     /// Each binding is one of:
-    /// - `EffectName = expr` — install `expr` as the handler for `EffectName`.
-    /// - `expr` (no `=`) — bundled handler, used for every effect `expr` implements.
+    /// - `EffectName => expr` — install `expr` as the handler for `EffectName`.
+    ///   The `=>` reads as "case E is dispatched to expr", mirroring match arms;
+    ///   this is not an assignment.
+    /// - `expr` (no `=>`) — bundled handler, used for every effect `expr` implements.
     ///
     /// See `docs/wep-2026-04-11-effect-handler.md`.
     fn parse_with_handler_expr(&mut self) -> ParseResult<Expr> {
@@ -3409,23 +3411,23 @@ impl Parser {
     }
 
     /// Parse one binding inside a `with ... do` clause. Two shapes:
-    /// - `Effect = handler_expr` — explicit effect on the LHS. The effect is
-    ///   any type expression, so `Stdout = ...` and `Stream<u8> = ...` both
+    /// - `Effect => handler_expr` — explicit effect on the LHS. The effect is
+    ///   any type expression, so `Stdout => ...` and `Stream<u8> => ...` both
     ///   parse here. Later compiler phases decide which forms they support.
-    /// - `handler_expr` (no `=`) — bundled handler.
+    /// - `handler_expr` (no `=>`) — bundled handler.
     fn parse_effect_handler_binding(&mut self) -> ParseResult<crate::ast::EffectHandlerBinding> {
         let id = self.alloc_ast_id();
         let start_span = self.peek().span;
 
         // Speculatively try the explicit form. The LHS is a type, so we have
-        // to commit to type parsing only if a `=` follows; otherwise this is
+        // to commit to type parsing only if a `=>` follows; otherwise this is
         // a bundled handler whose expression starts with an identifier.
         if matches!(self.peek_kind(), TokenKind::Ident(_)) {
             let checkpoint = self.pos;
             let saved_pending_gt = self.pending_gt;
             if let Ok(ty) = self.parse_type() {
-                if self.check(&TokenKind::Eq) {
-                    self.advance(); // consume `=`
+                if self.check(&TokenKind::FatArrow) {
+                    self.advance(); // consume `=>`
                     // Handler expressions are parsed as unary expressions so
                     // we don't greedily consume the trailing `,` or `do`.
                     // Trade-off: cast / `if` / `match` expressions can't sit
@@ -6188,7 +6190,7 @@ line 2
 
     #[test]
     fn parse_with_handler_explicit_effect() {
-        let expr = parse_expr_from("with Stdout = &mut mock do { println(\"hi\"); }");
+        let expr = parse_expr_from("with Stdout => &mut mock do { println(\"hi\"); }");
         let Expr::WithHandler(w) = expr else {
             panic!("expected WithHandler, got {expr:?}");
         };
@@ -6203,7 +6205,7 @@ line 2
 
     #[test]
     fn parse_with_handler_multiple_handlers() {
-        let expr = parse_expr_from("with Stdout = &mut s, Stderr = &mut e do { f(); }");
+        let expr = parse_expr_from("with Stdout => &mut s, Stderr => &mut e do { f(); }");
         let Expr::WithHandler(w) = expr else {
             panic!("expected WithHandler");
         };
@@ -6216,7 +6218,7 @@ line 2
     fn parse_with_handler_generic_effect() {
         // Generic effect names (`Stream<u8>`) must parse cleanly; later
         // compiler phases decide whether to support them.
-        let expr = parse_expr_from("with Stream<u8> = &mut cm do { f(); }");
+        let expr = parse_expr_from("with Stream<u8> => &mut cm do { f(); }");
         let Expr::WithHandler(w) = expr else {
             panic!("expected WithHandler");
         };

--- a/wado-compiler/src/resolver/handlers.rs
+++ b/wado-compiler/src/resolver/handlers.rs
@@ -1,4 +1,4 @@
-//! Resolver lowering for effect handler installation (`with E = h do { ... }`)
+//! Resolver lowering for effect handler installation (`with E => h do { ... }`)
 //! and the `resume` control-flow expression.
 //!
 //! See WEP 2026-04-11 (Effect Handler) for the language semantics.
@@ -27,7 +27,7 @@ use super::Resolver;
 use super::types::{FunctionContext, TypeError};
 
 impl<H: CompilerHost> Resolver<'_, H> {
-    /// Resolve `with E1 = h1, ... do { body }`.
+    /// Resolve `with E1 => h1, ... do { body }`.
     pub(super) fn resolve_with_handler(
         &mut self,
         with_expr: &ast::WithHandlerExpr,

--- a/wado-compiler/src/resolver/types.rs
+++ b/wado-compiler/src/resolver/types.rs
@@ -285,7 +285,7 @@ pub enum TypeError {
     /// to an `impl Effect for Type` block (see WEP 2026-04-11).
     ResumeOutsideHandler { span: Span },
 
-    /// `with E = h do { ... }` clause where the handler value's type
+    /// `with E => h do { ... }` clause where the handler value's type
     /// does not implement effect `E`.
     HandlerEffectNotImplemented {
         type_name: String,
@@ -296,10 +296,10 @@ pub enum TypeError {
     /// Bundled-handler form `with h do { ... }` (no effect on LHS) — not yet
     /// implemented. The full form requires enumerating every effect the
     /// handler's type implements; the MVP only supports the explicit
-    /// `with E = h` form.
+    /// `with E => h` form.
     BundledHandlerNotSupported { span: Span },
 
-    /// `with E = h do` clause where `E` is not a known effect declaration
+    /// `with E => h do` clause where `E` is not a known effect declaration
     /// (it might be a regular trait, an unrelated type, or an unknown name).
     NotAnEffect { name: String, span: Span },
 }
@@ -561,14 +561,14 @@ impl std::fmt::Display for TypeError {
             TypeError::BundledHandlerNotSupported { span } => {
                 write!(
                     f,
-                    "{}:{}: bundled effect handlers (`with h do`) are not yet implemented; use `with E = h do` instead",
+                    "{}:{}: bundled effect handlers (`with h do`) are not yet implemented; use `with E => h do` instead",
                     span.line, span.column
                 )
             }
             TypeError::NotAnEffect { name, span } => {
                 write!(
                     f,
-                    "{}:{}: '{}' is not an effect; only effect names are valid in `with E = h do` clauses",
+                    "{}:{}: '{}' is not an effect; only effect names are valid in `with E => h do` clauses",
                     span.line, span.column, name
                 )
             }
@@ -795,13 +795,13 @@ impl From<TypeError> for crate::compiler_host::Diagnostic {
             ),
             TypeError::BundledHandlerNotSupported { span } => (
                 Code::UnsupportedFeature,
-                "bundled effect handlers (`with h do`) are not yet implemented; use `with E = h do` instead".to_string(),
+                "bundled effect handlers (`with h do`) are not yet implemented; use `with E => h do` instead".to_string(),
                 *span,
             ),
             TypeError::NotAnEffect { name, span } => (
                 Code::UnknownType,
                 format!(
-                    "'{name}' is not an effect; only effect names are valid in `with E = h do` clauses"
+                    "'{name}' is not an effect; only effect names are valid in `with E => h do` clauses"
                 ),
                 *span,
             ),

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -9042,7 +9042,7 @@ fn rewrite_calls_in_expr(
         }
         TirExprKind::WithHandler { bindings, body, .. } => {
             // Walk the handler value and the do-block body so calls
-            // inside `with E = h do { ... }` get the same adapter-binding
+            // inside `with E => h do { ... }` get the same adapter-binding
             // rewrite the rest of the function gets. The effect-dispatch
             // synthesis pass that runs next consumes
             // `__cm_binding__<E>_<op>` Calls and routes them through
@@ -9320,7 +9320,7 @@ fn collect_effect_calls_in_expr(
         }
         TirExprKind::WithHandler { bindings, body, .. } => {
             // Walk the handler value and the do-block body so effect calls
-            // reached only from inside `with E = h do { ... }` (which the
+            // reached only from inside `with E => h do { ... }` (which the
             // effect-dispatch synthesis later routes through wrapper
             // functions whose else-branch falls back to the CM-binding
             // adapter) still trigger adapter generation here.

--- a/wado-compiler/src/synthesis/effect_dispatch.rs
+++ b/wado-compiler/src/synthesis/effect_dispatch.rs
@@ -601,7 +601,7 @@ fn build_dispatch_wrapper_function(
     } else {
         // User-defined effect: well-typed programs never reach the wrapper
         // without a handler installed, since effect-check requires every
-        // call-site to have a `with E = h do { ... }` in scope. If we get
+        // call-site to have a `with E => h do { ... }` in scope. If we get
         // here anyway, panic with a diagnostic identifying the operation
         // — useful when a future refactor introduces a path that bypasses
         // effect-check.

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -2509,7 +2509,7 @@ pub enum TirExprKind {
         parts: Vec<TirTemplatePart>,
     },
 
-    /// Effect handler installation: `with E1 = h1, ... do { body }`.
+    /// Effect handler installation: `with E1 => h1, ... do { body }`.
     /// See `docs/wep-2026-04-11-effect-handler.md`.
     ///
     /// Each binding installs a handler for one effect for the duration of `body`.
@@ -2532,7 +2532,7 @@ pub enum TirExprKind {
     },
 }
 
-/// One `Effect = handler` binding inside a `with ... do` block.
+/// One `Effect => handler` binding inside a `with ... do` block.
 #[derive(Debug, Clone)]
 pub struct TirHandlerBinding {
     /// The effect being handled. `None` is reserved for bundled handlers

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -1688,7 +1688,7 @@ impl<'a> Unparser<'a> {
             }
             if let Some(effect) = &binding.effect {
                 self.unparse_type(effect);
-                self.output.push_str(" = ");
+                self.output.push_str(" => ");
             }
             self.unparse_expr(&binding.handler);
         }
@@ -3264,7 +3264,7 @@ fn unparse_expr_into(expr: &Expr, output: &mut String, _parens_for_binary: bool)
                 }
                 if let Some(effect) = &binding.effect {
                     unparse_type_into(effect, output);
-                    output.push_str(" = ");
+                    output.push_str(" => ");
                 }
                 unparse_expr_into(&binding.handler, output, false);
             }
@@ -5031,7 +5031,7 @@ impl<'a> TirUnparser<'a> {
                     }
                     if let Some(eff) = &binding.effect {
                         self.output.push_str(eff.name());
-                        self.output.push_str(" = ");
+                        self.output.push_str(" => ");
                     }
                     self.unparse_expr(&binding.handler);
                 }

--- a/wado-compiler/tests/fixtures/effect_handler_break_label_cross.wado
+++ b/wado-compiler/tests/fixtures/effect_handler_break_label_cross.wado
@@ -1,4 +1,4 @@
-// `break label` crossing a `with E = h do { ... }` body must restore
+// `break label` crossing a `with E => h do { ... }` body must restore
 // the per-effect dispatch global so the rest of the function observes
 // the outer scope's handler. The break target is a labeled block
 // declared *outside* the `with`, so the jump exits the do-block and
@@ -36,7 +36,7 @@ fn helper(early: bool) -> i32 {
     let inner = Inner {};
     let mut inside = 0;
     outer_label: {
-        with Counter = &inner do {
+        with Counter => &inner do {
             inside = Counter::next();
             if early {
                 break outer_label;
@@ -49,7 +49,7 @@ fn helper(early: bool) -> i32 {
 
 export fn run() with Stdout {
     let outer = Outer {};
-    with Counter = &outer do {
+    with Counter => &outer do {
         let early = helper(true);
         let normal = helper(false);
         println(`early={early}, normal={normal}`);

--- a/wado-compiler/tests/fixtures/effect_handler_continue_cross.wado
+++ b/wado-compiler/tests/fixtures/effect_handler_continue_cross.wado
@@ -1,4 +1,4 @@
-// `continue` crossing a `with E = h do { ... }` body must restore the
+// `continue` crossing a `with E => h do { ... }` body must restore the
 // per-effect dispatch global. The `while` loop is declared *outside*
 // the `with`, so `continue` exits the do-block to retry the loop
 // header — without the fix, the inner handler's dispatch struct
@@ -38,7 +38,7 @@ fn helper() -> i32 {
     let mut iters = 0;
     while iters < 3 {
         iters += 1;
-        with Counter = &inner do {
+        with Counter => &inner do {
             if iters == 2 {
                 continue;
             }
@@ -51,7 +51,7 @@ fn helper() -> i32 {
 
 export fn run() with Stdout {
     let outer = Outer {};
-    with Counter = &outer do {
+    with Counter => &outer do {
         let r = helper();
         println(`r={r}`);
     }

--- a/wado-compiler/tests/fixtures/effect_handler_cross_function.wado
+++ b/wado-compiler/tests/fixtures/effect_handler_cross_function.wado
@@ -26,7 +26,7 @@ impl Counter for CounterState {
     }
 }
 
-// Helper function — the `with Counter = ... do` block does not
+// Helper function — the `with Counter => ... do` block does not
 // contain `Counter::next()` directly; it delegates to this helper.
 fn pull_three() -> i32 with Counter {
     let a = Counter::next();
@@ -37,7 +37,7 @@ fn pull_three() -> i32 with Counter {
 
 export fn run() with Stdout {
     let mut c = CounterState { value: 0 };
-    with Counter = &mut c do {
+    with Counter => &mut c do {
         let total = pull_three();
         println(`total={total}, final={c.value}`);
     }

--- a/wado-compiler/tests/fixtures/effect_handler_early_return.wado
+++ b/wado-compiler/tests/fixtures/effect_handler_early_return.wado
@@ -1,4 +1,4 @@
-// Early `return` from inside `with E = h do { ... }` must restore the
+// Early `return` from inside `with E => h do { ... }` must restore the
 // per-effect dispatch global so the caller sees the outer scope's
 // handler, not the do-block's. Verifies the case described in WEP
 // 2026-04-11 (lines 150–153) by stacking two handlers for the same
@@ -35,7 +35,7 @@ impl Counter for Inner {
 
 fn helper() -> i32 {
     let inner = Inner {};
-    with Counter = &inner do {
+    with Counter => &inner do {
         return Counter::next();
     }
     return 999;
@@ -43,7 +43,7 @@ fn helper() -> i32 {
 
 export fn run() with Stdout {
     let outer = Outer {};
-    with Counter = &outer do {
+    with Counter => &outer do {
         let h = helper();
         let after = Counter::next();
         println(`helper={h}, after={after}`);

--- a/wado-compiler/tests/fixtures/effect_handler_inner_break.wado
+++ b/wado-compiler/tests/fixtures/effect_handler_inner_break.wado
@@ -32,10 +32,10 @@ impl Counter for Inner {
 export fn run() with Stdout {
     let outer = Outer {};
     let inner = Inner {};
-    with Counter = &outer do {
+    with Counter => &outer do {
         let mut a = 0;
         let mut b = 0;
-        with Counter = &inner do {
+        with Counter => &inner do {
             inside_label: {
                 a = Counter::next();
                 break inside_label;

--- a/wado-compiler/tests/fixtures/effect_handler_nested_same.wado
+++ b/wado-compiler/tests/fixtures/effect_handler_nested_same.wado
@@ -37,9 +37,9 @@ impl Counter for AddTen {
 export fn run() with Stdout {
     let mut outer = AddOne { base: 0 };
     let mut inner = AddTen { base: 100 };
-    with Counter = &mut outer do {
+    with Counter => &mut outer do {
         let o1 = Counter::next();           // 1 (outer)
-        with Counter = &mut inner do {
+        with Counter => &mut inner do {
             let i1 = Counter::next();       // 110 (inner)
             let i2 = Counter::next();       // 120 (inner)
             println(`outer1={o1}, inner1={i1}, inner2={i2}`);

--- a/wado-compiler/tests/fixtures/effect_handler_resume.wado
+++ b/wado-compiler/tests/fixtures/effect_handler_resume.wado
@@ -31,7 +31,7 @@ impl Counter for CounterState {
 
 export fn run() with Stdout {
     let mut c = CounterState { value: 0 };
-    with Counter = &mut c do {
+    with Counter => &mut c do {
         let a = Counter::next();
         let b = Counter::next();
         println(`{a}+{b}={a + b}, final={c.value}`);

--- a/wado-compiler/tests/fixtures/effect_handler_self_delegation.wado
+++ b/wado-compiler/tests/fixtures/effect_handler_self_delegation.wado
@@ -43,8 +43,8 @@ impl Counter for OffsetCounter {
 export fn run() with Stdout {
     let mut base = BaseCounter { value: 0 };
     let offset = OffsetCounter { offset: 1000 };
-    with Counter = &mut base do {
-        with Counter = &offset do {
+    with Counter => &mut base do {
+        with Counter => &offset do {
             let a = Counter::next();    // 1001 (base.value -> 1, +1000)
             let b = Counter::next();    // 1002 (base.value -> 2, +1000)
             println(`{a},{b}`);

--- a/wado-compiler/tests/fixtures/effect_handler_with_do.wado
+++ b/wado-compiler/tests/fixtures/effect_handler_with_do.wado
@@ -26,7 +26,7 @@ impl MonotonicClock for FixedClock {
 
 export fn run() with Stdout {
     let clock = FixedClock { mark: 12345 as Mark };
-    with MonotonicClock = &clock do {
+    with MonotonicClock => &clock do {
         let m = MonotonicClock::now();
         println(`mark: {m}`);
     }


### PR DESCRIPTION
## Summary

- Replace `=` with `=>` in the explicit-effect form of effect handler installation: `with E => h do { ... }`. Bundled form `with &mut h do` is unchanged.
- The `=` read as an assignment, but the operation actually pushes a handler onto a per-effect dispatch chain (popped on scope exit). `=>` mirrors match-arm syntax ("calls to E dispatch to h") and avoids the assignment connotation.
- Pure surface-syntax change. Lexer/token unchanged (`=>` / `FatArrow` was already in use for match arms). AST/TIR node shapes unchanged.

## Changes

- Parser: `parse_effect_handler_binding` now consumes `TokenKind::FatArrow` instead of `TokenKind::Eq`.
- Unparser: AST + TIR variants emit `" => "`.
- AST/TIR doc comments, resolver diagnostic messages, and synthesis-pass comments updated to reflect the new syntax.
- Docs: WEP 2026-04-11, `cheatsheet.md` (added an Effect Handlers subsection), `spec.md` (Handlers section now describes the syntax).
- Fixtures: all `effect_handler_*.wado` switched to `=>`.

## Test plan

- [x] Parser unit tests (`parse_with_handler_*`, 4 tests)
- [x] Effect handler e2e fixtures across `-O0` / `-O1` / `-O2` / `-O3` / `-Os` (50 tests)
- [x] Format roundtrip suite (85 tests) — confirms unparse/parse roundtrip stays consistent
- [x] Full `wado-compiler` lib unit tests (409 tests)
- [x] `wado-lsp` tests (42 tests)

https://claude.ai/code/session_013TX186cr1opDkXZdvwb6ix

---
_Generated by [Claude Code](https://claude.ai/code/session_013TX186cr1opDkXZdvwb6ix)_