### PR TITLE
fix(wado-from-idl): attribute generated sources by package, not short name

### DIFF
--- a/wado-compiler/lib/wasi/cli/types.wado
+++ b/wado-compiler/lib/wasi/cli/types.wado
@@ -1,4 +1,4 @@
-#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/sockets.wit"])]
+#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
 
 #[cm("wasi:cli/types@0.3.0-rc-2026-03-15#error-code")]
 pub enum ErrorCode {

--- a/wado-compiler/lib/wasi/cli/worlds.wado
+++ b/wado-compiler/lib/wasi/cli/worlds.wado
@@ -1,4 +1,4 @@
-#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit", "vendor/wasmtime/crates/wasi/src/p3/wit/deps/random.wit"])]
+#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
 
 #[cm("wasi:cli/imports@0.3.0-rc-2026-03-15")]
 pub world Imports {

--- a/wado-compiler/lib/wasi/clocks/types.wado
+++ b/wado-compiler/lib/wasi/clocks/types.wado
@@ -1,4 +1,4 @@
-#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/sockets.wit"])]
+#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit"])]
 
 #[cm("wasi:clocks/types@0.3.0-rc-2026-03-15#duration")]
 pub type Duration = u64;

--- a/wado-compiler/lib/wasi/clocks/worlds.wado
+++ b/wado-compiler/lib/wasi/clocks/worlds.wado
@@ -1,4 +1,4 @@
-#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/random.wit"])]
+#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit"])]
 
 #[cm("wasi:clocks/imports@0.3.0-rc-2026-03-15")]
 pub world Imports {

--- a/wado-compiler/lib/wasi/filesystem/types.wado
+++ b/wado-compiler/lib/wasi/filesystem/types.wado
@@ -1,4 +1,4 @@
-#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/sockets.wit"])]
+#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/filesystem.wit"])]
 
 use { Instant } from "wasi:clocks/system_clock.wado";
 

--- a/wado-compiler/lib/wasi/filesystem/worlds.wado
+++ b/wado-compiler/lib/wasi/filesystem/worlds.wado
@@ -1,4 +1,4 @@
-#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/random.wit"])]
+#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/filesystem.wit"])]
 
 #[cm("wasi:filesystem/imports@0.3.0-rc-2026-03-15")]
 pub world Imports {

--- a/wado-compiler/lib/wasi/http/types.wado
+++ b/wado-compiler/lib/wasi/http/types.wado
@@ -1,4 +1,4 @@
-#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-http/src/p3/wit/deps/sockets.wit"])]
+#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-http/src/p3/wit/deps/http.wit"])]
 
 use { Duration } from "wasi:clocks/types.wado";
 

--- a/wado-compiler/lib/wasi/sockets/worlds.wado
+++ b/wado-compiler/lib/wasi/sockets/worlds.wado
@@ -1,4 +1,4 @@
-#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/random.wit"])]
+#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/sockets.wit"])]
 
 #[cm("wasi:sockets/imports@0.3.0-rc-2026-03-15")]
 pub world Imports {

--- a/wado-compiler/lib/wasi/tls/client.wado
+++ b/wado-compiler/lib/wasi/tls/client.wado
@@ -1,4 +1,4 @@
-#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/client.wit"])]
+#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/client.wit", "vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/types.wit", "vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/world.wit"])]
 
 use { Error } from "wasi:tls/types.wado";
 

--- a/wado-compiler/lib/wasi/tls/types.wado
+++ b/wado-compiler/lib/wasi/tls/types.wado
@@ -1,4 +1,4 @@
-#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/types.wit"])]
+#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/client.wit", "vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/types.wit", "vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/world.wit"])]
 
 #[cm("wasi:tls/types@0.3.0-draft#error")]
 pub resource Error {

--- a/wado-compiler/lib/wasi/tls/worlds.wado
+++ b/wado-compiler/lib/wasi/tls/worlds.wado
@@ -1,4 +1,4 @@
-#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/world.wit"])]
+#![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/client.wit", "vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/types.wit", "vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/world.wit"])]
 
 #[cm("wasi:tls/imports@0.3.0-draft")]
 pub world Imports {

--- a/wado-from-idl/src/main.rs
+++ b/wado-from-idl/src/main.rs
@@ -1,6 +1,6 @@
 //! wado-from-idl CLI
 
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexSet;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
@@ -8,7 +8,7 @@ use std::process;
 
 use anyhow::{Context, Result};
 use lexopt::Arg::Long;
-use wit_parser::Resolve;
+use wit_parser::{PackageId, PackageSourceMap, Resolve};
 
 use wado_from_idl::{Transformer, WadoCodeGenerator, naming::to_snake_case};
 
@@ -193,12 +193,11 @@ fn run_directory_mode(
         all_features: !skip_unstable,
         ..Default::default()
     };
-    let (_pkg_id, _) = resolve
+    let (_pkg_id, source_map) = resolve
         .push_dir(wit_dir)
         .with_context(|| format!("Failed to parse WIT files from {}", wit_dir.display()))?;
 
-    // Build a map from interface/world name to source WIT file
-    let iface_to_file = build_interface_to_file_map(wit_dir)?;
+    let base_dir = std::env::current_dir()?;
 
     let transformer = Transformer::new(&resolve);
     let mut generator = WadoCodeGenerator::new();
@@ -208,13 +207,15 @@ fn run_directory_mode(
         .with_context(|| format!("Failed to create directory {}", output_dir.display()))?;
 
     // Process each package — generate one file per interface + one worlds file per package
-    for (_current_pkg_id, pkg) in &resolve.packages {
+    for (current_pkg_id, pkg) in &resolve.packages {
         let pkg_name = &pkg.name.name;
 
         // Filter by package if specified
         if package_filter.is_some_and(|filter| pkg_name != filter) {
             continue;
         }
+
+        let sources = package_sources(&source_map, current_pkg_id, &base_dir);
 
         let version = pkg
             .name
@@ -245,9 +246,7 @@ fn run_directory_mode(
                 continue;
             }
 
-            if let Some(source_file) = iface_to_file.get(iface_name) {
-                module.source_files = vec![source_file.clone()];
-            }
+            module.source_files.clone_from(&sources);
             module.package_name.clone_from(&version);
 
             let names = module.public_names();
@@ -268,15 +267,10 @@ fn run_directory_mode(
             eprintln!("Generated: {}", output_path.display());
         }
 
-        // Collect all world source files and emit worlds file
+        // Emit worlds file aggregating every world in this package
         let mut worlds_module = wado_from_idl::WadoModule::new(pkg_name.clone(), version.clone());
-        let mut worlds_source_files: IndexSet<String> = IndexSet::new();
 
         for (world_name, world_id) in &pkg.worlds {
-            if let Some(source_file) = iface_to_file.get(world_name) {
-                worlds_source_files.insert(source_file.clone());
-            }
-
             let world = transformer
                 .transform_world(*world_id)
                 .with_context(|| format!("Failed to transform world {world_name}"))?;
@@ -284,9 +278,7 @@ fn run_directory_mode(
         }
 
         if !worlds_module.worlds.is_empty() {
-            let mut source_files: Vec<_> = worlds_source_files.into_iter().collect();
-            source_files.sort();
-            worlds_module.source_files = source_files;
+            worlds_module.source_files = sources;
 
             let code = generator.generate(&worlds_module);
 
@@ -353,50 +345,18 @@ fn write_flat_reexport_file(
     Ok(())
 }
 
-/// Build a map from interface/world name to the WIT file that defines it
-fn build_interface_to_file_map(dir: &PathBuf) -> Result<IndexMap<String, String>> {
-    let mut map = IndexMap::new();
-    let base_dir = std::env::current_dir()?;
-    build_interface_map_recursive(dir, &base_dir, &mut map)?;
-    Ok(map)
-}
-
-fn build_interface_map_recursive(
-    dir: &PathBuf,
-    base_dir: &PathBuf,
-    map: &mut IndexMap<String, String>,
-) -> Result<()> {
-    if dir.is_dir() {
-        for entry in fs::read_dir(dir)? {
-            let entry = entry?;
-            let path = entry.path();
-            if path.is_dir() {
-                build_interface_map_recursive(&path, base_dir, map)?;
-            } else if path.extension().is_some_and(|ext| ext == "wit") {
-                let rel_path = path
-                    .strip_prefix(base_dir)
-                    .unwrap_or(&path)
-                    .display()
-                    .to_string();
-
-                // Parse the file to find interface/world definitions
-                if let Ok(content) = fs::read_to_string(&path) {
-                    for line in content.lines() {
-                        let line = line.trim();
-                        // Match "interface <name> {" or "world <name> {"
-                        if let Some(rest) = line.strip_prefix("interface ") {
-                            if let Some(name) = rest.split_whitespace().next() {
-                                map.insert(name.to_string(), rel_path.clone());
-                            }
-                        } else if let Some(rest) = line.strip_prefix("world ")
-                            && let Some(name) = rest.split_whitespace().next()
-                        {
-                            map.insert(name.to_string(), rel_path.clone());
-                        }
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
+fn package_sources(
+    source_map: &PackageSourceMap,
+    pkg_id: PackageId,
+    base_dir: &Path,
+) -> Vec<String> {
+    let Some(paths) = source_map.package_paths(pkg_id) else {
+        return Vec::new();
+    };
+    let mut out: Vec<String> = paths
+        .map(|p| p.strip_prefix(base_dir).unwrap_or(p).display().to_string())
+        .collect();
+    out.sort();
+    out.dedup();
+    out
 }


### PR DESCRIPTION
## Summary

- The previous `build_interface_to_file_map` keyed file lookup on the bare interface/world name (e.g. `"types"`, `"imports"`). WIT short names collide across packages — there are 4 interfaces named `types` in wasi p3 deps and 5 worlds named `imports` — so the last file processed always won. As a result every `wado-compiler/lib/wasi/<pkg>/types.wado` wrongly listed `sockets.wit`, and most `worlds.wado` files pointed at `random.wit`.
- Switch to `PackageSourceMap`, which `wit-parser` already returns from `push_dir`. For each package iterated from `resolve.packages`, list its own `.wit` source files via `package_paths(pkg_id)`. This is exact, unambiguous, and naturally handles packages split across multiple files (e.g. `wasi-tls` now correctly lists all three of its `.wit` files).

## Before / after for `sources = [...]`

| File | Before | After |
| --- | --- | --- |
| `wasi/cli/types.wado` | `sockets.wit` ❌ | `cli.wit` ✅ |
| `wasi/clocks/types.wado` | `sockets.wit` ❌ | `clocks.wit` ✅ |
| `wasi/filesystem/types.wado` | `sockets.wit` ❌ | `filesystem.wit` ✅ |
| `wasi/http/types.wado` | `wasi-http/.../sockets.wit` ❌ | `wasi-http/.../http.wit` ✅ |
| `wasi/cli/worlds.wado` | `cli.wit + random.wit` ❌ | `cli.wit` ✅ |
| `wasi/clocks/worlds.wado` | `random.wit` ❌ | `clocks.wit` ✅ |
| `wasi/filesystem/worlds.wado` | `random.wit` ❌ | `filesystem.wit` ✅ |
| `wasi/sockets/worlds.wado` | `random.wit` ❌ | `sockets.wit` ✅ |
| `wasi/tls/{client,types,worlds}.wado` | only one tls file each | all three tls files (more accurate) |

## Test plan

- [x] `cargo build -p wado-from-idl`
- [x] `mise run update-stdlib-wasi` — all `sources = [...]` now reference the package's own `.wit` files
- [x] `mise run on-task-done` (clippy, golden fixtures, format, full Rust test suite, `wado test` over examples / stdlib / benchmarks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)