### PR TITLE
fix(lsp): clean diagnostics when opening bundled stdlib files

### DIFF
--- a/docs/stdlib-core-prelude.md
+++ b/docs/stdlib-core-prelude.md
@@ -5,6 +5,10 @@
 
 Auto-imported in every module. Disable with `#![no_prelude]`.
 
+`core:prelude` _is_ the prelude — it cannot auto-import itself, and
+the names it re-exports (Option, Result, Eq, Array, …) must not
+collide with "prelude" because they are the prelude. Mark accordingly.
+
 ## Functions
 
 ### `pub fn panic(message: String) -> !`

--- a/docs/stdlib-core-prelude.md
+++ b/docs/stdlib-core-prelude.md
@@ -5,10 +5,6 @@
 
 Auto-imported in every module. Disable with `#![no_prelude]`.
 
-`core:prelude` _is_ the prelude — it cannot auto-import itself, and
-the names it re-exports (Option, Result, Eq, Array, …) must not
-collide with "prelude" because they are the prelude. Mark accordingly.
-
 ## Functions
 
 ### `pub fn panic(message: String) -> !`

--- a/docs/stdlib-core-simd.md
+++ b/docs/stdlib-core-simd.md
@@ -10,11 +10,11 @@ All types are newtypes of the primitive `v128` and can be freely reinterpreted v
 
 ## Types
 
-| Category         | Types                              |
-| ---------------- | ---------------------------------- |
-| Signed integer   | `i8x16`, `i16x8`, `i32x4`, `i64x2` |
+| Category | Types |
+|----------|-------|
+| Signed integer | `i8x16`, `i16x8`, `i32x4`, `i64x2` |
 | Unsigned integer | `u8x16`, `u16x8`, `u32x4`, `u64x2` |
-| Floating-point   | `f32x4`, `f64x2`                   |
+| Floating-point | `f32x4`, `f64x2` |
 
 ## Construction
 

--- a/docs/stdlib-core-simd.md
+++ b/docs/stdlib-core-simd.md
@@ -10,11 +10,11 @@ All types are newtypes of the primitive `v128` and can be freely reinterpreted v
 
 ## Types
 
-| Category | Types |
-|----------|-------|
-| Signed integer | `i8x16`, `i16x8`, `i32x4`, `i64x2` |
+| Category         | Types                              |
+| ---------------- | ---------------------------------- |
+| Signed integer   | `i8x16`, `i16x8`, `i32x4`, `i64x2` |
 | Unsigned integer | `u8x16`, `u16x8`, `u32x4`, `u64x2` |
-| Floating-point | `f32x4`, `f64x2` |
+| Floating-point   | `f32x4`, `f64x2`                   |
 
 ## Construction
 

--- a/wado-compiler/lib/core/allocator.wado
+++ b/wado-compiler/lib/core/allocator.wado
@@ -1,5 +1,6 @@
 #![wasm_module("mem")]
 #![no_prelude]
+#![stdlib("core:allocator")]
 
 /// This module defines the linear memory allocator for the Component Model.
 /// All items here are compiled into a separate Wasm core module named "mem".

--- a/wado-compiler/lib/core/base64.wado
+++ b/wado-compiler/lib/core/base64.wado
@@ -14,6 +14,7 @@
 //   let b64 = encode(&data);           // "SGVsbG8="
 //   let url = encode_url(&data);       // "SGVsbG8"
 //   if let Some(decoded) = decode(b64) { ... }
+#![stdlib("core:base64")]
 
 pub flags Encoding {
     UrlSafe,

--- a/wado-compiler/lib/core/benchmark.wado
+++ b/wado-compiler/lib/core/benchmark.wado
@@ -24,6 +24,7 @@
 //! let compressed = b.run("compress", || zlib_compress(&data));
 //! let _ = b.run("decompress", || inflate_zlib(&compressed).unwrap());
 //! ```
+#![stdlib("core:benchmark")]
 
 use { println, Stdout } from "core:cli";
 use { MonotonicClock } from "wasi:clocks";

--- a/wado-compiler/lib/core/builtin.wado
+++ b/wado-compiler/lib/core/builtin.wado
@@ -9,6 +9,10 @@
 //
 // Functions with #[canonical("namespace", "name")] are imported as CM canonical built-ins.
 // Functions without #[canonical(...)] compile to Wasm instructions directly.
+//
+// Part of the language processing system, not user code — opt out of the
+// prelude auto-import.
+#![no_prelude]
 
 // libm functions live in `core:libm` and are imported through
 // `pub use { libm_X as f64_X, ... } from "./libm.wat" with { type: "wat" };`.

--- a/wado-compiler/lib/core/builtin.wado
+++ b/wado-compiler/lib/core/builtin.wado
@@ -9,9 +9,6 @@
 //
 // Functions with #[canonical("namespace", "name")] are imported as CM canonical built-ins.
 // Functions without #[canonical(...)] compile to Wasm instructions directly.
-//
-// Part of the language processing system, not user code — opt out of the
-// prelude auto-import.
 #![no_prelude]
 #![stdlib("core:builtin")]
 

--- a/wado-compiler/lib/core/builtin.wado
+++ b/wado-compiler/lib/core/builtin.wado
@@ -13,6 +13,7 @@
 // Part of the language processing system, not user code — opt out of the
 // prelude auto-import.
 #![no_prelude]
+#![stdlib("core:builtin")]
 
 // libm functions live in `core:libm` and are imported through
 // `pub use { libm_X as f64_X, ... } from "./libm.wat" with { type: "wat" };`.

--- a/wado-compiler/lib/core/cli.wado
+++ b/wado-compiler/lib/core/cli.wado
@@ -12,6 +12,7 @@
 // 3. Write data to tx via StreamWritable::write()
 // 4. Drop tx via StreamWritable::drop()
 // 5. Cast handle to Future and drop to signal completion
+#![stdlib("core:cli")]
 
 use { Stdout, Stderr, Environment, Exit } from "wasi:cli";
 // Re-export commonly used effects for convenience

--- a/wado-compiler/lib/core/collections.wado
+++ b/wado-compiler/lib/core/collections.wado
@@ -1,4 +1,5 @@
 //! Collection types: `TreeMap<K, V>` and `TreeSet<T>` (insertion-order preserved).
+#![stdlib("core:collections")]
 
 use {
     Serialize,

--- a/wado-compiler/lib/core/internal.wado
+++ b/wado-compiler/lib/core/internal.wado
@@ -4,6 +4,10 @@
 // operations like template string interpolation. These functions are
 // implemented in Wado itself rather than as inline Wasm instructions,
 // making the codegen simpler and the compiler more maintainable.
+//
+// Part of the language processing system, not user code — opt out of the
+// prelude auto-import.
+#![no_prelude]
 
 /// Copies bytes from linear memory to a new GC array.
 pub fn memory_to_gc_array(ptr: i32, len: i32) -> builtin::array<u8> {

--- a/wado-compiler/lib/core/internal.wado
+++ b/wado-compiler/lib/core/internal.wado
@@ -4,9 +4,6 @@
 // operations like template string interpolation. These functions are
 // implemented in Wado itself rather than as inline Wasm instructions,
 // making the codegen simpler and the compiler more maintainable.
-//
-// Part of the language processing system, not user code — opt out of the
-// prelude auto-import.
 #![no_prelude]
 #![stdlib("core:internal")]
 

--- a/wado-compiler/lib/core/internal.wado
+++ b/wado-compiler/lib/core/internal.wado
@@ -8,6 +8,7 @@
 // Part of the language processing system, not user code — opt out of the
 // prelude auto-import.
 #![no_prelude]
+#![stdlib("core:internal")]
 
 /// Copies bytes from linear memory to a new GC array.
 pub fn memory_to_gc_array(ptr: i32, len: i32) -> builtin::array<u8> {

--- a/wado-compiler/lib/core/json.wado
+++ b/wado-compiler/lib/core/json.wado
@@ -7,6 +7,7 @@
 //!
 //!   let json = to_string::<i32>(&42);            // "42"
 //!   let val = from_string::<i32>("42");           // Result::Ok(42)
+#![stdlib("core:json")]
 
 use {
     Serialize,

--- a/wado-compiler/lib/core/json_nsd.wado
+++ b/wado-compiler/lib/core/json_nsd.wado
@@ -13,6 +13,7 @@
 //!
 //!   let json = to_string(&Point { x: 1, y: 2 });  // "[1,2]"
 //!   let val: Result<Point, DeserializeError> = from_string("[1,2]");  // Ok(Point { x: 1, y: 2 })
+#![stdlib("core:json_nsd")]
 
 use {
     Serialize,

--- a/wado-compiler/lib/core/json_value.wado
+++ b/wado-compiler/lib/core/json_value.wado
@@ -10,6 +10,7 @@
 //!
 //!   let v = from_string::<Value>(`{"x": 1, "y": [true, null]}`);
 //!   let s = to_string::<Value>(&v);
+#![stdlib("core:json_value")]
 
 use {
     Serialize,

--- a/wado-compiler/lib/core/kiln.wado
+++ b/wado-compiler/lib/core/kiln.wado
@@ -7,6 +7,7 @@
 //! against.
 //!
 //! See WEP 2026-04-12 (Kiln) §"The `kiln` world" and §"M6.5 stage 2".
+#![stdlib("core:kiln")]
 
 use { from_string } from "core:json";
 use { Deserialize } from "core:serde";

--- a/wado-compiler/lib/core/kiln/kiln_host.wado
+++ b/wado-compiler/lib/core/kiln/kiln_host.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["wado-compiler/lib/core/kiln/generator.wit"])]
+#![stdlib("core:kiln/kiln_host.wado")]
 
 #[cm("core:kiln/kiln-host@0.1.0#host-error")]
 pub variant HostError {

--- a/wado-compiler/lib/core/kiln/types.wado
+++ b/wado-compiler/lib/core/kiln/types.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["wado-compiler/lib/core/kiln/generator.wit"])]
+#![stdlib("core:kiln/types.wado")]
 
 /// One schema file the compiler has pre-loaded for the generator.
 /// The file is always supplied by value so that the initial input

--- a/wado-compiler/lib/core/kiln/worlds.wado
+++ b/wado-compiler/lib/core/kiln/worlds.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["wado-compiler/lib/core/kiln/generator.wit"])]
+#![stdlib("core:kiln/worlds.wado")]
 
 #[cm("core:kiln/generator@0.1.0")]
 pub world Generator {

--- a/wado-compiler/lib/core/prelude.wado
+++ b/wado-compiler/lib/core/prelude.wado
@@ -1,8 +1,4 @@
 //! Auto-imported in every module. Disable with `#![no_prelude]`.
-//!
-//! `core:prelude` *is* the prelude — it cannot auto-import itself, and
-//! the names it re-exports (Option, Result, Eq, Array, …) must not
-//! collide with "prelude" because they are the prelude. Mark accordingly.
 #![no_prelude]
 #![stdlib("core:prelude")]
 

--- a/wado-compiler/lib/core/prelude.wado
+++ b/wado-compiler/lib/core/prelude.wado
@@ -1,4 +1,9 @@
 //! Auto-imported in every module. Disable with `#![no_prelude]`.
+//!
+//! `core:prelude` *is* the prelude — it cannot auto-import itself, and
+//! the names it re-exports (Option, Result, Eq, Array, …) must not
+//! collide with "prelude" because they are the prelude. Mark accordingly.
+#![no_prelude]
 
 // The Wado Prelude Module.
 // Auto-imported in every module. Disable with: #![no_prelude]

--- a/wado-compiler/lib/core/prelude.wado
+++ b/wado-compiler/lib/core/prelude.wado
@@ -4,6 +4,7 @@
 //! the names it re-exports (Option, Result, Eq, Array, …) must not
 //! collide with "prelude" because they are the prelude. Mark accordingly.
 #![no_prelude]
+#![stdlib("core:prelude")]
 
 // The Wado Prelude Module.
 // Auto-imported in every module. Disable with: #![no_prelude]

--- a/wado-compiler/lib/core/prelude/array.wado
+++ b/wado-compiler/lib/core/prelude/array.wado
@@ -1,4 +1,5 @@
 #![no_prelude]
+#![stdlib("core:prelude/array.wado")]
 // Array type and iterators for Wado.
 // Provides Array<T>, ArrayIter<T>, and iterator combinators.
 

--- a/wado-compiler/lib/core/prelude/format.wado
+++ b/wado-compiler/lib/core/prelude/format.wado
@@ -1,4 +1,5 @@
 #![no_prelude]
+#![stdlib("core:prelude/format.wado")]
 // Format Infrastructure
 //
 // This module defines the Formatter and Alignment types that

--- a/wado-compiler/lib/core/prelude/fpfmt.wado
+++ b/wado-compiler/lib/core/prelude/fpfmt.wado
@@ -1,4 +1,5 @@
 #![no_prelude]
+#![stdlib("core:prelude/fpfmt.wado")]
 // Float-to-String conversion using Russ Cox's unrounded scaling algorithm
 // Ported from rsc.io/fpfmt (https://research.swtch.com/fp)
 //

--- a/wado-compiler/lib/core/prelude/int128.wado
+++ b/wado-compiler/lib/core/prelude/int128.wado
@@ -1,6 +1,7 @@
 // 128-bit Integer Types
 // Implemented as structs wrapping two 64-bit values, using Wasm Wide Arithmetic instructions.
 #![no_prelude]
+#![stdlib("core:prelude/int128.wado")]
 
 use {
     IntErrorKind,

--- a/wado-compiler/lib/core/prelude/int128.wado
+++ b/wado-compiler/lib/core/prelude/int128.wado
@@ -1,5 +1,6 @@
 // 128-bit Integer Types
 // Implemented as structs wrapping two 64-bit values, using Wasm Wide Arithmetic instructions.
+#![no_prelude]
 
 use {
     IntErrorKind,

--- a/wado-compiler/lib/core/prelude/intparse.wado
+++ b/wado-compiler/lib/core/prelude/intparse.wado
@@ -5,6 +5,7 @@
 // `from_str_hex` methods on primitive numeric types (see `primitive.wado`
 // and `int128.wado`).
 #![no_prelude]
+#![stdlib("core:prelude/intparse.wado")]
 
 use { parse_text } from "core:prelude/fpfmt.wado";
 

--- a/wado-compiler/lib/core/prelude/intparse.wado
+++ b/wado-compiler/lib/core/prelude/intparse.wado
@@ -4,6 +4,7 @@
 // core digit-parsing routines used by the `from_str_radix`, `from_str`, and
 // `from_str_hex` methods on primitive numeric types (see `primitive.wado`
 // and `int128.wado`).
+#![no_prelude]
 
 use { parse_text } from "core:prelude/fpfmt.wado";
 

--- a/wado-compiler/lib/core/prelude/primitive.wado
+++ b/wado-compiler/lib/core/prelude/primitive.wado
@@ -6,6 +6,7 @@
 // This module intentionally does NOT depend on core:internal to keep the
 // dependency structure simple.
 #![no_prelude]
+#![stdlib("core:prelude/primitive.wado")]
 
 use {
     check_special,

--- a/wado-compiler/lib/core/prelude/primitive.wado
+++ b/wado-compiler/lib/core/prelude/primitive.wado
@@ -5,6 +5,7 @@
 //
 // This module intentionally does NOT depend on core:internal to keep the
 // dependency structure simple.
+#![no_prelude]
 
 use {
     check_special,

--- a/wado-compiler/lib/core/prelude/range.wado
+++ b/wado-compiler/lib/core/prelude/range.wado
@@ -1,4 +1,5 @@
 #![no_prelude]
+#![stdlib("core:prelude/range.wado")]
 // Range types for the Wado Prelude.
 
 use { Option } from "core:prelude/types.wado";

--- a/wado-compiler/lib/core/prelude/string.wado
+++ b/wado-compiler/lib/core/prelude/string.wado
@@ -1,4 +1,5 @@
 #![no_prelude]
+#![stdlib("core:prelude/string.wado")]
 // String Type Module
 // Separated from prelude to allow other stdlib modules to depend on String
 // without creating circular dependencies.

--- a/wado-compiler/lib/core/prelude/traits.wado
+++ b/wado-compiler/lib/core/prelude/traits.wado
@@ -1,5 +1,7 @@
 // Prelude Traits
 // This module defines all traits that are automatically available in every Wado module.
+#![no_prelude]
+
 /// Result of a comparison between two values.
 pub enum Ordering {
     /// The first value is less than the second.

--- a/wado-compiler/lib/core/prelude/traits.wado
+++ b/wado-compiler/lib/core/prelude/traits.wado
@@ -1,6 +1,7 @@
 // Prelude Traits
 // This module defines all traits that are automatically available in every Wado module.
 #![no_prelude]
+#![stdlib("core:prelude/traits.wado")]
 
 /// Result of a comparison between two values.
 pub enum Ordering {

--- a/wado-compiler/lib/core/prelude/tuple.wado
+++ b/wado-compiler/lib/core/prelude/tuple.wado
@@ -2,6 +2,7 @@
 //
 // These implementations use compile-time tuple enumeration (for let v of *self)
 // which is expanded at monomorphization time.
+#![no_prelude]
 
 use { Formatter } from "core:prelude/format.wado";
 

--- a/wado-compiler/lib/core/prelude/tuple.wado
+++ b/wado-compiler/lib/core/prelude/tuple.wado
@@ -3,6 +3,7 @@
 // These implementations use compile-time tuple enumeration (for let v of *self)
 // which is expanded at monomorphization time.
 #![no_prelude]
+#![stdlib("core:prelude/tuple.wado")]
 
 use { Formatter } from "core:prelude/format.wado";
 

--- a/wado-compiler/lib/core/prelude/types.wado
+++ b/wado-compiler/lib/core/prelude/types.wado
@@ -1,6 +1,7 @@
 // Core variant types for the Wado Prelude.
 //
 // This module defines fundamental sum types that are used throughout Wado programs.
+#![no_prelude]
 
 /// Tuple type family declaration — establishes `core:prelude` as the owner of all tuple types.
 #[comp_feature("tuple")]

--- a/wado-compiler/lib/core/prelude/types.wado
+++ b/wado-compiler/lib/core/prelude/types.wado
@@ -2,6 +2,7 @@
 //
 // This module defines fundamental sum types that are used throughout Wado programs.
 #![no_prelude]
+#![stdlib("core:prelude/types.wado")]
 
 /// Tuple type family declaration — establishes `core:prelude` as the owner of all tuple types.
 #[comp_feature("tuple")]

--- a/wado-compiler/lib/core/serde.wado
+++ b/wado-compiler/lib/core/serde.wado
@@ -63,6 +63,7 @@
 //! // {"host":"localhost"}
 //! //   -> Config { host: "localhost", port: 0, timeout: 30 }
 //! ```
+#![stdlib("core:serde")]
 
 
 pub enum SerializeErrorKind {

--- a/wado-compiler/lib/core/simd.wado
+++ b/wado-compiler/lib/core/simd.wado
@@ -83,6 +83,7 @@
 //! - **Swizzle:** `i8x16.relaxed_swizzle` (out-of-range indices implementation-defined)
 //! - **Q15 multiply:** `i16x8.relaxed_q15mulr_s`
 //! - **Dot product:** `i16x8.relaxed_dot_i8x16_i7x16_s`, `i32x4.relaxed_dot_i8x16_i7x16_add_s`
+#![stdlib("core:simd")]
 
 pub type i8x16 = v128;
 pub type i16x8 = v128;

--- a/wado-compiler/lib/core/url.wado
+++ b/wado-compiler/lib/core/url.wado
@@ -9,6 +9,7 @@
 //!   if let Ok(url) = url {
 //!       let pq = url.path_with_query();  // "/path?key=val"
 //!   }
+#![stdlib("core:url")]
 
 use { TreeMap } from "core:collections";
 use {

--- a/wado-compiler/lib/core/zlib.wado
+++ b/wado-compiler/lib/core/zlib.wado
@@ -48,6 +48,7 @@
 //! stream.update(&chunk2);
 //! let compressed = stream.finish();
 //! ```
+#![stdlib("core:zlib")]
 
 
 /// Error type for zlib/gzip decompression operations.

--- a/wado-compiler/lib/wasi/cli.wado
+++ b/wado-compiler/lib/wasi/cli.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl")]
+#![stdlib("wasi:cli")]
 
 pub use { Environment } from "wasi:cli/environment.wado";
 pub use { Exit } from "wasi:cli/exit.wado";

--- a/wado-compiler/lib/wasi/cli/environment.wado
+++ b/wado-compiler/lib/wasi/cli/environment.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
+#![stdlib("wasi:cli/environment.wado")]
 
 #[cm("wasi:cli/environment@0.3.0-rc-2026-03-15")]
 pub interface Environment {

--- a/wado-compiler/lib/wasi/cli/exit.wado
+++ b/wado-compiler/lib/wasi/cli/exit.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
+#![stdlib("wasi:cli/exit.wado")]
 
 #[cm("wasi:cli/exit@0.3.0-rc-2026-03-15")]
 pub interface Exit {

--- a/wado-compiler/lib/wasi/cli/run.wado
+++ b/wado-compiler/lib/wasi/cli/run.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
+#![stdlib("wasi:cli/run.wado")]
 
 #[cm("wasi:cli/run@0.3.0-rc-2026-03-15")]
 pub interface Run {

--- a/wado-compiler/lib/wasi/cli/stderr.wado
+++ b/wado-compiler/lib/wasi/cli/stderr.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
+#![stdlib("wasi:cli/stderr.wado")]
 
 use { ErrorCode } from "wasi:cli/types.wado";
 

--- a/wado-compiler/lib/wasi/cli/stdin.wado
+++ b/wado-compiler/lib/wasi/cli/stdin.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
+#![stdlib("wasi:cli/stdin.wado")]
 
 use { ErrorCode } from "wasi:cli/types.wado";
 

--- a/wado-compiler/lib/wasi/cli/stdout.wado
+++ b/wado-compiler/lib/wasi/cli/stdout.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
+#![stdlib("wasi:cli/stdout.wado")]
 
 use { ErrorCode } from "wasi:cli/types.wado";
 

--- a/wado-compiler/lib/wasi/cli/terminal_input.wado
+++ b/wado-compiler/lib/wasi/cli/terminal_input.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
+#![stdlib("wasi:cli/terminal_input.wado")]
 
 /// The input side of a terminal.
 #[cm("wasi:cli/terminal-input@0.3.0-rc-2026-03-15#terminal-input")]

--- a/wado-compiler/lib/wasi/cli/terminal_output.wado
+++ b/wado-compiler/lib/wasi/cli/terminal_output.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
+#![stdlib("wasi:cli/terminal_output.wado")]
 
 /// The output side of a terminal.
 #[cm("wasi:cli/terminal-output@0.3.0-rc-2026-03-15#terminal-output")]

--- a/wado-compiler/lib/wasi/cli/terminal_stderr.wado
+++ b/wado-compiler/lib/wasi/cli/terminal_stderr.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
+#![stdlib("wasi:cli/terminal_stderr.wado")]
 
 use { TerminalOutput } from "wasi:cli/terminal_output.wado";
 

--- a/wado-compiler/lib/wasi/cli/terminal_stdin.wado
+++ b/wado-compiler/lib/wasi/cli/terminal_stdin.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
+#![stdlib("wasi:cli/terminal_stdin.wado")]
 
 use { TerminalInput } from "wasi:cli/terminal_input.wado";
 

--- a/wado-compiler/lib/wasi/cli/terminal_stdout.wado
+++ b/wado-compiler/lib/wasi/cli/terminal_stdout.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
+#![stdlib("wasi:cli/terminal_stdout.wado")]
 
 use { TerminalOutput } from "wasi:cli/terminal_output.wado";
 

--- a/wado-compiler/lib/wasi/cli/types.wado
+++ b/wado-compiler/lib/wasi/cli/types.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
+#![stdlib("wasi:cli/types.wado")]
 
 #[cm("wasi:cli/types@0.3.0-rc-2026-03-15#error-code")]
 pub enum ErrorCode {

--- a/wado-compiler/lib/wasi/cli/worlds.wado
+++ b/wado-compiler/lib/wasi/cli/worlds.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/cli.wit"])]
+#![stdlib("wasi:cli/worlds.wado")]
 
 #[cm("wasi:cli/imports@0.3.0-rc-2026-03-15")]
 pub world Imports {

--- a/wado-compiler/lib/wasi/clocks.wado
+++ b/wado-compiler/lib/wasi/clocks.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl")]
+#![stdlib("wasi:clocks")]
 
 pub use { Duration } from "wasi:clocks/types.wado";
 pub use { Mark, MonotonicClock } from "wasi:clocks/monotonic_clock.wado";

--- a/wado-compiler/lib/wasi/clocks/monotonic_clock.wado
+++ b/wado-compiler/lib/wasi/clocks/monotonic_clock.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit"])]
+#![stdlib("wasi:clocks/monotonic_clock.wado")]
 
 use { Duration } from "wasi:clocks/types.wado";
 

--- a/wado-compiler/lib/wasi/clocks/system_clock.wado
+++ b/wado-compiler/lib/wasi/clocks/system_clock.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit"])]
+#![stdlib("wasi:clocks/system_clock.wado")]
 
 use { Duration } from "wasi:clocks/types.wado";
 

--- a/wado-compiler/lib/wasi/clocks/timezone.wado
+++ b/wado-compiler/lib/wasi/clocks/timezone.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit"])]
+#![stdlib("wasi:clocks/timezone.wado")]
 
 use { Instant } from "wasi:clocks/system_clock.wado";
 

--- a/wado-compiler/lib/wasi/clocks/types.wado
+++ b/wado-compiler/lib/wasi/clocks/types.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit"])]
+#![stdlib("wasi:clocks/types.wado")]
 
 #[cm("wasi:clocks/types@0.3.0-rc-2026-03-15#duration")]
 pub type Duration = u64;

--- a/wado-compiler/lib/wasi/clocks/worlds.wado
+++ b/wado-compiler/lib/wasi/clocks/worlds.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/clocks.wit"])]
+#![stdlib("wasi:clocks/worlds.wado")]
 
 #[cm("wasi:clocks/imports@0.3.0-rc-2026-03-15")]
 pub world Imports {

--- a/wado-compiler/lib/wasi/filesystem.wado
+++ b/wado-compiler/lib/wasi/filesystem.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl")]
+#![stdlib("wasi:filesystem")]
 
 pub use {
     Filesize,

--- a/wado-compiler/lib/wasi/filesystem/preopens.wado
+++ b/wado-compiler/lib/wasi/filesystem/preopens.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/filesystem.wit"])]
+#![stdlib("wasi:filesystem/preopens.wado")]
 
 use { Descriptor } from "wasi:filesystem/types.wado";
 

--- a/wado-compiler/lib/wasi/filesystem/types.wado
+++ b/wado-compiler/lib/wasi/filesystem/types.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/filesystem.wit"])]
+#![stdlib("wasi:filesystem/types.wado")]
 
 use { Instant } from "wasi:clocks/system_clock.wado";
 

--- a/wado-compiler/lib/wasi/filesystem/worlds.wado
+++ b/wado-compiler/lib/wasi/filesystem/worlds.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/filesystem.wit"])]
+#![stdlib("wasi:filesystem/worlds.wado")]
 
 #[cm("wasi:filesystem/imports@0.3.0-rc-2026-03-15")]
 pub world Imports {

--- a/wado-compiler/lib/wasi/http.wado
+++ b/wado-compiler/lib/wasi/http.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl")]
+#![stdlib("wasi:http")]
 
 pub use {
     Method,

--- a/wado-compiler/lib/wasi/http/client.wado
+++ b/wado-compiler/lib/wasi/http/client.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-http/src/p3/wit/deps/http.wit"])]
+#![stdlib("wasi:http/client.wado")]
 
 use { ErrorCode, Request, Response } from "wasi:http/types.wado";
 

--- a/wado-compiler/lib/wasi/http/handler.wado
+++ b/wado-compiler/lib/wasi/http/handler.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-http/src/p3/wit/deps/http.wit"])]
+#![stdlib("wasi:http/handler.wado")]
 
 use { ErrorCode, Request, Response } from "wasi:http/types.wado";
 

--- a/wado-compiler/lib/wasi/http/types.wado
+++ b/wado-compiler/lib/wasi/http/types.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-http/src/p3/wit/deps/http.wit"])]
+#![stdlib("wasi:http/types.wado")]
 
 use { Duration } from "wasi:clocks/types.wado";
 

--- a/wado-compiler/lib/wasi/http/worlds.wado
+++ b/wado-compiler/lib/wasi/http/worlds.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-http/src/p3/wit/deps/http.wit"])]
+#![stdlib("wasi:http/worlds.wado")]
 
 /// The `wasi:http/service` world captures a broad category of HTTP services
 /// including web applications, API servers, and proxies. It may be `include`d

--- a/wado-compiler/lib/wasi/random.wado
+++ b/wado-compiler/lib/wasi/random.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl")]
+#![stdlib("wasi:random")]
 
 pub use { InsecureSeed } from "wasi:random/insecure_seed.wado";
 pub use { Insecure } from "wasi:random/insecure.wado";

--- a/wado-compiler/lib/wasi/random/insecure.wado
+++ b/wado-compiler/lib/wasi/random/insecure.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/random.wit"])]
+#![stdlib("wasi:random/insecure.wado")]
 
 /// The insecure interface for insecure pseudo-random numbers.
 /// 

--- a/wado-compiler/lib/wasi/random/insecure_seed.wado
+++ b/wado-compiler/lib/wasi/random/insecure_seed.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/random.wit"])]
+#![stdlib("wasi:random/insecure_seed.wado")]
 
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 /// 

--- a/wado-compiler/lib/wasi/random/random.wado
+++ b/wado-compiler/lib/wasi/random/random.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/random.wit"])]
+#![stdlib("wasi:random/random.wado")]
 
 /// WASI Random is a random data API.
 /// 

--- a/wado-compiler/lib/wasi/random/worlds.wado
+++ b/wado-compiler/lib/wasi/random/worlds.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/random.wit"])]
+#![stdlib("wasi:random/worlds.wado")]
 
 #[cm("wasi:random/imports@0.3.0-rc-2026-03-15")]
 pub world Imports {

--- a/wado-compiler/lib/wasi/sockets.wado
+++ b/wado-compiler/lib/wasi/sockets.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl")]
+#![stdlib("wasi:sockets")]
 
 pub use {
     ErrorCode,

--- a/wado-compiler/lib/wasi/sockets/ip_name_lookup.wado
+++ b/wado-compiler/lib/wasi/sockets/ip_name_lookup.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/sockets.wit"])]
+#![stdlib("wasi:sockets/ip_name_lookup.wado")]
 
 use { IpAddress } from "wasi:sockets/types.wado";
 

--- a/wado-compiler/lib/wasi/sockets/types.wado
+++ b/wado-compiler/lib/wasi/sockets/types.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/sockets.wit"])]
+#![stdlib("wasi:sockets/types.wado")]
 
 use { Duration } from "wasi:clocks/types.wado";
 

--- a/wado-compiler/lib/wasi/sockets/worlds.wado
+++ b/wado-compiler/lib/wasi/sockets/worlds.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi/src/p3/wit/deps/sockets.wit"])]
+#![stdlib("wasi:sockets/worlds.wado")]
 
 #[cm("wasi:sockets/imports@0.3.0-rc-2026-03-15")]
 pub world Imports {

--- a/wado-compiler/lib/wasi/tls.wado
+++ b/wado-compiler/lib/wasi/tls.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl")]
+#![stdlib("wasi:tls")]
 
 pub use { Error } from "wasi:tls/types.wado";
 pub use { Connector } from "wasi:tls/client.wado";

--- a/wado-compiler/lib/wasi/tls/client.wado
+++ b/wado-compiler/lib/wasi/tls/client.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/client.wit", "vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/types.wit", "vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/world.wit"])]
+#![stdlib("wasi:tls/client.wado")]
 
 use { Error } from "wasi:tls/types.wado";
 

--- a/wado-compiler/lib/wasi/tls/types.wado
+++ b/wado-compiler/lib/wasi/tls/types.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/client.wit", "vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/types.wit", "vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/world.wit"])]
+#![stdlib("wasi:tls/types.wado")]
 
 #[cm("wasi:tls/types@0.3.0-draft#error")]
 pub resource Error {

--- a/wado-compiler/lib/wasi/tls/worlds.wado
+++ b/wado-compiler/lib/wasi/tls/worlds.wado
@@ -1,4 +1,5 @@
 #![generated(by = "wado-from-idl", sources = ["vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/client.wit", "vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/types.wit", "vendor/wasmtime/crates/wasi-tls/src/p3/wit/deps/tls/world.wit"])]
+#![stdlib("wasi:tls/worlds.wado")]
 
 #[cm("wasi:tls/imports@0.3.0-draft")]
 pub world Imports {

--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -517,11 +517,17 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
     /// Check for type names that collide with prelude-exported types.
     ///
     /// Runs after pub use processing so that `is_prelude_type` can resolve
-    /// re-exports from `core:prelude`. Only non-core modules are checked.
+    /// re-exports from `core:prelude`. Skipped for modules carrying
+    /// `#![no_prelude]`: a module that opts out of the prelude auto-import
+    /// is also opting out of the prelude's name reservation, and the
+    /// bundled stdlib files that *implement* the prelude carry the
+    /// attribute precisely so they can define names like `Option`, `Eq`,
+    /// `Array` without being flagged as collisions with themselves.
     fn check_prelude_collisions(&mut self, module: &Module, module_source: &ModuleSource) {
-        if module_source.is_core() {
+        if module.has_no_prelude() {
             return;
         }
+        self.logger.set_file(module_source.diagnostic_filename());
         for item in &module.items {
             let (name, span) = match item {
                 Item::Struct(d) => (&d.name, d.span),

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -828,6 +828,23 @@ impl Module {
             .map(AttrArg::as_str)
     }
 
+    /// Returns the canonical bundled-stdlib import path declared by
+    /// `#![stdlib("core:...")]` / `#![stdlib("wasi:...")]`, if any.
+    ///
+    /// This attribute is intended for use only by files inside
+    /// `wado-compiler/lib/`. It declares the module's canonical identity
+    /// independent of how the file is loaded (entry vs. transitive
+    /// import), so the loader can pin the entry to its `Core`/`Wasi`
+    /// `ModuleSource` and dedup against the bundled cache when an editor
+    /// opens the file directly.
+    pub fn stdlib_identity(&self) -> Option<&str> {
+        self.inner_attributes
+            .iter()
+            .find(|a| a.name == "stdlib")
+            .and_then(|a| a.args.first())
+            .map(AttrArg::as_str)
+    }
+
     /// Returns the value of a scalar `key = "value"` argument on any
     /// `#![generated(...)]` inner attribute.
     ///

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -758,19 +758,53 @@ fn parse_bind_desugar_stdlib(label: &str, source: &str) -> Module {
 /// Resolve a `#![stdlib("…")]` declaration on `module` to a canonical
 /// `ModuleSource`.
 ///
-/// Returns `None` if the attribute is absent or its argument is not a
-/// recognized `core:` / `wasi:` import path. The attribute is intended
-/// only for files inside `wado-compiler/lib/` — its sole effect on the
-/// pipeline is to pin an entry-loaded bundled stdlib source to the
-/// `Core { name }` / `Wasi { interface }` identity it occupies in the
-/// transitive load graph, so opening such a file in an editor doesn't
-/// produce a duplicate copy of every type the file defines.
+/// Returns `None` only when the attribute is absent. The attribute is
+/// authored exclusively by files inside `wado-compiler/lib/`, so a
+/// malformed argument (anything not registered in
+/// [`stdlib::get_stdlib_module`]) is a stdlib bug — it panics rather than
+/// silently degrading to `EntryPoint`, since the LSP would then see the
+/// duplicate-definition cascade we introduced this attribute to suppress.
 fn parse_stdlib_identity_attribute(module: &Module) -> Option<ModuleSource> {
     let path = module.stdlib_identity()?;
-    if let Some(name) = path.strip_prefix("core:") {
-        Some(ModuleSource::core(name))
+    let resolved = if let Some(name) = path.strip_prefix("core:") {
+        ModuleSource::core(name)
+    } else if let Some(interface) = path.strip_prefix("wasi:") {
+        ModuleSource::wasi(interface)
     } else {
-        path.strip_prefix("wasi:").map(ModuleSource::wasi)
+        panic!(
+            "#![stdlib({path:?})] must use a `core:` or `wasi:` prefix; \
+             this attribute is internal to bundled stdlib files"
+        );
+    };
+    assert!(
+        stdlib::get_stdlib_module(path).is_some(),
+        "#![stdlib({path:?})] does not match any bundled stdlib module; \
+         add the registration to `stdlib::get_stdlib_module` or correct the path",
+    );
+    Some(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::Lexer;
+    use crate::parser::Parser;
+
+    fn parse_test_module(source: &str) -> Module {
+        let mut lexer = Lexer::new(source);
+        let tokens = lexer.tokenize().expect("test source must lex");
+        let (data_section, _comments, shebang) = lexer.into_parts();
+        let mut parser = Parser::with_metadata(tokens, shebang, data_section);
+        parser.parse().expect("test source must parse")
+    }
+
+    #[test]
+    fn stdlib_identity_attribute_resolves_to_core_module_source() {
+        let module = parse_test_module("#![no_prelude]\n#![stdlib(\"core:prelude/types.wado\")]\n");
+        assert_eq!(
+            parse_stdlib_identity_attribute(&module),
+            Some(ModuleSource::core("prelude/types.wado"))
+        );
     }
 }
 

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -769,7 +769,9 @@ fn parse_stdlib_identity_attribute(module: &Module) -> Option<ModuleSource> {
     let path = module.stdlib_identity()?;
     if let Some(name) = path.strip_prefix("core:") {
         Some(ModuleSource::core(name))
-    } else { path.strip_prefix("wasi:").map(ModuleSource::wasi) }
+    } else {
+        path.strip_prefix("wasi:").map(ModuleSource::wasi)
+    }
 }
 
 /// Cached desugared AST modules for all stdlib modules (core + WASI).
@@ -920,17 +922,14 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         // identity — see `Module::stdlib_identity` for why bundled
         // stdlib sources self-declare.
         let entry_ast = {
-            let _span = self
-                .logger
-                .span(&format!("parse {tentative_entry_source}"));
+            let _span = self.logger.span(&format!("parse {tentative_entry_source}"));
             self.parse_source(entry_source, &tentative_entry_source)?
         };
 
-        let entry_module_source = parse_stdlib_identity_attribute(&entry_ast)
-            .unwrap_or(tentative_entry_source);
+        let entry_module_source =
+            parse_stdlib_identity_attribute(&entry_ast).unwrap_or(tentative_entry_source);
         self.entry_module_source = Some(entry_module_source.clone());
-        self.entry_canonical_name =
-            Some(crate::name::canonicalize_entry_point(resolved_filename));
+        self.entry_canonical_name = Some(crate::name::canonicalize_entry_point(resolved_filename));
 
         let entry_name = entry_module_source.to_string();
         self.logger.span_start(&format!("load {entry_name}"));

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -755,6 +755,27 @@ fn parse_bind_desugar_stdlib(label: &str, source: &str) -> Module {
     desugar_module(&ast)
 }
 
+/// Resolve a `#![stdlib("…")]` declaration on `module` to a canonical
+/// `ModuleSource`.
+///
+/// Returns `None` if the attribute is absent or its argument is not a
+/// recognized `core:` / `wasi:` import path. The attribute is intended
+/// only for files inside `wado-compiler/lib/` — its sole effect on the
+/// pipeline is to pin an entry-loaded bundled stdlib source to the
+/// `Core { name }` / `Wasi { interface }` identity it occupies in the
+/// transitive load graph, so opening such a file in an editor doesn't
+/// produce a duplicate copy of every type the file defines.
+fn parse_stdlib_identity_attribute(module: &Module) -> Option<ModuleSource> {
+    let path = module.stdlib_identity()?;
+    if let Some(name) = path.strip_prefix("core:") {
+        Some(ModuleSource::core(name))
+    } else if let Some(interface) = path.strip_prefix("wasi:") {
+        Some(ModuleSource::wasi(interface))
+    } else {
+        None
+    }
+}
+
 /// Cached desugared AST modules for all stdlib modules (core + WASI).
 ///
 /// Each module is parsed, bound, and desugared exactly once per process.
@@ -894,21 +915,29 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     ) -> Result<LoadResult, LoadError> {
         // Parse, bind, and desugar entry module
         // Use "<stdin>" as synthetic filename when no filename is provided (e.g., REPL, embedded code)
-        let entry_module_source =
-            ModuleSource::entry_point_with_filename(entry_filename.unwrap_or("<stdin>"));
+        let resolved_filename = entry_filename.unwrap_or("<stdin>");
+        let tentative_entry_source = ModuleSource::entry_point_with_filename(resolved_filename);
+
+        // Parse first; the parser only needs `module_source` for error
+        // reporting, so a tentative `EntryPoint` is fine. After parsing we
+        // consult `#![stdlib("…")]` to decide the entry's canonical
+        // identity — see `Module::stdlib_identity` for why bundled
+        // stdlib sources self-declare.
+        let entry_ast = {
+            let _span = self
+                .logger
+                .span(&format!("parse {tentative_entry_source}"));
+            self.parse_source(entry_source, &tentative_entry_source)?
+        };
+
+        let entry_module_source = parse_stdlib_identity_attribute(&entry_ast)
+            .unwrap_or(tentative_entry_source);
         self.entry_module_source = Some(entry_module_source.clone());
-        self.entry_canonical_name = Some(crate::name::canonicalize_entry_point(
-            entry_filename.unwrap_or("<stdin>"),
-        ));
+        self.entry_canonical_name =
+            Some(crate::name::canonicalize_entry_point(resolved_filename));
 
         let entry_name = entry_module_source.to_string();
         self.logger.span_start(&format!("load {entry_name}"));
-
-        // Parse first to collect imports before binding
-        let entry_ast = {
-            let _span = self.logger.span(&format!("parse {entry_name}"));
-            self.parse_source(entry_source, &entry_module_source)?
-        };
 
         // Collect imports from entry module (before bind/desugar)
         let mut pending: VecDeque<(ModuleSource, ModuleSource)> = VecDeque::new();

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -894,18 +894,12 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     ) -> Result<LoadResult, LoadError> {
         // Parse, bind, and desugar entry module
         // Use "<stdin>" as synthetic filename when no filename is provided (e.g., REPL, embedded code)
-        let resolved_filename = entry_filename.unwrap_or("<stdin>");
-        // If the entry file is a bundled stdlib source (e.g. opened in an
-        // editor for inspection or in-place edits), identify it as the
-        // corresponding `core:`/`wasi:` module rather than a generic
-        // `EntryPoint`. This keeps `is_core()`-gated checks like
-        // `check_prelude_collisions` and the implicit-module dedup in
-        // `load_implicit_modules` consistent with how the same file is
-        // treated when loaded as a dependency.
-        let entry_module_source = stdlib::stdlib_module_source_for_path(resolved_filename)
-            .unwrap_or_else(|| ModuleSource::entry_point_with_filename(resolved_filename));
+        let entry_module_source =
+            ModuleSource::entry_point_with_filename(entry_filename.unwrap_or("<stdin>"));
         self.entry_module_source = Some(entry_module_source.clone());
-        self.entry_canonical_name = Some(crate::name::canonicalize_entry_point(resolved_filename));
+        self.entry_canonical_name = Some(crate::name::canonicalize_entry_point(
+            entry_filename.unwrap_or("<stdin>"),
+        ));
 
         let entry_name = entry_module_source.to_string();
         self.logger.span_start(&format!("load {entry_name}"));

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -769,11 +769,7 @@ fn parse_stdlib_identity_attribute(module: &Module) -> Option<ModuleSource> {
     let path = module.stdlib_identity()?;
     if let Some(name) = path.strip_prefix("core:") {
         Some(ModuleSource::core(name))
-    } else if let Some(interface) = path.strip_prefix("wasi:") {
-        Some(ModuleSource::wasi(interface))
-    } else {
-        None
-    }
+    } else { path.strip_prefix("wasi:").map(ModuleSource::wasi) }
 }
 
 /// Cached desugared AST modules for all stdlib modules (core + WASI).

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -894,12 +894,18 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     ) -> Result<LoadResult, LoadError> {
         // Parse, bind, and desugar entry module
         // Use "<stdin>" as synthetic filename when no filename is provided (e.g., REPL, embedded code)
-        let entry_module_source =
-            ModuleSource::entry_point_with_filename(entry_filename.unwrap_or("<stdin>"));
+        let resolved_filename = entry_filename.unwrap_or("<stdin>");
+        // If the entry file is a bundled stdlib source (e.g. opened in an
+        // editor for inspection or in-place edits), identify it as the
+        // corresponding `core:`/`wasi:` module rather than a generic
+        // `EntryPoint`. This keeps `is_core()`-gated checks like
+        // `check_prelude_collisions` and the implicit-module dedup in
+        // `load_implicit_modules` consistent with how the same file is
+        // treated when loaded as a dependency.
+        let entry_module_source = stdlib::stdlib_module_source_for_path(resolved_filename)
+            .unwrap_or_else(|| ModuleSource::entry_point_with_filename(resolved_filename));
         self.entry_module_source = Some(entry_module_source.clone());
-        self.entry_canonical_name = Some(crate::name::canonicalize_entry_point(
-            entry_filename.unwrap_or("<stdin>"),
-        ));
+        self.entry_canonical_name = Some(crate::name::canonicalize_entry_point(resolved_filename));
 
         let entry_name = entry_module_source.to_string();
         self.logger.span_start(&format!("load {entry_name}"));

--- a/wado-compiler/src/stdlib.rs
+++ b/wado-compiler/src/stdlib.rs
@@ -180,56 +180,6 @@ pub fn get_stdlib_wasm_asset(import_path: &str) -> Option<&'static [u8]> {
     }
 }
 
-/// Map a filesystem path to a bundled stdlib `ModuleSource`, if any.
-///
-/// Returns `Some(ModuleSource::Core { ... })` when `path` points to a file
-/// under `lib/core/` that is bundled into the compiler (per
-/// [`get_stdlib_module`]); likewise `Some(ModuleSource::Wasi { ... })` for
-/// `lib/wasi/`. The check is suffix-based, so absolute paths like
-/// `/home/user/wado/wado-compiler/lib/core/prelude/types.wado` resolve as
-/// well as relative ones.
-///
-/// Used by the LSP entry path so opening (and editing) bundled stdlib files
-/// in the editor does not redefine prelude types under an unrelated
-/// `EntryPoint` identity, which would otherwise trigger spurious
-/// `PreludeTypeCollision` / `DuplicateDefinition` diagnostics.
-#[must_use]
-pub fn stdlib_module_source_for_path(path: &str) -> Option<crate::name::ModuleSource> {
-    use crate::name::ModuleSource;
-
-    // Locate the `lib/` segment that prefixes a bundled stdlib file. Use
-    // `rfind` so paths that themselves contain `lib/` earlier (unlikely but
-    // possible) still match the closest-to-leaf occurrence.
-    let after_lib = if let Some(idx) = path.rfind("/lib/") {
-        &path[idx + "/lib/".len()..]
-    } else {
-        path.strip_prefix("lib/")?
-    };
-
-    let (ns, rest) = after_lib.split_once('/')?;
-    let make = |canonical: &str| -> Option<ModuleSource> {
-        match ns {
-            "core" => Some(ModuleSource::core(canonical)),
-            "wasi" => Some(ModuleSource::wasi(canonical)),
-            _ => None,
-        }
-    };
-
-    // Multi-segment paths (e.g. `prelude/types.wado`) keep the `.wado`
-    // suffix in the canonical key; top-level files (e.g. `cli.wado`) drop
-    // it. Try both forms and validate against the registry.
-    if get_stdlib_module(&format!("{ns}:{rest}")).is_some() {
-        return make(rest);
-    }
-    if let Some(stem) = rest.strip_suffix(".wado")
-        && !stem.contains('/')
-        && get_stdlib_module(&format!("{ns}:{stem}")).is_some()
-    {
-        return make(stem);
-    }
-    None
-}
-
 /// Get embedded module source by import path.
 ///
 /// # Arguments
@@ -418,52 +368,5 @@ mod tests {
     fn test_non_stdlib_module() {
         assert!(get_stdlib_module("myapp:utils").is_none());
         assert!(get_stdlib_module("https://example.com/lib.wado").is_none());
-    }
-
-    #[test]
-    fn test_stdlib_module_source_for_path_top_level() {
-        use crate::name::ModuleSource;
-        assert_eq!(
-            stdlib_module_source_for_path("/some/abs/wado-compiler/lib/core/cli.wado"),
-            Some(ModuleSource::core("cli"))
-        );
-        assert_eq!(
-            stdlib_module_source_for_path("wado-compiler/lib/core/prelude.wado"),
-            Some(ModuleSource::core("prelude"))
-        );
-        assert_eq!(
-            stdlib_module_source_for_path("lib/core/zlib.wado"),
-            Some(ModuleSource::core("zlib"))
-        );
-        assert_eq!(
-            stdlib_module_source_for_path("lib/wasi/cli.wado"),
-            Some(ModuleSource::wasi("cli"))
-        );
-    }
-
-    #[test]
-    fn test_stdlib_module_source_for_path_submodule() {
-        use crate::name::ModuleSource;
-        assert_eq!(
-            stdlib_module_source_for_path("/home/u/wado/wado-compiler/lib/core/prelude/types.wado"),
-            Some(ModuleSource::core("prelude/types.wado"))
-        );
-        assert_eq!(
-            stdlib_module_source_for_path("lib/wasi/cli/stdout.wado"),
-            Some(ModuleSource::wasi("cli/stdout.wado"))
-        );
-        assert_eq!(
-            stdlib_module_source_for_path("lib/core/kiln/types.wado"),
-            Some(ModuleSource::core("kiln/types.wado"))
-        );
-    }
-
-    #[test]
-    fn test_stdlib_module_source_for_path_rejects_non_stdlib() {
-        assert!(stdlib_module_source_for_path("/path/to/main.wado").is_none());
-        assert!(stdlib_module_source_for_path("src/foo.wado").is_none());
-        // No bundled module by that name even though the path shape matches.
-        assert!(stdlib_module_source_for_path("lib/core/nonexistent.wado").is_none());
-        assert!(stdlib_module_source_for_path("lib/other/cli.wado").is_none());
     }
 }

--- a/wado-compiler/src/stdlib.rs
+++ b/wado-compiler/src/stdlib.rs
@@ -180,6 +180,56 @@ pub fn get_stdlib_wasm_asset(import_path: &str) -> Option<&'static [u8]> {
     }
 }
 
+/// Map a filesystem path to a bundled stdlib `ModuleSource`, if any.
+///
+/// Returns `Some(ModuleSource::Core { ... })` when `path` points to a file
+/// under `lib/core/` that is bundled into the compiler (per
+/// [`get_stdlib_module`]); likewise `Some(ModuleSource::Wasi { ... })` for
+/// `lib/wasi/`. The check is suffix-based, so absolute paths like
+/// `/home/user/wado/wado-compiler/lib/core/prelude/types.wado` resolve as
+/// well as relative ones.
+///
+/// Used by the LSP entry path so opening (and editing) bundled stdlib files
+/// in the editor does not redefine prelude types under an unrelated
+/// `EntryPoint` identity, which would otherwise trigger spurious
+/// `PreludeTypeCollision` / `DuplicateDefinition` diagnostics.
+#[must_use]
+pub fn stdlib_module_source_for_path(path: &str) -> Option<crate::name::ModuleSource> {
+    use crate::name::ModuleSource;
+
+    // Locate the `lib/` segment that prefixes a bundled stdlib file. Use
+    // `rfind` so paths that themselves contain `lib/` earlier (unlikely but
+    // possible) still match the closest-to-leaf occurrence.
+    let after_lib = if let Some(idx) = path.rfind("/lib/") {
+        &path[idx + "/lib/".len()..]
+    } else {
+        path.strip_prefix("lib/")?
+    };
+
+    let (ns, rest) = after_lib.split_once('/')?;
+    let make = |canonical: &str| -> Option<ModuleSource> {
+        match ns {
+            "core" => Some(ModuleSource::core(canonical)),
+            "wasi" => Some(ModuleSource::wasi(canonical)),
+            _ => None,
+        }
+    };
+
+    // Multi-segment paths (e.g. `prelude/types.wado`) keep the `.wado`
+    // suffix in the canonical key; top-level files (e.g. `cli.wado`) drop
+    // it. Try both forms and validate against the registry.
+    if get_stdlib_module(&format!("{ns}:{rest}")).is_some() {
+        return make(rest);
+    }
+    if let Some(stem) = rest.strip_suffix(".wado")
+        && !stem.contains('/')
+        && get_stdlib_module(&format!("{ns}:{stem}")).is_some()
+    {
+        return make(stem);
+    }
+    None
+}
+
 /// Get embedded module source by import path.
 ///
 /// # Arguments
@@ -368,5 +418,52 @@ mod tests {
     fn test_non_stdlib_module() {
         assert!(get_stdlib_module("myapp:utils").is_none());
         assert!(get_stdlib_module("https://example.com/lib.wado").is_none());
+    }
+
+    #[test]
+    fn test_stdlib_module_source_for_path_top_level() {
+        use crate::name::ModuleSource;
+        assert_eq!(
+            stdlib_module_source_for_path("/some/abs/wado-compiler/lib/core/cli.wado"),
+            Some(ModuleSource::core("cli"))
+        );
+        assert_eq!(
+            stdlib_module_source_for_path("wado-compiler/lib/core/prelude.wado"),
+            Some(ModuleSource::core("prelude"))
+        );
+        assert_eq!(
+            stdlib_module_source_for_path("lib/core/zlib.wado"),
+            Some(ModuleSource::core("zlib"))
+        );
+        assert_eq!(
+            stdlib_module_source_for_path("lib/wasi/cli.wado"),
+            Some(ModuleSource::wasi("cli"))
+        );
+    }
+
+    #[test]
+    fn test_stdlib_module_source_for_path_submodule() {
+        use crate::name::ModuleSource;
+        assert_eq!(
+            stdlib_module_source_for_path("/home/u/wado/wado-compiler/lib/core/prelude/types.wado"),
+            Some(ModuleSource::core("prelude/types.wado"))
+        );
+        assert_eq!(
+            stdlib_module_source_for_path("lib/wasi/cli/stdout.wado"),
+            Some(ModuleSource::wasi("cli/stdout.wado"))
+        );
+        assert_eq!(
+            stdlib_module_source_for_path("lib/core/kiln/types.wado"),
+            Some(ModuleSource::core("kiln/types.wado"))
+        );
+    }
+
+    #[test]
+    fn test_stdlib_module_source_for_path_rejects_non_stdlib() {
+        assert!(stdlib_module_source_for_path("/path/to/main.wado").is_none());
+        assert!(stdlib_module_source_for_path("src/foo.wado").is_none());
+        // No bundled module by that name even though the path shape matches.
+        assert!(stdlib_module_source_for_path("lib/core/nonexistent.wado").is_none());
+        assert!(stdlib_module_source_for_path("lib/other/cli.wado").is_none());
     }
 }

--- a/wado-compiler/tests/fixtures.golden/display_2.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/display_2.wir.wado
@@ -7151,7 +7151,7 @@ fn "core:prelude/fpfmt.wado/fixed_width"(f, n) {
             "core:prelude/string.wado/String::push"(__local_13, 58);
             __local_14 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_13 };
             f_18 = __local_14;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(289, f_18);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(290, f_18);
             "core:prelude/string.wado/String::push"(__local_13, 58);
             "core:prelude/string.wado/String::push"(__local_13, 32);
             "core:prelude/string.wado/String::push_str"(__local_13, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("digits must be <= 18"), used: 20 });

--- a/wado-compiler/tests/fixtures.golden/string-truncate-panic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/string-truncate-panic.wir.wado
@@ -372,7 +372,7 @@ fn "core:prelude/string.wado/String::truncate"(self, byte_len) {
             "core:prelude/string.wado/String::push"(__local_10, 58);
             __local_11 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_10 };
             f_17 = __local_11;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(394, f_17);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(395, f_17);
             "core:prelude/string.wado/String::push"(__local_10, 58);
             "core:prelude/string.wado/String::push"(__local_10, 32);
             "core:prelude/string.wado/String::push_str"(__local_10, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative length"), used: 15 });
@@ -411,7 +411,7 @@ condition: byte_len >= 0
                 "core:prelude/string.wado/String::push"(__local_12, 58);
                 __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
                 f_28 = __local_13;
-                "core:prelude/primitive.wado/i32::fmt_decimal"(399, f_28);
+                "core:prelude/primitive.wado/i32::fmt_decimal"(400, f_28);
                 "core:prelude/string.wado/String::push"(__local_12, 58);
                 "core:prelude/string.wado/String::push"(__local_12, 32);
                 "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("not on a UTF-8 character boundary"), used: 33 });

--- a/wado-compiler/tests/format.fixtures.golden/all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/all.lower.wado
@@ -5266,7 +5266,7 @@ pub fn fixed_width(f: f64, n: i32) -> FormatResult {
                 __r.String::push_str("core:prelude/fpfmt.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 289 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 290 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("digits must be <= 18");
                 __r.String::push_str("\ncondition: n <= 18\n");
@@ -13161,7 +13161,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 394 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 395 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -13190,7 +13190,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 399 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 400 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -13659,7 +13659,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 754 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 755 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -13704,7 +13704,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 757 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 758 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -13789,7 +13789,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 801 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 802 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -13834,7 +13834,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 804 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 805 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -13895,7 +13895,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 827 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 828 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");

--- a/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
@@ -4663,7 +4663,7 @@ pub fn fixed_width(f: f64, n: i32) -> FormatResult {
                 __r.String::push_str("core:prelude/fpfmt.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 289 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 290 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("digits must be <= 18");
                 __r.String::push_str("\ncondition: n <= 18\n");
@@ -12158,7 +12158,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 394 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 395 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -12187,7 +12187,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 399 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 400 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -12656,7 +12656,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 754 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 755 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -12701,7 +12701,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 757 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 758 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -12786,7 +12786,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 801 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 802 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -12831,7 +12831,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 804 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 805 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -12892,7 +12892,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 827 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 828 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");

--- a/wado-compiler/tests/format.fixtures.golden/ops.all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.all.lower.wado
@@ -4031,7 +4031,7 @@ pub fn fixed_width(f: f64, n: i32) -> FormatResult {
                 __r.String::push_str("core:prelude/fpfmt.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 289 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 290 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("digits must be <= 18");
                 __r.String::push_str("\ncondition: n <= 18\n");
@@ -11446,7 +11446,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 394 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 395 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -11475,7 +11475,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 399 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 400 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -11944,7 +11944,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 754 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 755 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -11989,7 +11989,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 757 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 758 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -12074,7 +12074,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 801 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 802 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -12119,7 +12119,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 804 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 805 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -12180,7 +12180,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 827 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 828 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");

--- a/wado-compiler/tests/format.fixtures.golden/ops.mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.mess.lower.wado
@@ -4031,7 +4031,7 @@ pub fn fixed_width(f: f64, n: i32) -> FormatResult {
                 __r.String::push_str("core:prelude/fpfmt.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 289 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 290 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("digits must be <= 18");
                 __r.String::push_str("\ncondition: n <= 18\n");
@@ -11446,7 +11446,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 394 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 395 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -11475,7 +11475,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 399 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 400 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -11944,7 +11944,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 754 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 755 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -11989,7 +11989,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 757 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 758 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -12074,7 +12074,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 801 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 802 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index <= self.used\n");
@@ -12119,7 +12119,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                     __r.String::push_str("core:prelude/string.wado");
                     __r.String::push_str(":");
                     let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                    Box<i32> { value: 804 }."i32^Display::fmt"(&mut __f);
+                    Box<i32> { value: 805 }."i32^Display::fmt"(&mut __f);
                     __r.String::push_str(": ");
                     __r.String::push_str("not on a UTF-8 character boundary");
                     __r.String::push_str("\ncondition: b < 0x80 || b >= 0xC0\n");
@@ -12180,7 +12180,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 827 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 828 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -9,7 +9,7 @@ pub mod semantic_tokens;
 pub mod server;
 
 use indexmap::IndexMap;
-use wado_compiler::{CompilerHost, CompilerOptions, Diagnostic as CompilerDiagnostic, LogLevel};
+use wado_compiler::{CompilerHost, Diagnostic as CompilerDiagnostic};
 
 pub use definition::DefinitionResult;
 pub use diagnostics::{Diagnostic, Position, Range, Severity};
@@ -133,25 +133,22 @@ impl Engine {
 
     /// Compute diagnostics for the given document.
     ///
-    /// Runs the compiler with a silent host that collects diagnostics without printing.
-    /// The `host` is used to load imported modules from the filesystem (or any other source).
+    /// Runs the compiler's `annotate` pipeline (parse → bind → desugar → load
+    /// → analyze → resolve) with a silent host that collects diagnostics
+    /// without printing. Codegen and downstream phases are intentionally
+    /// skipped: they can panic on compiler-internal bugs (e.g. invalid Wasm
+    /// emitted from an unusual entry module) and produce nothing useful for
+    /// editor feedback even when they succeed. All user-actionable
+    /// diagnostics — type errors, undefined symbols, prelude collisions,
+    /// effect violations — surface during `annotate`.
     pub async fn diagnostics<H: CompilerHost>(&self, uri: &str, host: &H) -> Vec<Diagnostic> {
         let Some(source) = self.documents.get(uri) else {
             return Vec::new();
         };
 
         let filename = uri_to_filename(uri);
-        let options = CompilerOptions {
-            log_level: Some(LogLevel::Off),
-            ..CompilerOptions::default()
-        };
-
-        // Compile and collect diagnostics. We don't care about the result —
-        // errors are captured by the host via emit_diagnostic.
         let collecting_host = DiagnosticCollector::new(host);
-        let _ =
-            wado_compiler::compile_with_options(source, &collecting_host, Some(&filename), options)
-                .await;
+        let _ = wado_compiler::annotate(source, &collecting_host, Some(&filename)).await;
 
         collecting_host
             .take_diagnostics()

--- a/wado-lsp/tests/diagnostics.rs
+++ b/wado-lsp/tests/diagnostics.rs
@@ -2,13 +2,15 @@
 //!
 //! `Engine::diagnostics` runs only the `annotate` pipeline (parse → bind →
 //! desugar → load → analyze → resolve), deliberately stopping before
-//! codegen. These tests pin the resulting contract:
+//! codegen. These tests pin two contracts:
 //!
-//! - Inputs that cause downstream phases to panic (notably codegen
-//!   validation on unusual entry modules) must not propagate that panic to
-//!   the LSP layer.
-//! - User-actionable diagnostics that surface during annotation —
-//!   prelude-name collisions, undefined symbols — are still reported.
+//! - Bundled stdlib files carry `#![no_prelude]`, so opening them in an
+//!   editor produces a clean compile (no `PreludeTypeCollision` against
+//!   the types they themselves define for the prelude).
+//! - User code that redefines a prelude name without opting out via
+//!   `#![no_prelude]` still surfaces the collision diagnostic.
+//! - Inputs that historically panicked during codegen validation now
+//!   complete cleanly because `Engine::diagnostics` stops at `annotate`.
 
 use indexmap::IndexMap;
 use wado_compiler::{CompilerHost, Diagnostic as CompilerDiagnostic, SourceError};
@@ -47,32 +49,74 @@ async fn diagnostics_for(path: &str, source: &str) -> Vec<Diagnostic> {
     engine.diagnostics(&uri, &host).await
 }
 
-/// Bundled stdlib sources that, when fed to the full compile pipeline as the
-/// entry module, panic during codegen validation (the WIR emitted for them
-/// is not a valid component because they expose stdlib internals rather
-/// than a runnable world). `Engine::diagnostics` must complete without
-/// panicking by stopping at `annotate`.
+fn errors(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
+    diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect()
+}
+
+/// Opening `core:prelude/types.wado` no longer surfaces prelude-name
+/// collisions for the types it itself defines (Option, Result, Waitable, …)
+/// because the file carries `#![no_prelude]`. Some duplicate-definition
+/// noise still surfaces because the bundled cache loads the same file
+/// under its `core:` identity in addition to the entry — entry-identity
+/// declaration is tracked separately. The contract pinned here is that
+/// the call completes (no panic) and that no prelude-collision diagnostic
+/// is emitted.
 #[test]
-fn opening_prelude_types_does_not_panic() {
+fn opening_prelude_types_no_collision_diagnostic() {
     futures::executor::block_on(async {
         let path = "/work/wado-compiler/lib/core/prelude/types.wado";
         let source = include_str!("../../wado-compiler/lib/core/prelude/types.wado");
-        let _ = diagnostics_for(path, source).await;
+        let diags = diagnostics_for(path, source).await;
+        let collisions: Vec<_> = diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error && d.message.contains("prelude type"))
+            .collect();
+        assert!(
+            collisions.is_empty(),
+            "expected no prelude-collision errors when opening prelude/types.wado, got: {collisions:#?}",
+        );
     });
 }
 
+/// Top-level prelude module — purely re-exports — must compile clean too.
 #[test]
-fn opening_wasi_cli_stdout_does_not_panic() {
+fn opening_prelude_root_is_clean() {
+    futures::executor::block_on(async {
+        let path = "/work/wado-compiler/lib/core/prelude.wado";
+        let source = include_str!("../../wado-compiler/lib/core/prelude.wado");
+        let diags = diagnostics_for(path, source).await;
+        let errs = errors(&diags);
+        assert!(
+            errs.is_empty(),
+            "expected no errors, got {}: {:#?}",
+            errs.len(),
+            errs
+        );
+    });
+}
+
+/// Same for a wasi interface (which transitively depends on prelude).
+#[test]
+fn opening_wasi_cli_stdout_is_clean() {
     futures::executor::block_on(async {
         let path = "/work/wado-compiler/lib/wasi/cli/stdout.wado";
         let source = include_str!("../../wado-compiler/lib/wasi/cli/stdout.wado");
-        let _ = diagnostics_for(path, source).await;
+        let diags = diagnostics_for(path, source).await;
+        let errs = errors(&diags);
+        assert!(
+            errs.is_empty(),
+            "expected no errors, got {}: {:#?}",
+            errs.len(),
+            errs
+        );
     });
 }
 
-/// A user module that redefines a prelude type still surfaces the
-/// collision diagnostic. Guards against accidentally suppressing legitimate
-/// errors when the LSP layer is reworked.
+/// Plain user code redefining `Option` does *not* opt out of the prelude
+/// and must therefore still see the collision diagnostic.
 #[test]
 fn user_module_redefining_option_still_errors() {
     futures::executor::block_on(async {
@@ -85,6 +129,26 @@ fn user_module_redefining_option_still_errors() {
         assert!(
             saw_prelude_collision,
             "expected a prelude-collision error in user module, got: {diags:#?}",
+        );
+    });
+}
+
+/// User code that explicitly opts out via `#![no_prelude]` is allowed to
+/// reuse prelude names — the collision check is keyed off the attribute,
+/// not off the file's location or content.
+#[test]
+fn user_module_with_no_prelude_can_redefine_option() {
+    futures::executor::block_on(async {
+        let path = "/work/myapp/standalone.wado";
+        let source = "#![no_prelude]\npub variant Option<T> { Some(T), None }\n";
+        let diags = diagnostics_for(path, source).await;
+        let collisions: Vec<_> = diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error && d.message.contains("prelude type"))
+            .collect();
+        assert!(
+            collisions.is_empty(),
+            "expected no prelude-collision errors with #![no_prelude], got: {collisions:#?}",
         );
     });
 }

--- a/wado-lsp/tests/diagnostics.rs
+++ b/wado-lsp/tests/diagnostics.rs
@@ -113,6 +113,26 @@ fn opening_wasi_cli_stdout_is_clean() {
     });
 }
 
+/// WASI flat-package roots (`lib/wasi/<pkg>.wado`) are pure re-export
+/// hubs and carry both `#![generated]` and `#![stdlib("wasi:<pkg>")]`.
+/// Cover the non-sub-interface code path so a regression in flat-package
+/// identity resolution surfaces directly.
+#[test]
+fn opening_wasi_cli_flat_package_is_clean() {
+    futures::executor::block_on(async {
+        let path = "/work/wado-compiler/lib/wasi/cli.wado";
+        let source = include_str!("../../wado-compiler/lib/wasi/cli.wado");
+        let diags = diagnostics_for(path, source).await;
+        let errs = errors(&diags);
+        assert!(
+            errs.is_empty(),
+            "expected no errors, got {}: {:#?}",
+            errs.len(),
+            errs
+        );
+    });
+}
+
 /// Plain user code redefining `Option` does *not* opt out of the prelude
 /// and must therefore still see the collision diagnostic.
 #[test]

--- a/wado-lsp/tests/diagnostics.rs
+++ b/wado-lsp/tests/diagnostics.rs
@@ -56,27 +56,25 @@ fn errors(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
         .collect()
 }
 
-/// Opening `core:prelude/types.wado` no longer surfaces prelude-name
-/// collisions for the types it itself defines (Option, Result, Waitable, …)
-/// because the file carries `#![no_prelude]`. Some duplicate-definition
-/// noise still surfaces because the bundled cache loads the same file
-/// under its `core:` identity in addition to the entry — entry-identity
-/// declaration is tracked separately. The contract pinned here is that
-/// the call completes (no panic) and that no prelude-collision diagnostic
-/// is emitted.
+/// Opening `core:prelude/types.wado` is clean: the file declares both
+/// `#![no_prelude]` (gating the prelude-collision check) and
+/// `#![stdlib("core:prelude/types.wado")]` (pinning the entry's
+/// `ModuleSource` to its bundled identity, which dedups the entry against
+/// the cache and so eliminates the cross-module duplicate-definition
+/// errors on `Option` / `Waitable` / … that arise when an entry copy and a
+/// cached copy of the same module both define the same names).
 #[test]
-fn opening_prelude_types_no_collision_diagnostic() {
+fn opening_prelude_types_is_clean() {
     futures::executor::block_on(async {
         let path = "/work/wado-compiler/lib/core/prelude/types.wado";
         let source = include_str!("../../wado-compiler/lib/core/prelude/types.wado");
         let diags = diagnostics_for(path, source).await;
-        let collisions: Vec<_> = diags
-            .iter()
-            .filter(|d| d.severity == Severity::Error && d.message.contains("prelude type"))
-            .collect();
+        let errs = errors(&diags);
         assert!(
-            collisions.is_empty(),
-            "expected no prelude-collision errors when opening prelude/types.wado, got: {collisions:#?}",
+            errs.is_empty(),
+            "expected no errors, got {}: {:#?}",
+            errs.len(),
+            errs
         );
     });
 }

--- a/wado-lsp/tests/diagnostics.rs
+++ b/wado-lsp/tests/diagnostics.rs
@@ -1,7 +1,14 @@
-//! Integration tests for `Engine::diagnostics`. Focused on the cases where
-//! the open document is itself a bundled stdlib source — the LSP must not
-//! report `PreludeTypeCollision` / `DuplicateDefinition` against types that
-//! the entry module legitimately defines as part of the prelude.
+//! Integration tests for `Engine::diagnostics`.
+//!
+//! `Engine::diagnostics` runs only the `annotate` pipeline (parse → bind →
+//! desugar → load → analyze → resolve), deliberately stopping before
+//! codegen. These tests pin the resulting contract:
+//!
+//! - Inputs that cause downstream phases to panic (notably codegen
+//!   validation on unusual entry modules) must not propagate that panic to
+//!   the LSP layer.
+//! - User-actionable diagnostics that surface during annotation —
+//!   prelude-name collisions, undefined symbols — are still reported.
 
 use indexmap::IndexMap;
 use wado_compiler::{CompilerHost, Diagnostic as CompilerDiagnostic, SourceError};
@@ -40,69 +47,32 @@ async fn diagnostics_for(path: &str, source: &str) -> Vec<Diagnostic> {
     engine.diagnostics(&uri, &host).await
 }
 
-fn errors(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
-    diags
-        .iter()
-        .filter(|d| d.severity == Severity::Error)
-        .collect()
-}
-
-/// Opening `core:prelude/types.wado` (where Option, Result, … are defined)
-/// must not surface duplicate-definition / prelude-collision errors against
-/// the same prelude that gets implicitly loaded.
+/// Bundled stdlib sources that, when fed to the full compile pipeline as the
+/// entry module, panic during codegen validation (the WIR emitted for them
+/// is not a valid component because they expose stdlib internals rather
+/// than a runnable world). `Engine::diagnostics` must complete without
+/// panicking by stopping at `annotate`.
 #[test]
-fn opening_prelude_types_is_clean() {
+fn opening_prelude_types_does_not_panic() {
     futures::executor::block_on(async {
         let path = "/work/wado-compiler/lib/core/prelude/types.wado";
         let source = include_str!("../../wado-compiler/lib/core/prelude/types.wado");
-        let diags = diagnostics_for(path, source).await;
-        let errs = errors(&diags);
-        assert!(
-            errs.is_empty(),
-            "expected no errors, got {}: {:#?}",
-            errs.len(),
-            errs
-        );
+        let _ = diagnostics_for(path, source).await;
     });
 }
 
-/// Top-level prelude module — purely re-exports — must compile clean too.
 #[test]
-fn opening_prelude_root_is_clean() {
-    futures::executor::block_on(async {
-        let path = "/work/wado-compiler/lib/core/prelude.wado";
-        let source = include_str!("../../wado-compiler/lib/core/prelude.wado");
-        let diags = diagnostics_for(path, source).await;
-        let errs = errors(&diags);
-        assert!(
-            errs.is_empty(),
-            "expected no errors, got {}: {:#?}",
-            errs.len(),
-            errs
-        );
-    });
-}
-
-/// Same for a wasi interface (which transitively imports prelude).
-#[test]
-fn opening_wasi_cli_stdout_is_clean() {
+fn opening_wasi_cli_stdout_does_not_panic() {
     futures::executor::block_on(async {
         let path = "/work/wado-compiler/lib/wasi/cli/stdout.wado";
         let source = include_str!("../../wado-compiler/lib/wasi/cli/stdout.wado");
-        let diags = diagnostics_for(path, source).await;
-        let errs = errors(&diags);
-        assert!(
-            errs.is_empty(),
-            "expected no errors, got {}: {:#?}",
-            errs.len(),
-            errs
-        );
+        let _ = diagnostics_for(path, source).await;
     });
 }
 
-/// Sanity check — a non-stdlib entry that *does* redefine a prelude type
-/// must still surface the collision (the fix above must not silently
-/// suppress all collisions).
+/// A user module that redefines a prelude type still surfaces the
+/// collision diagnostic. Guards against accidentally suppressing legitimate
+/// errors when the LSP layer is reworked.
 #[test]
 fn user_module_redefining_option_still_errors() {
     futures::executor::block_on(async {

--- a/wado-lsp/tests/diagnostics.rs
+++ b/wado-lsp/tests/diagnostics.rs
@@ -1,0 +1,120 @@
+//! Integration tests for `Engine::diagnostics`. Focused on the cases where
+//! the open document is itself a bundled stdlib source — the LSP must not
+//! report `PreludeTypeCollision` / `DuplicateDefinition` against types that
+//! the entry module legitimately defines as part of the prelude.
+
+use indexmap::IndexMap;
+use wado_compiler::{CompilerHost, Diagnostic as CompilerDiagnostic, SourceError};
+use wado_lsp::{Diagnostic, Engine, Severity};
+
+struct TestHost {
+    sources: IndexMap<String, Vec<u8>>,
+}
+
+impl TestHost {
+    fn empty() -> Self {
+        Self {
+            sources: IndexMap::new(),
+        }
+    }
+}
+
+impl CompilerHost for TestHost {
+    async fn load_source(&self, path: &str) -> Result<Vec<u8>, SourceError> {
+        if let Some(b) = self.sources.get(path) {
+            return Ok(b.clone());
+        }
+        Err(SourceError::NotFound {
+            path: path.to_string(),
+        })
+    }
+
+    fn emit_diagnostic(&self, _diagnostic: CompilerDiagnostic) {}
+}
+
+async fn diagnostics_for(path: &str, source: &str) -> Vec<Diagnostic> {
+    let uri = format!("file://{path}");
+    let host = TestHost::empty();
+    let mut engine = Engine::new();
+    engine.open_document(&uri, source.to_string());
+    engine.diagnostics(&uri, &host).await
+}
+
+fn errors(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
+    diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect()
+}
+
+/// Opening `core:prelude/types.wado` (where Option, Result, … are defined)
+/// must not surface duplicate-definition / prelude-collision errors against
+/// the same prelude that gets implicitly loaded.
+#[test]
+fn opening_prelude_types_is_clean() {
+    futures::executor::block_on(async {
+        let path = "/work/wado-compiler/lib/core/prelude/types.wado";
+        let source = include_str!("../../wado-compiler/lib/core/prelude/types.wado");
+        let diags = diagnostics_for(path, source).await;
+        let errs = errors(&diags);
+        assert!(
+            errs.is_empty(),
+            "expected no errors, got {}: {:#?}",
+            errs.len(),
+            errs
+        );
+    });
+}
+
+/// Top-level prelude module — purely re-exports — must compile clean too.
+#[test]
+fn opening_prelude_root_is_clean() {
+    futures::executor::block_on(async {
+        let path = "/work/wado-compiler/lib/core/prelude.wado";
+        let source = include_str!("../../wado-compiler/lib/core/prelude.wado");
+        let diags = diagnostics_for(path, source).await;
+        let errs = errors(&diags);
+        assert!(
+            errs.is_empty(),
+            "expected no errors, got {}: {:#?}",
+            errs.len(),
+            errs
+        );
+    });
+}
+
+/// Same for a wasi interface (which transitively imports prelude).
+#[test]
+fn opening_wasi_cli_stdout_is_clean() {
+    futures::executor::block_on(async {
+        let path = "/work/wado-compiler/lib/wasi/cli/stdout.wado";
+        let source = include_str!("../../wado-compiler/lib/wasi/cli/stdout.wado");
+        let diags = diagnostics_for(path, source).await;
+        let errs = errors(&diags);
+        assert!(
+            errs.is_empty(),
+            "expected no errors, got {}: {:#?}",
+            errs.len(),
+            errs
+        );
+    });
+}
+
+/// Sanity check — a non-stdlib entry that *does* redefine a prelude type
+/// must still surface the collision (the fix above must not silently
+/// suppress all collisions).
+#[test]
+fn user_module_redefining_option_still_errors() {
+    futures::executor::block_on(async {
+        let path = "/work/myapp/main.wado";
+        let source = "pub variant Option<T> { Some(T), None }\n";
+        let diags = diagnostics_for(path, source).await;
+        let saw_prelude_collision = diags
+            .iter()
+            .any(|d| d.severity == Severity::Error && d.message.contains("prelude type"));
+        assert!(
+            saw_prelude_collision,
+            "expected a prelude-collision error in user module, got: {diags:#?}",
+        );
+    });
+}


### PR DESCRIPTION
## Problem

Opening a bundled stdlib source (e.g. `wado-compiler/lib/core/prelude/types.wado`) in an editor produced a flood of `PreludeTypeCollision` errors against types like `Option`, `Result`, `Waitable`, …. The file *implements* the prelude but the LSP treated it as ordinary user code, so every prelude-named definition tripped the collision check. A separate latent bug also panicked the LSP when codegen was reached for those files.

## Approach

Two attribute-driven mechanisms, plus an LSP-side hardening:

1. **`#![no_prelude]` is now wired up.** Previously the attribute was parsed but had no effect. `analyze::check_prelude_collisions` now skips modules with `#![no_prelude]` (instead of `module_source.is_core()`). Bundled prelude submodules and the language-processing-system files (`builtin`, `internal`, `allocator`) carry the attribute because they *implement* the prelude rather than auto-importing it.

2. **`#![stdlib("core:…")]` declares a bundled file's canonical identity.** When the LSP opens such a file as the entry, the loader pins `entry_module_source` to the declared `Core{…}` / `Wasi{…}` instead of `EntryPoint{…}`. The transitive load of the same canonical identity then dedups against the entry's parsed AST, eliminating the duplicate-definition cascade (orphan-rule violations, `Option<T>` ≠ `Option<T>`, etc.) that otherwise arises from two copies of the same module sitting in the symbol table.

3. **`Engine::diagnostics` runs on `wado_compiler::annotate`** instead of the full `compile_with_options`. Codegen panics on validation failures for unusual entry modules; downstream phases (TIR, mono, lower, optimize, codegen) produce nothing user-actionable for editor diagnostics anyway. This also matches the architecture WEP, where LSP queries already entered through `annotate`.

The earlier path-based heuristic (matching filenames against `lib/core/...`) was reverted in favour of this attribute-based design.

## Code shape

- `wado-compiler/src/ast.rs` — new `Module::stdlib_identity()` accessor (alongside the existing `has_no_prelude`, `wasm_module`, … pattern).
- `wado-compiler/src/loader.rs` — parse the entry first with a tentative `EntryPoint`, then promote to the declared canonical `ModuleSource` if `#![stdlib("…")]` is present.
- `wado-compiler/src/analyze.rs` — collision-check gate switched to `module.has_no_prelude()`. Also fixes a long-standing diagnostic-filename misattribution by calling `set_file` here.
- `wado-compiler/lib/core/**`, `wado-compiler/lib/wasi/**` — 72 files annotated with `#![stdlib("…")]`. The 15 prelude/builtin/internal/allocator files additionally carry `#![no_prelude]`.
- `wado-lsp/src/lib.rs` — `Engine::diagnostics` switched to `annotate`.
- `wado-lsp/tests/diagnostics.rs` — new test file pinning the contracts: opening prelude/wasi sources is clean, user code redefining `Option` still errors, and `#![no_prelude]` lets user code opt out of the collision check.

## Test plan
- [x] `cargo test -p wado-lsp` — 5 / 5 (incl. `opening_prelude_types_is_clean`)
- [x] `cargo test -p wado-compiler --lib` — 438 / 438
- [x] `cargo test -p wado-compiler --test e2e` — 5690 / 5690
- [x] `time mise run on-task-done` — compile 193 ok, test 1657 passed
- [x] Manual: `wado compile lib/core/prelude/types.wado` no longer reports spurious prelude collisions; opening any bundled stdlib file in `wado lsp` returns a clean diagnostics list

https://claude.ai/code/session_01M3T2lAyUnpcS6KTzDF7Lao

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVM77WKHiMXAjCbMER8i8a)_