### PR TITLE
perf(resolver): remove per-module flat-map clones via TypeLookup (~28% faster compile)

### DIFF
--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -51,8 +51,7 @@ use crate::tir::{
 use trait_env::TraitEnv;
 pub use types::TypeError;
 use types::{
-    EnumInfo, FlagsInfo, GenericNewtypeInfo, ModuleTypeMaps, ResourceInfo, StructFieldInfo,
-    VariantInfo,
+    EnumInfo, FlagsInfo, GenericNewtypeInfo, ResourceInfo, StructFieldInfo, TypeLookup, VariantInfo,
 };
 
 pub struct Resolver<'a, H: CompilerHost> {
@@ -64,27 +63,33 @@ pub struct Resolver<'a, H: CompilerHost> {
     /// Loaded modules from analyzer
     #[allow(dead_code)]
     loaded_modules: &'a IndexMap<ModuleSource, Module>,
-    /// Newtypes (name -> resolved type) - flat map for current module
-    newtypes: IndexMap<String, TypeId>,
-    /// Generic newtype definitions (name -> info) - flat map for current module
-    generic_newtype_defs: IndexMap<String, GenericNewtypeInfo>,
-    /// Struct field info (struct name -> (`module_source`, fields)) - flat map for current module
-    struct_fields: IndexMap<String, StructFieldInfo>,
-    /// Variant case info (variant name -> (`module_source`, `type_params`, cases)) - flat map for current module
-    variant_cases: IndexMap<String, VariantInfo>,
-    /// Enum case info (enum name -> (`module_source`, cases)) - flat map for current module
-    enum_cases: IndexMap<String, EnumInfo>,
-    /// Flags type info (flags name -> (`module_source`, `type_id`, members)) - flat map for current module
-    flags_cases: IndexMap<String, FlagsInfo>,
-    /// Resource info (resource name -> module source and methods) - flat map for current module
-    resource_types: IndexMap<String, ResourceInfo>,
-    /// Per-module nested maps for cross-module type resolution (shared via Rc)
+    /// Per-module nested maps for cross-module type resolution (shared via Rc).
+    /// These are the *single source of truth* for declared type info; all
+    /// per-module name resolution is performed by walking these via
+    /// [`TypeLookup`] without cloning their contents into per-module flat maps.
     all_newtypes: Rc<IndexMap<ModuleSource, IndexMap<String, TypeId>>>,
+    all_generic_newtypes: Rc<IndexMap<ModuleSource, IndexMap<String, GenericNewtypeInfo>>>,
     all_struct_fields: Rc<IndexMap<ModuleSource, IndexMap<String, StructFieldInfo>>>,
     all_variant_cases: Rc<IndexMap<ModuleSource, IndexMap<String, VariantInfo>>>,
     all_enum_cases: Rc<IndexMap<ModuleSource, IndexMap<String, EnumInfo>>>,
     all_flags_cases: Rc<IndexMap<ModuleSource, IndexMap<String, FlagsInfo>>>,
     all_resource_types: Rc<IndexMap<ModuleSource, IndexMap<String, ResourceInfo>>>,
+    /// Per-module import context (consumed by [`TypeLookup`]). Built once per
+    /// module from `use` declarations; replaces the 7 flat maps the resolver
+    /// used to clone for each module.
+    imported_type_sources: IndexMap<String, ModuleSource>,
+    import_original_names: IndexMap<String, String>,
+    /// Locally discovered additions to the type tables. Anonymous structs
+    /// (synthesized from struct literals) and the resolver's own walk of
+    /// `module.items` insert here so [`TypeLookup`] can find them at the
+    /// highest priority. Always empty unless the current module has a
+    /// reason to override / extend the shared tables.
+    local_struct_fields: IndexMap<String, StructFieldInfo>,
+    local_newtypes: IndexMap<String, TypeId>,
+    local_generic_newtypes: IndexMap<String, GenericNewtypeInfo>,
+    local_enum_cases: IndexMap<String, EnumInfo>,
+    local_flags_cases: IndexMap<String, FlagsInfo>,
+    local_variant_cases: IndexMap<String, VariantInfo>,
     /// Function return types (name -> return type)
     function_return_types: IndexMap<String, TypeId>,
     /// Imported function names for the current module
@@ -140,10 +145,6 @@ pub struct Resolver<'a, H: CompilerHost> {
     /// Associated constants from impl blocks ("`TypeName::CONST`" -> (type, expr))
     /// These are inlined at every use site during resolution.
     associated_constants: IndexMap<String, (ast::Type, ast::Expr)>,
-    /// Cache of per-module type maps for cross-module type resolution.
-    /// Built lazily on first access per module. Avoids rebuilding `build_module_map`
-    /// on every imported method call or field access.
-    module_type_maps_cache: IndexMap<ModuleSource, ModuleTypeMaps>,
     /// Immutable trait knowledge base: impl indices, trait declarations, and blanket impls.
     /// Built once and shared across all module resolvers via `Arc`.
     trait_env: Arc<TraitEnv>,
@@ -205,19 +206,21 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             type_table,
             symbols,
             loaded_modules,
-            newtypes: IndexMap::default(),
-            generic_newtype_defs: IndexMap::default(),
-            struct_fields: IndexMap::default(),
-            variant_cases: IndexMap::default(),
-            enum_cases: IndexMap::default(),
-            flags_cases: IndexMap::default(),
-            resource_types: IndexMap::default(),
             all_newtypes: Rc::new(IndexMap::default()),
+            all_generic_newtypes: Rc::new(IndexMap::default()),
             all_struct_fields: Rc::new(IndexMap::default()),
             all_variant_cases: Rc::new(IndexMap::default()),
             all_enum_cases: Rc::new(IndexMap::default()),
             all_flags_cases: Rc::new(IndexMap::default()),
             all_resource_types: Rc::new(IndexMap::default()),
+            imported_type_sources: IndexMap::default(),
+            import_original_names: IndexMap::default(),
+            local_struct_fields: IndexMap::default(),
+            local_newtypes: IndexMap::default(),
+            local_generic_newtypes: IndexMap::default(),
+            local_enum_cases: IndexMap::default(),
+            local_flags_cases: IndexMap::default(),
+            local_variant_cases: IndexMap::default(),
             function_return_types: IndexMap::default(),
             imported_functions: IndexSet::default(),
             namespace_imports: IndexMap::default(),
@@ -240,7 +243,6 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             current_module_globals: IndexMap::default(),
             imported_globals: IndexMap::default(),
             associated_constants: IndexMap::default(),
-            module_type_maps_cache: IndexMap::default(),
             trait_env,
             included_files,
             known_type_names_cache: IndexSet::default(),
@@ -255,6 +257,100 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             default_scope_module: None,
             invocations: Rc::new(crate::kiln::InvocationIndex::new()),
         }
+    }
+
+    /// Construct a [`TypeLookup`] view over the resolver's current import
+    /// context and shared `all_*` tables. Use this for any type-name
+    /// resolution; never reach into `all_*` directly.
+    pub(crate) fn type_lookup(&self) -> TypeLookup<'_> {
+        TypeLookup {
+            current_module_source: &self.current_module_source,
+            imported_type_sources: &self.imported_type_sources,
+            import_original_names: &self.import_original_names,
+            all_newtypes: &self.all_newtypes,
+            all_struct_fields: &self.all_struct_fields,
+            all_variant_cases: &self.all_variant_cases,
+            all_enum_cases: &self.all_enum_cases,
+            all_flags_cases: &self.all_flags_cases,
+            all_resource_types: &self.all_resource_types,
+            all_generic_newtypes: &self.all_generic_newtypes,
+            local_struct_fields: &self.local_struct_fields,
+            local_newtypes: &self.local_newtypes,
+            local_enum_cases: &self.local_enum_cases,
+            local_flags_cases: &self.local_flags_cases,
+            local_generic_newtypes: &self.local_generic_newtypes,
+            local_variant_cases: &self.local_variant_cases,
+        }
+    }
+
+    pub(super) fn lookup_struct_fields(&self, name: &str) -> Option<&StructFieldInfo> {
+        self.type_lookup().struct_fields(name)
+    }
+
+    pub(super) fn lookup_variant_case(&self, name: &str) -> Option<&VariantInfo> {
+        self.type_lookup().variant_case(name)
+    }
+
+    pub(super) fn lookup_enum_case(&self, name: &str) -> Option<&EnumInfo> {
+        self.type_lookup().enum_case(name)
+    }
+
+    pub(super) fn lookup_flags_case(&self, name: &str) -> Option<&FlagsInfo> {
+        self.type_lookup().flags_case(name)
+    }
+
+    pub(super) fn lookup_resource_type(&self, name: &str) -> Option<&ResourceInfo> {
+        self.type_lookup().resource_type(name)
+    }
+
+    pub(super) fn lookup_generic_newtype(&self, name: &str) -> Option<&GenericNewtypeInfo> {
+        self.type_lookup().generic_newtype(name)
+    }
+
+    pub(super) fn lookup_newtype(&self, name: &str) -> Option<TypeId> {
+        self.type_lookup().newtype(name)
+    }
+
+    pub(super) fn contains_variant(&self, name: &str) -> bool {
+        self.lookup_variant_case(name).is_some()
+    }
+
+    /// Run `body` with the resolver's "current module" perspective swapped to
+    /// `module_source` and the supplied import context. Locals are cleared
+    /// because they describe in-progress resolution, not the target module's
+    /// pre-existing definitions; they are restored on return.
+    ///
+    /// Replaces the legacy pattern of cloning per-module flat maps via
+    /// `build_module_map` and swapping six fields in/out.
+    pub(super) fn with_module_perspective<R>(
+        &mut self,
+        module_source: ModuleSource,
+        imported_type_sources: IndexMap<String, ModuleSource>,
+        import_original_names: IndexMap<String, String>,
+        body: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let saved_src = std::mem::replace(&mut self.current_module_source, module_source);
+        let saved_imp = std::mem::replace(&mut self.imported_type_sources, imported_type_sources);
+        let saved_orig = std::mem::replace(&mut self.import_original_names, import_original_names);
+        let saved_local_struct = std::mem::take(&mut self.local_struct_fields);
+        let saved_local_newtypes = std::mem::take(&mut self.local_newtypes);
+        let saved_local_enum = std::mem::take(&mut self.local_enum_cases);
+        let saved_local_flags = std::mem::take(&mut self.local_flags_cases);
+        let saved_local_gnt = std::mem::take(&mut self.local_generic_newtypes);
+        let saved_local_variant = std::mem::take(&mut self.local_variant_cases);
+
+        let result = body(self);
+
+        self.current_module_source = saved_src;
+        self.imported_type_sources = saved_imp;
+        self.import_original_names = saved_orig;
+        self.local_struct_fields = saved_local_struct;
+        self.local_newtypes = saved_local_newtypes;
+        self.local_enum_cases = saved_local_enum;
+        self.local_flags_cases = saved_local_flags;
+        self.local_generic_newtypes = saved_local_gnt;
+        self.local_variant_cases = saved_local_variant;
+        result
     }
 
     /// Record that an identifier resolved to a local binding in the current
@@ -462,19 +558,16 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
 
     /// Look up struct field info by (name, `module_source`).
     ///
-    /// This is the correct way to look up struct fields — it disambiguates
-    /// The flat `struct_fields` map is a visibility-scoped projection of `all_struct_fields`,
-    /// containing only types visible to the current module (own definitions + explicit imports).
-    ///
-    /// `all_struct_fields` covers ALL modules and is needed for cross-module lookups where
-    /// the type wasn't explicitly imported (e.g., a struct returned by a function from another
-    /// module).
-    fn lookup_struct_fields(
+    /// Disambiguates same-named structs across modules by also matching the
+    /// owning `module_source`. Falls back to scanning the shared `all_*`
+    /// table when the visible projection (current module + locally created
+    /// anonymous structs) doesn't have the entry.
+    pub(super) fn lookup_struct_fields_in(
         &self,
         name: &str,
         module_source: &ModuleSource,
     ) -> Option<&StructFieldInfo> {
-        self.struct_fields
+        self.local_struct_fields
             .get(name)
             .filter(|info| info.module_source == *module_source)
             .or_else(|| {
@@ -1016,7 +1109,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     tir_module.add_enum(tir_enum);
                 }
                 Item::Flags(flags_decl) => {
-                    if let Some(flags_info) = self.flags_cases.get(&flags_decl.name) {
+                    if let Some(flags_info) = self.lookup_flags_case(&flags_decl.name) {
                         let tir_flags = TirFlags {
                             name: flags_decl.name.clone(),
                             module_source: self.current_module_source.clone(),
@@ -1038,7 +1131,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     }
                 }
                 Item::Newtype(newtype_decl) => {
-                    if let Some(&type_id) = self.newtypes.get(&newtype_decl.name) {
+                    if let Some(type_id) = self.lookup_newtype(&newtype_decl.name) {
                         tir_module.add_newtype(TirNewtype {
                             name: newtype_decl.name.clone(),
                             module_source: self.current_module_source.clone(),

--- a/wado-compiler/src/resolver/call.rs
+++ b/wado-compiler/src/resolver/call.rs
@@ -173,7 +173,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         {
             let prefix = &ident.name[..pos];
             let suffix = &ident.name[pos + 2..];
-            if let Some(variant_info) = self.variant_cases.get(prefix).cloned()
+            if let Some(variant_info) = self.lookup_variant_case(prefix).cloned()
                 && let Some((_, case_data)) = variant_info
                     .cases
                     .iter()
@@ -429,7 +429,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             }
 
                             // Base→Newtype: UserId::from(u64_val) where type UserId = u64
-                            if let Some(&newtype_type_id) = self.newtypes.get(prefix) {
+                            if let Some(newtype_type_id) = self.lookup_newtype(prefix) {
                                 let base_opt =
                                     self.type_table.borrow().get_newtype_base(newtype_type_id);
                                 if let Some(base_id) = base_opt
@@ -488,7 +488,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         );
                     }
                     // Check if this is a flags type method call: Perms::none(), Perms::all()
-                    else if let Some(flags_info) = self.flags_cases.get(prefix).cloned()
+                    else if let Some(flags_info) = self.lookup_flags_case(prefix).cloned()
                         && matches!(suffix, "none" | "all")
                     {
                         if let Some(prefix_seg) = ident.segments.first() {
@@ -510,7 +510,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         );
                     }
                     // Check if this is a variant case construction (Color::Red)
-                    else if let Some(variant_info) = self.variant_cases.get(prefix) {
+                    else if let Some(variant_info) = self.lookup_variant_case(prefix) {
                         // Clone needed data to release the borrow on self
                         let variant_info = variant_info.clone();
                         let case_match = variant_info
@@ -645,11 +645,10 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             let method_name = &suffix[inner_pos + 2..];
 
                             // Check if this is a variant construction in the namespace
-                            self.ensure_module_maps_cached(&ns_source);
                             let ns_variant = self
-                                .module_type_maps_cache
+                                .all_variant_cases
                                 .get(&ns_source)
-                                .and_then(|maps| maps.variant_cases.get(type_name))
+                                .and_then(|m| m.get(type_name))
                                 .cloned();
                             if let Some(variant_info) = ns_variant {
                                 let case_match = variant_info
@@ -1030,10 +1029,9 @@ impl<H: CompilerHost> Resolver<'_, H> {
             if let Some((ty, type_params)) = func_info
                 && let Some(return_type_ast) = ty
             {
-                // Build the callee module's flat maps so that type names resolve to the
-                // callee's types, not the caller's (which may have same-named different types).
-                // These reads only borrow immutable fields, so they happen before the scope
-                // guard which mutably borrows `self`.
+                // Build the callee module's import context so type names in the
+                // callee's signature resolve to the callee's types, not the
+                // caller's (which may have same-named different types).
                 let callee_module_ast = self.loaded_modules.get(callee_module);
                 let (callee_imported, callee_original_names) = callee_module_ast.map_or_else(
                     || (IndexMap::default(), IndexMap::default()),
@@ -1046,72 +1044,23 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         )
                     },
                 );
-                let callee_newtypes = Self::build_module_map(
-                    &self.all_newtypes,
-                    callee_module,
-                    &callee_imported,
-                    &callee_original_names,
-                );
-                let callee_struct_fields = Self::build_module_map(
-                    &self.all_struct_fields,
-                    callee_module,
-                    &callee_imported,
-                    &callee_original_names,
-                );
-                let callee_variant_cases = Self::build_module_map(
-                    &self.all_variant_cases,
-                    callee_module,
-                    &callee_imported,
-                    &callee_original_names,
-                );
-                let callee_enum_cases = Self::build_module_map(
-                    &self.all_enum_cases,
-                    callee_module,
-                    &callee_imported,
-                    &callee_original_names,
-                );
-                let callee_flags_cases = Self::build_module_map(
-                    &self.all_flags_cases,
-                    callee_module,
-                    &callee_imported,
-                    &callee_original_names,
-                );
-                let callee_resource_types = Self::build_module_map(
-                    &self.all_resource_types,
-                    callee_module,
-                    &callee_imported,
-                    &callee_original_names,
-                );
 
                 // Set up the function's type parameters in an inherited scope so we
                 // can resolve type parameter references (like T -> TypeParam { index: 0 }).
-                // Only `type_params` is replaced, matching the original
-                // `mem::take(&mut self.trait_ctx.type_params)` semantics.
                 let mut scope = self.enter_inherited_type_param_scope();
                 scope.trait_ctx.type_params.clear();
                 scope.register_generic_params(&type_params, 0);
 
-                // Temporarily swap in callee's flat maps
-                let old_newtypes = std::mem::replace(&mut scope.newtypes, callee_newtypes);
-                let old_struct_fields =
-                    std::mem::replace(&mut scope.struct_fields, callee_struct_fields);
-                let old_variant_cases =
-                    std::mem::replace(&mut scope.variant_cases, callee_variant_cases);
-                let old_enum_cases = std::mem::replace(&mut scope.enum_cases, callee_enum_cases);
-                let old_flags_cases = std::mem::replace(&mut scope.flags_cases, callee_flags_cases);
-                let old_resource_types =
-                    std::mem::replace(&mut scope.resource_types, callee_resource_types);
-
-                let resolved = scope.resolve_type(&return_type_ast);
-
-                // Restore caller's flat maps; trait_ctx is restored by the scope
-                // guard's Drop impl when `scope` goes out of scope below.
-                scope.newtypes = old_newtypes;
-                scope.struct_fields = old_struct_fields;
-                scope.variant_cases = old_variant_cases;
-                scope.enum_cases = old_enum_cases;
-                scope.flags_cases = old_flags_cases;
-                scope.resource_types = old_resource_types;
+                // Swap the resolver's "current module" perspective onto the
+                // callee for the duration of `resolve_type`. Locals are cleared
+                // because they only ever describe the active resolution, not
+                // the callee's pre-existing definitions.
+                let resolved = scope.with_module_perspective(
+                    callee_module.clone(),
+                    callee_imported,
+                    callee_original_names,
+                    |s| s.resolve_type(&return_type_ast),
+                );
                 drop(scope);
 
                 return resolved;
@@ -1202,7 +1151,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 // Type aliases from WASI (e.g., Mark, Instant, Duration)
                 _ => {
                     // First check if it's a registered newtype in newtypes
-                    if let Some(&newtype_id) = self.newtypes.get(&named.name) {
+                    if let Some(newtype_id) = self.lookup_newtype(&named.name) {
                         return newtype_id;
                     }
                     // Otherwise, try to resolve via WASI registry's newtypes.
@@ -1221,7 +1170,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             base_type,
                         );
                         // Cache the newtype for future lookups
-                        self.newtypes.insert(named.name.clone(), newtype_id);
+                        self.local_newtypes.insert(named.name.clone(), newtype_id);
                         newtype_id
                     } else if self
                         .wasi_registry
@@ -1528,7 +1477,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     )
                     .map(|func| func.params.clone());
                     if let Some(params) = params {
-                        // Temporarily swap to the definition module's type maps
+                        // Resolve types in the definition module's perspective
                         // so that type names resolve to the correct module's types
                         // (e.g., "Direction" resolves to module B's Direction, not module A's)
                         let callee_module = self
@@ -1547,70 +1496,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             } else {
                                 (IndexMap::default(), IndexMap::default())
                             };
-                        let saved_newtypes =
-                            if let Some(module_newtypes) = self.all_newtypes.get(&src) {
-                                Some(std::mem::replace(
-                                    &mut self.newtypes,
-                                    module_newtypes.clone(),
-                                ))
-                            } else {
-                                None
-                            };
-                        let saved_enum_cases = std::mem::replace(
-                            &mut self.enum_cases,
-                            Self::build_module_map(
-                                &self.all_enum_cases,
-                                &src,
-                                &imported_type_sources,
-                                &import_original_names,
-                            ),
+                        return self.with_module_perspective(
+                            src.clone(),
+                            imported_type_sources,
+                            import_original_names,
+                            |s| params.iter().map(|p| s.resolve_type(&p.ty)).collect(),
                         );
-                        let saved_struct_fields = std::mem::replace(
-                            &mut self.struct_fields,
-                            Self::build_module_map(
-                                &self.all_struct_fields,
-                                &src,
-                                &imported_type_sources,
-                                &import_original_names,
-                            ),
-                        );
-                        let saved_variant_cases = std::mem::replace(
-                            &mut self.variant_cases,
-                            Self::build_module_map(
-                                &self.all_variant_cases,
-                                &src,
-                                &imported_type_sources,
-                                &import_original_names,
-                            ),
-                        );
-                        let saved_flags_cases = std::mem::replace(
-                            &mut self.flags_cases,
-                            Self::build_module_map(
-                                &self.all_flags_cases,
-                                &src,
-                                &imported_type_sources,
-                                &import_original_names,
-                            ),
-                        );
-                        let saved_resource_types = std::mem::replace(
-                            &mut self.resource_types,
-                            Self::build_module_map(
-                                &self.all_resource_types,
-                                &src,
-                                &imported_type_sources,
-                                &import_original_names,
-                            ),
-                        );
-                        let result = params.iter().map(|p| self.resolve_type(&p.ty)).collect();
-                        self.resource_types = saved_resource_types;
-                        self.flags_cases = saved_flags_cases;
-                        self.variant_cases = saved_variant_cases;
-                        self.struct_fields = saved_struct_fields;
-                        self.enum_cases = saved_enum_cases;
-                        if let Some(saved) = saved_newtypes {
-                            self.newtypes = saved;
-                        }
-                        return result;
                     }
                 }
 

--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -376,7 +376,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             let prefix = &ident.name[..pos];
             let suffix = &ident.name[pos + 2..];
 
-            if let Some(variant_info) = self.variant_cases.get(prefix).cloned() {
+            if let Some(variant_info) = self.lookup_variant_case(prefix).cloned() {
                 // Find the case by name
                 if let Some((case_index, case_data)) = variant_info
                     .cases
@@ -435,7 +435,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
 
             // Check for enum case: Color::Red (enums have no payload)
-            if let Some(enum_info) = self.enum_cases.get(prefix).cloned()
+            if let Some(enum_info) = self.lookup_enum_case(prefix).cloned()
                 && let Some(case_data) = enum_info.find_case(suffix).cloned()
             {
                 self.record_qualified_case(
@@ -463,7 +463,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
             // Check for flags member: PathFlags::SymlinkFollow
             // Flags members are bitmask integers (1 << index) represented as IntLiteral
-            if let Some(flags_info) = self.flags_cases.get(prefix).cloned()
+            if let Some(flags_info) = self.lookup_flags_case(prefix).cloned()
                 && let Some(member) = flags_info
                     .members
                     .iter()
@@ -488,12 +488,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 let type_name = &suffix[..inner_pos];
                 let case_name = &suffix[inner_pos + 2..];
 
-                self.ensure_module_maps_cached(&ns_source);
-                // Check variant cases
+                // Check variant cases — namespace imports always look up by
+                // canonical name in the source module, so we can read directly
+                // from the shared `all_*` table without any per-module cache.
                 let ns_variant = self
-                    .module_type_maps_cache
+                    .all_variant_cases
                     .get(&ns_source)
-                    .and_then(|maps| maps.variant_cases.get(type_name))
+                    .and_then(|m| m.get(type_name))
                     .cloned();
                 if let Some(variant_info) = ns_variant
                     && let Some((case_index, case_data)) = variant_info
@@ -548,9 +549,9 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
                 // Check enum cases
                 let ns_enum = self
-                    .module_type_maps_cache
+                    .all_enum_cases
                     .get(&ns_source)
-                    .and_then(|maps| maps.enum_cases.get(type_name))
+                    .and_then(|m| m.get(type_name))
                     .cloned();
                 if let Some(enum_info) = ns_enum
                     && let Some(case_data) = enum_info.find_case(case_name).cloned()
@@ -573,9 +574,9 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
                 // Check flags members
                 let ns_flags = self
-                    .module_type_maps_cache
+                    .all_flags_cases
                     .get(&ns_source)
-                    .and_then(|maps| maps.flags_cases.get(type_name))
+                    .and_then(|m| m.get(type_name))
                     .cloned();
                 if let Some(flags_info) = ns_flags
                     && let Some(member) = flags_info
@@ -782,7 +783,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
             _ => return,
         };
-        if let Some(info) = self.lookup_struct_fields(&struct_name, &module_source) {
+        if let Some(info) = self.lookup_struct_fields_in(&struct_name, &module_source) {
             for ((fname, _, _), fid) in info.fields.iter().zip(info.field_ast_ids.iter()) {
                 if fname == field_name {
                     self.record_reference_to_decl(use_id, &module_source, *fid);
@@ -808,7 +809,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 module_source,
                 ..
             } => {
-                if let Some(struct_info) = self.lookup_struct_fields(&name, &module_source) {
+                if let Some(struct_info) = self.lookup_struct_fields_in(&name, &module_source) {
                     for (index, (fname, ftype, _)) in struct_info.fields.iter().enumerate() {
                         if fname == field_name {
                             return (index as u32, *ftype);
@@ -850,7 +851,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     return (0, TypeTable::UNKNOWN);
                 }
                 // Clone fields to avoid borrow issues
-                let fields_clone = self.lookup_struct_fields(&name, &module_source).cloned();
+                let fields_clone = self.lookup_struct_fields_in(&name, &module_source).cloned();
                 if let Some(struct_info) = fields_clone {
                     for (index, (fname, ftype, _)) in struct_info.fields.iter().enumerate() {
                         if fname == field_name {
@@ -898,7 +899,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         }
 
         // Look up field visibility
-        if let Some(struct_info) = self.lookup_struct_fields(&struct_name, &module_source) {
+        if let Some(struct_info) = self.lookup_struct_fields_in(&struct_name, &module_source) {
             for (fname, _, is_pub) in &struct_info.fields {
                 if fname == field_name && !is_pub {
                     let _ = self.logger.error(TypeError::PrivateFieldAccess {
@@ -1500,7 +1501,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
         match &resolved {
             ResolvedType::Enum { name, .. } => {
-                if let Some(enum_info) = self.enum_cases.get(name) {
+                if let Some(enum_info) = self.lookup_enum_case(name) {
                     let all_cases: IndexSet<&str> =
                         enum_info.cases.iter().map(|c| c.name.as_str()).collect();
                     let covered: IndexSet<&str> = {
@@ -1528,7 +1529,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 self.check_variant_exhaustiveness(arms, name, span);
             }
             ResolvedType::GenericInstance { name, .. } => {
-                if self.variant_cases.contains_key(name) {
+                if self.contains_variant(name) {
                     self.check_variant_exhaustiveness(arms, name, span);
                 }
             }
@@ -1568,7 +1569,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
     }
 
     fn check_variant_exhaustiveness(&self, arms: &[TirMatchArm], variant_name: &str, span: Span) {
-        if let Some(variant_info) = self.variant_cases.get(variant_name) {
+        if let Some(variant_info) = self.lookup_variant_case(variant_name) {
             let all_cases: IndexSet<&str> =
                 variant_info.cases.iter().map(|c| c.name.as_str()).collect();
             let covered: IndexSet<&str> = {
@@ -2240,7 +2241,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // Resolve struct name and module_source.
         // Local definitions shadow imported/prelude structs.
         let (struct_name, struct_module_source) = if self
-            .lookup_struct_fields(name, &self.current_module_source)
+            .lookup_struct_fields_in(name, &self.current_module_source)
             .is_some()
         {
             (name.clone(), self.current_module_source.clone())
@@ -2257,13 +2258,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
         // Use canonical name from struct_fields info (not import alias) for consistent TypeId
         let struct_name = self
-            .lookup_struct_fields(&struct_name, &struct_module_source)
+            .lookup_struct_fields_in(&struct_name, &struct_module_source)
             .map(|info| info.name.clone())
             .unwrap_or(struct_name);
 
         // Get expected field types using (name, module_source) lookup.
         let struct_field_types: Vec<(String, TypeId)> = self
-            .lookup_struct_fields(&struct_name, &struct_module_source)
+            .lookup_struct_fields_in(&struct_name, &struct_module_source)
             .map(|info| {
                 info.fields
                     .iter()
@@ -2275,7 +2276,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // Record use→def references for each field name, pointing at the
         // field definition's AstId in the struct declaration.
         let field_refs: Vec<(AstId, AstId)> = self
-            .lookup_struct_fields(&struct_name, &struct_module_source)
+            .lookup_struct_fields_in(&struct_name, &struct_module_source)
             .map(|info| {
                 struct_lit
                     .fields
@@ -2417,7 +2418,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // provided; fields with `= expr` are synthesized from the default
         // expression (pure, resolved in the struct's module scope).
         let struct_field_defaults: Vec<Option<ast::Expr>> = self
-            .lookup_struct_fields(&struct_name, &struct_module_source)
+            .lookup_struct_fields_in(&struct_name, &struct_module_source)
             .map(|info| info.field_defaults.clone())
             .unwrap_or_default();
         let mut fields = fields;
@@ -2450,7 +2451,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // Check field visibility: non-pub fields cannot be set from other modules
         if struct_module_source != self.current_module_source
             && let Some(struct_info) =
-                self.lookup_struct_fields(&struct_name, &struct_module_source)
+                self.lookup_struct_fields_in(&struct_name, &struct_module_source)
         {
             for (fname, _, is_pub) in &struct_info.fields {
                 if !is_pub && fields.iter().any(|f| f.name == *fname) {
@@ -2488,8 +2489,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 fields
             } else {
                 let struct_param_map: IndexMap<TypeId, TypeId> = self
-                    .struct_fields
-                    .get(&struct_name)
+                    .lookup_struct_fields(&struct_name)
                     .map(|info| {
                         info.type_param_type_ids
                             .iter()
@@ -2533,7 +2533,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
             // Check trait bounds on inferred type arguments
             if let Some(struct_info) = self
-                .lookup_struct_fields(&struct_name, &struct_module_source)
+                .lookup_struct_fields_in(&struct_name, &struct_module_source)
                 .cloned()
             {
                 for (i, (param_name, bounds)) in struct_info.type_param_bounds.iter().enumerate() {
@@ -2650,7 +2650,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
             type_param_bounds: Vec::new(),
             type_param_type_ids: Vec::new(),
         };
-        self.struct_fields.insert(anon_name.clone(), field_info);
+        self.local_struct_fields
+            .insert(anon_name.clone(), field_info);
 
         // Create TirStruct definition for codegen
         let tir_fields: Vec<TirField> = resolved_fields
@@ -2712,7 +2713,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         fields: &[TirStructField],
         expected_type: Option<TypeId>,
     ) -> Vec<TypeId> {
-        let Some(struct_info) = self.struct_fields.get(struct_name).cloned() else {
+        let Some(struct_info) = self.lookup_struct_fields(struct_name).cloned() else {
             return vec![];
         };
         if struct_info.type_param_type_ids.is_empty() {

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -732,7 +732,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 }
             };
             if let Some((name, instance_type_args)) = generic_data
-                && let Some(variant_info) = self.variant_cases.get(&name).cloned()
+                && let Some(variant_info) = self.lookup_variant_case(&name).cloned()
                 && let Some((_, case_data)) = variant_info
                     .cases
                     .iter()
@@ -845,7 +845,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 _ => None,
             };
             if let Some(ref name) = flags_name
-                && let Some(flags_info) = self.flags_cases.get(name).cloned()
+                && let Some(flags_info) = self.lookup_flags_case(name).cloned()
             {
                 match static_call.method.as_str() {
                     "none" => {
@@ -912,7 +912,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         } = self.type_table.borrow().get(target_type_id).clone()
         {
             // Look up the variant case info
-            if let Some(variant_info) = self.variant_cases.get(&name) {
+            if let Some(variant_info) = self.lookup_variant_case(&name) {
                 // Find the case by name
                 if let Some((case_index, case_data)) = variant_info
                     .cases
@@ -967,7 +967,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         };
         if let Some(name) = generic_name {
             // Check if the base type is a variant
-            if let Some(variant_info) = self.variant_cases.get(&name).cloned() {
+            if let Some(variant_info) = self.lookup_variant_case(&name).cloned() {
                 // This is a generic variant like Result<T, E>
                 // Find the case by name
                 if let Some((case_index, case_data)) = variant_info
@@ -1461,9 +1461,6 @@ impl<H: CompilerHost> Resolver<'_, H> {
         }
 
         // Try looking up in loaded modules
-        if !struct_module.is_entry_point() {
-            self.ensure_module_maps_cached(struct_module);
-        }
         if !struct_module.is_entry_point()
             && let Some(module) = self.loaded_modules.get(struct_module)
         {
@@ -2173,7 +2170,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         }
 
         // For newtypes/flags, check if the base type has the static method
-        if let Some(&newtype_id) = self.newtypes.get(struct_name) {
+        if let Some(newtype_id) = self.lookup_newtype(struct_name) {
             let base_name = match self.type_table.borrow().get(newtype_id).clone() {
                 ResolvedType::Newtype { base_type, .. } => {
                     Some(self.type_table.borrow().type_name(base_type))
@@ -2213,7 +2210,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // For newtypes, check if the newtype itself has the method first,
         // then fall back to the base type's static method
         let (actual_struct_name, actual_mangled_name) =
-            if let Some(&newtype_id) = self.newtypes.get(struct_name) {
+            if let Some(newtype_id) = self.lookup_newtype(struct_name) {
                 // First check if the newtype itself has this static method
                 if self.has_static_method_direct(struct_name, method_name) {
                     (struct_name.to_string(), mangled_func_name.to_string())

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -282,18 +282,15 @@ impl<H: CompilerHost> Resolver<'_, H> {
     /// callers should consult this only as a fallback after the regular
     /// impl-lookup paths.
     pub(super) fn auto_derive_default_struct_type(&self, struct_name: &str) -> Option<TypeId> {
-        let info = self.struct_fields.get(struct_name)?;
+        let info = self.lookup_struct_fields(struct_name)?;
         if info.fields.is_empty() || !info.field_defaults.iter().all(Option::is_some) {
             return None;
         }
         if !info.type_param_type_ids.is_empty() {
             return None;
         }
-        Some(
-            self.type_table
-                .borrow_mut()
-                .make_struct(info.name.clone(), info.module_source.clone()),
-        )
+        let (n, src) = (info.name.clone(), info.module_source.clone());
+        Some(self.type_table.borrow_mut().make_struct(n, src))
     }
 
     /// Find the module source for a struct by name.
@@ -346,7 +343,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         }
 
         // Check newtypes/flags — the impl block may live in the module that defines the type
-        if let Some(&type_id) = self.newtypes.get(struct_name) {
+        if let Some(type_id) = self.lookup_newtype(struct_name) {
             let ms = match self.type_table.borrow().get(type_id).clone() {
                 ResolvedType::Newtype { module_source, .. }
                 | ResolvedType::Flags { module_source, .. } => Some(module_source),
@@ -574,8 +571,20 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // Try looking up in loaded modules (for imported structs)
         // Only check inherent impls (not trait impls) - trait impls are handled separately
         if let Some(ref module_source) = struct_module_source {
-            // Pre-populate module type maps cache before borrowing loaded_modules
-            self.ensure_module_maps_cached(module_source);
+            // Build the source module's import context once so that type names
+            // in the method's signature resolve in that module's perspective.
+            let (target_imports, target_originals) = self
+                .loaded_modules
+                .get(module_source)
+                .map(|m| {
+                    Self::build_imported_type_sources(
+                        m,
+                        module_source,
+                        Some(&self.entry_module_source),
+                        &self.invocations,
+                    )
+                })
+                .unwrap_or_default();
             if let Some(module) = self.loaded_modules.get(module_source) {
                 for item in &module.items {
                     if let Item::Impl(impl_block) = item {
@@ -627,80 +636,61 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                         );
                                     }
 
-                                    // Resolve return type and param types in the source module's
-                                    // type context, not the caller's. This prevents same-named types
-                                    // from different modules being confused (e.g., both modules
-                                    // define "Config" with different fields).
-                                    // Use cached module type maps (O(1) swap) instead of
-                                    // rebuilding maps from scratch on every call.
-                                    let mut cached = scope
-                                        .module_type_maps_cache
-                                        .shift_remove(module_source)
-                                        .expect("cache populated by ensure_module_maps_cached");
-                                    std::mem::swap(
-                                        &mut scope.struct_fields,
-                                        &mut cached.struct_fields,
+                                    // Resolve return / param types in the source module's
+                                    // perspective so same-named types from different modules
+                                    // don't get confused. The perspective swap keeps existing
+                                    // local additions out of the way and restores them on exit.
+                                    let (
+                                        return_type,
+                                        self_kind,
+                                        param_types,
+                                        param_is_mut,
+                                        param_defaults,
+                                        param_names,
+                                    ) = scope.with_module_perspective(
+                                        module_source.clone(),
+                                        target_imports,
+                                        target_originals,
+                                        |s| {
+                                            let return_type = method
+                                                .return_type
+                                                .as_ref()
+                                                .map(|t| s.resolve_type(t))
+                                                .unwrap_or(TypeTable::UNIT);
+                                            let self_kind = method
+                                                .params
+                                                .first()
+                                                .map(|p| p.self_kind)
+                                                .unwrap_or(ast::SelfKind::None);
+                                            let param_types = s.extract_param_types(&method.params);
+                                            let param_is_mut: Vec<bool> = method
+                                                .params
+                                                .iter()
+                                                .filter(|p| p.name != "self")
+                                                .map(|p| p.is_mut)
+                                                .collect();
+                                            let param_defaults: Vec<Option<ast::Expr>> = method
+                                                .params
+                                                .iter()
+                                                .filter(|p| p.name != "self")
+                                                .map(|p| p.default.clone())
+                                                .collect();
+                                            let param_names: Vec<String> = method
+                                                .params
+                                                .iter()
+                                                .filter(|p| p.name != "self")
+                                                .map(|p| p.name.clone())
+                                                .collect();
+                                            (
+                                                return_type,
+                                                self_kind,
+                                                param_types,
+                                                param_is_mut,
+                                                param_defaults,
+                                                param_names,
+                                            )
+                                        },
                                     );
-                                    std::mem::swap(
-                                        &mut scope.variant_cases,
-                                        &mut cached.variant_cases,
-                                    );
-                                    std::mem::swap(&mut scope.enum_cases, &mut cached.enum_cases);
-                                    std::mem::swap(&mut scope.flags_cases, &mut cached.flags_cases);
-                                    std::mem::swap(&mut scope.newtypes, &mut cached.newtypes);
-                                    std::mem::swap(
-                                        &mut scope.resource_types,
-                                        &mut cached.resource_types,
-                                    );
-
-                                    let return_type = method
-                                        .return_type
-                                        .as_ref()
-                                        .map(|t| scope.resolve_type(t))
-                                        .unwrap_or(TypeTable::UNIT);
-                                    let self_kind = method
-                                        .params
-                                        .first()
-                                        .map(|p| p.self_kind)
-                                        .unwrap_or(ast::SelfKind::None);
-                                    let param_types = scope.extract_param_types(&method.params);
-                                    let param_is_mut: Vec<bool> = method
-                                        .params
-                                        .iter()
-                                        .filter(|p| p.name != "self")
-                                        .map(|p| p.is_mut)
-                                        .collect();
-                                    let param_defaults: Vec<Option<ast::Expr>> = method
-                                        .params
-                                        .iter()
-                                        .filter(|p| p.name != "self")
-                                        .map(|p| p.default.clone())
-                                        .collect();
-                                    let param_names: Vec<String> = method
-                                        .params
-                                        .iter()
-                                        .filter(|p| p.name != "self")
-                                        .map(|p| p.name.clone())
-                                        .collect();
-
-                                    std::mem::swap(
-                                        &mut scope.struct_fields,
-                                        &mut cached.struct_fields,
-                                    );
-                                    std::mem::swap(
-                                        &mut scope.variant_cases,
-                                        &mut cached.variant_cases,
-                                    );
-                                    std::mem::swap(&mut scope.enum_cases, &mut cached.enum_cases);
-                                    std::mem::swap(&mut scope.flags_cases, &mut cached.flags_cases);
-                                    std::mem::swap(&mut scope.newtypes, &mut cached.newtypes);
-                                    std::mem::swap(
-                                        &mut scope.resource_types,
-                                        &mut cached.resource_types,
-                                    );
-                                    scope
-                                        .module_type_maps_cache
-                                        .insert(module_source.clone(), cached);
                                     drop(scope);
 
                                     return Some(MethodInfo {
@@ -1653,7 +1643,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // all items in all modules.
         let names_to_check: Vec<String> = {
             let mut names = vec![struct_name.to_string()];
-            if let Some(&newtype_id) = self.newtypes.get(struct_name) {
+            if let Some(newtype_id) = self.lookup_newtype(struct_name) {
                 let mut current = newtype_id;
                 loop {
                     match self.type_table.borrow().get(current).clone() {
@@ -2945,12 +2935,10 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     // Falling back to current_module_source causes type identity mismatches when
                     // the struct is defined in a different module.
                     let module_source = self
-                        .variant_cases
-                        .get(base_name.as_str())
+                        .lookup_variant_case(base_name.as_str())
                         .map(|info| info.module_source.clone())
                         .or_else(|| {
-                            self.struct_fields
-                                .get(base_name.as_str())
+                            self.lookup_struct_fields(base_name.as_str())
                                 .map(|info| info.module_source.clone())
                         })
                         .unwrap_or_else(|| self.current_module_source.clone());

--- a/wado-compiler/src/resolver/module.rs
+++ b/wado-compiler/src/resolver/module.rs
@@ -19,13 +19,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 if let Item::Newtype(newtype_decl) = item {
                     if !newtype_decl.type_params.is_empty() {
                         // Generic newtype: store definition only if not already present
-                        if !self.generic_newtype_defs.contains_key(&newtype_decl.name) {
+                        if self.lookup_generic_newtype(&newtype_decl.name).is_none() {
                             let type_params = newtype_decl
                                 .type_params
                                 .iter()
                                 .map(|p| p.name.clone())
                                 .collect();
-                            self.generic_newtype_defs.insert(
+                            self.local_generic_newtypes.insert(
                                 newtype_decl.name.clone(),
                                 GenericNewtypeInfo {
                                     module_source: module_source.clone(),
@@ -34,7 +34,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                 },
                             );
                         }
-                    } else if !self.newtypes.contains_key(&newtype_decl.name) {
+                    } else if self.lookup_newtype(&newtype_decl.name).is_none() {
                         // Concrete newtype: resolve immediately
                         let base_type_id = self.resolve_type(&newtype_decl.ty);
                         let newtype_id = self.type_table.borrow_mut().make_newtype(
@@ -42,7 +42,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             module_source.clone(),
                             base_type_id,
                         );
-                        self.newtypes.insert(newtype_decl.name.clone(), newtype_id);
+                        self.local_newtypes
+                            .insert(newtype_decl.name.clone(), newtype_id);
                     }
                 }
             }
@@ -115,7 +116,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         .collect();
 
                     let module_source = scope.current_module_source.clone();
-                    scope.struct_fields.insert(
+                    scope.local_struct_fields.insert(
                         struct_decl.name.clone(),
                         StructFieldInfo {
                             name: struct_decl.name.clone(),
@@ -139,7 +140,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             self.current_module_source.clone(),
                             base_type_id,
                         );
-                        self.newtypes.insert(newtype_decl.name.clone(), newtype_id);
+                        self.local_newtypes
+                            .insert(newtype_decl.name.clone(), newtype_id);
                     } else {
                         // Generic newtype: store definition for lazy instantiation
                         let type_params = newtype_decl
@@ -147,7 +149,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             .iter()
                             .map(|p| p.name.clone())
                             .collect();
-                        self.generic_newtype_defs.insert(
+                        self.local_generic_newtypes.insert(
                             newtype_decl.name.clone(),
                             GenericNewtypeInfo {
                                 module_source: self.current_module_source.clone(),
@@ -196,7 +198,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     }
 
                     let module_source = scope.current_module_source.clone();
-                    scope.variant_cases.insert(
+                    scope.local_variant_cases.insert(
                         variant_decl.name.clone(),
                         VariantInfo {
                             name: variant_decl.name.clone(),
@@ -229,7 +231,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             ast_id: case.id,
                         })
                         .collect();
-                    self.enum_cases.insert(
+                    self.local_enum_cases.insert(
                         enum_decl.name.clone(),
                         EnumInfo::new(
                             enum_decl.name.clone(),
@@ -245,7 +247,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         .borrow_mut()
                         .make_flags(flags_decl.name.clone(), self.current_module_source.clone());
                     // Add to newtypes so it can be used as a type name
-                    self.newtypes.insert(flags_decl.name.clone(), flags_type);
+                    self.local_newtypes
+                        .insert(flags_decl.name.clone(), flags_type);
                     // Store member info with bitmask values (1 << index)
                     let members: Vec<FlagsMemberData> = flags_decl
                         .flags
@@ -257,7 +260,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             ast_id: m.id,
                         })
                         .collect();
-                    self.flags_cases.insert(
+                    self.local_flags_cases.insert(
                         flags_decl.name.clone(),
                         FlagsInfo {
                             type_id: flags_type,

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -39,8 +39,8 @@ use crate::world_registry::WorldRegistry;
 use super::Resolver;
 use super::trait_env::TraitEnv;
 use super::types::{
-    EnumCaseData, EnumInfo, FlagsInfo, FlagsMemberData, GenericNewtypeInfo, ModuleTypeMaps,
-    ResourceInfo, StructFieldInfo, TypeError, VariantCaseData, VariantInfo,
+    EnumCaseData, EnumInfo, FlagsInfo, FlagsMemberData, GenericNewtypeInfo, ResourceInfo,
+    StructFieldInfo, TypeError, TypeLookup, VariantCaseData, VariantInfo,
 };
 
 /// Analysis state produced by [`Resolver::annotate_modules`] and consumed by
@@ -266,9 +266,10 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             }
         }
 
-        // Second sub-pass: resolve struct fields and newtypes
+        // Second sub-pass: resolve struct fields and newtypes.
+        // Each module's lookup goes directly through the in-progress shared
+        // tables (`all_*`) via [`TypeLookup`] — no per-module flat-map cloning.
         for (module_source, module) in modules {
-            // Build imported type sources for this module
             let (imported_type_sources, import_original_names) = Self::build_imported_type_sources(
                 module,
                 module_source,
@@ -276,45 +277,36 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 &invocations,
             );
 
-            // Build module-specific flat maps for resolving types in this module
-            let mut flat_newtypes = Self::build_module_map(
-                &all_newtypes,
-                module_source,
-                &imported_type_sources,
-                &import_original_names,
-            );
-            let mut flat_struct_fields = Self::build_module_map(
-                &all_struct_fields,
-                module_source,
-                &imported_type_sources,
-                &import_original_names,
-            );
-            let flat_resource_types = Self::build_module_map(
-                &all_resource_types,
-                module_source,
-                &imported_type_sources,
-                &import_original_names,
-            );
-            let flat_enum_cases = Self::build_module_map(
-                &all_enum_cases,
-                module_source,
-                &imported_type_sources,
-                &import_original_names,
-            );
-            let flat_variant_cases = Self::build_module_map(
-                &all_variant_cases,
-                module_source,
-                &imported_type_sources,
-                &import_original_names,
-            );
-            let flat_flags_cases = Self::build_module_map(
-                &all_flags_cases,
-                module_source,
-                &imported_type_sources,
-                &import_original_names,
-            );
+            // Helper closure: build a fresh TypeLookup pointed at the
+            // current state of the shared tables. Recreated per call site so
+            // that the previous borrow is released before each `borrow_mut()`
+            // on `type_table`.
+            let empty_struct: IndexMap<String, StructFieldInfo> = IndexMap::default();
+            let empty_newtype: IndexMap<String, TypeId> = IndexMap::default();
+            let empty_enum: IndexMap<String, EnumInfo> = IndexMap::default();
+            let empty_flags: IndexMap<String, FlagsInfo> = IndexMap::default();
+            let empty_gnt: IndexMap<String, GenericNewtypeInfo> = IndexMap::default();
+            let empty_variant: IndexMap<String, VariantInfo> = IndexMap::default();
 
             for item in &module.items {
+                let lookup = TypeLookup {
+                    current_module_source: module_source,
+                    imported_type_sources: &imported_type_sources,
+                    import_original_names: &import_original_names,
+                    all_newtypes: &all_newtypes,
+                    all_struct_fields: &all_struct_fields,
+                    all_variant_cases: &all_variant_cases,
+                    all_enum_cases: &all_enum_cases,
+                    all_flags_cases: &all_flags_cases,
+                    all_resource_types: &all_resource_types,
+                    all_generic_newtypes: &all_generic_newtypes,
+                    local_struct_fields: &empty_struct,
+                    local_newtypes: &empty_newtype,
+                    local_enum_cases: &empty_enum,
+                    local_flags_cases: &empty_flags,
+                    local_generic_newtypes: &empty_gnt,
+                    local_variant_cases: &empty_variant,
+                };
                 match item {
                     Item::Struct(struct_decl) => {
                         let mut fields = Vec::new();
@@ -333,23 +325,13 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                                 Self::resolve_type_static(
                                     &field.ty,
                                     &mut type_table.borrow_mut(),
-                                    &flat_newtypes,
-                                    &flat_struct_fields,
-                                    &flat_resource_types,
-                                    &flat_enum_cases,
-                                    &flat_variant_cases,
-                                    &flat_flags_cases,
+                                    &lookup,
                                 )
                             } else {
                                 Self::resolve_type_static_with_params(
                                     &field.ty,
                                     &mut type_table.borrow_mut(),
-                                    &flat_newtypes,
-                                    &flat_struct_fields,
-                                    &flat_resource_types,
-                                    &flat_enum_cases,
-                                    &flat_variant_cases,
-                                    &flat_flags_cases,
+                                    &lookup,
                                     &type_params,
                                 )
                             };
@@ -381,7 +363,12 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             })
                             .collect();
 
-                        // Update the nested map entry with actual fields
+                        // Drop lookup so we can mutate `all_struct_fields`.
+
+                        // Update the nested map entry with actual fields. The
+                        // next iteration's `lookup` will see the new entry via
+                        // the "current module" path, so no flat-map echo is
+                        // needed.
                         let info = StructFieldInfo {
                             name: struct_decl.name.clone(),
                             module_source: module_source.clone(),
@@ -394,9 +381,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                         all_struct_fields
                             .entry(module_source.clone())
                             .or_default()
-                            .insert(struct_decl.name.clone(), info.clone());
-                        // Also update flat map for subsequent items in this module
-                        flat_struct_fields.insert(struct_decl.name.clone(), info);
+                            .insert(struct_decl.name.clone(), info);
                     }
                     Item::Newtype(newtype_decl) => {
                         if newtype_decl.type_params.is_empty() {
@@ -404,12 +389,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             let base_type_id = Self::resolve_type_static(
                                 &newtype_decl.ty,
                                 &mut type_table.borrow_mut(),
-                                &flat_newtypes,
-                                &flat_struct_fields,
-                                &flat_resource_types,
-                                &flat_enum_cases,
-                                &flat_variant_cases,
-                                &flat_flags_cases,
+                                &lookup,
                             );
                             let newtype_id = type_table.borrow_mut().make_newtype(
                                 newtype_decl.name.clone(),
@@ -420,7 +400,6 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                                 .entry(module_source.clone())
                                 .or_default()
                                 .insert(newtype_decl.name.clone(), newtype_id);
-                            flat_newtypes.insert(newtype_decl.name.clone(), newtype_id);
                         } else {
                             // Generic newtype: store definition for lazy instantiation
                             let type_params = newtype_decl
@@ -456,12 +435,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                                 Self::resolve_type_static_with_params(
                                     payload_ty,
                                     &mut type_table.borrow_mut(),
-                                    &flat_newtypes,
-                                    &flat_struct_fields,
-                                    &flat_resource_types,
-                                    &flat_enum_cases,
-                                    &flat_variant_cases,
-                                    &flat_flags_cases,
+                                    &lookup,
                                     &type_params,
                                 )
                             } else {
@@ -527,8 +501,6 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             .entry(module_source.clone())
                             .or_default()
                             .insert(flags_decl.name.clone(), flags_type);
-                        // Also update flat_newtypes for subsequent items in this module
-                        flat_newtypes.insert(flags_decl.name.clone(), flags_type);
                         // Store member info with bitmask values (1 << index)
                         let members: Vec<FlagsMemberData> = flags_decl
                             .flags
@@ -738,69 +710,48 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 Some(&entry_module_source),
                 &state.invocations,
             );
-            let newtypes = Self::build_module_map(
-                &state.all_newtypes,
-                module_source,
-                &imported_type_sources,
-                &import_original_names,
-            );
-            let generic_newtype_defs = Self::build_module_map(
-                &state.all_generic_newtypes,
-                module_source,
-                &imported_type_sources,
-                &import_original_names,
-            );
-            let struct_fields = Self::build_module_map(
-                &state.all_struct_fields,
-                module_source,
-                &imported_type_sources,
-                &import_original_names,
-            );
-            let variant_cases = Self::build_module_map(
-                &state.all_variant_cases,
-                module_source,
-                &imported_type_sources,
-                &import_original_names,
-            );
-            let enum_cases = Self::build_module_map(
-                &state.all_enum_cases,
-                module_source,
-                &imported_type_sources,
-                &import_original_names,
-            );
-            let flags_cases = Self::build_module_map(
-                &state.all_flags_cases,
-                module_source,
-                &imported_type_sources,
-                &import_original_names,
-            );
-            let resource_types = Self::build_module_map(
-                &state.all_resource_types,
-                module_source,
-                &imported_type_sources,
-                &import_original_names,
-            );
-
             // Build function_return_types for this module only
-            // (functions defined in this module)
+            // (functions defined in this module). The lookup borrows the
+            // shared `all_*` tables; no per-module flat-map cloning.
             let mut function_return_types = IndexMap::default();
-            for item in &module.items {
-                if let Item::Function(func) = item {
-                    let return_type = if let Some(ret_ty) = &func.return_type {
-                        Self::resolve_type_static(
-                            ret_ty,
-                            &mut state.type_table.borrow_mut(),
-                            &newtypes,
-                            &struct_fields,
-                            &resource_types,
-                            &enum_cases,
-                            &variant_cases,
-                            &flags_cases,
-                        )
-                    } else {
-                        TypeTable::UNIT
-                    };
-                    function_return_types.insert(func.name.clone(), return_type);
+            {
+                let empty_struct: IndexMap<String, StructFieldInfo> = IndexMap::default();
+                let empty_newtype: IndexMap<String, TypeId> = IndexMap::default();
+                let empty_enum: IndexMap<String, EnumInfo> = IndexMap::default();
+                let empty_flags: IndexMap<String, FlagsInfo> = IndexMap::default();
+                let empty_gnt: IndexMap<String, GenericNewtypeInfo> = IndexMap::default();
+                let empty_variant: IndexMap<String, VariantInfo> = IndexMap::default();
+                let lookup = TypeLookup {
+                    current_module_source: module_source,
+                    imported_type_sources: &imported_type_sources,
+                    import_original_names: &import_original_names,
+                    all_newtypes: &state.all_newtypes,
+                    all_struct_fields: &state.all_struct_fields,
+                    all_variant_cases: &state.all_variant_cases,
+                    all_enum_cases: &state.all_enum_cases,
+                    all_flags_cases: &state.all_flags_cases,
+                    all_resource_types: &state.all_resource_types,
+                    all_generic_newtypes: &state.all_generic_newtypes,
+                    local_struct_fields: &empty_struct,
+                    local_newtypes: &empty_newtype,
+                    local_enum_cases: &empty_enum,
+                    local_flags_cases: &empty_flags,
+                    local_generic_newtypes: &empty_gnt,
+                    local_variant_cases: &empty_variant,
+                };
+                for item in &module.items {
+                    if let Item::Function(func) = item {
+                        let return_type = if let Some(ret_ty) = &func.return_type {
+                            Self::resolve_type_static(
+                                ret_ty,
+                                &mut state.type_table.borrow_mut(),
+                                &lookup,
+                            )
+                        } else {
+                            TypeTable::UNIT
+                        };
+                        function_return_types.insert(func.name.clone(), return_type);
+                    }
                 }
             }
 
@@ -852,19 +803,21 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 type_table: Rc::clone(&state.type_table),
                 symbols,
                 loaded_modules: modules,
-                newtypes,
-                generic_newtype_defs,
-                struct_fields,
-                variant_cases,
-                enum_cases,
-                flags_cases,
-                resource_types,
                 all_newtypes: Rc::clone(&state.all_newtypes),
+                all_generic_newtypes: Rc::clone(&state.all_generic_newtypes),
                 all_struct_fields: Rc::clone(&state.all_struct_fields),
                 all_variant_cases: Rc::clone(&state.all_variant_cases),
                 all_enum_cases: Rc::clone(&state.all_enum_cases),
                 all_flags_cases: Rc::clone(&state.all_flags_cases),
                 all_resource_types: Rc::clone(&state.all_resource_types),
+                imported_type_sources,
+                import_original_names,
+                local_struct_fields: IndexMap::default(),
+                local_newtypes: IndexMap::default(),
+                local_generic_newtypes: IndexMap::default(),
+                local_enum_cases: IndexMap::default(),
+                local_flags_cases: IndexMap::default(),
+                local_variant_cases: IndexMap::default(),
                 function_return_types,
                 imported_functions,
                 namespace_imports,
@@ -887,7 +840,6 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 current_module_globals: IndexMap::default(),
                 imported_globals: IndexMap::default(),
                 associated_constants: IndexMap::default(),
-                module_type_maps_cache: IndexMap::default(),
                 trait_env: Arc::clone(&state.trait_env),
                 included_files,
                 known_type_names_cache: state.global_known_type_names.clone(),
@@ -1006,62 +958,6 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         }
     }
 
-    /// Build a module-specific flat map from per-module entries.
-    ///
-    /// Priority: current module > imported types > any available definition.
-    pub(super) fn build_module_map<V: Clone>(
-        per_module: &IndexMap<ModuleSource, IndexMap<String, V>>,
-        current_module: &ModuleSource,
-        imported_type_sources: &IndexMap<String, ModuleSource>,
-        import_original_names: &IndexMap<String, String>,
-    ) -> IndexMap<String, V> {
-        let mut result = IndexMap::default();
-        // First: add all entries from all modules (arbitrary winner for conflicts)
-        for name_map in per_module.values() {
-            for (name, value) in name_map {
-                result.entry(name.clone()).or_insert_with(|| value.clone());
-            }
-        }
-        // Second: override with imported modules' types
-        for (local_name, import_src) in imported_type_sources {
-            // Use original name to look up in the source module (handles `use { Foo as Bar }`)
-            let lookup_name = import_original_names.get(local_name).unwrap_or(local_name);
-            // Try exact module first, then sub-modules for umbrella imports
-            // (e.g., `use { ErrorCode } from "wasi:http"` should find ErrorCode
-            // in `wasi:http/types.wado` when `wasi:http` is an umbrella module).
-            let found = per_module
-                .get(import_src)
-                .and_then(|m| m.get(lookup_name))
-                .cloned()
-                .or_else(|| {
-                    if let ModuleSource::Wasi { interface } = import_src {
-                        let prefix = format!("{interface}/");
-                        for (src, name_map) in per_module {
-                            if let ModuleSource::Wasi {
-                                interface: sub_iface,
-                            } = src
-                                && sub_iface.starts_with(&prefix)
-                                && let Some(value) = name_map.get(lookup_name)
-                            {
-                                return Some(value.clone());
-                            }
-                        }
-                    }
-                    None
-                });
-            if let Some(value) = found {
-                result.insert(local_name.clone(), value);
-            }
-        }
-        // Third: override with current module's types (highest priority)
-        if let Some(name_map) = per_module.get(current_module) {
-            for (name, value) in name_map {
-                result.insert(name.clone(), value.clone());
-            }
-        }
-        result
-    }
-
     /// Build a map of imported names to their source modules from use declarations.
     /// Build a mapping from local import names to their source modules and original names.
     ///
@@ -1102,102 +998,34 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         (sources, original_names)
     }
 
-    /// Lazily build and cache per-module type maps for cross-module type resolution.
-    ///
-    /// Must be called before borrowing `loaded_modules` for the same module,
-    /// so the cache is populated without borrow conflicts. After calling this,
-    /// use `self.module_type_maps_cache.remove(module_source)` to get the cached
-    /// maps and swap them into the resolver's active maps.
-    pub(super) fn ensure_module_maps_cached(&mut self, module_source: &ModuleSource) {
-        if self.module_type_maps_cache.contains_key(module_source) {
-            return;
-        }
-        let Some(module) = self.loaded_modules.get(module_source) else {
-            return;
-        };
-        let (imported_sources, import_names) = Self::build_imported_type_sources(
-            module,
-            module_source,
-            Some(&self.entry_module_source),
-            &self.invocations,
-        );
-        let maps = ModuleTypeMaps {
-            struct_fields: Self::build_module_map(
-                &self.all_struct_fields,
-                module_source,
-                &imported_sources,
-                &import_names,
-            ),
-            variant_cases: Self::build_module_map(
-                &self.all_variant_cases,
-                module_source,
-                &imported_sources,
-                &import_names,
-            ),
-            enum_cases: Self::build_module_map(
-                &self.all_enum_cases,
-                module_source,
-                &imported_sources,
-                &import_names,
-            ),
-            flags_cases: Self::build_module_map(
-                &self.all_flags_cases,
-                module_source,
-                &imported_sources,
-                &import_names,
-            ),
-            newtypes: Self::build_module_map(
-                &self.all_newtypes,
-                module_source,
-                &imported_sources,
-                &import_names,
-            ),
-            resource_types: Self::build_module_map(
-                &self.all_resource_types,
-                module_source,
-                &imported_sources,
-                &import_names,
-            ),
-        };
-        self.module_type_maps_cache
-            .insert(module_source.clone(), maps);
-    }
-
     /// Resolve an optional AST return type using the source module's type context.
     ///
-    /// Temporarily swaps the active type maps with those of `module_source` so that
-    /// same-named types from different modules are resolved correctly.
-    /// Requires `ensure_module_maps_cached(module_source)` to have been called first.
+    /// Temporarily swaps the resolver's "current module" perspective to
+    /// `module_source` so that same-named types from different modules are
+    /// resolved correctly. The shared `all_*` tables stay intact; only the
+    /// import context (and locals) is swapped.
     pub(super) fn resolve_return_type_in_module(
         &mut self,
         module_source: &ModuleSource,
         return_type: Option<&crate::ast::Type>,
     ) -> crate::tir::TypeId {
-        let mut cached = self
-            .module_type_maps_cache
-            .shift_remove(module_source)
-            .expect("cache populated by ensure_module_maps_cached");
-        std::mem::swap(&mut self.struct_fields, &mut cached.struct_fields);
-        std::mem::swap(&mut self.variant_cases, &mut cached.variant_cases);
-        std::mem::swap(&mut self.enum_cases, &mut cached.enum_cases);
-        std::mem::swap(&mut self.flags_cases, &mut cached.flags_cases);
-        std::mem::swap(&mut self.newtypes, &mut cached.newtypes);
-        std::mem::swap(&mut self.resource_types, &mut cached.resource_types);
-
-        let result = return_type
-            .map(|t| self.resolve_type(t))
-            .unwrap_or(crate::tir::TypeTable::UNIT);
-
-        std::mem::swap(&mut self.struct_fields, &mut cached.struct_fields);
-        std::mem::swap(&mut self.variant_cases, &mut cached.variant_cases);
-        std::mem::swap(&mut self.enum_cases, &mut cached.enum_cases);
-        std::mem::swap(&mut self.flags_cases, &mut cached.flags_cases);
-        std::mem::swap(&mut self.newtypes, &mut cached.newtypes);
-        std::mem::swap(&mut self.resource_types, &mut cached.resource_types);
-        self.module_type_maps_cache
-            .insert(module_source.clone(), cached);
-
-        result
+        let (imports, originals) = self
+            .loaded_modules
+            .get(module_source)
+            .map(|module| {
+                Self::build_imported_type_sources(
+                    module,
+                    module_source,
+                    Some(&self.entry_module_source),
+                    &self.invocations,
+                )
+            })
+            .unwrap_or_default();
+        self.with_module_perspective(module_source.clone(), imports, originals, |s| {
+            return_type
+                .map(|t| s.resolve_type(t))
+                .unwrap_or(crate::tir::TypeTable::UNIT)
+        })
     }
 
     /// Topologically sort modules based on struct field type dependencies.
@@ -2337,21 +2165,18 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         }
     }
 
-    /// Static version of `resolve_type` for use before the resolver is fully constructed
+    /// Static version of `resolve_type` for use before the resolver is fully
+    /// constructed. Reads type info via [`TypeLookup`] — the same path the
+    /// fully-constructed resolver uses, so name resolution stays in one place.
     pub(super) fn resolve_type_static(
         ty: &Type,
         type_table: &mut TypeTable,
-        newtypes: &IndexMap<String, TypeId>,
-        struct_fields: &IndexMap<String, StructFieldInfo>,
-        resource_types: &IndexMap<String, ResourceInfo>,
-        enum_cases: &IndexMap<String, EnumInfo>,
-        variant_cases: &IndexMap<String, VariantInfo>,
-        flags_cases: &IndexMap<String, FlagsInfo>,
+        lookup: &TypeLookup<'_>,
     ) -> TypeId {
         match ty {
             Type::Named(named) => {
                 // Check newtypes first
-                if let Some(&alias_type_id) = newtypes.get(&named.name) {
+                if let Some(alias_type_id) = lookup.newtype(&named.name) {
                     return alias_type_id;
                 }
 
@@ -2373,21 +2198,18 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     "()" => TypeTable::UNIT,
                     "!" => TypeTable::NEVER,
                     _ => {
-                        // Check if it's a struct type
                         // Use canonical name from info (not alias) for consistent TypeId interning
-                        if let Some(info) = struct_fields.get(&named.name) {
+                        if let Some(info) = lookup.struct_fields(&named.name) {
                             type_table.make_struct(info.name.clone(), info.module_source.clone())
-                        } else if let Some(info) = resource_types.get(&named.name) {
+                        } else if let Some(info) = lookup.resource_type(&named.name) {
                             type_table.make_resource(info.name.clone(), info.module_source.clone())
-                        } else if let Some(info) = variant_cases.get(&named.name) {
+                        } else if let Some(info) = lookup.variant_case(&named.name) {
                             type_table.make_variant(info.name.clone(), info.module_source.clone())
-                        } else if let Some(info) = enum_cases.get(&named.name) {
+                        } else if let Some(info) = lookup.enum_case(&named.name) {
                             type_table.make_enum(info.name.clone(), info.module_source.clone())
-                        } else if flags_cases.contains_key(&named.name) {
-                            // Flags are newtypes over u32, should be handled by newtypes check above.
-                            // This is a fallback in case the newtype wasn't registered yet.
-                            TypeTable::UNKNOWN
                         } else {
+                            // Flags are newtypes over u32 and should be picked up by the
+                            // newtype branch above; this catches unknown names too.
                             TypeTable::UNKNOWN
                         }
                     }
@@ -2395,41 +2217,21 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             }
             Type::Generic(generic) => match generic.name.as_str() {
                 "Option" if !generic.args.is_empty() => {
-                    let inner = Self::resolve_type_static(
-                        &generic.args[0],
-                        type_table,
-                        newtypes,
-                        struct_fields,
-                        resource_types,
-                        enum_cases,
-                        variant_cases,
-                        flags_cases,
-                    );
+                    let inner = Self::resolve_type_static(&generic.args[0], type_table, lookup);
                     type_table.make_option(inner)
                 }
                 _ => {
                     // Check if it's a generic struct type
-                    if let Some(info) = struct_fields.get(&generic.name) {
-                        // Resolve type arguments
+                    if let Some(info) = lookup.struct_fields(&generic.name) {
+                        let module_source = info.module_source.clone();
                         let type_args: Vec<TypeId> = generic
                             .args
                             .iter()
-                            .map(|arg| {
-                                Self::resolve_type_static(
-                                    arg,
-                                    type_table,
-                                    newtypes,
-                                    struct_fields,
-                                    resource_types,
-                                    enum_cases,
-                                    variant_cases,
-                                    flags_cases,
-                                )
-                            })
+                            .map(|arg| Self::resolve_type_static(arg, type_table, lookup))
                             .collect();
                         type_table.make_generic_instance(
                             generic.name.clone(),
-                            info.module_source.clone(),
+                            module_source,
                             type_args,
                         )
                     } else {
@@ -2438,29 +2240,11 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 }
             },
             Type::Reference(inner) => {
-                let inner_type = Self::resolve_type_static(
-                    inner,
-                    type_table,
-                    newtypes,
-                    struct_fields,
-                    resource_types,
-                    enum_cases,
-                    variant_cases,
-                    flags_cases,
-                );
+                let inner_type = Self::resolve_type_static(inner, type_table, lookup);
                 type_table.make_ref(inner_type)
             }
             Type::MutReference(inner) => {
-                let inner_type = Self::resolve_type_static(
-                    inner,
-                    type_table,
-                    newtypes,
-                    struct_fields,
-                    resource_types,
-                    enum_cases,
-                    variant_cases,
-                    flags_cases,
-                );
+                let inner_type = Self::resolve_type_static(inner, type_table, lookup);
                 type_table.make_mut_ref(inner_type)
             }
             Type::NamespacedGeneric(namespaced) => {
@@ -2469,16 +2253,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     && namespaced.name == "array"
                     && let Some(elem_ty) = namespaced.args.first()
                 {
-                    let elem = Self::resolve_type_static(
-                        elem_ty,
-                        type_table,
-                        newtypes,
-                        struct_fields,
-                        resource_types,
-                        enum_cases,
-                        variant_cases,
-                        flags_cases,
-                    );
+                    let elem = Self::resolve_type_static(elem_ty, type_table, lookup);
                     return type_table.make_builtin_array(elem);
                 }
                 TypeTable::UNKNOWN
@@ -2486,18 +2261,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             Type::Tuple(elements) => {
                 let elem_types: Vec<TypeId> = elements
                     .iter()
-                    .map(|e| {
-                        Self::resolve_type_static(
-                            e,
-                            type_table,
-                            newtypes,
-                            struct_fields,
-                            resource_types,
-                            enum_cases,
-                            variant_cases,
-                            flags_cases,
-                        )
-                    })
+                    .map(|e| Self::resolve_type_static(e, type_table, lookup))
                     .collect();
                 type_table.make_tuple(elem_types)
             }
@@ -2513,18 +2277,13 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
     pub(super) fn resolve_type_static_with_params(
         ty: &Type,
         type_table: &mut TypeTable,
-        newtypes: &IndexMap<String, TypeId>,
-        struct_fields: &IndexMap<String, StructFieldInfo>,
-        resource_types: &IndexMap<String, ResourceInfo>,
-        enum_cases: &IndexMap<String, EnumInfo>,
-        variant_cases: &IndexMap<String, VariantInfo>,
-        flags_cases: &IndexMap<String, FlagsInfo>,
+        lookup: &TypeLookup<'_>,
         type_params: &[String],
     ) -> TypeId {
         match ty {
             Type::Named(named) => {
                 // Check newtypes first
-                if let Some(&alias_type_id) = newtypes.get(&named.name) {
+                if let Some(alias_type_id) = lookup.newtype(&named.name) {
                     return alias_type_id;
                 }
 
@@ -2551,14 +2310,13 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     "()" => TypeTable::UNIT,
                     "!" => TypeTable::NEVER,
                     _ => {
-                        // Use canonical name from info (not alias) for consistent TypeId interning
-                        if let Some(info) = struct_fields.get(&named.name) {
+                        if let Some(info) = lookup.struct_fields(&named.name) {
                             type_table.make_struct(info.name.clone(), info.module_source.clone())
-                        } else if let Some(info) = resource_types.get(&named.name) {
+                        } else if let Some(info) = lookup.resource_type(&named.name) {
                             type_table.make_resource(info.name.clone(), info.module_source.clone())
-                        } else if let Some(info) = variant_cases.get(&named.name) {
+                        } else if let Some(info) = lookup.variant_case(&named.name) {
                             type_table.make_variant(info.name.clone(), info.module_source.clone())
-                        } else if let Some(info) = enum_cases.get(&named.name) {
+                        } else if let Some(info) = lookup.enum_case(&named.name) {
                             type_table.make_enum(info.name.clone(), info.module_source.clone())
                         } else {
                             TypeTable::UNKNOWN
@@ -2571,20 +2329,14 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     let inner = Self::resolve_type_static_with_params(
                         &generic.args[0],
                         type_table,
-                        newtypes,
-                        struct_fields,
-                        resource_types,
-                        enum_cases,
-                        variant_cases,
-                        flags_cases,
+                        lookup,
                         type_params,
                     );
                     type_table.make_option(inner)
                 }
                 _ => {
-                    // Check if it's a generic struct type
-                    if let Some(info) = struct_fields.get(&generic.name) {
-                        // Resolve type arguments
+                    if let Some(info) = lookup.struct_fields(&generic.name) {
+                        let module_source = info.module_source.clone();
                         let type_args: Vec<TypeId> = generic
                             .args
                             .iter()
@@ -2592,19 +2344,14 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                                 Self::resolve_type_static_with_params(
                                     arg,
                                     type_table,
-                                    newtypes,
-                                    struct_fields,
-                                    resource_types,
-                                    enum_cases,
-                                    variant_cases,
-                                    flags_cases,
+                                    lookup,
                                     type_params,
                                 )
                             })
                             .collect();
                         type_table.make_generic_instance(
                             generic.name.clone(),
-                            info.module_source.clone(),
+                            module_source,
                             type_args,
                         )
                     } else {
@@ -2613,31 +2360,13 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 }
             },
             Type::Reference(inner) => {
-                let inner_type = Self::resolve_type_static_with_params(
-                    inner,
-                    type_table,
-                    newtypes,
-                    struct_fields,
-                    resource_types,
-                    enum_cases,
-                    variant_cases,
-                    flags_cases,
-                    type_params,
-                );
+                let inner_type =
+                    Self::resolve_type_static_with_params(inner, type_table, lookup, type_params);
                 type_table.make_ref(inner_type)
             }
             Type::MutReference(inner) => {
-                let inner_type = Self::resolve_type_static_with_params(
-                    inner,
-                    type_table,
-                    newtypes,
-                    struct_fields,
-                    resource_types,
-                    enum_cases,
-                    variant_cases,
-                    flags_cases,
-                    type_params,
-                );
+                let inner_type =
+                    Self::resolve_type_static_with_params(inner, type_table, lookup, type_params);
                 type_table.make_mut_ref(inner_type)
             }
             Type::NamespacedGeneric(namespaced) => {
@@ -2649,12 +2378,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     let elem = Self::resolve_type_static_with_params(
                         elem_ty,
                         type_table,
-                        newtypes,
-                        struct_fields,
-                        resource_types,
-                        enum_cases,
-                        variant_cases,
-                        flags_cases,
+                        lookup,
                         type_params,
                     );
                     return type_table.make_builtin_array(elem);
@@ -2676,17 +2400,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 let elem_types: Vec<TypeId> = elements
                     .iter()
                     .map(|e| {
-                        Self::resolve_type_static_with_params(
-                            e,
-                            type_table,
-                            newtypes,
-                            struct_fields,
-                            resource_types,
-                            enum_cases,
-                            variant_cases,
-                            flags_cases,
-                            type_params,
-                        )
+                        Self::resolve_type_static_with_params(e, type_table, lookup, type_params)
                     })
                     .collect();
                 type_table.make_tuple(elem_types)
@@ -2696,28 +2410,13 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                     .params
                     .iter()
                     .map(|p| {
-                        Self::resolve_type_static_with_params(
-                            p,
-                            type_table,
-                            newtypes,
-                            struct_fields,
-                            resource_types,
-                            enum_cases,
-                            variant_cases,
-                            flags_cases,
-                            type_params,
-                        )
+                        Self::resolve_type_static_with_params(p, type_table, lookup, type_params)
                     })
                     .collect();
                 let return_type = Self::resolve_type_static_with_params(
                     &func_type.return_type,
                     type_table,
-                    newtypes,
-                    struct_fields,
-                    resource_types,
-                    enum_cases,
-                    variant_cases,
-                    flags_cases,
+                    lookup,
                     type_params,
                 );
                 type_table.intern(crate::tir::ResolvedType::Function {

--- a/wado-compiler/src/resolver/stmt.rs
+++ b/wado-compiler/src/resolver/stmt.rs
@@ -196,8 +196,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         let struct_type = target_type;
 
                         let struct_field_types: Vec<(String, TypeId)> = self
-                            .struct_fields
-                            .get(&name)
+                            .lookup_struct_fields(&name)
                             .map(|info| {
                                 info.fields
                                     .iter()
@@ -208,7 +207,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
                         // Check field visibility for cross-module struct literal
                         if module_source != self.current_module_source
-                            && let Some(struct_info) = self.struct_fields.get(&name)
+                            && let Some(struct_info) = self.lookup_struct_fields(&name)
                         {
                             for (fname, _, is_pub) in &struct_info.fields {
                                 if !is_pub && struct_lit.fields.iter().any(|f| f.name == *fname) {
@@ -562,16 +561,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let resolved = self.type_table.borrow().get(type_id).clone();
         match &resolved {
             ResolvedType::Enum { name, .. } => self
-                .enum_cases
-                .get(name)
+                .lookup_enum_case(name)
                 .is_some_and(|info| info.cases.iter().any(|c| c.name == case_name)),
             ResolvedType::Variant { name, .. } => self
-                .variant_cases
-                .get(name)
+                .lookup_variant_case(name)
                 .is_some_and(|info| info.cases.iter().any(|c| c.name == case_name)),
             ResolvedType::GenericInstance { name, .. } => self
-                .variant_cases
-                .get(name)
+                .lookup_variant_case(name)
                 .is_some_and(|info| info.cases.iter().any(|c| c.name == case_name)),
             _ => false,
         }
@@ -769,7 +765,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 // Exhaustiveness check: without `..`, all fields must be listed
                 if !has_rest
                     && let Some(ref sname) = struct_name
-                    && let Some(struct_info) = self.struct_fields.get(sname)
+                    && let Some(struct_info) = self.lookup_struct_fields(sname)
                 {
                     let total_fields = struct_info.fields.len();
                     if fields.len() != total_fields {
@@ -1348,7 +1344,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         });
                     }
                     // Look up the enum case index
-                    if let Some(enum_info) = self.enum_cases.get(name).cloned() {
+                    if let Some(enum_info) = self.lookup_enum_case(name).cloned() {
                         if let Some(case_data) = enum_info.find_case(variant_name).cloned() {
                             // Record pattern's case-name identifier -> enum case decl
                             if let Some(id) = name_id {
@@ -1393,16 +1389,14 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 // span so LSP jump-to-def from the pattern lands on the case decl.
                 let variant_type_name: Option<String> = match &resolved_type {
                     ResolvedType::Variant { name, .. } => Some(name.clone()),
-                    ResolvedType::GenericInstance { name, .. }
-                        if self.variant_cases.contains_key(name) =>
-                    {
+                    ResolvedType::GenericInstance { name, .. } if self.contains_variant(name) => {
                         Some(name.clone())
                     }
                     _ => None,
                 };
                 if let Some(id) = name_id
                     && let Some(type_name) = variant_type_name.as_ref()
-                    && let Some(variant_info) = self.variant_cases.get(type_name).cloned()
+                    && let Some(variant_info) = self.lookup_variant_case(type_name).cloned()
                     && let Some(case_data) = variant_info
                         .cases
                         .iter()
@@ -1429,7 +1423,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         name, type_args, ..
                     } => {
                         // Check if this is a variant (not a struct)
-                        if self.variant_cases.contains_key(name) {
+                        if self.contains_variant(name) {
                             self.get_variant_case_payload_type(name, variant_name, type_args, *span)
                         } else {
                             let _ = self.logger.error(TypeError::PatternTypeMismatch {
@@ -1536,7 +1530,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         }
                     };
                     if let Some(ref sname) = struct_name
-                        && let Some(struct_info) = self.struct_fields.get(sname)
+                        && let Some(struct_info) = self.lookup_struct_fields(sname)
                     {
                         let total_fields = struct_info.fields.len();
                         if fields.len() != total_fields {
@@ -1676,12 +1670,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let resolved = self.type_table.borrow().get(scrutinee_type).clone();
         let variant_name = match &resolved {
             ResolvedType::Variant { name, .. } => Some(name.clone()),
-            ResolvedType::GenericInstance { name, .. } if self.variant_cases.contains_key(name) => {
+            ResolvedType::GenericInstance { name, .. } if self.contains_variant(name) => {
                 Some(name.clone())
             }
             _ => None,
         }?;
-        let variant_info = self.variant_cases.get(&variant_name)?;
+        let variant_info = self.lookup_variant_case(&variant_name)?;
         if variant_info.cases.iter().any(|c| c.name == "None") {
             Some(TirPattern::Variant {
                 enum_type: scrutinee_type,
@@ -1805,7 +1799,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         span: Span,
     ) -> TypeId {
         // Clone payload first to avoid borrow conflict with substitute_type_params
-        let payload_opt = self.variant_cases.get(variant_name).and_then(|info| {
+        let payload_opt = self.lookup_variant_case(variant_name).and_then(|info| {
             info.cases
                 .iter()
                 .find(|case| case.name == case_name)
@@ -1818,7 +1812,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         }
 
         // Check if variant exists but case not found
-        if self.variant_cases.contains_key(variant_name) {
+        if self.contains_variant(variant_name) {
             let _ = self.logger.error(TypeError::PatternTypeMismatch {
                 expected: format!("valid case of variant {variant_name}"),
                 found: case_name.to_string(),

--- a/wado-compiler/src/resolver/trait_query.rs
+++ b/wado-compiler/src/resolver/trait_query.rs
@@ -123,7 +123,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // Variants auto-implement Eq when all payload types implement Eq
         if let ResolvedType::Variant { name, .. } = &resolved
             && trait_name == "Eq"
-            && let Some(info) = self.variant_cases.get(name)
+            && let Some(info) = self.lookup_variant_case(name)
         {
             let all_impl = info.cases.iter().all(|c| {
                 c.payload == TypeTable::UNIT || self.type_implements_trait(c.payload, trait_name)
@@ -136,7 +136,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // Structs auto-implement Eq/Ord when all fields implement the trait
         if let ResolvedType::Struct { name, .. } = &resolved
             && matches!(trait_name, "Eq" | "Ord")
-            && let Some(info) = self.struct_fields.get(name)
+            && let Some(info) = self.lookup_struct_fields(name)
         {
             let field_types: Vec<TypeId> = info.fields.iter().map(|(_, tid, _)| *tid).collect();
             let all_impl = field_types
@@ -164,7 +164,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             name, type_args, ..
         } = &resolved
             && matches!(trait_name, "Eq" | "Ord")
-            && let Some(info) = self.struct_fields.get(name)
+            && let Some(info) = self.lookup_struct_fields(name)
         {
             // Build type param -> concrete type arg mapping
             let param_map: IndexMap<TypeId, TypeId> = info
@@ -188,7 +188,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             name, type_args, ..
         } = &resolved
             && trait_name == "Eq"
-            && let Some(info) = self.variant_cases.get(name)
+            && let Some(info) = self.lookup_variant_case(name)
         {
             let param_map: IndexMap<TypeId, TypeId> = info
                 .type_param_type_ids

--- a/wado-compiler/src/resolver/type_resolution.rs
+++ b/wado-compiler/src/resolver/type_resolution.rs
@@ -254,27 +254,27 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
             // Check newtypes, struct definitions, and variants
             _ => {
-                if let Some(&type_id) = self.newtypes.get(name) {
+                if let Some(type_id) = self.lookup_newtype(name) {
                     type_id
-                } else if let Some(struct_info) = self.struct_fields.get(name) {
+                } else if let Some(struct_info) = self.lookup_struct_fields(name) {
                     // Use canonical name (not import alias) so interning produces the same TypeId
-                    self.type_table
-                        .borrow_mut()
-                        .make_struct(struct_info.name.clone(), struct_info.module_source.clone())
-                } else if let Some(variant_info) = self.variant_cases.get(name) {
-                    self.type_table.borrow_mut().make_variant(
+                    let (n, src) = (struct_info.name.clone(), struct_info.module_source.clone());
+                    self.type_table.borrow_mut().make_struct(n, src)
+                } else if let Some(variant_info) = self.lookup_variant_case(name) {
+                    let (n, src) = (
                         variant_info.name.clone(),
                         variant_info.module_source.clone(),
-                    )
-                } else if let Some(enum_info) = self.enum_cases.get(name) {
-                    self.type_table
-                        .borrow_mut()
-                        .make_enum(enum_info.name.clone(), enum_info.module_source.clone())
-                } else if let Some(resource_info) = self.resource_types.get(name) {
-                    self.type_table.borrow_mut().make_resource(
+                    );
+                    self.type_table.borrow_mut().make_variant(n, src)
+                } else if let Some(enum_info) = self.lookup_enum_case(name) {
+                    let (n, src) = (enum_info.name.clone(), enum_info.module_source.clone());
+                    self.type_table.borrow_mut().make_enum(n, src)
+                } else if let Some(resource_info) = self.lookup_resource_type(name) {
+                    let (n, src) = (
                         resource_info.name.clone(),
                         resource_info.module_source.clone(),
-                    )
+                    );
+                    self.type_table.borrow_mut().make_resource(n, src)
                 } else {
                     // Unknown type
                     TypeTable::UNKNOWN
@@ -347,7 +347,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         args.iter().map(|t| self.resolve_type(t)).collect();
 
                     // Get struct info for module source and bounds checking
-                    let struct_info = self.struct_fields.get(name).cloned();
+                    let struct_info = self.lookup_struct_fields(name).cloned();
                     let module_source = struct_info
                         .as_ref()
                         .map(|info| info.module_source.clone())
@@ -380,7 +380,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         module_source,
                         type_args,
                     )
-                } else if let Some(variant_info) = self.variant_cases.get(name).cloned() {
+                } else if let Some(variant_info) = self.lookup_variant_case(name).cloned() {
                     // Check if it's a generic variant (like Result<T, E>)
                     if variant_info.type_params.is_empty() {
                         TypeTable::UNKNOWN
@@ -393,7 +393,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             type_args,
                         )
                     }
-                } else if let Some(gn_info) = self.generic_newtype_defs.get(name).cloned() {
+                } else if let Some(gn_info) = self.lookup_generic_newtype(name).cloned() {
                     // Generic newtype instantiation: type MyArray<T> = Array<T>
                     // Substitute type params in the base type AST, then resolve
                     let concrete_base_ast =

--- a/wado-compiler/src/resolver/types.rs
+++ b/wado-compiler/src/resolver/types.rs
@@ -1270,15 +1270,120 @@ pub(super) struct TraitMethodMatch {
     pub(super) is_blanket_ref_impl: bool,
 }
 
-/// Cached per-module type maps for cross-module type resolution.
-/// These are the flat maps that `build_module_map` produces.
-pub(super) struct ModuleTypeMaps {
-    pub(super) struct_fields: IndexMap<String, StructFieldInfo>,
-    pub(super) variant_cases: IndexMap<String, VariantInfo>,
-    pub(super) enum_cases: IndexMap<String, EnumInfo>,
-    pub(super) flags_cases: IndexMap<String, FlagsInfo>,
-    pub(super) newtypes: IndexMap<String, TypeId>,
-    pub(super) resource_types: IndexMap<String, ResourceInfo>,
+/// Read-only view that resolves a type name from a given module's perspective
+/// without cloning per-module flat maps.
+///
+/// Three-layer precedence (highest first):
+///   1. Local additions discovered during resolution (anonymous structs, in-progress
+///      newtypes/enums declared in the current module's body).
+///   2. The current module's own definitions.
+///   3. Imports of the current module (with `use { Foo as Bar }` aliasing).
+///   4. Any module that defines the name (legacy fallback for prelude-style visibility).
+///
+/// Constructed cheaply at each call site from the `Resolver`'s context. All
+/// fields are borrowed; no heap allocation.
+pub(crate) struct TypeLookup<'a> {
+    pub(crate) current_module_source: &'a ModuleSource,
+    pub(crate) imported_type_sources: &'a IndexMap<String, ModuleSource>,
+    pub(crate) import_original_names: &'a IndexMap<String, String>,
+    pub(crate) all_newtypes: &'a IndexMap<ModuleSource, IndexMap<String, TypeId>>,
+    pub(crate) all_struct_fields: &'a IndexMap<ModuleSource, IndexMap<String, StructFieldInfo>>,
+    pub(crate) all_variant_cases: &'a IndexMap<ModuleSource, IndexMap<String, VariantInfo>>,
+    pub(crate) all_enum_cases: &'a IndexMap<ModuleSource, IndexMap<String, EnumInfo>>,
+    pub(crate) all_flags_cases: &'a IndexMap<ModuleSource, IndexMap<String, FlagsInfo>>,
+    pub(crate) all_resource_types: &'a IndexMap<ModuleSource, IndexMap<String, ResourceInfo>>,
+    pub(crate) all_generic_newtypes:
+        &'a IndexMap<ModuleSource, IndexMap<String, GenericNewtypeInfo>>,
+    pub(crate) local_struct_fields: &'a IndexMap<String, StructFieldInfo>,
+    pub(crate) local_newtypes: &'a IndexMap<String, TypeId>,
+    pub(crate) local_enum_cases: &'a IndexMap<String, EnumInfo>,
+    pub(crate) local_flags_cases: &'a IndexMap<String, FlagsInfo>,
+    pub(crate) local_generic_newtypes: &'a IndexMap<String, GenericNewtypeInfo>,
+    pub(crate) local_variant_cases: &'a IndexMap<String, VariantInfo>,
+}
+
+impl<'a> TypeLookup<'a> {
+    /// Resolve `name` against `all_per_module` using the (local → current →
+    /// imports → any) precedence. Borrows have lifetime `'a`, so the caller
+    /// can keep the returned reference alive across `&self` re-borrows.
+    fn lookup_ref<V>(
+        &self,
+        name: &str,
+        local: Option<&'a IndexMap<String, V>>,
+        all_per_module: &'a IndexMap<ModuleSource, IndexMap<String, V>>,
+    ) -> Option<&'a V> {
+        if let Some(local) = local
+            && let Some(v) = local.get(name)
+        {
+            return Some(v);
+        }
+        if let Some(v) = all_per_module
+            .get(self.current_module_source)
+            .and_then(|m| m.get(name))
+        {
+            return Some(v);
+        }
+        if let Some(src) = self.imported_type_sources.get(name) {
+            let canonical = self
+                .import_original_names
+                .get(name)
+                .map(String::as_str)
+                .unwrap_or(name);
+            if let Some(v) = all_per_module.get(src).and_then(|m| m.get(canonical)) {
+                return Some(v);
+            }
+            if let ModuleSource::Wasi { interface } = src {
+                let prefix = format!("{interface}/");
+                for (s, m) in all_per_module {
+                    if let ModuleSource::Wasi { interface: sub } = s
+                        && sub.starts_with(&prefix)
+                        && let Some(v) = m.get(canonical)
+                    {
+                        return Some(v);
+                    }
+                }
+            }
+        }
+        for m in all_per_module.values() {
+            if let Some(v) = m.get(name) {
+                return Some(v);
+            }
+        }
+        None
+    }
+
+    pub(super) fn struct_fields(&self, name: &str) -> Option<&'a StructFieldInfo> {
+        self.lookup_ref(name, Some(self.local_struct_fields), self.all_struct_fields)
+    }
+
+    pub(super) fn variant_case(&self, name: &str) -> Option<&'a VariantInfo> {
+        self.lookup_ref(name, Some(self.local_variant_cases), self.all_variant_cases)
+    }
+
+    pub(super) fn enum_case(&self, name: &str) -> Option<&'a EnumInfo> {
+        self.lookup_ref(name, Some(self.local_enum_cases), self.all_enum_cases)
+    }
+
+    pub(super) fn flags_case(&self, name: &str) -> Option<&'a FlagsInfo> {
+        self.lookup_ref(name, Some(self.local_flags_cases), self.all_flags_cases)
+    }
+
+    pub(super) fn resource_type(&self, name: &str) -> Option<&'a ResourceInfo> {
+        self.lookup_ref(name, None, self.all_resource_types)
+    }
+
+    pub(super) fn generic_newtype(&self, name: &str) -> Option<&'a GenericNewtypeInfo> {
+        self.lookup_ref(
+            name,
+            Some(self.local_generic_newtypes),
+            self.all_generic_newtypes,
+        )
+    }
+
+    pub(super) fn newtype(&self, name: &str) -> Option<TypeId> {
+        self.lookup_ref(name, Some(self.local_newtypes), self.all_newtypes)
+            .copied()
+    }
 }
 
 /// Info about an Index trait implementation


### PR DESCRIPTION
## Summary

The resolver used to build seven per-module flat `IndexMap`s
(`struct_fields`, `variant_cases`, `enum_cases`, `flags_cases`, `newtypes`,
`generic_newtype_defs`, `resource_types`) by deep-cloning every entry from
the shared `all_*` tables on every module enter, plus a lazy
`module_type_maps_cache` that did the same on demand. For a project with
N modules this cloned ~N×N entries of heavy values (`StructFieldInfo`
carries a `Vec<Option<ast::Expr>>` of field defaults), and dominated the
resolve phase.

The information was redundant: the canonical value already lives exactly
once in `all_*: Rc<IndexMap<ModuleSource, IndexMap<String, V>>>`, and
"what does name `X` mean in module `M`" is fully determined by
`current_module_source` plus the import context that
`build_imported_type_sources` already produces (and used to discard
after building the flat maps).

This PR introduces a `TypeLookup<'a>` view that performs name resolution
directly against `all_*` using the four-layer precedence
(local additions → current module → imports → any-module fallback), and
replaces every `self.X.get(name)` with a `self.lookup_X(name)` method on
the resolver. Mutations during resolve (anonymous structs from struct
literals, in-progress newtypes/enums) go to small `local_*` maps.
`with_module_perspective` swaps three small fields instead of cloning
six big maps to resolve a callee's signature in its own module's
perspective.

**Deleted:**
- `build_module_map`
- `ensure_module_maps_cached`
- `module_type_maps_cache`
- `ModuleTypeMaps`
- 7 owned flat-map fields on `Resolver`

Net diff: **+589 / −818** (−229 lines).

## Performance

`benchmark/syntax_highlight` (release build, `-O2`, warm caches, median of 3 runs):

|         | before  | after   | Δ          |
|---------|--------:|--------:|-----------:|
| compile | 4.04 s  | 2.91 s  | **−28 %**  |

`samply` confirms `build_module_map`, `StructFieldInfo::clone`, and
`<IndexMap as Clone>::clone` have all dropped out of the top inclusive
samples; `libc` malloc/free time falls from ~38 % to ~26 % of total.

## Test plan

- [x] `cargo test -p wado-compiler --lib` — 438 passed
- [x] `cargo test -p wado-compiler --test e2e` — 5690 passed
- [x] `mise run test-wado` — 193 packages compiled, 1657 tests passed, 5 expected `#[TODO]` pending
- [x] `cargo build --release --bin wado` succeeds
- [x] Re-profiled with `samply` to confirm the hot clones are gone

https://claude.ai/code/session_016oRQKJtrNkMQQ5SXcd697r

---
_Generated by [Claude Code](https://claude.ai/code/session_016oRQKJtrNkMQQ5SXcd697r)_