### PR TITLE
feat(gale): close Phase 1 ANTLR4 descriptor compatibility

### DIFF
--- a/package-gale/antlr4-compatibility.md
+++ b/package-gale/antlr4-compatibility.md
@@ -274,19 +274,27 @@ Once a Gale gap is fixed:
 
 ### Phase 1 (landed) — Sets, LexerExec, ParseTrees
 
-- 83 descriptors extracted, 76 pass, 7 marked `#[TODO]`.
+- 83 descriptors processed, 81 pass, 2 in `[skip]`, 0 marked `#[TODO]`.
 
-The 7 `#[TODO]` items are real Gale gaps:
+The two skipped descriptors (`ParseTrees/AltNum` and
+`ParseTrees/TokenAndRuleContextString`) carry grammar-level `<…>`
+StringTemplate directives that the upstream test runner substitutes
+per target before `antlr4` ever sees the `.g4`. They are not
+self-contained grammars and cannot be promoted to a parse-only test.
 
-| Category / Descriptor                            | Gap                                                                                                                  |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `Sets/UnicodeEscapedBMPRangeSet`                 | Testsuite double-backslash unicode escape (`'\\u{…}'`) is not unwrapped before ANTLR-style parsing                   |
-| `Sets/UnicodeEscapedSMPRangeSet`                 | Same — supplementary plane variant                                                                                   |
-| `Sets/UnicodeEscapedSMPRangeSetMismatch`         | Same                                                                                                                 |
-| `Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints` | Same                                                                                                                 |
-| `LexerExec/NonGreedyOptional`                    | Parser does not recognise `??` non-greedy optional on a single element (`*?` and `+?` are handled)                   |
-| `ParseTrees/AltNum`                              | Grammar-level `<…>` StringTemplate directive that the upstream test runner substitutes per target before compilation |
-| `ParseTrees/TokenAndRuleContextString`           | Same shape as above                                                                                                  |
+Two structural fixes were needed to close Phase 1:
+
+- The descriptor extractor now applies StringTemplate-equivalent
+  text-mode unescape (`\\` → `\`, `\<` → `<`, `\>` → `>`) to the
+  `[grammar]` / `[slaveGrammar]` blocks. This mirrors the
+  `new ST(group, descriptor.grammar)` step in the upstream
+  `RuntimeTests.prepareGrammars`, so descriptors written for the Java
+  testsuite (e.g. `'\\u{1F600}'..'\\u{1F943}'`) reach the g4 parser
+  in the form `antlr4` would actually receive.
+- The g4 parser's postfix handler now accepts `??` (non-greedy
+  optional) on a single element, matching the existing handling of
+  `*?` and `+?`. See `parse_postfix` / `parse_lexer_postfix` in
+  `src/g4/parser.wado`.
 
 ### Phase 2 (planned) — `ParserExec`, `LeftRecursion`, `SemPred*`, `Composite*`, `FullContextParsing`, `*Errors`
 

--- a/package-gale/scripts/extract_antlr4_descriptors.wado
+++ b/package-gale/scripts/extract_antlr4_descriptors.wado
@@ -129,12 +129,45 @@ fn parse_descriptor_text(text: &String) -> ParsedDescriptor {
     for let p of pairs {
         let processed = post_process(&p.value);
         match p.name {
-            "grammar" => { grammar = processed; },
-            "slaveGrammar" => { slaves.push(processed); },
+            "grammar" => { grammar = unescape_st_text(&processed); },
+            "slaveGrammar" => { slaves.push(unescape_st_text(&processed)); },
             _ => {},
         }
     }
     return ParsedDescriptor { grammar, slave_grammars: slaves };
+}
+
+/// Mirror StringTemplate's text-mode escape handling for the descriptor's
+/// `[grammar]` / `[slaveGrammar]` blocks. The upstream test runner wraps
+/// the descriptor text in `new ST(group, descriptor.grammar)` with `<` /
+/// `>` delimiters before handing it to `antlr4`, so any literal that needs
+/// to survive ST as `\` must be written as `\\` in the descriptor (and any
+/// literal `<` / `>` as `\<` / `\>`). Without this step, descriptors like
+/// `LETTERS : ('a'|'\\u00E0'..'\\u00E5')` reach the g4 parser with a
+/// 6-char string `à` that cannot serve as a range bound.
+///
+/// We deliberately leave non-delimiter backslash sequences (`\n`, `\u…`,
+/// `\t`, …) intact: ST's text mode does not interpret them, so passing
+/// them through preserves the upstream-equivalent input for the g4 lexer.
+fn unescape_st_text(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let chars: Array<char> = s.chars().collect();
+    let n = chars.len();
+    let mut i = 0;
+    while i < n {
+        let c = chars[i];
+        if c == '\\' && i + 1 < n {
+            let next = chars[i + 1];
+            if next == '\\' || next == '<' || next == '>' {
+                out.push(next);
+                i += 2;
+                continue;
+            }
+        }
+        out.push(c);
+        i += 1;
+    }
+    return out;
 }
 
 /// If `line` is a known `[section]` header, return the section name.

--- a/package-gale/scripts/extract_antlr4_descriptors.wado
+++ b/package-gale/scripts/extract_antlr4_descriptors.wado
@@ -143,8 +143,8 @@ fn parse_descriptor_text(text: &String) -> ParsedDescriptor {
 /// `>` delimiters before handing it to `antlr4`, so any literal that needs
 /// to survive ST as `\` must be written as `\\` in the descriptor (and any
 /// literal `<` / `>` as `\<` / `\>`). Without this step, descriptors like
-/// `LETTERS : ('a'|'\\u00E0'..'\\u00E5')` reach the g4 parser with a
-/// 6-char string `à` that cannot serve as a range bound.
+/// `LETTERS : ('a'|'\\u00E0'..'\\u00E5')` reach the g4 parser with the
+/// 6-character escape text `\u00E0`, which cannot serve as a range bound.
 ///
 /// We deliberately leave non-delimiter backslash sequences (`\n`, `\u…`,
 /// `\t`, …) intact: ST's text mode does not interpret them, so passing

--- a/package-gale/src/g4/parser.wado
+++ b/package-gale/src/g4/parser.wado
@@ -1153,8 +1153,14 @@ impl G4Parser {
         }
         if self.is_kind(G4Token::Question) {
             self.advance();
+            let ng = if self.is_kind(G4Token::Question) {
+                self.advance();
+                true;
+            } else {
+                false;
+            };
             return Result::<Element, ParseError>::Ok(
-                Element::Repeat(RepeatElement { kind: RepeatKind::Optional, element: elem, non_greedy: false }),
+                Element::Repeat(RepeatElement { kind: RepeatKind::Optional, element: elem, non_greedy: ng }),
             );
         }
         return Result::<Element, ParseError>::Ok(elem);
@@ -1423,9 +1429,15 @@ impl G4Parser {
         }
         if self.is_kind(G4Token::Question) {
             self.advance();
+            let ng = if self.is_kind(G4Token::Question) {
+                self.advance();
+                true;
+            } else {
+                false;
+            };
             return Result::<LexerElement, ParseError>::Ok(
                 LexerElement::Repeat(
-                    LexerRepeatElement { kind: RepeatKind::Optional, element: elem, non_greedy: false },
+                    LexerRepeatElement { kind: RepeatKind::Optional, element: elem, non_greedy: ng },
                 ),
             );
         }

--- a/package-gale/src/g4/parser_test.wado
+++ b/package-gale/src/g4/parser_test.wado
@@ -1513,6 +1513,36 @@ INT : [0-9]+ ;";
     assert g.parser_rules.len() == 1;
 }
 
+test "parser rule with non-greedy optional ?? on rule ref" {
+    let input = "grammar Test;
+a : 'x' b ?? ;
+b : 'y' ;";
+    let g = parse(input).unwrap();
+    let elems = &g.parser_rules[0].alternatives[0].elements;
+    assert elems.len() == 2;
+    if let Repeat(r) = &elems[1] {
+        assert r.kind == RepeatKind::Optional;
+        assert r.non_greedy == true, "expected ?? to mark Optional repeat as non_greedy";
+    } else {
+        panic("expected Repeat at index 1");
+    }
+}
+
+test "lexer rule with non-greedy optional ?? on rule ref" {
+    let input = "lexer grammar L;
+CMT : '//' .*? '\\n' CMT?? ;";
+    let g = parse(input).unwrap();
+    let body = &g.lexer_rules[0].body;
+    let elems = &body[0].elements;
+    let last_idx = elems.len() - 1;
+    if let Repeat(r) = elems[last_idx] {
+        assert r.kind == RepeatKind::Optional;
+        assert r.non_greedy == true, "expected ?? to mark Optional lexer repeat as non_greedy";
+    } else {
+        panic("expected last lexer element to be a Repeat");
+    }
+}
+
 fn assert_option_ident(opt: &GrammarOption, expected: String) {
     if let Ident(v) = &opt.value {
         assert *v == expected, `option '{opt.name}': expected Ident('{expected}'), got Ident('{*v}')`;

--- a/package-gale/tests/antlr4-compat/grammars/LexerExec/CharSet.g4
+++ b/package-gale/tests/antlr4-compat/grammars/LexerExec/CharSet.g4
@@ -1,3 +1,3 @@
 lexer grammar L;
 I : '0'..'9'+ {<writeln("\"I\"")>} ;
-WS : [ \n\\u000D] -> skip ;
+WS : [ \n\u000D] -> skip ;

--- a/package-gale/tests/antlr4-compat/grammars/LexerExec/CharSetInSet.g4
+++ b/package-gale/tests/antlr4-compat/grammars/LexerExec/CharSetInSet.g4
@@ -1,3 +1,3 @@
 lexer grammar L;
-I : (~[ab \\n]|'a')  {<writeln("\"I\"")>} ;
-WS : [ \n\\u000D]+ -> skip ;
+I : (~[ab \n]|'a')  {<writeln("\"I\"")>} ;
+WS : [ \n\u000D]+ -> skip ;

--- a/package-gale/tests/antlr4-compat/grammars/LexerExec/CharSetNot.g4
+++ b/package-gale/tests/antlr4-compat/grammars/LexerExec/CharSetNot.g4
@@ -1,3 +1,3 @@
 lexer grammar L;
 I : ~[ab \n] ~[ \ncd]* {<writeln("\"I\"")>} ;
-WS : [ \n\\u000D]+ -> skip ;
+WS : [ \n\u000D]+ -> skip ;

--- a/package-gale/tests/antlr4-compat/grammars/LexerExec/CharSetPlus.g4
+++ b/package-gale/tests/antlr4-compat/grammars/LexerExec/CharSetPlus.g4
@@ -1,3 +1,3 @@
 lexer grammar L;
 I : '0'..'9'+ {<writeln("\"I\"")>} ;
-WS : [ \n\\u000D]+ -> skip ;
+WS : [ \n\u000D]+ -> skip ;

--- a/package-gale/tests/antlr4-compat/grammars/LexerExec/CharSetRange.g4
+++ b/package-gale/tests/antlr4-compat/grammars/LexerExec/CharSetRange.g4
@@ -1,4 +1,4 @@
 lexer grammar L;
 I : [0-9]+ {<writeln("\"I\"")>} ;
 ID : [a-zA-Z] [a-zA-Z0-9]* {<writeln("\"ID\"")>} ;
-WS : [ \n\\u0009\r]+ -> skip ;
+WS : [ \n\u0009\r]+ -> skip ;

--- a/package-gale/tests/antlr4-compat/grammars/LexerExec/CharSetWithEscapedChar.g4
+++ b/package-gale/tests/antlr4-compat/grammars/LexerExec/CharSetWithEscapedChar.g4
@@ -1,3 +1,3 @@
 lexer grammar L;
-DASHBRACK : [\\-\]]+ {<writeln("\"DASHBRACK\"")>} ;
+DASHBRACK : [\-\]]+ {<writeln("\"DASHBRACK\"")>} ;
 WS : [ \n]+ -> skip ;

--- a/package-gale/tests/antlr4-compat/grammars/LexerExec/CharSetWithQuote2.g4
+++ b/package-gale/tests/antlr4-compat/grammars/LexerExec/CharSetWithQuote2.g4
@@ -1,3 +1,3 @@
 lexer grammar L;
-A : ["\\\\ab]+ {<writeln("\"A\"")>} ;
+A : ["\\ab]+ {<writeln("\"A\"")>} ;
 WS : [ \n\t]+ -> skip ;

--- a/package-gale/tests/antlr4-compat/grammars/LexerExec/EscapedCharacters.g4
+++ b/package-gale/tests/antlr4-compat/grammars/LexerExec/EscapedCharacters.g4
@@ -1,3 +1,3 @@
 lexer grammar L;
-LF : '\\u000A';
+LF : '\u000A';
 X  : 'x';

--- a/package-gale/tests/antlr4-compat/grammars/LexerExec/Slashes.g4
+++ b/package-gale/tests/antlr4-compat/grammars/LexerExec/Slashes.g4
@@ -1,6 +1,6 @@
 lexer grammar L;
-Backslash : '\\\\';
+Backslash : '\\';
 Slash : '/';
-Vee : '\\\\/';
-Wedge : '/\\\\';
+Vee : '\\/';
+Wedge : '/\\';
 WS : [ \t] -> skip;

--- a/package-gale/tests/antlr4-compat/grammars/Sets/ComplementSet.g4
+++ b/package-gale/tests/antlr4-compat/grammars/Sets/ComplementSet.g4
@@ -1,3 +1,3 @@
 grammar T;
 parse : ~NEW_LINE;
-NEW_LINE: '\\r'? '\\n';
+NEW_LINE: '\r'? '\n';

--- a/package-gale/tests/antlr4-compat/grammars/Sets/UnicodeEscapedBMPRangeSet.g4
+++ b/package-gale/tests/antlr4-compat/grammars/Sets/UnicodeEscapedBMPRangeSet.g4
@@ -2,4 +2,4 @@ grammar T;
 a : LETTERS* 'd' {<InputText():writeln()>} ;
 // Note the double-backslash to avoid Java passing
 // unescaped values as part of the grammar.
-LETTERS : ('a'|'\\u00E0'..'\\u00E5');
+LETTERS : ('a'|'\u00E0'..'\u00E5');

--- a/package-gale/tests/antlr4-compat/grammars/Sets/UnicodeEscapedBMPSet.g4
+++ b/package-gale/tests/antlr4-compat/grammars/Sets/UnicodeEscapedBMPSet.g4
@@ -2,4 +2,4 @@ grammar T;
 a : LETTERS {<InputText():writeln()>} ;
 // Note the double-backslash to avoid Java passing
 // unescaped values as part of the grammar.
-LETTERS : ('a'|'\\u00E4'|'\\u4E9C'|'\\u3042')* 'c';
+LETTERS : ('a'|'\u00E4'|'\u4E9C'|'\u3042')* 'c';

--- a/package-gale/tests/antlr4-compat/grammars/Sets/UnicodeEscapedSMPRangeSet.g4
+++ b/package-gale/tests/antlr4-compat/grammars/Sets/UnicodeEscapedSMPRangeSet.g4
@@ -2,4 +2,4 @@ grammar T;
 a : LETTERS* 'd' {<InputText():writeln()>} ;
 // Note the double-backslash to avoid Java passing
 // unescaped values as part of the grammar.
-LETTERS : ('a'|'\\u{1F600}'..'\\u{1F943}');
+LETTERS : ('a'|'\u{1F600}'..'\u{1F943}');

--- a/package-gale/tests/antlr4-compat/grammars/Sets/UnicodeEscapedSMPRangeSetMismatch.g4
+++ b/package-gale/tests/antlr4-compat/grammars/Sets/UnicodeEscapedSMPRangeSetMismatch.g4
@@ -2,4 +2,4 @@ grammar T;
 a : LETTERS* 'd' {<InputText():writeln()>} ;
 // Note the double-backslash to avoid Java passing
 // unescaped values as part of the grammar.
-LETTERS : ('a'|'\\u{1F600}'..'\\u{1F943}');
+LETTERS : ('a'|'\u{1F600}'..'\u{1F943}');

--- a/package-gale/tests/antlr4-compat/grammars/Sets/UnicodeEscapedSMPSet.g4
+++ b/package-gale/tests/antlr4-compat/grammars/Sets/UnicodeEscapedSMPSet.g4
@@ -2,4 +2,4 @@ grammar T;
 a : LETTERS  {<InputText():writeln()>} ;
 // Note the double-backslash to avoid Java passing
 // unescaped values as part of the grammar.
-LETTERS : ('a'|'\\u{1D5BA}'|'\\u{1D5BE}'|'\\u{1D5C2}'|'\\u{1D5C8}'|'\\u{1D5CE}')* 'c';
+LETTERS : ('a'|'\u{1D5BA}'|'\u{1D5BE}'|'\u{1D5C2}'|'\u{1D5C8}'|'\u{1D5CE}')* 'c';

--- a/package-gale/tests/antlr4-compat/grammars/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4
+++ b/package-gale/tests/antlr4-compat/grammars/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4
@@ -1,3 +1,3 @@
 grammar T;
 a : LETTERS {<InputText():writeln()>} ;
-LETTERS : 'a' ~('\\u{1F600}'..'\\u{1F943}')+ 'c';
+LETTERS : 'a' ~('\u{1F600}'..'\u{1F943}')+ 'c';

--- a/package-gale/tests/antlr4-compat/lexer_exec_test.wado
+++ b/package-gale/tests/antlr4-compat/lexer_exec_test.wado
@@ -190,8 +190,6 @@ test "LexerExec/NonGreedyConfigs" {
     }
 }
 
-#[TODO]
-// triage: Gale parser does not recognise the non-greedy optional operator (??) on a single element
 test "LexerExec/NonGreedyOptional" {
     let input = #include_str("./grammars/LexerExec/NonGreedyOptional.g4");
     let result = parse(input);

--- a/package-gale/tests/antlr4-compat/parse_trees_test.wado
+++ b/package-gale/tests/antlr4-compat/parse_trees_test.wado
@@ -6,16 +6,6 @@
 
 use { parse } from "../../src/g4/parser.wado";
 
-#[TODO]
-// triage: descriptor uses StringTemplate <...> directives at grammar level that the ANTLR4 testsuite substitutes per-target before compilation
-test "ParseTrees/AltNum" {
-    let input = #include_str("./grammars/ParseTrees/AltNum.g4");
-    let result = parse(input);
-    if let Err(err) = &result {
-        panic(`parse failed: {err.message} at {err.span.start}..{err.span.end}`);
-    }
-}
-
 test "ParseTrees/ExtraToken" {
     let input = #include_str("./grammars/ParseTrees/ExtraToken.g4");
     let result = parse(input);
@@ -58,16 +48,6 @@ test "ParseTrees/Sync" {
 
 test "ParseTrees/Token2" {
     let input = #include_str("./grammars/ParseTrees/Token2.g4");
-    let result = parse(input);
-    if let Err(err) = &result {
-        panic(`parse failed: {err.message} at {err.span.start}..{err.span.end}`);
-    }
-}
-
-#[TODO]
-// triage: descriptor uses StringTemplate <...> directives at grammar level that the ANTLR4 testsuite substitutes per-target before compilation
-test "ParseTrees/TokenAndRuleContextString" {
-    let input = #include_str("./grammars/ParseTrees/TokenAndRuleContextString.g4");
     let result = parse(input);
     if let Err(err) = &result {
         panic(`parse failed: {err.message} at {err.span.start}..{err.span.end}`);

--- a/package-gale/tests/antlr4-compat/sets_test.wado
+++ b/package-gale/tests/antlr4-compat/sets_test.wado
@@ -182,8 +182,6 @@ test "Sets/StarSet" {
     }
 }
 
-#[TODO]
-// triage: descriptor uses the ANTLR4 testsuite double-backslash unicode escape form that Gale does not unwrap
 test "Sets/UnicodeEscapedBMPRangeSet" {
     let input = #include_str("./grammars/Sets/UnicodeEscapedBMPRangeSet.g4");
     let result = parse(input);
@@ -200,8 +198,6 @@ test "Sets/UnicodeEscapedBMPSet" {
     }
 }
 
-#[TODO]
-// triage: descriptor uses the ANTLR4 testsuite double-backslash unicode escape form that Gale does not unwrap
 test "Sets/UnicodeEscapedSMPRangeSet" {
     let input = #include_str("./grammars/Sets/UnicodeEscapedSMPRangeSet.g4");
     let result = parse(input);
@@ -210,8 +206,6 @@ test "Sets/UnicodeEscapedSMPRangeSet" {
     }
 }
 
-#[TODO]
-// triage: descriptor uses the ANTLR4 testsuite double-backslash unicode escape form that Gale does not unwrap
 test "Sets/UnicodeEscapedSMPRangeSetMismatch" {
     let input = #include_str("./grammars/Sets/UnicodeEscapedSMPRangeSetMismatch.g4");
     let result = parse(input);
@@ -236,8 +230,6 @@ test "Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints" {
     }
 }
 
-#[TODO]
-// triage: descriptor uses the ANTLR4 testsuite double-backslash unicode escape form that Gale does not unwrap
 test "Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints" {
     let input = #include_str("./grammars/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4");
     let result = parse(input);

--- a/package-gale/tests/antlr4-compat/status.toml
+++ b/package-gale/tests/antlr4-compat/status.toml
@@ -18,13 +18,7 @@
 #   package-gale/scripts/extract-antlr4-descriptors.sh
 
 [todo]
-"Sets/UnicodeEscapedBMPRangeSet" = "descriptor uses the ANTLR4 testsuite double-backslash unicode escape form that Gale does not unwrap"
-"Sets/UnicodeEscapedSMPRangeSet" = "descriptor uses the ANTLR4 testsuite double-backslash unicode escape form that Gale does not unwrap"
-"Sets/UnicodeEscapedSMPRangeSetMismatch" = "descriptor uses the ANTLR4 testsuite double-backslash unicode escape form that Gale does not unwrap"
-"Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints" = "descriptor uses the ANTLR4 testsuite double-backslash unicode escape form that Gale does not unwrap"
-"LexerExec/NonGreedyOptional" = "Gale parser does not recognise the non-greedy optional operator (??) on a single element"
-"ParseTrees/AltNum" = "descriptor uses StringTemplate <...> directives at grammar level that the ANTLR4 testsuite substitutes per-target before compilation"
-"ParseTrees/TokenAndRuleContextString" = "descriptor uses StringTemplate <...> directives at grammar level that the ANTLR4 testsuite substitutes per-target before compilation"
 
 [skip]
-# (none yet — every Phase 1 descriptor either parses or is recorded as TODO)
+"ParseTrees/AltNum" = "grammar-level <...> StringTemplate directive that the ANTLR4 testsuite substitutes per target before antlr4 ever sees the .g4 — not a self-contained grammar"
+"ParseTrees/TokenAndRuleContextString" = "grammar-level <...> StringTemplate directive that the ANTLR4 testsuite substitutes per target before antlr4 ever sees the .g4 — not a self-contained grammar"


### PR DESCRIPTION
## Summary

Closes the seven Phase 1 `#[TODO]`s in `package-gale/tests/antlr4-compat/`. After this change, the descriptor pipeline goes from **76 pass / 0 fail / 7 todo** to **81 pass / 0 fail / 0 todo + 2 skip** for `Sets`, `LexerExec`, and `ParseTrees`.

Two structural fixes:

- **Extractor: StringTemplate-equivalent unescape on `[grammar]` blocks.** The upstream `RuntimeTests.prepareGrammars` wraps every descriptor in `new ST(group, descriptor.grammar)` with `<` / `>` delimiters before handing it to `antlr4`, so any `\` that needs to survive into the `.g4` is written as `\\` in the descriptor (and any literal `<` / `>` as `\<` / `\>`). The Wado extractor was skipping that step, so descriptors like `'a'|'\\u00E0'..'\\u00E5'` reached the g4 parser as 6-char strings that cannot serve as range bounds. The new `unescape_st_text` in `scripts/extract_antlr4_descriptors.wado` applies the minimal text-mode rules (`\\` → `\`, `\<` → `<`, `\>` → `>`) to the grammar text. Other backslash sequences (`\n`, `\u…`, `\t`, …) are left intact — ST's text mode does not interpret them, and ANTLR4's own lexer does.
- **Parser: `??` non-greedy optional on a single element.** `parse_postfix` and `parse_lexer_postfix` already handle `*?` and `+?`; they now do the same for `??`, matching the upstream `ANTLRParser.g`. Covered by two new unit tests in `src/g4/parser_test.wado`.

`ParseTrees/AltNum` and `ParseTrees/TokenAndRuleContextString` move from `[todo]` to `[skip]`. Their grammar-level `<…>` directives are substituted per target by the testsuite before `antlr4` ever sees the `.g4`, so the `.txt` contents are not self-contained grammars and cannot be promoted to a parse-only test.

The regenerated `.g4` fixtures under `tests/antlr4-compat/grammars/{LexerExec,Sets}/` are a side effect of the extractor change: previously parse-only-correct grammars (e.g. `CharSet`, `Slashes`, `EscapedCharacters`) now reach Gale in semantically faithful form.

## Test plan

- [x] `wado test package-gale/src/g4/` — 173 passed, 0 failed (covers the two new `??` tests).
- [x] `wado test package-gale/tests/antlr4-compat/` — 81 passed, 0 failed, 0 todo, 2 skip.
- [x] `wado test package-gale` (full suite, including driver tests for SQLite / CSS3 / HTML / RustLexer / TypeScriptLexer / ANTLRv4Lexer) — 677 passed, 0 failed.
- [ ] CI: `mise run test` and `mise run test-wado` on this branch.

https://claude.ai/code/session_01DV3gwY1tfc9BLpEWjrt6XA

---
_Generated by [Claude Code](https://claude.ai/code/session_01DV3gwY1tfc9BLpEWjrt6XA)_