### PR TITLE
refactor: data-drive world-shape codegen, drop world-name string matches

### DIFF
--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -48,8 +48,11 @@ pub fn build_component(
     // The generator's single export `generate(raw: raw-request) ->
     // result<response, error>` plus its task-return canon need these
     // types defined before `emit_canonical_intrinsics` and
-    // `emit_world_exports` run.
-    if project.is_kiln_generator_world() {
+    // `emit_world_exports` run. Gate on the world's `import KilnHost`
+    // declaration so any kiln-generator-shaped world picks this path up
+    // — the previous form matched `target_world == "core:kiln/generator"`
+    // by string and missed future generator worlds.
+    if project.world_imports_effect("KilnHost") {
         emit_kiln_world_types(&mut builder, &mut ctx);
     }
 

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -1307,7 +1307,7 @@ fn emit_canonical_intrinsics(
             cm_export_type_to_idx(
                 ctx,
                 &export.cm_result,
-                &component_plan.world_package,
+                component_plan.world_package.as_deref(),
                 result_unit_type,
             )
         })
@@ -1524,7 +1524,7 @@ fn resolve_future_type(
 fn cm_export_type_to_idx(
     ctx: &ComponentModelContext,
     ty: &crate::wir_build::component_plan::CmExportType,
-    world_package: &str,
+    world_package: Option<&str>,
     result_unit_type: u32,
 ) -> u32 {
     use crate::wir_build::component_plan::CmExportType;
@@ -1534,27 +1534,24 @@ fn cm_export_type_to_idx(
             interface_fq,
             cm_name,
         } => {
-            let pkg = interface_fq_package(interface_fq).unwrap_or_else(|| {
-                panic!(
-                    "world export Named CM type interface `{interface_fq}` has no `scheme:pkg/...` shape",
-                )
-            });
+            let pkg = crate::world_registry::fq_name_package(interface_fq);
+            assert!(
+                !pkg.is_empty(),
+                "world export Named CM type interface `{interface_fq}` has no `scheme:pkg/...` shape",
+            );
             let key = format!("{pkg}-{cm_name}");
             ctx.type_idx(&key)
         }
         CmExportType::HandlerResult => {
-            let key = format!("{world_package}-handler-result");
+            // The plan only emits `HandlerResult` for worlds with a known
+            // package — `world_package` is guaranteed `Some` at this point.
+            let pkg = world_package.expect(
+                "HandlerResult emitted for a world with no package: stdlib bootstrap regression",
+            );
+            let key = format!("{pkg}-handler-result");
             ctx.type_idx(&key)
         }
     }
-}
-
-/// Extract the package segment of a CM interface FQ (`wasi:http/types` →
-/// `"http"`, `core:kiln/types` → `"kiln"`).
-fn interface_fq_package(interface_fq: &str) -> Option<&str> {
-    let (_, rest) = interface_fq.split_once(':')?;
-    let (pkg, _) = rest.split_once('/')?;
-    Some(pkg)
 }
 
 fn emit_world_exports(
@@ -1563,7 +1560,7 @@ fn emit_world_exports(
     component_plan: &crate::wir_build::component_plan::ComponentPlan,
     result_unit_type: u32,
 ) {
-    let world_package = component_plan.world_package.as_str();
+    let world_package = component_plan.world_package.as_deref();
     for export in &component_plan.world_exports {
         let core_name = format!("{}-core", export.name);
         let func_type_name = format!("{}-func-type", export.name);
@@ -1580,15 +1577,10 @@ fn emit_world_exports(
         {
             let (_, enc) = builder.ty(Some(&func_type_name));
 
-            // Resolve each plan-level [`CmExportType`] to a registered
-            // component type index. Resources and variants follow the
-            // `{pkg}-{cm-name}` naming convention emitted by
-            // `import_wasi_http_types` / `emit_kiln_world_types`; the
-            // synthesized `result<own<resp>, error>` lives under
-            // `{world_pkg}-handler-result`. The previous form here was a
-            // hand-coded `if export.is_http_handler { ... } else if
-            // is_kiln_generator { ... } else { ... }` branch — collapsing
-            // it to a uniform iteration is the point of this pass.
+            // Resources and variants follow the `{pkg}-{cm-name}` naming
+            // convention emitted by `import_wasi_http_types` /
+            // `emit_kiln_world_types`; the synthesized `result<own<resp>, error>`
+            // lives under `{world_pkg}-handler-result`. See [`CmExportType`].
             let param_idxs: Vec<(String, u32)> = export
                 .cm_params
                 .iter()
@@ -1616,13 +1608,14 @@ fn emit_world_exports(
             CanonicalOption::Async,
             CanonicalOption::Memory(ctx.memory_idx()),
         ];
-        // Exports that pass CM records / lists / strings / own-handles
-        // through their params need `realloc` so the canon can materialise
-        // those payloads into linear memory for the core function.
-        // Param-free exports (CLI `run`, the unknown-world fallback) stay
-        // realloc-free — `wasm-tools` rejects `realloc` on a canon with no
-        // lifting work to do.
-        if !export.cm_params.is_empty() {
+        // `realloc` is required iff the canon has any non-Unit param to
+        // materialise into linear memory. `wasm-tools` rejects `realloc`
+        // on a canon with no lifting work to do.
+        let needs_realloc = export
+            .cm_params
+            .iter()
+            .any(|(_, cm_ty)| cm_ty.needs_realloc());
+        if needs_realloc {
             lift_opts.push(CanonicalOption::Realloc(ctx.core_func_idx("realloc")));
         }
         builder.lift_func(

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -1604,20 +1604,16 @@ fn emit_world_exports(
         }
 
         ctx.register_comp_func(&export.name);
-        let mut lift_opts = vec![
+        // `realloc` is always supplied to the canon. The Wado runtime always
+        // exports a `realloc` (the chosen allocator), and wasm-tools accepts
+        // the option even on canons whose lift code never calls back into it
+        // (verified by running the full e2e suite, including param-free CLI
+        // `run` and `Result<(), ()>` exports).
+        let lift_opts = vec![
             CanonicalOption::Async,
             CanonicalOption::Memory(ctx.memory_idx()),
+            CanonicalOption::Realloc(ctx.core_func_idx("realloc")),
         ];
-        // `realloc` is required iff the canon has any non-Unit param to
-        // materialise into linear memory. `wasm-tools` rejects `realloc`
-        // on a canon with no lifting work to do.
-        let needs_realloc = export
-            .cm_params
-            .iter()
-            .any(|(_, cm_ty)| cm_ty.needs_realloc());
-        if needs_realloc {
-            lift_opts.push(CanonicalOption::Realloc(ctx.core_func_idx("realloc")));
-        }
         builder.lift_func(
             Some(&export.name),
             ctx.core_func_idx(&core_name),

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -224,8 +224,7 @@ pub fn build_component(
         trailers_future_type,
         &transmission_future_types,
         &scalar_future_types,
-        project.has_http_handler_export,
-        project.is_kiln_generator_world(),
+        component_plan,
     );
 
     // Lower WASI functions
@@ -360,13 +359,7 @@ pub fn build_component(
     builder.core_instantiate(Some("main"), ctx.core_module_idx("main-mod"), main_args);
 
     // World exports
-    emit_world_exports(
-        &mut builder,
-        &mut ctx,
-        component_plan,
-        result_unit_type,
-        project.is_kiln_generator_world(),
-    );
+    emit_world_exports(&mut builder, &mut ctx, component_plan, result_unit_type);
 
     if !project.strip_names {
         builder.append_names();
@@ -1298,9 +1291,24 @@ fn emit_canonical_intrinsics(
     trailers_future_type: u32,
     transmission_future_types: &IndexMap<String, u32>,
     scalar_future_types: &IndexSet<(CmScalarType, u32)>,
-    has_http_handler_export: bool,
-    is_kiln_generator: bool,
+    component_plan: &crate::wir_build::component_plan::ComponentPlan,
 ) {
+    // The `task.return` canon needs the export's CM-resolved result type.
+    // Worlds with one boundary export (HTTP service `handle`, kiln
+    // `generate`, CLI `Command::run`) all share this single-task assumption;
+    // the test world emits zero world exports so we fall back to `result<>`.
+    let task_return_type = component_plan
+        .world_exports
+        .first()
+        .map(|export| {
+            cm_export_type_to_idx(
+                ctx,
+                &export.cm_result,
+                &component_plan.world_package,
+                result_unit_type,
+            )
+        })
+        .unwrap_or(result_unit_type);
     for intrinsic in canonical_intrinsics {
         ctx.register_core_func(&intrinsic.import_name());
 
@@ -1419,21 +1427,17 @@ fn emit_canonical_intrinsics(
                 builder.future_drop_readable(ft);
             }
             CanonicalIntrinsic::TaskReturn => {
-                // Select the task-return result shape based on the
-                // active world: `result<response, error>` for the kiln
-                // generator, `http-handler-result` for HTTP service,
-                // bare `result<>` otherwise. The flat decomposition of
-                // this type must match the core module's task-return
+                // The `task.return` result shape is the active world
+                // export's CM-resolved return type — `result<response,
+                // error>` for the kiln generator, `http-handler-result`
+                // for HTTP service, `result<>` for CLI and the test
+                // world. Computed once at function entry from
+                // `component_plan.world_exports[0].cm_result` so the
+                // code path here is uniform across worlds. The flat
+                // decomposition must match the core module's task-return
                 // import signature (computed via
                 // `compute_export_flat_return_types`) or component
                 // validation fails at instantiation.
-                let task_return_type = if is_kiln_generator && ctx.has_type("kiln-handler-result") {
-                    ctx.type_idx("kiln-handler-result")
-                } else if has_http_handler_export && ctx.has_type("http-handler-result") {
-                    ctx.type_idx("http-handler-result")
-                } else {
-                    result_unit_type
-                };
                 // task.return lifts payloads from linear memory into
                 // component values; it does not allocate, so `realloc`
                 // must not appear in the option list (wasm-tools
@@ -1507,13 +1511,56 @@ fn resolve_future_type(
     }
 }
 
+/// Resolve a plan-level [`CmExportType`] to a component type index registered
+/// in `ctx`.
+///
+/// The naming convention `{pkg}-{cm_name}` mirrors what
+/// `import_wasi_http_types` and `emit_kiln_world_types` register for resource
+/// own-handles and named variants. `HandlerResult` resolves to the per-world
+/// `{world_package}-handler-result` synthesised by the same helpers.
+fn cm_export_type_to_idx(
+    ctx: &ComponentModelContext,
+    ty: &crate::wir_build::component_plan::CmExportType,
+    world_package: &str,
+    result_unit_type: u32,
+) -> u32 {
+    use crate::wir_build::component_plan::CmExportType;
+    match ty {
+        CmExportType::Unit => result_unit_type,
+        CmExportType::Named {
+            interface_fq,
+            cm_name,
+        } => {
+            let pkg = interface_fq_package(interface_fq).unwrap_or_else(|| {
+                panic!(
+                    "world export Named CM type interface `{interface_fq}` has no `scheme:pkg/...` shape",
+                )
+            });
+            let key = format!("{pkg}-{cm_name}");
+            ctx.type_idx(&key)
+        }
+        CmExportType::HandlerResult => {
+            let key = format!("{world_package}-handler-result");
+            ctx.type_idx(&key)
+        }
+    }
+}
+
+/// Extract the package segment of a CM interface FQ (`wasi:http/types` →
+/// `"http"`, `core:kiln/types` → `"kiln"`).
+fn interface_fq_package(interface_fq: &str) -> Option<&str> {
+    let (_, rest) = interface_fq.split_once(':')?;
+    let (pkg, _) = rest.split_once('/')?;
+    Some(pkg)
+}
+
 fn emit_world_exports(
     builder: &mut ComponentBuilder,
     ctx: &mut ComponentModelContext,
     component_plan: &crate::wir_build::component_plan::ComponentPlan,
     result_unit_type: u32,
-    is_kiln_generator: bool,
 ) {
+    let world_package = component_plan.world_package.as_str();
     for export in &component_plan.world_exports {
         let core_name = format!("{}-core", export.name);
         let func_type_name = format!("{}-func-type", export.name);
@@ -1530,29 +1577,35 @@ fn emit_world_exports(
         {
             let (_, enc) = builder.ty(Some(&func_type_name));
 
-            if export.is_http_handler {
-                let request_type_idx = ctx.type_idx("http-request");
-                let handler_result_type_idx = ctx.type_idx("http-handler-result");
-                enc.function()
-                    .async_(export.is_async)
-                    .params([("request", ComponentValType::Type(request_type_idx))])
-                    .result(Some(ComponentValType::Type(handler_result_type_idx)));
-            } else if is_kiln_generator
-                && ctx.has_type("kiln-raw-request")
-                && ctx.has_type("kiln-handler-result")
-            {
-                let raw_request_idx = ctx.type_idx("kiln-raw-request");
-                let handler_result_idx = ctx.type_idx("kiln-handler-result");
-                enc.function()
-                    .async_(export.is_async)
-                    .params([("req", ComponentValType::Type(raw_request_idx))])
-                    .result(Some(ComponentValType::Type(handler_result_idx)));
-            } else {
-                enc.function()
-                    .async_(export.is_async)
-                    .params::<[(&str, ComponentValType); 0], ComponentValType>([])
-                    .result(Some(ComponentValType::Type(result_unit_type)));
-            }
+            // Resolve each plan-level [`CmExportType`] to a registered
+            // component type index. Resources and variants follow the
+            // `{pkg}-{cm-name}` naming convention emitted by
+            // `import_wasi_http_types` / `emit_kiln_world_types`; the
+            // synthesized `result<own<resp>, error>` lives under
+            // `{world_pkg}-handler-result`. The previous form here was a
+            // hand-coded `if export.is_http_handler { ... } else if
+            // is_kiln_generator { ... } else { ... }` branch — collapsing
+            // it to a uniform iteration is the point of this pass.
+            let param_idxs: Vec<(String, u32)> = export
+                .cm_params
+                .iter()
+                .map(|(name, cm_ty)| {
+                    (
+                        name.clone(),
+                        cm_export_type_to_idx(ctx, cm_ty, world_package, result_unit_type),
+                    )
+                })
+                .collect();
+            let param_refs: Vec<(&str, ComponentValType)> = param_idxs
+                .iter()
+                .map(|(n, idx)| (n.as_str(), ComponentValType::Type(*idx)))
+                .collect();
+            let result_idx =
+                cm_export_type_to_idx(ctx, &export.cm_result, world_package, result_unit_type);
+            enc.function()
+                .async_(export.is_async)
+                .params(param_refs)
+                .result(Some(ComponentValType::Type(result_idx)));
         }
 
         ctx.register_comp_func(&export.name);
@@ -1560,12 +1613,13 @@ fn emit_world_exports(
             CanonicalOption::Async,
             CanonicalOption::Memory(ctx.memory_idx()),
         ];
-        // HTTP and Kiln exports pass CM-level records / lists / strings
-        // through their params, so the canon must materialize them into
-        // linear memory for the core function. `realloc` satisfies the
-        // validator; `result_unit_type` exports take no params so stay
-        // realloc-free.
-        if export.is_http_handler || (is_kiln_generator && ctx.has_type("kiln-raw-request")) {
+        // Exports that pass CM records / lists / strings / own-handles
+        // through their params need `realloc` so the canon can materialise
+        // those payloads into linear memory for the core function.
+        // Param-free exports (CLI `run`, the unknown-world fallback) stay
+        // realloc-free — `wasm-tools` rejects `realloc` on a canon with no
+        // lifting work to do.
+        if !export.cm_params.is_empty() {
             lift_opts.push(CanonicalOption::Realloc(ctx.core_func_idx("realloc")));
         }
         builder.lift_func(

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -63,7 +63,7 @@ pub fn unwrap_async_call_if_async(is_async: bool, declared: &Option<Type>) -> Op
 /// Returns true if `ty` is the Wado unit type. Recognises both surface
 /// syntaxes that the parser may emit: the empty tuple `[]` and the
 /// named form `()`.
-fn is_unit_type(ty: &Type) -> bool {
+pub fn is_unit_type(ty: &Type) -> bool {
     match ty {
         Type::Tuple(elems) => elems.is_empty(),
         Type::Named(named) => matches!(named.name.as_str(), "()" | "Unit" | "unit"),

--- a/wado-compiler/src/flat_package.rs
+++ b/wado-compiler/src/flat_package.rs
@@ -105,13 +105,21 @@ impl FlatPackage {
         self.target_world == world_registry::TEST_WORLD
     }
 
-    /// Check if the project targets the Kiln generator well-known world
-    /// (`core:kiln/generator`). The codegen path uses this to emit the
-    /// kiln-specific CM record/variant types and to point the
-    /// `task-return` canon at the `result<response, error>` shape
-    /// required by the generator's export signature.
-    pub fn is_kiln_generator_world(&self) -> bool {
-        self.target_world == "core:kiln/generator"
+    /// Check whether the active world declares an
+    /// `import {effect_name} { ... }` block.
+    ///
+    /// Drives world-shape decisions in codegen / lowering / DCE that used to
+    /// hinge on `target_world == "core:kiln/generator"` string matches —
+    /// `imports_effect("KilnHost")` is true for the kiln generator world and
+    /// any future world that imports the same effect, so adding a new
+    /// generator-shaped world no longer needs new branches.
+    ///
+    /// Returns `false` for the synthetic test world and for unknown worlds
+    /// (both have no entry in the registry).
+    pub fn world_imports_effect(&self, effect_name: &str) -> bool {
+        self.world_registry
+            .get(&self.target_world)
+            .is_some_and(|w| w.imports_effect(effect_name))
     }
 
     /// Look up a variant by `(module_source, name)`.

--- a/wado-compiler/src/link.rs
+++ b/wado-compiler/src/link.rs
@@ -52,6 +52,7 @@ pub fn link(package: Package) -> FlatPackage {
         entry_tests,
         &package.export_binding_names,
         package.world_registry,
+        package.wasi_registry,
     );
 
     // Flatten all per-module TIR into flat lists.

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -118,8 +118,10 @@ fn resolve_imports(
     // `unreachable` at the WIR level and never need the matching WASI
     // function registered as "used" — skip the usage registration so
     // the component doesn't transitively import `wasi:cli/stderr` or
-    // `wasi:cli/stdout`.
-    if !project.is_kiln_generator_world() {
+    // `wasi:cli/stdout`. Gate on `import KilnHost` so the rule fires
+    // for any kiln-generator-shaped world, not just the canonical
+    // `core:kiln/generator`.
+    if !project.world_imports_effect("KilnHost") {
         if reachable.iter().any(|func_id| {
             matches!(func_id, FunctionId::Free(f) if is_builtin_func(f) && {
                 let name = f.name.strip_prefix("builtin::").unwrap_or(&f.name);

--- a/wado-compiler/src/wir_build/calls.rs
+++ b/wado-compiler/src/wir_build/calls.rs
@@ -1686,7 +1686,7 @@ impl FunctionTranslator<'_, '_> {
                 // generator that calls `println` shouldn't compile past the
                 // import-refusal check anyway, but belt-and-suspenders is
                 // cheap at the builtin boundary.
-                if self.ctx.package.is_kiln_generator_world() {
+                if self.ctx.package.world_imports_effect("KilnHost") {
                     // `unreachable` is stack-polymorphic — it satisfies
                     // the declared i32 return of the stderr/stdout
                     // write-via-stream builtin without further work.

--- a/wado-compiler/src/wir_build/component_plan.rs
+++ b/wado-compiler/src/wir_build/component_plan.rs
@@ -82,21 +82,6 @@ pub enum CmExportType {
     HandlerResult,
 }
 
-impl CmExportType {
-    /// True if lifting this CM type out of linear memory requires the
-    /// canon `realloc` option.
-    ///
-    /// Records / lists / strings / own-handles all need `realloc` so the
-    /// canon can materialise the payload into the guest module's linear
-    /// memory. `Unit` and primitive variants don't allocate, and would be
-    /// rejected by `wasm-tools` if they shipped a `realloc` option.
-    /// Currently every [`Self::Named`] in a stdlib world ABI is a record or
-    /// resource; the conservative answer is "any non-Unit type needs realloc".
-    pub fn needs_realloc(&self) -> bool {
-        !matches!(self, CmExportType::Unit)
-    }
-}
-
 /// A test function to export from the component.
 #[derive(Debug, Clone)]
 pub struct TestExportPlan {
@@ -497,21 +482,5 @@ mod tests {
             }
             other => panic!("expected Named, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn test_needs_realloc() {
-        // Unit needs no realloc; the canon would be rejected by wasm-tools
-        // if it shipped one with no lifting work.
-        assert!(!CmExportType::Unit.needs_realloc());
-        // Named records / resources are lifted into linear memory.
-        assert!(
-            CmExportType::Named {
-                interface_fq: "wasi:http/types".to_string(),
-                cm_name: "request".to_string(),
-            }
-            .needs_realloc()
-        );
-        assert!(CmExportType::HandlerResult.needs_realloc());
     }
 }

--- a/wado-compiler/src/wir_build/component_plan.rs
+++ b/wado-compiler/src/wir_build/component_plan.rs
@@ -4,10 +4,10 @@
 //! structure. Built by `wir_build::plan_project`, consumed by `codegen`.
 
 use crate::ast::Type;
-use crate::component_model::WasiRegistry;
+use crate::component_model::{WasiRegistry, is_unit_type};
 use crate::hashmap::IndexMap;
 use crate::tir::TirTest;
-use crate::world_registry::{WorldExportInfo, WorldInfo, WorldRegistry};
+use crate::world_registry::{WorldExportInfo, WorldRegistry};
 
 /// Plan for the Component Model structure.
 ///
@@ -24,10 +24,12 @@ pub struct ComponentPlan {
     /// Test functions to export.
     pub test_exports: Vec<TestExportPlan>,
     /// CM package segment of the target world's `fq_name` (e.g., `"http"`,
-    /// `"kiln"`). Empty for the test world or when the target world is not
-    /// in the registry. Used by codegen to resolve [`CmExportType::HandlerResult`]
-    /// to the per-world `{pkg}-handler-result` registered type.
-    pub world_package: String,
+    /// `"kiln"`). `None` for the test world or when the target world is not
+    /// in the registry — both cases never produce a [`CmExportType::HandlerResult`]
+    /// so the package is genuinely absent rather than empty. Used by codegen
+    /// to resolve `HandlerResult` to the per-world `{pkg}-handler-result`
+    /// registered type.
+    pub world_package: Option<String>,
 }
 
 /// A world export to create at the component boundary.
@@ -39,15 +41,9 @@ pub struct WorldExportPlan {
     pub core_func_name: String,
     /// Whether this is an async export
     pub is_async: bool,
-    /// Whether this is an HTTP handler (Service world)
-    pub is_http_handler: bool,
-    /// Parameter types from world definition
-    pub params: Vec<(String, Type)>,
-    /// Return type from world definition
-    pub return_type: Option<Type>,
-    /// CM-resolved parameter types at the component boundary, derived from
-    /// `params` via the type registry. Codegen iterates this list to build
-    /// the export's CM signature without needing per-world discriminators.
+    /// CM-resolved parameter types at the component boundary. Codegen
+    /// iterates this list to build the export's CM signature without
+    /// needing per-world discriminators.
     pub cm_params: Vec<(String, CmExportType)>,
     /// CM-resolved return type at the component boundary.
     pub cm_result: CmExportType,
@@ -84,6 +80,21 @@ pub enum CmExportType {
     /// (e.g. `http-handler-result`, `kiln-handler-result`) and resolves this
     /// variant to `ctx.type_idx(&format!("{world_package}-handler-result"))`.
     HandlerResult,
+}
+
+impl CmExportType {
+    /// True if lifting this CM type out of linear memory requires the
+    /// canon `realloc` option.
+    ///
+    /// Records / lists / strings / own-handles all need `realloc` so the
+    /// canon can materialise the payload into the guest module's linear
+    /// memory. `Unit` and primitive variants don't allocate, and would be
+    /// rejected by `wasm-tools` if they shipped a `realloc` option.
+    /// Currently every [`Self::Named`] in a stdlib world ABI is a record or
+    /// resource; the conservative answer is "any non-Unit type needs realloc".
+    pub fn needs_realloc(&self) -> bool {
+        !matches!(self, CmExportType::Unit)
+    }
 }
 
 /// A test function to export from the component.
@@ -158,12 +169,11 @@ pub fn build_component_plan(
     };
 
     let world_package = if is_test_world {
-        String::new()
+        None
     } else {
         world_registry
             .get(target_world)
             .map(|w| w.package().to_string())
-            .unwrap_or_default()
     };
 
     ComponentPlan {
@@ -191,20 +201,9 @@ fn build_world_export_plans(
         }]
     });
 
-    // Route through `WorldInfo::has_http_handler_export` so the "is this
-    // the HTTP service world?" check stays in one place — no ad-hoc
-    // `starts_with("wasi:http/")` string parsing scattered across the
-    // codegen pipeline.
-    let is_http_world = world.is_some_and(WorldInfo::has_http_handler_export);
     exports
         .into_iter()
         .map(|export| {
-            // Only mark as HTTP handler when the world itself is under
-            // `wasi:http/…`. Without this guard, any world whose export
-            // returns `Result<Response, _>` (for example
-            // `core:kiln/generator`'s `Response`) would be misrouted
-            // through the HTTP codegen branch.
-            let is_http_handler = is_http_world && export.returns_http_response();
             // Use export adapter if one was synthesized by synthesis::cm_binding
             let core_func_name = export_binding_names
                 .get(&export.name)
@@ -229,9 +228,6 @@ fn build_world_export_plans(
                 name: export.name,
                 core_func_name,
                 is_async: export.is_async,
-                is_http_handler,
-                params: export.params,
-                return_type: export.return_type,
                 cm_params,
                 cm_result,
             }
@@ -248,21 +244,21 @@ fn build_world_export_plans(
 /// - `Result<X, Y>` with at least one non-unit component →
 ///   [`CmExportType::HandlerResult`]
 /// - Any other named type whose source interface and CM kebab-name are known
-///   to the WASI registry → [`CmExportType::Named`]
+///   to the registry → [`CmExportType::Named`]
 ///
 /// Panics on shapes the registry cannot resolve. World export signatures
-/// originate in stdlib `lib/wasi/**/worlds.wado` and `lib/core/kiln/worlds.wado`,
-/// so any unresolved name indicates a bug in the stdlib bootstrap rather than
-/// user input.
+/// originate in stdlib `lib/wasi/**/worlds.wado` and
+/// `lib/core/kiln/worlds.wado`, so any unresolved name indicates a bug in the
+/// stdlib bootstrap rather than user input.
 fn resolve_cm_export_type(ty: &Type, wasi_registry: &WasiRegistry) -> CmExportType {
-    if is_unit_like(ty) {
+    if is_unit_type(ty) {
         return CmExportType::Unit;
     }
     if let Type::Generic(generic) = ty
         && generic.name == "Result"
         && generic.args.len() == 2
     {
-        if is_unit_like(&generic.args[0]) && is_unit_like(&generic.args[1]) {
+        if is_unit_type(&generic.args[0]) && is_unit_type(&generic.args[1]) {
             return CmExportType::Unit;
         }
         return CmExportType::HandlerResult;
@@ -271,31 +267,17 @@ fn resolve_cm_export_type(ty: &Type, wasi_registry: &WasiRegistry) -> CmExportTy
         // World bodies (`lib/wasi/**/worlds.wado`, `lib/core/kiln/worlds.wado`)
         // reference type names like `Request` / `RawRequest` directly without
         // a `use { ... } from "..."` import, so `populate_named_type_sources`
-        // leaves `source_interface = None`. Fall back to the by-name lookups
-        // that the rest of the CM codegen uses for the same shape — trying
-        // both the `wasi:*` and `core:kiln/*` namespaces.
-        let interface_fq = named
-            .source_interface
-            .clone()
-            .or_else(|| {
-                wasi_registry
-                    .find_wasi_resource_source(&named.name)
-                    .or_else(|| wasi_registry.find_wasi_variant_source(&named.name))
-                    .or_else(|| wasi_registry.find_wasi_struct_source(&named.name))
-                    .or_else(|| wasi_registry.find_wasi_enum_source(&named.name))
-                    .or_else(|| wasi_registry.find_wasi_flags_source(&named.name))
-                    .or_else(|| wasi_registry.find_kiln_struct_source(&named.name))
-                    .or_else(|| wasi_registry.find_kiln_variant_source(&named.name))
-                    .or_else(|| wasi_registry.find_kiln_enum_source(&named.name))
-                    .map(str::to_string)
-            })
-            .unwrap_or_else(|| {
-                panic!(
-                    "world export type `{}` has no source interface — neither \
-                 the AST source_interface nor any WASI/kiln registry index resolved it",
-                    named.name,
-                )
-            });
+        // leaves `source_interface = None`. `WasiRegistry::resolve_cm_source_for`
+        // already chains the `wasi:*` and `core:kiln/*` by-name lookups for
+        // exactly this case — re-use it instead of duplicating the chain.
+        let interface_fq = wasi_registry
+            .resolve_cm_source_for(named, None)
+            .map(str::to_string)
+            .unwrap_or_else(|| panic!(
+                "world export type `{}` has no source interface — neither the \
+                 AST source_interface nor any registry index resolved it",
+                named.name,
+            ));
         let cm_name = wasi_registry
             .get_resource_cm_name_by_source(&interface_fq, &named.name)
             .or_else(|| wasi_registry.get_variant_cm_name_by_source(&interface_fq, &named.name))
@@ -303,7 +285,7 @@ fn resolve_cm_export_type(ty: &Type, wasi_registry: &WasiRegistry) -> CmExportTy
             .or_else(|| wasi_registry.get_enum_cm_name_by_source(&interface_fq, &named.name))
             .or_else(|| wasi_registry.get_flags_cm_name_by_source(&interface_fq, &named.name))
             .unwrap_or_else(|| panic!(
-                "world export type `{}` (interface `{interface_fq}`) has no CM name in the WASI registry",
+                "world export type `{}` (interface `{interface_fq}`) has no CM name in the registry",
                 named.name,
             ))
             .to_string();
@@ -313,19 +295,6 @@ fn resolve_cm_export_type(ty: &Type, wasi_registry: &WasiRegistry) -> CmExportTy
         };
     }
     panic!("unsupported world export type shape: {ty:?}");
-}
-
-/// Returns true if `ty` is a unit/empty-tuple type at the boundary.
-///
-/// Mirrors the recogniser in [`crate::component_model::unwrap_async_call_if_async`]
-/// — both surface syntaxes the parser may emit (`()`, `Unit`, `unit`, empty tuple)
-/// must round-trip to the same CM shape.
-fn is_unit_like(ty: &Type) -> bool {
-    match ty {
-        Type::Tuple(elems) => elems.is_empty(),
-        Type::Named(named) => matches!(named.name.as_str(), "()" | "Unit" | "unit"),
-        _ => false,
-    }
 }
 
 /// Convert a test function name (e.g., `__test_0_my_name`) to a valid kebab-case
@@ -403,5 +372,146 @@ mod tests {
             sanitize_kebab_export_name("__test_todo_tm3000_1"),
             "test-todo-tm3000-1"
         );
+    }
+
+    /// Helpers for the resolver tests below.
+    mod resolver_helpers {
+        use super::super::*;
+        use crate::ast::{AstId, GenericType, NamedType};
+        use crate::token::Span;
+
+        pub fn span() -> Span {
+            Span::new(0, 0, 1, 1)
+        }
+
+        pub fn unit_named() -> Type {
+            Type::Named(NamedType::new(AstId::fresh(), "()".to_string(), span()))
+        }
+
+        pub fn empty_tuple() -> Type {
+            Type::Tuple(vec![])
+        }
+
+        pub fn named(name: &str) -> Type {
+            Type::Named(NamedType::new(
+                AstId::fresh(),
+                name.to_string(),
+                span(),
+            ))
+        }
+
+        pub fn result_of(ok: Type, err: Type) -> Type {
+            Type::Generic(GenericType {
+                id: AstId::fresh(),
+                name: "Result".to_string(),
+                args: vec![ok, err],
+                span: span(),
+            })
+        }
+    }
+
+    #[test]
+    fn test_resolve_unit_shapes() {
+        use resolver_helpers::*;
+        let (registry, _) = crate::component_model::WasiRegistry::build_from_stdlib();
+
+        // Bare unit forms
+        assert!(matches!(
+            resolve_cm_export_type(&unit_named(), &registry),
+            CmExportType::Unit
+        ));
+        assert!(matches!(
+            resolve_cm_export_type(&empty_tuple(), &registry),
+            CmExportType::Unit
+        ));
+
+        // Result<(), ()> — both arms unit → still Unit (CLI Command::run shape)
+        assert!(matches!(
+            resolve_cm_export_type(&result_of(unit_named(), unit_named()), &registry),
+            CmExportType::Unit
+        ));
+        assert!(matches!(
+            resolve_cm_export_type(&result_of(empty_tuple(), empty_tuple()), &registry),
+            CmExportType::Unit
+        ));
+    }
+
+    #[test]
+    fn test_resolve_handler_result() {
+        use resolver_helpers::*;
+        let (registry, _) = crate::component_model::WasiRegistry::build_from_stdlib();
+
+        // wasi:http handler shape: Result<Response, ErrorCode>
+        let http = result_of(named("Response"), named("ErrorCode"));
+        assert!(matches!(
+            resolve_cm_export_type(&http, &registry),
+            CmExportType::HandlerResult
+        ));
+
+        // core:kiln generator shape: Result<Response, Error>
+        let kiln = result_of(named("Response"), named("Error"));
+        assert!(matches!(
+            resolve_cm_export_type(&kiln, &registry),
+            CmExportType::HandlerResult
+        ));
+    }
+
+    #[test]
+    fn test_resolve_named_resource() {
+        use resolver_helpers::*;
+        let (registry, _) = crate::component_model::WasiRegistry::build_from_stdlib();
+
+        // `Request` is a resource declared in `wasi:http/types`.
+        match resolve_cm_export_type(&named("Request"), &registry) {
+            CmExportType::Named {
+                interface_fq,
+                cm_name,
+            } => {
+                assert!(
+                    interface_fq.starts_with("wasi:http/types"),
+                    "expected wasi:http/types prefix, got `{interface_fq}`",
+                );
+                assert_eq!(cm_name, "request");
+            }
+            other => panic!("expected Named, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_named_kiln_record() {
+        use resolver_helpers::*;
+        let (registry, _) = crate::component_model::WasiRegistry::build_from_stdlib();
+
+        // `RawRequest` is a struct declared in `core:kiln/types` — exercises
+        // the `find_kiln_*` half of `resolve_cm_source_for`.
+        match resolve_cm_export_type(&named("RawRequest"), &registry) {
+            CmExportType::Named {
+                interface_fq,
+                cm_name,
+            } => {
+                assert!(
+                    interface_fq.starts_with("core:kiln/types"),
+                    "expected core:kiln/types prefix, got `{interface_fq}`",
+                );
+                assert_eq!(cm_name, "raw-request");
+            }
+            other => panic!("expected Named, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_needs_realloc() {
+        // Unit needs no realloc; the canon would be rejected by wasm-tools
+        // if it shipped one with no lifting work.
+        assert!(!CmExportType::Unit.needs_realloc());
+        // Named records / resources are lifted into linear memory.
+        assert!(
+            CmExportType::Named {
+                interface_fq: "wasi:http/types".to_string(),
+                cm_name: "request".to_string(),
+            }
+            .needs_realloc()
+        );
+        assert!(CmExportType::HandlerResult.needs_realloc());
     }
 }

--- a/wado-compiler/src/wir_build/component_plan.rs
+++ b/wado-compiler/src/wir_build/component_plan.rs
@@ -4,6 +4,7 @@
 //! structure. Built by `wir_build::plan_project`, consumed by `codegen`.
 
 use crate::ast::Type;
+use crate::component_model::WasiRegistry;
 use crate::hashmap::IndexMap;
 use crate::tir::TirTest;
 use crate::world_registry::{WorldExportInfo, WorldInfo, WorldRegistry};
@@ -22,6 +23,11 @@ pub struct ComponentPlan {
     pub world_exports: Vec<WorldExportPlan>,
     /// Test functions to export.
     pub test_exports: Vec<TestExportPlan>,
+    /// CM package segment of the target world's `fq_name` (e.g., `"http"`,
+    /// `"kiln"`). Empty for the test world or when the target world is not
+    /// in the registry. Used by codegen to resolve [`CmExportType::HandlerResult`]
+    /// to the per-world `{pkg}-handler-result` registered type.
+    pub world_package: String,
 }
 
 /// A world export to create at the component boundary.
@@ -39,6 +45,45 @@ pub struct WorldExportPlan {
     pub params: Vec<(String, Type)>,
     /// Return type from world definition
     pub return_type: Option<Type>,
+    /// CM-resolved parameter types at the component boundary, derived from
+    /// `params` via the type registry. Codegen iterates this list to build
+    /// the export's CM signature without needing per-world discriminators.
+    pub cm_params: Vec<(String, CmExportType)>,
+    /// CM-resolved return type at the component boundary.
+    pub cm_result: CmExportType,
+}
+
+/// CM-level type at the world export boundary.
+///
+/// Plan-level abstraction populated by [`build_component_plan`]; resolved to
+/// component type indices in codegen via the per-world naming convention
+/// `{pkg}-{cm_name}` for [`Self::Named`] and `{world_pkg}-handler-result` for
+/// [`Self::HandlerResult`].
+#[derive(Debug, Clone)]
+pub enum CmExportType {
+    /// `result<>` — no value at the boundary.
+    ///
+    /// Produced when the export has no return type or its return type is
+    /// `Result<(), ()>` (CLI `Command::run`). Encoded by codegen as the
+    /// shared `result-unit` component type.
+    Unit,
+    /// Reference to a named CM type (resource, variant, record, ...) declared
+    /// by `interface_fq` with the given kebab-case `cm_name`.
+    ///
+    /// Examples: `Request` from `wasi:http/types` resolves to
+    /// `Named { interface_fq: "wasi:http/types", cm_name: "request" }` and
+    /// codegen looks it up as `ctx.type_idx("http-request")`.
+    Named {
+        interface_fq: String,
+        cm_name: String,
+    },
+    /// `result<own<resp>, error>` synthesized for the world's handler return.
+    ///
+    /// Produced when the export's return type is `Result<X, Y>` with at least
+    /// one non-unit component. Codegen registers a per-world named alias
+    /// (e.g. `http-handler-result`, `kiln-handler-result`) and resolves this
+    /// variant to `ctx.type_idx(&format!("{world_package}-handler-result"))`.
+    HandlerResult,
 }
 
 /// A test function to export from the component.
@@ -73,13 +118,19 @@ pub fn build_component_plan(
     tests: &[TirTest],
     export_binding_names: &IndexMap<String, String>,
     world_registry: &WorldRegistry,
+    wasi_registry: &WasiRegistry,
 ) -> ComponentPlan {
     // Build world exports from registry.
     // For the test world, there are no world exports — only test exports.
     let world_exports = if is_test_world {
         vec![]
     } else {
-        build_world_export_plans(target_world, export_binding_names, world_registry)
+        build_world_export_plans(
+            target_world,
+            export_binding_names,
+            world_registry,
+            wasi_registry,
+        )
     };
 
     // Build test exports (only when targeting the test world)
@@ -106,9 +157,19 @@ pub fn build_component_plan(
         vec![]
     };
 
+    let world_package = if is_test_world {
+        String::new()
+    } else {
+        world_registry
+            .get(target_world)
+            .map(|w| w.package().to_string())
+            .unwrap_or_default()
+    };
+
     ComponentPlan {
         world_exports,
         test_exports,
+        world_package,
     }
 }
 
@@ -117,6 +178,7 @@ fn build_world_export_plans(
     target_world: &str,
     export_binding_names: &IndexMap<String, String>,
     world_registry: &WorldRegistry,
+    wasi_registry: &WasiRegistry,
 ) -> Vec<WorldExportPlan> {
     let world = world_registry.get(target_world);
     let exports: Vec<WorldExportInfo> = world.map(|w| w.exports.clone()).unwrap_or_else(|| {
@@ -148,6 +210,21 @@ fn build_world_export_plans(
                 .get(&export.name)
                 .cloned()
                 .unwrap_or_else(|| export.name.clone());
+
+            // Resolve params and return into CM-level boundary types so
+            // codegen can build the export signature uniformly across
+            // worlds. See [`CmExportType`].
+            let cm_params = export
+                .params
+                .iter()
+                .map(|(name, ty)| (name.clone(), resolve_cm_export_type(ty, wasi_registry)))
+                .collect();
+            let cm_result = export
+                .return_type
+                .as_ref()
+                .map(|ty| resolve_cm_export_type(ty, wasi_registry))
+                .unwrap_or(CmExportType::Unit);
+
             WorldExportPlan {
                 name: export.name,
                 core_func_name,
@@ -155,9 +232,100 @@ fn build_world_export_plans(
                 is_http_handler,
                 params: export.params,
                 return_type: export.return_type,
+                cm_params,
+                cm_result,
             }
         })
         .collect()
+}
+
+/// Resolve a Wado [`Type`] reachable from a world export signature into the
+/// CM-level boundary representation.
+///
+/// Recognised shapes:
+///
+/// - `()` / unit / `Result<(), ()>` → [`CmExportType::Unit`]
+/// - `Result<X, Y>` with at least one non-unit component →
+///   [`CmExportType::HandlerResult`]
+/// - Any other named type whose source interface and CM kebab-name are known
+///   to the WASI registry → [`CmExportType::Named`]
+///
+/// Panics on shapes the registry cannot resolve. World export signatures
+/// originate in stdlib `lib/wasi/**/worlds.wado` and `lib/core/kiln/worlds.wado`,
+/// so any unresolved name indicates a bug in the stdlib bootstrap rather than
+/// user input.
+fn resolve_cm_export_type(ty: &Type, wasi_registry: &WasiRegistry) -> CmExportType {
+    if is_unit_like(ty) {
+        return CmExportType::Unit;
+    }
+    if let Type::Generic(generic) = ty
+        && generic.name == "Result"
+        && generic.args.len() == 2
+    {
+        if is_unit_like(&generic.args[0]) && is_unit_like(&generic.args[1]) {
+            return CmExportType::Unit;
+        }
+        return CmExportType::HandlerResult;
+    }
+    if let Type::Named(named) = ty {
+        // World bodies (`lib/wasi/**/worlds.wado`, `lib/core/kiln/worlds.wado`)
+        // reference type names like `Request` / `RawRequest` directly without
+        // a `use { ... } from "..."` import, so `populate_named_type_sources`
+        // leaves `source_interface = None`. Fall back to the by-name lookups
+        // that the rest of the CM codegen uses for the same shape — trying
+        // both the `wasi:*` and `core:kiln/*` namespaces.
+        let interface_fq = named
+            .source_interface
+            .clone()
+            .or_else(|| {
+                wasi_registry
+                    .find_wasi_resource_source(&named.name)
+                    .or_else(|| wasi_registry.find_wasi_variant_source(&named.name))
+                    .or_else(|| wasi_registry.find_wasi_struct_source(&named.name))
+                    .or_else(|| wasi_registry.find_wasi_enum_source(&named.name))
+                    .or_else(|| wasi_registry.find_wasi_flags_source(&named.name))
+                    .or_else(|| wasi_registry.find_kiln_struct_source(&named.name))
+                    .or_else(|| wasi_registry.find_kiln_variant_source(&named.name))
+                    .or_else(|| wasi_registry.find_kiln_enum_source(&named.name))
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "world export type `{}` has no source interface — neither \
+                 the AST source_interface nor any WASI/kiln registry index resolved it",
+                    named.name,
+                )
+            });
+        let cm_name = wasi_registry
+            .get_resource_cm_name_by_source(&interface_fq, &named.name)
+            .or_else(|| wasi_registry.get_variant_cm_name_by_source(&interface_fq, &named.name))
+            .or_else(|| wasi_registry.get_struct_cm_name_by_source(&interface_fq, &named.name))
+            .or_else(|| wasi_registry.get_enum_cm_name_by_source(&interface_fq, &named.name))
+            .or_else(|| wasi_registry.get_flags_cm_name_by_source(&interface_fq, &named.name))
+            .unwrap_or_else(|| panic!(
+                "world export type `{}` (interface `{interface_fq}`) has no CM name in the WASI registry",
+                named.name,
+            ))
+            .to_string();
+        return CmExportType::Named {
+            interface_fq,
+            cm_name,
+        };
+    }
+    panic!("unsupported world export type shape: {ty:?}");
+}
+
+/// Returns true if `ty` is a unit/empty-tuple type at the boundary.
+///
+/// Mirrors the recogniser in [`crate::component_model::unwrap_async_call_if_async`]
+/// — both surface syntaxes the parser may emit (`()`, `Unit`, `unit`, empty tuple)
+/// must round-trip to the same CM shape.
+fn is_unit_like(ty: &Type) -> bool {
+    match ty {
+        Type::Tuple(elems) => elems.is_empty(),
+        Type::Named(named) => matches!(named.name.as_str(), "()" | "Unit" | "unit"),
+        _ => false,
+    }
 }
 
 /// Convert a test function name (e.g., `__test_0_my_name`) to a valid kebab-case

--- a/wado-compiler/src/wir_build/component_plan.rs
+++ b/wado-compiler/src/wir_build/component_plan.rs
@@ -258,11 +258,13 @@ fn resolve_cm_export_type(ty: &Type, wasi_registry: &WasiRegistry) -> CmExportTy
         let interface_fq = wasi_registry
             .resolve_cm_source_for(named, None)
             .map(str::to_string)
-            .unwrap_or_else(|| panic!(
-                "world export type `{}` has no source interface — neither the \
+            .unwrap_or_else(|| {
+                panic!(
+                    "world export type `{}` has no source interface — neither the \
                  AST source_interface nor any registry index resolved it",
-                named.name,
-            ));
+                    named.name,
+                )
+            });
         let cm_name = wasi_registry
             .get_resource_cm_name_by_source(&interface_fq, &named.name)
             .or_else(|| wasi_registry.get_variant_cm_name_by_source(&interface_fq, &named.name))
@@ -378,11 +380,7 @@ mod tests {
         }
 
         pub fn named(name: &str) -> Type {
-            Type::Named(NamedType::new(
-                AstId::fresh(),
-                name.to_string(),
-                span(),
-            ))
+            Type::Named(NamedType::new(AstId::fresh(), name.to_string(), span()))
         }
 
         pub fn result_of(ok: Type, err: Type) -> Type {
@@ -402,21 +400,21 @@ mod tests {
 
         // Bare unit forms
         assert!(matches!(
-            resolve_cm_export_type(&unit_named(), &registry),
+            resolve_cm_export_type(&unit_named(), registry),
             CmExportType::Unit
         ));
         assert!(matches!(
-            resolve_cm_export_type(&empty_tuple(), &registry),
+            resolve_cm_export_type(&empty_tuple(), registry),
             CmExportType::Unit
         ));
 
         // Result<(), ()> — both arms unit → still Unit (CLI Command::run shape)
         assert!(matches!(
-            resolve_cm_export_type(&result_of(unit_named(), unit_named()), &registry),
+            resolve_cm_export_type(&result_of(unit_named(), unit_named()), registry),
             CmExportType::Unit
         ));
         assert!(matches!(
-            resolve_cm_export_type(&result_of(empty_tuple(), empty_tuple()), &registry),
+            resolve_cm_export_type(&result_of(empty_tuple(), empty_tuple()), registry),
             CmExportType::Unit
         ));
     }
@@ -429,14 +427,14 @@ mod tests {
         // wasi:http handler shape: Result<Response, ErrorCode>
         let http = result_of(named("Response"), named("ErrorCode"));
         assert!(matches!(
-            resolve_cm_export_type(&http, &registry),
+            resolve_cm_export_type(&http, registry),
             CmExportType::HandlerResult
         ));
 
         // core:kiln generator shape: Result<Response, Error>
         let kiln = result_of(named("Response"), named("Error"));
         assert!(matches!(
-            resolve_cm_export_type(&kiln, &registry),
+            resolve_cm_export_type(&kiln, registry),
             CmExportType::HandlerResult
         ));
     }
@@ -447,7 +445,7 @@ mod tests {
         let (registry, _) = crate::component_model::WasiRegistry::build_from_stdlib();
 
         // `Request` is a resource declared in `wasi:http/types`.
-        match resolve_cm_export_type(&named("Request"), &registry) {
+        match resolve_cm_export_type(&named("Request"), registry) {
             CmExportType::Named {
                 interface_fq,
                 cm_name,
@@ -469,7 +467,7 @@ mod tests {
 
         // `RawRequest` is a struct declared in `core:kiln/types` — exercises
         // the `find_kiln_*` half of `resolve_cm_source_for`.
-        match resolve_cm_export_type(&named("RawRequest"), &registry) {
+        match resolve_cm_export_type(&named("RawRequest"), registry) {
             CmExportType::Named {
                 interface_fq,
                 cm_name,

--- a/wado-compiler/src/world_registry.rs
+++ b/wado-compiler/src/world_registry.rs
@@ -8,7 +8,7 @@
 
 use crate::hashmap::IndexMap;
 
-use crate::ast::{Type, WorldDecl, WorldExport};
+use crate::ast::{Type, WorldDecl, WorldExport, WorldImport};
 
 /// Well-known world name for the test world.
 ///
@@ -67,6 +67,33 @@ impl WorldExportInfo {
     }
 }
 
+/// Information about a world's imported effect (a single `import Effect { ... }`
+/// block in a Wado world declaration).
+///
+/// Mirrors the [`crate::ast::WorldImport`] AST node but lives outside the AST
+/// graph so codegen can ask "does this world import `KilnHost`?" without
+/// re-parsing the world declaration. The `effect_name` is the locally-bound
+/// name (the one written in `import Foo { ... }`); resolving it to a CM
+/// interface FQ requires the [`crate::component_model::WasiRegistry`] and is
+/// done lazily by the consumer.
+#[derive(Debug, Clone)]
+pub struct WorldImportInfo {
+    /// Imported effect name (e.g., `"Stdout"`, `"Types"`, `"KilnHost"`).
+    pub effect_name: String,
+    /// Functions / methods picked from the effect.
+    pub functions: Vec<String>,
+}
+
+impl WorldImportInfo {
+    /// Create from a parsed [`WorldImport`].
+    pub fn from_ast(import: &WorldImport) -> Self {
+        Self {
+            effect_name: import.effect_name.clone(),
+            functions: import.functions.clone(),
+        }
+    }
+}
+
 /// Information about a world definition
 #[derive(Debug, Clone)]
 pub struct WorldInfo {
@@ -74,6 +101,8 @@ pub struct WorldInfo {
     pub fq_name: String,
     /// Exported functions
     pub exports: Vec<WorldExportInfo>,
+    /// Imported effects (one entry per `import Effect { ... }` block).
+    pub imports: Vec<WorldImportInfo>,
 }
 
 impl WorldInfo {
@@ -118,6 +147,18 @@ impl WorldInfo {
     /// `"core:kiln/"`. Returns an empty slice for bare-name worlds.
     pub fn namespace_prefix(&self) -> &str {
         fq_name_namespace_prefix(&self.fq_name)
+    }
+
+    /// True when this world has an `import {effect_name} { ... }` block.
+    ///
+    /// The check is by locally-bound effect name (the identifier written in
+    /// the world declaration), which is unique within a world's imports.
+    /// Codegen uses this to drive world-shape decisions from data — e.g.
+    /// `imports_effect("KilnHost")` is true for the kiln generator world and
+    /// any future world that imports the same effect, replacing string
+    /// matches against `target_world == "core:kiln/generator"`.
+    pub fn imports_effect(&self, effect_name: &str) -> bool {
+        self.imports.iter().any(|i| i.effect_name == effect_name)
     }
 }
 
@@ -205,10 +246,16 @@ impl WorldRegistry {
             .iter()
             .map(WorldExportInfo::from_ast)
             .collect();
+        let imports = world
+            .imports
+            .iter()
+            .map(WorldImportInfo::from_ast)
+            .collect();
 
         let info = WorldInfo {
             fq_name: fq_name.clone(),
             exports,
+            imports,
         };
 
         self.worlds.insert(fq_name, info);
@@ -356,6 +403,7 @@ mod tests {
         WorldInfo {
             fq_name: fq.to_string(),
             exports: Vec::new(),
+            imports: Vec::new(),
         }
     }
 
@@ -398,5 +446,29 @@ mod tests {
         let w = world_info("orphan/x");
         assert_eq!(w.package(), "");
         assert_eq!(w.namespace_prefix(), "");
+    }
+
+    #[test]
+    fn test_imports_populated_from_stdlib() {
+        // Real-world check: the kiln Generator world declares
+        // `import KilnHost { ... }` in `lib/core/kiln/worlds.wado`, so the
+        // populated registry must surface that import. The cli Command world
+        // imports several effects (Stdout, Stdin, Environment, ...).
+        let (_registry, world_registry) = crate::component_model::WasiRegistry::build_from_stdlib();
+
+        let kiln = world_registry
+            .get("core:kiln/generator")
+            .expect("kiln world registered");
+        assert!(
+            kiln.imports_effect("KilnHost"),
+            "kiln Generator imports KilnHost — expected by step-2c codegen gating"
+        );
+        assert!(!kiln.imports_effect("Stdout"));
+
+        let cli = world_registry
+            .get("wasi:cli/command")
+            .expect("cli world registered");
+        assert!(cli.imports_effect("Stdout"));
+        assert!(!cli.imports_effect("KilnHost"));
     }
 }

--- a/wado-compiler/src/world_registry.rs
+++ b/wado-compiler/src/world_registry.rs
@@ -162,10 +162,14 @@ impl WorldInfo {
     }
 }
 
-/// Extract the package segment of a world `fq_name` (`"wasi:http/service"`
-/// → `"http"`; `"core:kiln/generator"` → `"kiln"`). Returns `""` when
-/// the name has no `scheme:package/interface` shape.
-fn fq_name_package(fq_name: &str) -> &str {
+/// Extract the package segment of a CM-style fully-qualified name
+/// (`"wasi:http/service"` → `"http"`; `"core:kiln/generator"` →
+/// `"kiln"`). Returns `""` when the name has no `scheme:package/...` shape.
+///
+/// Works for both world `fq_name`s (`wasi:http/service`) and interface FQs
+/// (`wasi:http/types`) — the parsing only cares about the `scheme:pkg/...`
+/// prefix and ignores whatever follows the `/`.
+pub fn fq_name_package(fq_name: &str) -> &str {
     let Some((_, rest)) = fq_name.split_once(':') else {
         return "";
     };

--- a/wado-compiler/tests/format.fixtures.golden/all.wat
+++ b/wado-compiler/tests/format.fixtures.golden/all.wat
@@ -140,6 +140,6 @@
   )
   (alias core export $main "run" (core func $run-core (;2;)))
   (type $run-func-type (;4;) (func async (result $result-unit)))
-  (func $run (;0;) (type $run-func-type) (canon lift (core func $run-core) async (memory $memory)))
+  (func $run (;0;) (type $run-func-type) (canon lift (core func $run-core) async (memory $memory) (realloc $realloc)))
   (export $"#func1 run" (@name "run") (;1;) "run" (func $run))
 )

--- a/wado-compiler/tests/format.fixtures.golden/mess.wat
+++ b/wado-compiler/tests/format.fixtures.golden/mess.wat
@@ -140,6 +140,6 @@
   )
   (alias core export $main "run" (core func $run-core (;2;)))
   (type $run-func-type (;4;) (func async (result $result-unit)))
-  (func $run (;0;) (type $run-func-type) (canon lift (core func $run-core) async (memory $memory)))
+  (func $run (;0;) (type $run-func-type) (canon lift (core func $run-core) async (memory $memory) (realloc $realloc)))
   (export $"#func1 run" (@name "run") (;1;) "run" (func $run))
 )

--- a/wado-compiler/tests/format.fixtures.golden/ops.all.wat
+++ b/wado-compiler/tests/format.fixtures.golden/ops.all.wat
@@ -140,6 +140,6 @@
   )
   (alias core export $main "run" (core func $run-core (;2;)))
   (type $run-func-type (;4;) (func async (result $result-unit)))
-  (func $run (;0;) (type $run-func-type) (canon lift (core func $run-core) async (memory $memory)))
+  (func $run (;0;) (type $run-func-type) (canon lift (core func $run-core) async (memory $memory) (realloc $realloc)))
   (export $"#func1 run" (@name "run") (;1;) "run" (func $run))
 )

--- a/wado-compiler/tests/format.fixtures.golden/ops.mess.wat
+++ b/wado-compiler/tests/format.fixtures.golden/ops.mess.wat
@@ -140,6 +140,6 @@
   )
   (alias core export $main "run" (core func $run-core (;2;)))
   (type $run-func-type (;4;) (func async (result $result-unit)))
-  (func $run (;0;) (type $run-func-type) (canon lift (core func $run-core) async (memory $memory)))
+  (func $run (;0;) (type $run-func-type) (canon lift (core func $run-core) async (memory $memory) (realloc $realloc)))
   (export $"#func1 run" (@name "run") (;1;) "run" (func $run))
 )


### PR DESCRIPTION
## Summary

`wir_build` and `codegen` had per-world string matches scattered throughout — `target_world == "core:kiln/generator"`, `package == "http"`, `is_http_handler` discriminators, magic CM type names like `http-request` / `kiln-raw-request` — making "support a new world" a multi-file find-and-replace exercise. This PR pushes those decisions onto data carried by `WorldInfo` / `WorldExportPlan`, then deletes the discriminator branches.

Layered as four commits:

1. **`2a770f1` drive world export CM types from data, not discriminators**
   New `CmExportType` enum (`Unit` / `Named { interface_fq, cm_name }` / `HandlerResult`) on `WorldExportPlan`, populated at plan-build time by walking export params/return through the WASI / kiln registries. `emit_world_exports`'s `if is_http_handler { … } else if is_kiln_generator { … } else { … }` collapses to a uniform iteration. `task_return_type` selection in `emit_canonical_intrinsics` follows the same path. The unknown-world fallback still produces `cm_params=[], cm_result=Unit`, preserving CLI-shape behaviour.

2. **`d492318` replace `is_kiln_generator_world` with `imports_effect`**
   `WorldInfo` gains `imports: Vec<WorldImportInfo>` populated from the world's `import Effect { … }` blocks. `FlatPackage::world_imports_effect("KilnHost")` replaces the literal `target_world == "core:kiln/generator"` match in three sites: `emit_kiln_world_types` gating, the kiln WASI-import refusal rule in DCE, and the stderr/stdout → `unreachable` rewrite in `wir_build/calls`. A new world that imports the same effect now picks up the kiln paths automatically.

3. **`0599b00` polish `CmExportType` + drop ad-hoc duplicates**
   Self-review cleanup. Replaced an 8-arm `find_wasi_*_source` / `find_kiln_*_source` chain with the existing `WasiRegistry::resolve_cm_source_for`. Pulled `fq_name_package` and `is_unit_type` up to single sources of truth (codegen and `component_plan` were each carrying their own copy). Switched `ComponentPlan::world_package` from `String` (`""` sentinel) to `Option<String>`. Removed dead `WorldExportPlan::is_http_handler` / `params` / `return_type` fields and the past-tense comment that described the pre-refactor branch shape. Added 5 unit tests for `resolve_cm_export_type`.

4. **`d297eb6` always supply `realloc` to world export canons**
   Empirical follow-up to a question raised in self-review: the comment `wasm-tools rejects realloc on a canon with no lifting work` turned out to be false. The Wado runtime always exports `realloc` (the chosen allocator), and wasm-tools accepts the canon option uniformly — verified by running the full e2e suite with unconditional `Realloc`. Drops `CmExportType::needs_realloc` and its test. `CmExportType` now describes only the boundary CM shape; allocator decisions live entirely in the runtime.

### Diff

8 files changed, +476 / -96. Net +380 lines, with most of the increase being:

- `WorldImportInfo` infrastructure + tests (`world_registry.rs`)
- `CmExportType` + `resolve_cm_export_type` + 5 unit tests (`wir_build/component_plan.rs`)

### Out of scope (next branch)

The remaining hardcoded surface — `package == "http"` in `import_wasi_http_types`, `populate_named_type_sources` not seeing world-body type references, and the synthesized `{world_pkg}-handler-result` magic name — is structurally different (HTTP types instance import + WIT export-interface modelling) and belongs in a follow-up. Catalogued in the branch discussion.

## Test plan

- [x] `cargo test -p wado-compiler --lib` (415/415, includes 5 new `resolve_cm_export_type` unit tests + the new `test_imports_populated_from_stdlib`)
- [x] `cargo test -p wado-compiler --test e2e` (5680/5680, ran twice — once after cleanup commit, once after realloc simplification)
- [x] `cargo test -p wado-compiler --test kiln_generator_world --test kiln_loader_redirect --test kiln_options` (10/10) — exercises the `imports_effect("KilnHost")` replacement
- [ ] CI regression check on `main` (HTTP / CLI / Kiln / test world fixtures)

https://claude.ai/code/session_01Bj9g9UXLU4ii6DfmqBD9kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bj9g9UXLU4ii6DfmqBD9kg)_