### PR TITLE
chore(kiln): regenerate stale wado.lock files for parser-gen output

### DIFF
--- a/benchmark/sqlite_parse/wado.lock
+++ b/benchmark/sqlite_parse/wado.lock
@@ -10,5 +10,5 @@ options-hash = "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f
 inputs = []
 reads = []
 outputs = [
-    { path = "build/kiln/kiln-b277d3c4e6c19928/sqlite.wado", hash = "e799427cbfa0cda51941bf2d40265541b6fd79dfce21e31e0e606dca49349832", entry = true },
+    { path = "build/kiln/kiln-b277d3c4e6c19928/sqlite.wado", hash = "203a4f78101c6ad5ae91478be314dee1ff6946face9bef7c4535dce8c7aad385", entry = true },
 ]

--- a/benchmark/syntax_highlight/wado.lock
+++ b/benchmark/syntax_highlight/wado.lock
@@ -10,5 +10,5 @@ options-hash = "221a81964a4e4212ce2e828643b07faa05ae8ecd824158743f342b88120c56f5
 inputs = []
 reads = []
 outputs = [
-    { path = "build/kiln/kiln-b277d3c4e6c19928/sqlite.wado", hash = "6a4928515b169a8c7870c55110455f90a0276b771fec2d68599293fb0f474f04", entry = true },
+    { path = "build/kiln/kiln-b277d3c4e6c19928/sqlite.wado", hash = "b4dee60792ab684c8ab3c5f742142bbb4e6d30b96d63b81736679d09ea5ab3aa", entry = true },
 ]

--- a/wasm-size/sqlite_highlight/wado.lock
+++ b/wasm-size/sqlite_highlight/wado.lock
@@ -10,5 +10,5 @@ options-hash = "221a81964a4e4212ce2e828643b07faa05ae8ecd824158743f342b88120c56f5
 inputs = []
 reads = []
 outputs = [
-    { path = "build/kiln/kiln-b277d3c4e6c19928/sqlite.wado", hash = "6a4928515b169a8c7870c55110455f90a0276b771fec2d68599293fb0f474f04", entry = true },
+    { path = "build/kiln/kiln-b277d3c4e6c19928/sqlite.wado", hash = "b4dee60792ab684c8ab3c5f742142bbb4e6d30b96d63b81736679d09ea5ab3aa", entry = true },
 ]


### PR DESCRIPTION
## Summary

- `2f1c70a gale(parser-gen): collapse all-single-token-alts scan into one match` changed the generator output but only refreshed `package-gale/wado.lock`. The three downstream lockfiles that pin the same `kiln-b277d3c4e6c19928` invocation were left stale.
- Re-ran `mise run benchmark-all` and `mise run report-wasm-size` to regenerate them. Only `outputs[].hash` moves; `invocation`, `primary`, `options-hash`, `inputs`, `reads` all preserved.
- Files updated:
  - `benchmark/sqlite_parse/wado.lock`: `e799427c…` → `203a4f78…` (options-hash `664ab6cf…`)
  - `benchmark/syntax_highlight/wado.lock`: `6a492851…` → `b4dee607…` (options-hash `221a8196…`)
  - `wasm-size/sqlite_highlight/wado.lock`: `6a492851…` → `b4dee607…` (same `221a8196…`, matches benchmark/syntax_highlight as expected)

## Why does `wado.lock` keep churning?

Structural, not a one-off. The `[[generator-cache]]` schema records `outputs[].hash` (SHA-256 of the generated file), but the cache key (`wado-compiler/src/kiln/cache.rs:compose_cache_key`) hashes `generator_source_hash` separately — that field is **not** persisted in the lockfile. So:

1. Edit `package-gale/src/parser_gen.wado` → generator source hash changes → cache key changes → next run regenerates → output bytes differ → `outputs[].hash` differs from what is committed.
2. The `invocation` id (`kiln-b277d3c4e6c19928`) does *not* depend on generator source, so the same row gets rewritten in place.
3. Every project that pins this invocation (here: 3 of them) needs its lockfile re-committed, or the next `git switch` / CI run trips over a dirty worktree.

`outputs[].hash` is doing only two jobs: tamper detection of the cached file, and reproducibility verification across clean checkouts. Cache validity itself is fully covered by `compose_cache_key`. Worth a follow-up discussion on whether to keep it (see thread on the PR).

## Test plan

- [x] `mise run benchmark-all` — all benchmarks green; sqlite_parse / syntax_highlight regenerate cleanly with the new hashes
- [x] `mise run report-wasm-size` — `sqlite_highlight wado` 1,524,496 bytes; lock regenerates to the predicted `b4dee607…`
- [x] `git status` clean after both runs (mise.lock side effects from sandbox URL rewriting were discarded; not part of this PR)

https://claude.ai/code/session_01DQcGgtpQ3JFhkWVzp9FBs7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQcGgtpQ3JFhkWVzp9FBs7)_