### PR TITLE
name: intern ModuleSource payloads with strict ptr-eq identity

### DIFF
--- a/wado-cli/src/discover.rs
+++ b/wado-cli/src/discover.rs
@@ -9,10 +9,10 @@
 //! - `[test].exclude` glob patterns from the root manifest
 //! - symbolic links (followed once each, with cycle detection on canonical paths)
 
-use std::collections::HashSet;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use wado_compiler::hashmap::IndexSet;
 
 use glob::{MatchOptions, Pattern, PatternError};
 
@@ -133,9 +133,9 @@ pub fn discover_test_files(
     let submodules = read_submodule_paths(root)?
         .into_iter()
         .map(|rel| root.join(rel))
-        .collect::<HashSet<_>>();
+        .collect::<IndexSet<_>>();
 
-    let mut visited: HashSet<PathBuf> = HashSet::new();
+    let mut visited: IndexSet<PathBuf> = IndexSet::default();
     if let Ok(canon) = fs::canonicalize(root) {
         visited.insert(canon);
     }
@@ -162,9 +162,9 @@ fn walk_dir(
     dir: &Path,
     root: &Path,
     excludes: &ExcludeSet,
-    submodules: &HashSet<PathBuf>,
+    submodules: &IndexSet<PathBuf>,
     rules: &mut Vec<GitignoreRule>,
-    visited: &mut HashSet<PathBuf>,
+    visited: &mut IndexSet<PathBuf>,
     out: &mut DiscoveryResult,
 ) -> Result<(), WalkError> {
     let added_rules = load_gitignore(dir, rules)?;

--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -10,6 +10,8 @@ use crate::compiler_host::CompilerHost;
 use crate::loader::{resolve_wasm_asset_path, wasm_asset_kind_from_attrs};
 use crate::logger::{Bail, Logger};
 use crate::name::{ModuleSource, validate_module_path};
+use std::cell::RefCell;
+use std::rc::Rc;
 
 /// Resolve `use_decl.source` against `from`, recognising
 /// `with { type: "wat" | "wasm" }` attributes and routing them to the
@@ -20,6 +22,7 @@ use crate::name::{ModuleSource, validate_module_path};
 /// `core:libm.wat` with no leading `./`); the caller emits the
 /// downstream `InvalidModulePath` diagnostic.
 fn resolve_use_decl_module_source(
+    interner: &mut crate::name::ModuleSourceInterner,
     from: &ModuleSource,
     use_decl: &UseDecl,
     entry: Option<&ModuleSource>,
@@ -28,9 +31,10 @@ fn resolve_use_decl_module_source(
     if let Some(kind) = wasm_asset_kind_from_attrs(use_decl.attributes.as_ref()) {
         return resolve_wasm_asset_path(from, &use_decl.source)
             .ok()
-            .map(|path| ModuleSource::Wasm { path, kind });
+            .map(|path| interner.wasm(&path, kind));
     }
     Some(crate::name::resolve_import_with_invocations(
+        interner,
         from,
         &use_decl.source,
         entry,
@@ -220,6 +224,10 @@ pub struct Analyzer<'a, H: CompilerHost> {
     /// (`validate_imports`, re-export registration). Empty when the
     /// compilation did not run the Kiln pipeline.
     invocations: crate::kiln::InvocationIndex,
+    /// `ModuleSource` interner shared with the loader. Forwarded to
+    /// [`resolve_use_decl_module_source`] so analyze-phase imports get
+    /// canonicalized identities.
+    interner: Rc<RefCell<crate::name::ModuleSourceInterner>>,
 }
 
 impl<'a, H: CompilerHost> Analyzer<'a, H> {
@@ -229,9 +237,21 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
             symbols: SymbolTable::new(),
             logger,
             implicit_modules: crate::hashmap::IndexSet::default(),
-            entry_module_source: ModuleSource::entry_point_with_filename("<uninitialized>"),
+            entry_module_source: ModuleSource::entry_point_uninitialized(),
             invocations: crate::kiln::InvocationIndex::new(),
+            interner: Rc::new(RefCell::new(crate::name::ModuleSourceInterner::new())),
         }
+    }
+
+    /// Seed the analyzer with the loader's interner so import-site
+    /// resolution canonicalizes module identities consistently.
+    #[must_use]
+    pub fn with_interner(
+        mut self,
+        interner: Rc<RefCell<crate::name::ModuleSourceInterner>>,
+    ) -> Self {
+        self.interner = interner;
+        self
     }
 
     /// Seed the analyzer with a Kiln invocation index. Call before
@@ -648,6 +668,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                 // Resolve the source path to ModuleSource, honoring
                 // wasm-asset attributes and Kiln invocation redirects.
                 let Some(source_module) = resolve_use_decl_module_source(
+                    &mut self.interner.borrow_mut(),
                     module_source,
                     use_decl,
                     Some(&self.entry_module_source),
@@ -724,6 +745,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                 // Resolve the import path to ModuleSource, honoring
                 // wasm-asset attributes and Kiln invocation redirects.
                 let Some(module_source) = resolve_use_decl_module_source(
+                    &mut self.interner.borrow_mut(),
                     from_module_source,
                     use_decl,
                     Some(&self.entry_module_source),

--- a/wado-compiler/src/annotate.rs
+++ b/wado-compiler/src/annotate.rs
@@ -43,6 +43,13 @@ pub struct Annotated {
     /// LSP queries (definition / hover / references) borrow this when
     /// they need to resolve an import path the user clicked into a
     /// `ModuleSource`.
+    ///
+    /// Re-entrancy: only single-threaded callers, and only one
+    /// `borrow_mut` at a time. Do not hold a [`std::cell::RefMut`]
+    /// across calls into other [`Annotated`] / [`crate::Resolver`]
+    /// methods — a nested `borrow_mut` will panic. The intended
+    /// pattern is `annotated.interner.borrow_mut().<one method call>`,
+    /// dropping the borrow at the statement boundary.
     pub interner: std::rc::Rc<std::cell::RefCell<crate::name::ModuleSourceInterner>>,
     /// Per-module structural index (name spans, write targets, span lookup).
     /// Built once per [`Module`] in [`annotate_loaded`]. LSP queries (and

--- a/wado-compiler/src/annotate.rs
+++ b/wado-compiler/src/annotate.rs
@@ -39,6 +39,11 @@ pub struct Annotated {
     pub modules: IndexMap<ModuleSource, Module>,
     pub symbols: SymbolTable,
     pub types: TypeTable,
+    /// `ModuleSource` interner shared with the analyze + resolve phases.
+    /// LSP queries (definition / hover / references) borrow this when
+    /// they need to resolve an import path the user clicked into a
+    /// `ModuleSource`.
+    pub interner: std::rc::Rc<std::cell::RefCell<crate::name::ModuleSourceInterner>>,
     /// Per-module structural index (name spans, write targets, span lookup).
     /// Built once per [`Module`] in [`annotate_loaded`]. LSP queries (and
     /// the in-tree [`name_span_of`] / [`span_of_key`] helpers) consult this
@@ -375,9 +380,16 @@ pub(crate) fn annotate_loaded<H: CompilerHost>(
     load_result: loader::LoadResult,
     logger: &Logger<'_, H>,
 ) -> Result<Annotated, Bail> {
+    // Wrap the loader's interner in `Rc<RefCell<>>` so analyze and the
+    // per-module resolvers can each `borrow_mut()` it from `&self`
+    // contexts. Single-threaded sharing matches the rest of the
+    // compiler's `Rc<RefCell<TypeTable>>` plumbing.
+    let interner = std::rc::Rc::new(std::cell::RefCell::new(load_result.interner));
     let symbols = {
         let _span = logger.span("analyze");
-        let mut analyzer = Analyzer::new(logger).with_invocations(load_result.invocations.clone());
+        let mut analyzer = Analyzer::new(logger)
+            .with_invocations(load_result.invocations.clone())
+            .with_interner(interner.clone());
         analyzer.analyze_loaded_modules(
             &load_result.modules,
             &load_result.entry_module_source,
@@ -394,6 +406,7 @@ pub(crate) fn annotate_loaded<H: CompilerHost>(
             &load_result.entry_module_source,
             logger,
             load_result.invocations.clone(),
+            interner.clone(),
         )?
     };
 
@@ -443,6 +456,7 @@ pub(crate) fn annotate_loaded<H: CompilerHost>(
         modules: load_result.modules,
         symbols,
         types,
+        interner,
         ast_indices,
         state,
         references,

--- a/wado-compiler/src/flat_package.rs
+++ b/wado-compiler/src/flat_package.rs
@@ -97,6 +97,14 @@ pub struct FlatPackage {
     /// "<export>")]` attributes). Consumed by
     /// `codegen::component::embed_imported_wasm_modules`.
     pub wasm_assets: IndexMap<String, crate::loader::WasmAsset>,
+
+    /// `ModuleSource` interner inherited from [`crate::package::Package`].
+    /// Kept alive through the lower phase because passes such as
+    /// `expand_cm_intrinsics` synthesise fresh `ModuleSource` values
+    /// when lifting WASI records and need them ptr-equal to the
+    /// resolver-registered counterparts. Dropped at the
+    /// `FlatPackage → WirPackage` boundary.
+    pub interner: std::rc::Rc<std::cell::RefCell<crate::name::ModuleSourceInterner>>,
 }
 
 impl FlatPackage {

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -675,10 +675,14 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
             })?
     };
 
+    // Wrap the loader's interner for sharing across analyze + resolve.
+    let interner =
+        std::rc::Rc::new(std::cell::RefCell::new(load_result.interner));
+
     // === Phase 6: Analyze all modules ===
     let symbols = {
         let _span = logger.span("analyze");
-        let mut analyzer = Analyzer::new(&logger);
+        let mut analyzer = Analyzer::new(&logger).with_interner(interner.clone());
         analyzer.analyze_loaded_modules(
             &load_result.modules,
             &load_result.entry_module_source,
@@ -697,6 +701,7 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
             &logger,
             &load_result.included_files,
             load_result.invocations.clone(),
+            interner.clone(),
         )
         .ok()
     };

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -678,8 +678,7 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
     };
 
     // Wrap the loader's interner for sharing across analyze + resolve.
-    let interner =
-        std::rc::Rc::new(std::cell::RefCell::new(load_result.interner));
+    let interner = std::rc::Rc::new(std::cell::RefCell::new(load_result.interner));
 
     // === Phase 6: Analyze all modules ===
     let symbols = {
@@ -745,7 +744,7 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
                 wasi_registry,
                 world_registry,
                 builtin_registry,
-                interner.clone(),
+                interner,
             );
 
             // Apply target world override (must be before synthesis)

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -359,6 +359,7 @@ fn compile_after_load<H: CompilerHost>(
         symbols,
         state,
         tir_modules,
+        interner,
         ..
     } = annotated;
 
@@ -371,6 +372,7 @@ fn compile_after_load<H: CompilerHost>(
         state.wasi_registry,
         state.world_registry,
         state.builtin_registry,
+        interner,
     );
 
     // Apply options to package (must be before synthesis)
@@ -743,6 +745,7 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
                 wasi_registry,
                 world_registry,
                 builtin_registry,
+                interner.clone(),
             );
 
             // Apply target world override (must be before synthesis)

--- a/wado-compiler/src/link.rs
+++ b/wado-compiler/src/link.rs
@@ -133,5 +133,6 @@ pub fn link(package: Package) -> FlatPackage {
         builtin_registry: package.builtin_registry,
         task_return_flat_params: package.task_return_flat_params,
         wasm_assets: package.wasm_assets,
+        interner: package.interner,
     }
 }

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -187,8 +187,14 @@ impl From<LoadError> for crate::compiler_host::Diagnostic {
 impl From<SourceError> for LoadError {
     fn from(err: SourceError) -> Self {
         match err {
+            // Error path: the `module_source` here is only consumed by
+            // `Display` / `Diagnostic::from`. We deliberately use an
+            // uncanonicalized `InternedStr` because no interner is
+            // reachable from `From::from`.
             SourceError::NotFound { path } => LoadError::ModuleNotFound {
-                module_source: ModuleSource::Local { path },
+                module_source: ModuleSource::Local {
+                    path: crate::name::InternedStr::from_string_uncanonicalized(path),
+                },
             },
             SourceError::IoError { path, message } => LoadError::IoError { path, message },
             SourceError::NetworkError { url, message } => LoadError::IoError { path: url, message },
@@ -269,6 +275,11 @@ pub struct LoadResult {
     /// (analyze, resolver) can also rewrite `use ... from "<schema>"`
     /// clauses consistently.
     pub invocations: crate::kiln::InvocationIndex,
+    /// `ModuleSource` interner created during loading. Downstream phases
+    /// (analyze / resolver / synthesis / monomorphize) borrow this to
+    /// canonicalize any `ModuleSource` they construct so that ptr-eq
+    /// remains a valid identity check across phases.
+    pub interner: crate::name::ModuleSourceInterner,
 }
 
 use crate::compiler_host::LogLevel;
@@ -764,12 +775,15 @@ fn parse_bind_desugar_stdlib(label: &str, source: &str) -> Module {
 /// [`stdlib::get_stdlib_module`]) is a stdlib bug — it panics rather than
 /// silently degrading to `EntryPoint`, since the LSP would then see the
 /// duplicate-definition cascade we introduced this attribute to suppress.
-fn parse_stdlib_identity_attribute(module: &Module) -> Option<ModuleSource> {
+fn parse_stdlib_identity_attribute(
+    interner: &mut crate::name::ModuleSourceInterner,
+    module: &Module,
+) -> Option<ModuleSource> {
     let path = module.stdlib_identity()?;
     let resolved = if let Some(name) = path.strip_prefix("core:") {
-        ModuleSource::core(name)
+        interner.core(name)
     } else if let Some(interface) = path.strip_prefix("wasi:") {
-        ModuleSource::wasi(interface)
+        interner.wasi(interface)
     } else {
         panic!(
             "#![stdlib({path:?})] must use a `core:` or `wasi:` prefix; \
@@ -801,9 +815,11 @@ mod tests {
     #[test]
     fn stdlib_identity_attribute_resolves_to_core_module_source() {
         let module = parse_test_module("#![no_prelude]\n#![stdlib(\"core:prelude/types.wado\")]\n");
+        let mut interner = crate::name::ModuleSourceInterner::new();
+        let want = interner.core("prelude/types.wado");
         assert_eq!(
-            parse_stdlib_identity_attribute(&module),
-            Some(ModuleSource::core("prelude/types.wado"))
+            parse_stdlib_identity_attribute(&mut interner, &module),
+            Some(want)
         );
     }
 }
@@ -811,10 +827,18 @@ mod tests {
 /// Cached desugared AST modules for all stdlib modules (core + WASI).
 ///
 /// Each module is parsed, bound, and desugared exactly once per process.
-fn cached_stdlib() -> &'static IndexMap<ModuleSource, Module> {
+///
+/// Keyed by the canonical display form (`"core:foo"`, `"wasi:bar/baz.wado"`)
+/// rather than by `ModuleSource` value. The cache is process-global, but
+/// every `ModuleLoader` instance creates `ModuleSource` keys through its
+/// own private interner — using string keys here keeps the cache lookup
+/// content-addressed and avoids forcing the cache to share an interner
+/// with every loader. See [`stdlib_cache_key`] for how callers compute
+/// the lookup string from a `ModuleSource`.
+fn cached_stdlib() -> &'static IndexMap<String, Module> {
     use std::sync::OnceLock;
 
-    static CACHE: OnceLock<IndexMap<ModuleSource, Module>> = OnceLock::new();
+    static CACHE: OnceLock<IndexMap<String, Module>> = OnceLock::new();
     CACHE.get_or_init(|| {
         let core_modules: &[(&str, &str)] = &[
             ("allocator", stdlib::CORE_ALLOCATOR),
@@ -847,28 +871,31 @@ fn cached_stdlib() -> &'static IndexMap<ModuleSource, Module> {
         let mut cache = IndexMap::with_capacity_and_hasher(total_count, FxBuildHasher);
 
         for &(name, source) in core_modules {
-            let module_source = ModuleSource::Core {
-                name: name.to_string(),
-            };
-            cache.insert(
-                module_source,
-                parse_bind_desugar_stdlib(&format!("core:{name}"), source),
-            );
+            let import_path = format!("core:{name}");
+            let module = parse_bind_desugar_stdlib(&import_path, source);
+            cache.insert(import_path, module);
         }
 
         for &(import_path, source) in stdlib::ALL_WASI_MODULES {
-            let interface = import_path.strip_prefix("wasi:").unwrap();
-            let module_source = ModuleSource::Wasi {
-                interface: interface.to_string(),
-            };
             cache.insert(
-                module_source,
+                import_path.to_string(),
                 parse_bind_desugar_stdlib(import_path, source),
             );
         }
 
         cache
     })
+}
+
+/// Compute the cache key string used by [`cached_stdlib`] for a
+/// `ModuleSource`. Returns `None` for variants that the stdlib cache
+/// never holds (Local / Remote / EntryPoint / Redirected / Wasm).
+fn stdlib_cache_key(ms: &ModuleSource) -> Option<String> {
+    match ms {
+        ModuleSource::Core { name } => Some(format!("core:{name}")),
+        ModuleSource::Wasi { interface } => Some(format!("wasi:{interface}")),
+        _ => None,
+    }
 }
 
 pub struct ModuleLoader<'a, H: CompilerHost> {
@@ -878,6 +905,10 @@ pub struct ModuleLoader<'a, H: CompilerHost> {
     log_level: LogLevel,
     /// Logger for timing spans and diagnostics
     logger: Logger<'a, H>,
+    /// Interner for `ModuleSource` payloads. Owned by the loader so that
+    /// every loader-produced module identity goes through the same pool.
+    /// Re-exported from [`LoadResult`] for downstream phases.
+    interner: crate::name::ModuleSourceInterner,
     /// Cache of already parsed modules
     loaded: IndexMap<ModuleSource, Module>,
     /// Set of modules currently being loaded (for cycle detection during collection)
@@ -911,6 +942,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             host,
             log_level,
             logger: Logger::new(host, log_level),
+            interner: crate::name::ModuleSourceInterner::new(),
             loaded: IndexMap::default(),
             loading: IndexSet::default(),
             implicit_modules: IndexSet::default(),
@@ -921,6 +953,13 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             entry_canonical_name: None,
             invocations: crate::kiln::InvocationIndex::new(),
         }
+    }
+
+    /// Borrow the loader's interner mutably. Used by downstream phases
+    /// (analyze / resolve / synthesis) when they need to construct
+    /// fresh `ModuleSource` values during loader-driven processing.
+    pub fn interner_mut(&mut self) -> &mut crate::name::ModuleSourceInterner {
+        &mut self.interner
     }
 
     /// Seed the loader with a Kiln invocation index. Must be called before
@@ -948,7 +987,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         // Parse, bind, and desugar entry module
         // Use "<stdin>" as synthetic filename when no filename is provided (e.g., REPL, embedded code)
         let resolved_filename = entry_filename.unwrap_or("<stdin>");
-        let tentative_entry_source = ModuleSource::entry_point_with_filename(resolved_filename);
+        let tentative_entry_source = self.interner.entry_point(resolved_filename);
 
         // Parse first; the parser only needs `module_source` for error
         // reporting, so a tentative `EntryPoint` is fine. After parsing we
@@ -961,7 +1000,8 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         };
 
         let entry_module_source =
-            parse_stdlib_identity_attribute(&entry_ast).unwrap_or(tentative_entry_source);
+            parse_stdlib_identity_attribute(&mut self.interner, &entry_ast)
+                .unwrap_or(tentative_entry_source);
         self.entry_module_source = Some(entry_module_source.clone());
         self.entry_canonical_name = Some(crate::name::canonicalize_entry_point(resolved_filename));
 
@@ -1011,9 +1051,13 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             let mod_name = module_source.to_string();
 
             // Use cached desugared module for core stdlib
-            if let Some(cached) = core_cache.get(&module_source) {
-                let _span = self.logger.span(&format!("load {mod_name} (cached)"));
+            if let Some(cached) =
+                stdlib_cache_key(&module_source).and_then(|k| core_cache.get(&k))
+            {
+                let span_name = format!("load {mod_name} (cached)");
+                self.logger.span_start(&span_name);
                 self.collect_imports(cached, &module_source, &mut pending, &mut wasm_imports)?;
+                self.logger.span_end(&span_name);
                 self.loaded.insert(module_source, cached.clone());
                 continue;
             }
@@ -1076,6 +1120,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             included_files,
             wasm_assets: self.wasm_assets,
             invocations: self.invocations,
+            interner: self.interner,
         })
     }
 
@@ -1086,7 +1131,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     /// accumulated into a side-channel `wasm_imports_out` so the caller
     /// can run their async loading after this synchronous walk.
     fn collect_imports(
-        &self,
+        &mut self,
         module: &Module,
         from_module_source: &ModuleSource,
         pending: &mut VecDeque<(ModuleSource, ModuleSource)>,
@@ -1127,10 +1172,8 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         kind: WasmAssetKind,
         use_decl: &crate::ast::UseDecl,
     ) -> Result<(), LoadError> {
-        let source = ModuleSource::wasm(
-            resolve_wasm_asset_path(from_module_source, &use_decl.source)?,
-            kind,
-        );
+        let path = resolve_wasm_asset_path(from_module_source, &use_decl.source)?;
+        let source = self.interner.wasm(&path, kind);
 
         let _ = use_decl; // accepted for both wildcard and named forms; the
         // named form's items are resolved against the synthesized Wado
@@ -1227,7 +1270,9 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                 continue;
             }
 
-            if let Some(cached) = cache.get(&module_source) {
+            if let Some(cached) =
+                stdlib_cache_key(&module_source).and_then(|k| cache.get(&k))
+            {
                 // Load transitive dependencies from cache
                 let mut pending = VecDeque::new();
                 let mut wasm_imports = Vec::new();
@@ -1242,7 +1287,9 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                     if self.loaded.contains_key(&dep_ms) {
                         continue;
                     }
-                    if let Some(dep_cached) = cache.get(&dep_ms) {
+                    if let Some(dep_cached) =
+                        stdlib_cache_key(&dep_ms).and_then(|k| cache.get(&k))
+                    {
                         let _ = self.collect_imports(
                             dep_cached,
                             &dep_ms,
@@ -1284,9 +1331,9 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     ) {
         use crate::compiler_host::{Code, Diagnostic, DiagnosticSpan, Severity};
         let file = match from_module_source {
-            ModuleSource::Local { path } => path.clone(),
-            ModuleSource::EntryPoint { filename } => filename.clone(),
-            ModuleSource::Redirected { uri } => uri.clone(),
+            ModuleSource::Local { path } => path.to_string(),
+            ModuleSource::EntryPoint { filename } => filename.to_string(),
+            ModuleSource::Redirected { uri } => uri.to_string(),
             _ => String::new(),
         };
         self.host.emit_diagnostic(Diagnostic {
@@ -1306,7 +1353,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
 
     /// Resolve an import source relative to the importing module
     fn resolve_import(
-        &self,
+        &mut self,
         from_module_source: &ModuleSource,
         import_source: &str,
     ) -> Result<ModuleSource, LoadError> {
@@ -1325,9 +1372,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             if !decl_file.is_empty()
                 && let Some(entry_uri) = self.invocations.redirect(decl_file, import_source)
             {
-                return Ok(ModuleSource::Redirected {
-                    uri: entry_uri.to_string(),
-                });
+                return Ok(self.interner.redirected(&entry_uri));
             }
         }
 
@@ -1335,21 +1380,15 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         // Top-level: "core:cli" → Core { name: "cli" }
         // Sub-module: "core:prelude/traits.wado" → Core { name: "prelude/traits.wado" }
         if let Some(name) = import_source.strip_prefix("core:") {
-            return Ok(ModuleSource::Core {
-                name: name.to_string(),
-            });
+            return Ok(self.interner.core(name));
         }
         if let Some(interface) = import_source.strip_prefix("wasi:") {
-            return Ok(ModuleSource::Wasi {
-                interface: interface.to_string(),
-            });
+            return Ok(self.interner.wasi(interface));
         }
 
         // Handle remote modules (http:// or https://)
         if import_source.starts_with("https://") || import_source.starts_with("http://") {
-            return Ok(ModuleSource::Remote {
-                url: import_source.to_string(),
-            });
+            return Ok(self.interner.remote(import_source));
         }
 
         // Handle local modules (./ or ../)
@@ -1365,15 +1404,15 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                 {
                     return Ok(entry_ms.clone());
                 }
-                return Ok(ModuleSource::Local { path: resolved });
+                return Ok(self.interner.local(&resolved));
             }
             if let ModuleSource::Remote { url: from_url } = from_module_source {
                 let resolved = resolve_module_path(from_url, import_source);
-                return Ok(ModuleSource::Remote { url: resolved });
+                return Ok(self.interner.remote(&resolved));
             }
             // Entry point or stdlib: treat as relative to project root
             let canonical = normalize_module_path(import_source);
-            return Ok(ModuleSource::Local { path: canonical });
+            return Ok(self.interner.local(&canonical));
         }
 
         // Check for unknown namespace pattern (xxx:yyy)
@@ -1407,14 +1446,14 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             ModuleSource::Local { path } => {
                 let bytes = self.host.load_source(path).await.map_err(LoadError::from)?;
                 String::from_utf8(bytes).map_err(|_| LoadError::IoError {
-                    path: path.clone(),
+                    path: path.to_string(),
                     message: "file is not valid UTF-8".to_string(),
                 })
             }
             ModuleSource::Remote { url } => {
                 let bytes = self.host.load_source(url).await.map_err(LoadError::from)?;
                 String::from_utf8(bytes).map_err(|_| LoadError::IoError {
-                    path: url.clone(),
+                    path: url.to_string(),
                     message: "file is not valid UTF-8".to_string(),
                 })
             }
@@ -1457,7 +1496,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                 // Strip the `file:` scheme so the host sees a plain
                 // absolute path. Other schemes are passed through
                 // unchanged so in-memory hosts can use the URI as a key.
-                let host_path = strip_kiln_scheme(uri).unwrap_or_else(|| uri.clone());
+                let host_path = strip_kiln_scheme(uri).unwrap_or_else(|| uri.to_string());
                 let bytes = self
                     .host
                     .load_source(&host_path)

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -23,8 +23,12 @@ use crate::stdlib;
 /// Error that can occur during module loading
 #[derive(Debug, Clone)]
 pub enum LoadError {
-    /// Module was not found
-    ModuleNotFound { module_source: ModuleSource },
+    /// Module was not found. `path` is the canonical display form
+    /// (`"core:foo"`, `"./bar.wado"`, `"<entry>"`) — kept as a plain
+    /// `String` so error construction does not need a
+    /// `ModuleSourceInterner`. This matches the shape of the other
+    /// `path`-bearing variants below (`IoError`, `InvalidModulePath`).
+    ModuleNotFound { path: String },
     /// Error while parsing module
     ParseError {
         module_source: ModuleSource,
@@ -60,8 +64,8 @@ pub enum LoadError {
 impl std::fmt::Display for LoadError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LoadError::ModuleNotFound { module_source } => {
-                write!(f, "module not found: {module_source}")
+            LoadError::ModuleNotFound { path } => {
+                write!(f, "module not found: {path}")
             }
             LoadError::ParseError {
                 module_source,
@@ -187,15 +191,7 @@ impl From<LoadError> for crate::compiler_host::Diagnostic {
 impl From<SourceError> for LoadError {
     fn from(err: SourceError) -> Self {
         match err {
-            // Error path: the `module_source` here is only consumed by
-            // `Display` / `Diagnostic::from`. We deliberately use an
-            // uncanonicalized `InternedStr` because no interner is
-            // reachable from `From::from`.
-            SourceError::NotFound { path } => LoadError::ModuleNotFound {
-                module_source: ModuleSource::Local {
-                    path: crate::name::InternedStr::from_string_uncanonicalized(path),
-                },
-            },
+            SourceError::NotFound { path } => LoadError::ModuleNotFound { path },
             SourceError::IoError { path, message } => LoadError::IoError { path, message },
             SourceError::NetworkError { url, message } => LoadError::IoError { path: url, message },
         }
@@ -1247,7 +1243,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             return stdlib::get_stdlib_wasm_asset(path)
                 .map(<[u8]>::to_vec)
                 .ok_or_else(|| LoadError::ModuleNotFound {
-                    module_source: source.clone(),
+                    path: source.to_string(),
                 });
         }
         self.host.load_source(path).await.map_err(LoadError::from)
@@ -1462,9 +1458,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                 if let Some(source) = stdlib::get_stdlib_module(&import_path) {
                     Ok(source.to_string())
                 } else {
-                    Err(LoadError::ModuleNotFound {
-                        module_source: module_source.clone(),
-                    })
+                    Err(LoadError::ModuleNotFound { path: import_path })
                 }
             }
             ModuleSource::Wasi { interface } => {
@@ -1472,15 +1466,13 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                 if let Some(source) = stdlib::get_stdlib_module(&import_path) {
                     Ok(source.to_string())
                 } else {
-                    Err(LoadError::ModuleNotFound {
-                        module_source: module_source.clone(),
-                    })
+                    Err(LoadError::ModuleNotFound { path: import_path })
                 }
             }
             ModuleSource::EntryPoint { .. } => {
                 // Entry point source is provided directly, not loaded from host
                 Err(LoadError::ModuleNotFound {
-                    module_source: module_source.clone(),
+                    path: module_source.to_string(),
                 })
             }
             ModuleSource::Wasm { .. } => {
@@ -1489,7 +1481,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                 // Wado parsing path; reaching this branch means a Wasm asset was
                 // accidentally routed through the Wado loader.
                 Err(LoadError::ModuleNotFound {
-                    module_source: module_source.clone(),
+                    path: module_source.to_string(),
                 })
             }
             ModuleSource::Redirected { uri } => {

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -885,7 +885,7 @@ fn cached_stdlib() -> &'static IndexMap<String, Module> {
 
 /// Compute the cache key string used by [`cached_stdlib`] for a
 /// `ModuleSource`. Returns `None` for variants that the stdlib cache
-/// never holds (Local / Remote / EntryPoint / Redirected / Wasm).
+/// never holds (Local / Remote / `EntryPoint` / Redirected / Wasm).
 fn stdlib_cache_key(ms: &ModuleSource) -> Option<String> {
     match ms {
         ModuleSource::Core { name } => Some(format!("core:{name}")),
@@ -995,9 +995,8 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             self.parse_source(entry_source, &tentative_entry_source)?
         };
 
-        let entry_module_source =
-            parse_stdlib_identity_attribute(&mut self.interner, &entry_ast)
-                .unwrap_or(tentative_entry_source);
+        let entry_module_source = parse_stdlib_identity_attribute(&mut self.interner, &entry_ast)
+            .unwrap_or(tentative_entry_source);
         self.entry_module_source = Some(entry_module_source.clone());
         self.entry_canonical_name = Some(crate::name::canonicalize_entry_point(resolved_filename));
 
@@ -1047,8 +1046,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             let mod_name = module_source.to_string();
 
             // Use cached desugared module for core stdlib
-            if let Some(cached) =
-                stdlib_cache_key(&module_source).and_then(|k| core_cache.get(&k))
+            if let Some(cached) = stdlib_cache_key(&module_source).and_then(|k| core_cache.get(&k))
             {
                 let span_name = format!("load {mod_name} (cached)");
                 self.logger.span_start(&span_name);
@@ -1266,9 +1264,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                 continue;
             }
 
-            if let Some(cached) =
-                stdlib_cache_key(&module_source).and_then(|k| cache.get(&k))
-            {
+            if let Some(cached) = stdlib_cache_key(&module_source).and_then(|k| cache.get(&k)) {
                 // Load transitive dependencies from cache
                 let mut pending = VecDeque::new();
                 let mut wasm_imports = Vec::new();
@@ -1283,8 +1279,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                     if self.loaded.contains_key(&dep_ms) {
                         continue;
                     }
-                    if let Some(dep_cached) =
-                        stdlib_cache_key(&dep_ms).and_then(|k| cache.get(&k))
+                    if let Some(dep_cached) = stdlib_cache_key(&dep_ms).and_then(|k| cache.get(&k))
                     {
                         let _ = self.collect_imports(
                             dep_cached,
@@ -1368,7 +1363,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             if !decl_file.is_empty()
                 && let Some(entry_uri) = self.invocations.redirect(decl_file, import_source)
             {
-                return Ok(self.interner.redirected(&entry_uri));
+                return Ok(self.interner.redirected(entry_uri));
             }
         }
 

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -98,7 +98,7 @@ pub fn lower(flat: &mut FlatPackage) {
     // lift code using the concrete T (post-monomorphise). Must happen
     // before boxing so the newly-emitted struct/variant constructors get
     // boxed consistently with the rest of the module.
-    cm_intrinsics::expand_cm_intrinsics(&mut temp_module);
+    cm_intrinsics::expand_cm_intrinsics(&mut temp_module, &flat.interner);
 
     // Pre-boxing passes
     lower_pre_boxing(&mut temp_module, &global_variant_map);

--- a/wado-compiler/src/lower/cm_intrinsics.rs
+++ b/wado-compiler/src/lower/cm_intrinsics.rs
@@ -34,7 +34,10 @@ use crate::token::Span;
 
 /// Expand all occurrences of `builtin::cm_lift_async_result::<T>(outptr)`
 /// in `module` into inline lift code.
-pub fn expand_cm_intrinsics(module: &mut TirModule) {
+pub fn expand_cm_intrinsics(
+    module: &mut TirModule,
+    interner: &RefCell<crate::name::ModuleSourceInterner>,
+) {
     // Acquire a static reference to the WASI registry — lift of WASI
     // variants / records needs it for layout information. Reusing the
     // shared registry avoids the cost of rebuilding from stdlib.
@@ -57,6 +60,7 @@ pub fn expand_cm_intrinsics(module: &mut TirModule) {
                 locals: &mut locals,
                 type_table: &type_table,
                 wasi_registry,
+                interner,
                 rewrite_count: 0,
                 function_name: &fn_name,
             };
@@ -74,6 +78,7 @@ struct Rewriter<'a> {
     locals: &'a mut Vec<TirLocal>,
     type_table: &'a RefCell<TypeTable>,
     wasi_registry: &'a WasiRegistry,
+    interner: &'a RefCell<crate::name::ModuleSourceInterner>,
     rewrite_count: u32,
     #[allow(dead_code)]
     function_name: &'a str,
@@ -118,6 +123,7 @@ impl TirMutVisitor for Rewriter<'_> {
                 wasi_registry: self.wasi_registry,
                 type_table: self.type_table,
                 cm_package: &wasi_pkg,
+                interner: self.interner,
             },
         );
 

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -120,16 +120,17 @@ fn well_known_arcs() -> [Arc<str>; 22] {
 
 /// Interned string used for `ModuleSource` payloads.
 ///
-/// Eq compares by pointer identity first (fast path: O(1) when both
-/// values went through the same interner or share a well-known
-/// `LazyLock<Arc<str>>` static), then falls back to byte comparison so
-/// values produced via the `from_string_uncanonicalized` escape hatch
-/// (e.g., during synthesis where no interner is reachable) still
-/// behave correctly.
+/// Identity is by pointer: every `InternedStr` is constructed either
+/// through a [`ModuleSourceInterner`] (which canonicalises content
+/// against its `Arc<str>` pool) or by adopting one of the well-known
+/// `LazyLock<Arc<str>>` statics. The interner adopts every well-known
+/// static on construction, so calls like
+/// `interner.core("prelude")` and `ModuleSource::prelude()` share the
+/// same `Arc` and compare equal in O(1).
 ///
-/// Hash uses the byte content so a non-canonical `InternedStr` and a
-/// canonical one with the same content collide at the same bucket and
-/// `Eq` then reports them equal — required for `IndexMap` correctness.
+/// Hash also uses pointer identity. This is sound because two values
+/// with the same content always land in the same canonical `Arc` —
+/// either through the interner or via a well-known static.
 #[derive(Debug, Clone)]
 pub struct InternedStr(Arc<str>);
 
@@ -138,22 +139,6 @@ impl InternedStr {
     /// callers cannot bypass the interner.
     pub(crate) fn from_arc(arc: Arc<str>) -> Self {
         Self(arc)
-    }
-
-    /// Build from a `String` without going through a
-    /// `ModuleSourceInterner`. The resulting value has an identity
-    /// unique to this call — `Arc::ptr_eq` against a canonical interned
-    /// value with the same content returns false, but [`PartialEq`]
-    /// falls back to byte comparison so equality still holds. Hash uses
-    /// byte content so map lookups remain consistent with canonicalized
-    /// counterparts.
-    ///
-    /// Use at boundaries where an interner is not reachable: the
-    /// `From<SourceError>` impl in the loader, deep synthesis sites
-    /// that run after annotate, integration tests that build expected
-    /// `ModuleSource` values directly.
-    pub fn from_string_uncanonicalized(s: String) -> Self {
-        Self(Arc::from(s))
     }
 
     pub fn as_str(&self) -> &str {
@@ -180,26 +165,14 @@ impl AsRef<str> for InternedStr {
 
 impl PartialEq for InternedStr {
     fn eq(&self, other: &Self) -> bool {
-        // Fast path: same Arc => equal (always true for canonicalized
-        // values produced by a single `ModuleSourceInterner` and for
-        // well-known statics).
-        if Arc::ptr_eq(&self.0, &other.0) {
-            return true;
-        }
-        // Slow path: bytes match. Required because the
-        // `from_string_uncanonicalized` escape hatch produces values
-        // whose pointer identity differs from canonical values with the
-        // same content.
-        &*self.0 == &*other.0
+        Arc::ptr_eq(&self.0, &other.0)
     }
 }
 impl Eq for InternedStr {}
 
 impl Hash for InternedStr {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        // Hash by byte content so canonicalized and uncanonicalized
-        // values with the same content land at the same bucket.
-        (&*self.0).hash(state);
+        (Arc::as_ptr(&self.0).cast::<()>() as usize).hash(state);
     }
 }
 
@@ -228,6 +201,7 @@ impl PartialEq<&str> for InternedStr {
 /// (`PLACEHOLDER_NAME`, `CORE_PRELUDE`, ...), so calls like
 /// `interner.core("prelude")` return the same `Arc` as the static — and
 /// therefore the same `InternedStr` as `ModuleSource::prelude()`.
+#[derive(Debug)]
 pub struct ModuleSourceInterner {
     strings: HashSet<Arc<str>>,
 }

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -30,8 +30,8 @@
 //! - For projects with `wado.toml`: relative to the directory containing `wado.toml`
 //! - For standalone scripts: relative to the entry point's directory
 
+use crate::hashmap::IndexSet;
 use fluent_uri::UriRef;
-use std::collections::HashSet;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
@@ -90,8 +90,8 @@ static ENTRY_FILENAME_STDIN: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::f
 static ENTRY_FILENAME_UNINITIALIZED: LazyLock<Arc<str>> =
     LazyLock::new(|| Arc::<str>::from("<uninitialized>"));
 
-fn well_known_arcs() -> [Arc<str>; 22] {
-    [
+fn well_known_arcs() -> Vec<Arc<str>> {
+    vec![
         PLACEHOLDER_NAME.clone(),
         CORE_PRELUDE.clone(),
         CORE_BUILTIN.clone(),
@@ -141,10 +141,6 @@ impl InternedStr {
     }
 
     pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    pub fn as_arc(&self) -> &Arc<str> {
         &self.0
     }
 }
@@ -202,13 +198,15 @@ impl PartialEq<&str> for InternedStr {
 /// therefore the same `InternedStr` as `ModuleSource::prelude()`.
 #[derive(Debug)]
 pub struct ModuleSourceInterner {
-    strings: HashSet<Arc<str>>,
+    strings: IndexSet<Arc<str>>,
 }
 
 impl ModuleSourceInterner {
     pub fn new() -> Self {
-        let mut strings = HashSet::new();
-        for arc in well_known_arcs() {
+        let well_known = well_known_arcs();
+        let mut strings =
+            IndexSet::with_capacity_and_hasher(well_known.len(), rustc_hash::FxBuildHasher);
+        for arc in well_known {
             strings.insert(arc);
         }
         Self { strings }
@@ -263,10 +261,8 @@ impl ModuleSourceInterner {
     /// Convert from the legacy `&[String]` module path representation.
     pub fn from_path(&mut self, segments: &[String]) -> ModuleSource {
         match segments {
-            // Legacy: empty path represents entry module
-            [] => ModuleSource::EntryPoint {
-                filename: InternedStr::from_arc(ENTRY_FILENAME_ENTRY.clone()),
-            },
+            // Legacy: empty path represents entry module.
+            [] => ModuleSource::entry_point_synthetic(),
             [first] if first.starts_with("./") || first.starts_with("../") => self.local(first),
             [first, rest @ ..] if first == "core" => self.core(&rest.join("/")),
             [first, rest @ ..] if first == "wasi" => self.wasi(&rest.join("/")),
@@ -312,18 +308,23 @@ impl WasmAssetKind {
 /// This enum provides a structured representation of module paths,
 /// replacing raw `Vec<String>` for better type safety and clearer semantics.
 ///
+/// String payloads are [`InternedStr`]; construct values via the
+/// well-known zero-arg constructors (e.g. [`ModuleSource::prelude`])
+/// or through [`ModuleSourceInterner`].
+///
 /// # Examples
 ///
 /// ```ignore
-/// // Core library modules
-/// ModuleSource::Core { name: "prelude".to_string() }  // core:prelude
-/// ModuleSource::Core { name: "cli".to_string() }      // core:cli
+/// // Well-known sources need no interner.
+/// let prelude = ModuleSource::prelude();           // core:prelude
+/// let cli     = ModuleSource::cli();               // core:cli
+/// let wasi    = ModuleSource::wasi_cli();          // wasi:cli
 ///
-/// // WASI modules
-/// ModuleSource::Wasi { interface: "cli".to_string() } // wasi:cli
-///
-/// // Local modules
-/// ModuleSource::Local { path: "./geometry.wado".to_string() }
+/// // Arbitrary content goes through the interner so identity is
+/// // canonicalised (`Arc::ptr_eq` on the inner string).
+/// let mut interner = ModuleSourceInterner::new();
+/// let local  = interner.local("./geometry.wado");
+/// let wasi_x = interner.wasi("io");
 /// ```
 ///
 /// Note: Two `EntryPoint` variants are considered equal regardless of their
@@ -450,173 +451,72 @@ impl Default for ModuleSource {
     }
 }
 
+/// Generate a zero-arg `ModuleSource` constructor that adopts a
+/// well-known `LazyLock<Arc<str>>` static. Keeps the constructor body
+/// regular so the only per-name input is the variant + field + static.
+macro_rules! well_known_module_sources {
+    (
+        $(
+            $(#[$meta:meta])*
+            $vis:vis fn $fn_name:ident() = $variant:ident { $field:ident: $arc:ident }
+        ),* $(,)?
+    ) => {
+        $(
+            $(#[$meta])*
+            #[must_use]
+            $vis fn $fn_name() -> Self {
+                Self::$variant { $field: InternedStr::from_arc($arc.clone()) }
+            }
+        )*
+    };
+}
+
 impl ModuleSource {
-    /// `core:prelude` — the prelude module.
-    #[must_use]
-    pub fn prelude() -> Self {
-        Self::Core {
-            name: InternedStr::from_arc(CORE_PRELUDE.clone()),
-        }
-    }
+    well_known_module_sources! {
+        /// `core:prelude` — the prelude module.
+        pub fn prelude() = Core { name: CORE_PRELUDE },
+        /// `core:prelude/string.wado` — the String type.
+        pub fn string() = Core { name: CORE_PRELUDE_STRING },
+        /// `core:prelude/array.wado` — the Array type.
+        pub fn array() = Core { name: CORE_PRELUDE_ARRAY },
+        /// `core:prelude/format.wado` — format trait helpers.
+        pub fn format() = Core { name: CORE_PRELUDE_FORMAT },
+        /// `core:prelude/int128.wado` — 128-bit integer types.
+        pub fn int128() = Core { name: CORE_PRELUDE_INT128 },
+        /// `core:prelude/primitive.wado` — primitive type methods.
+        pub fn primitive() = Core { name: CORE_PRELUDE_PRIMITIVE },
+        /// `core:prelude/types.wado` — core type definitions.
+        pub fn types() = Core { name: CORE_PRELUDE_TYPES },
+        /// `core:prelude/traits.wado` — builtin trait definitions.
+        pub fn traits() = Core { name: CORE_PRELUDE_TRAITS },
+        /// `core:prelude/range` — range types.
+        pub fn range() = Core { name: CORE_PRELUDE_RANGE },
+        /// `core:internal` — compiler internal functions.
+        pub fn internal() = Core { name: CORE_INTERNAL },
+        /// `core:allocator` — linear memory allocator (compiled into "mem" Wasm module).
+        pub fn allocator() = Core { name: CORE_ALLOCATOR },
+        /// `core:builtin` — builtin wasm instruction mappings.
+        pub fn builtin() = Core { name: CORE_BUILTIN },
+        /// `core:cli` — CLI output functions.
+        pub fn cli() = Core { name: CORE_CLI },
+        /// `core:serde` — serde framework.
+        pub fn serde() = Core { name: CORE_SERDE },
 
-    /// `core:prelude/string.wado` — the String type.
-    #[must_use]
-    pub fn string() -> Self {
-        Self::Core {
-            name: InternedStr::from_arc(CORE_PRELUDE_STRING.clone()),
-        }
-    }
+        /// `wasi:cli` — CLI interface root.
+        pub fn wasi_cli() = Wasi { interface: WASI_CLI },
+        /// `wasi:clocks` — clocks interface root.
+        pub fn wasi_clocks() = Wasi { interface: WASI_CLOCKS },
+        /// `wasi:filesystem` — filesystem interface root.
+        pub fn wasi_filesystem() = Wasi { interface: WASI_FILESYSTEM },
+        /// `wasi:http` — http interface root.
+        pub fn wasi_http() = Wasi { interface: WASI_HTTP },
 
-    /// `core:prelude/array.wado` — the Array type.
-    #[must_use]
-    pub fn array() -> Self {
-        Self::Core {
-            name: InternedStr::from_arc(CORE_PRELUDE_ARRAY.clone()),
-        }
-    }
-
-    /// `core:prelude/format.wado` — format trait helpers.
-    #[must_use]
-    pub fn format() -> Self {
-        Self::Core {
-            name: InternedStr::from_arc(CORE_PRELUDE_FORMAT.clone()),
-        }
-    }
-
-    /// `core:prelude/int128.wado` — 128-bit integer types.
-    #[must_use]
-    pub fn int128() -> Self {
-        Self::Core {
-            name: InternedStr::from_arc(CORE_PRELUDE_INT128.clone()),
-        }
-    }
-
-    /// `core:prelude/primitive.wado` — primitive type methods.
-    #[must_use]
-    pub fn primitive() -> Self {
-        Self::Core {
-            name: InternedStr::from_arc(CORE_PRELUDE_PRIMITIVE.clone()),
-        }
-    }
-
-    /// `core:prelude/types.wado` — core type definitions.
-    #[must_use]
-    pub fn types() -> Self {
-        Self::Core {
-            name: InternedStr::from_arc(CORE_PRELUDE_TYPES.clone()),
-        }
-    }
-
-    /// `core:prelude/traits.wado` — builtin trait definitions.
-    #[must_use]
-    pub fn traits() -> Self {
-        Self::Core {
-            name: InternedStr::from_arc(CORE_PRELUDE_TRAITS.clone()),
-        }
-    }
-
-    /// `core:prelude/range` — range types.
-    #[must_use]
-    pub fn range() -> Self {
-        Self::Core {
-            name: InternedStr::from_arc(CORE_PRELUDE_RANGE.clone()),
-        }
-    }
-
-    /// `core:internal` — compiler internal functions.
-    #[must_use]
-    pub fn internal() -> Self {
-        Self::Core {
-            name: InternedStr::from_arc(CORE_INTERNAL.clone()),
-        }
-    }
-
-    /// `core:allocator` — linear memory allocator (compiled into "mem" Wasm module).
-    #[must_use]
-    pub fn allocator() -> Self {
-        Self::Core {
-            name: InternedStr::from_arc(CORE_ALLOCATOR.clone()),
-        }
-    }
-
-    /// `core:builtin` — builtin wasm instruction mappings.
-    #[must_use]
-    pub fn builtin() -> Self {
-        Self::Core {
-            name: InternedStr::from_arc(CORE_BUILTIN.clone()),
-        }
-    }
-
-    /// `core:cli` — CLI output functions.
-    #[must_use]
-    pub fn cli() -> Self {
-        Self::Core {
-            name: InternedStr::from_arc(CORE_CLI.clone()),
-        }
-    }
-
-    /// `core:serde` — serde framework.
-    #[must_use]
-    pub fn serde() -> Self {
-        Self::Core {
-            name: InternedStr::from_arc(CORE_SERDE.clone()),
-        }
-    }
-
-    /// `wasi:cli` — CLI interface root.
-    #[must_use]
-    pub fn wasi_cli() -> Self {
-        Self::Wasi {
-            interface: InternedStr::from_arc(WASI_CLI.clone()),
-        }
-    }
-
-    /// `wasi:clocks` — clocks interface root.
-    #[must_use]
-    pub fn wasi_clocks() -> Self {
-        Self::Wasi {
-            interface: InternedStr::from_arc(WASI_CLOCKS.clone()),
-        }
-    }
-
-    /// `wasi:filesystem` — filesystem interface root.
-    #[must_use]
-    pub fn wasi_filesystem() -> Self {
-        Self::Wasi {
-            interface: InternedStr::from_arc(WASI_FILESYSTEM.clone()),
-        }
-    }
-
-    /// `wasi:http` — http interface root.
-    #[must_use]
-    pub fn wasi_http() -> Self {
-        Self::Wasi {
-            interface: InternedStr::from_arc(WASI_HTTP.clone()),
-        }
-    }
-
-    /// Synthetic `<entry>` placeholder used by `from_path(&[])`.
-    #[must_use]
-    pub fn entry_point_synthetic() -> Self {
-        Self::EntryPoint {
-            filename: InternedStr::from_arc(ENTRY_FILENAME_ENTRY.clone()),
-        }
-    }
-
-    /// `<uninitialized>` sentinel for resolver bootstrap.
-    #[must_use]
-    pub fn entry_point_uninitialized() -> Self {
-        Self::EntryPoint {
-            filename: InternedStr::from_arc(ENTRY_FILENAME_UNINITIALIZED.clone()),
-        }
-    }
-
-    /// `<stdin>` placeholder.
-    #[must_use]
-    pub fn entry_point_stdin() -> Self {
-        Self::EntryPoint {
-            filename: InternedStr::from_arc(ENTRY_FILENAME_STDIN.clone()),
-        }
+        /// Synthetic `<entry>` placeholder used by `from_path(&[])`.
+        pub fn entry_point_synthetic() = EntryPoint { filename: ENTRY_FILENAME_ENTRY },
+        /// `<uninitialized>` sentinel for resolver bootstrap.
+        pub fn entry_point_uninitialized() = EntryPoint { filename: ENTRY_FILENAME_UNINITIALIZED },
+        /// `<stdin>` placeholder.
+        pub fn entry_point_stdin() = EntryPoint { filename: ENTRY_FILENAME_STDIN },
     }
 
     /// Convert to the legacy `Vec<String>` module path representation.

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -75,8 +75,7 @@ static CORE_PRELUDE_TYPES: LazyLock<Arc<str>> =
     LazyLock::new(|| Arc::<str>::from("prelude/types.wado"));
 static CORE_PRELUDE_TRAITS: LazyLock<Arc<str>> =
     LazyLock::new(|| Arc::<str>::from("prelude/traits.wado"));
-static CORE_PRELUDE_RANGE: LazyLock<Arc<str>> =
-    LazyLock::new(|| Arc::<str>::from("prelude/range"));
+static CORE_PRELUDE_RANGE: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("prelude/range"));
 static CORE_SERDE: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("serde"));
 
 // Well-known WASI interface names embedded in the compiler.
@@ -1545,7 +1544,7 @@ pub fn resolve_import_with_invocations(
             _ => "",
         };
         if let Some(entry_uri) = invocations.redirect(decl_file, import_source) {
-            return interner.redirected(&entry_uri);
+            return interner.redirected(entry_uri);
         }
     }
     resolve_import_with_entry(interner, from_module, import_source, entry_module)
@@ -1965,11 +1964,8 @@ mod tests {
             &["./geometry.wado".to_string()],
             "Point",
         );
-        let s3 = StructName::from_path_and_name(
-            &mut interner,
-            &["./other.wado".to_string()],
-            "Point",
-        );
+        let s3 =
+            StructName::from_path_and_name(&mut interner, &["./other.wado".to_string()], "Point");
 
         let mut set = IndexSet::default();
         set.insert(s1);

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -31,8 +31,282 @@
 //! - For standalone scripts: relative to the entry point's directory
 
 use fluent_uri::UriRef;
+use std::collections::HashSet;
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+use std::sync::{Arc, LazyLock};
+
+// =============================================================================
+// Module source string interning (strict ptr-eq / ptr-hash)
+// =============================================================================
+//
+// `ModuleSource` is used pervasively as `IndexMap` key during monomorphization
+// and resolver lookups. To make `clone`/`eq`/`hash` O(1), every string field
+// is canonicalized into an `Arc<str>` shared via `ModuleSourceInterner`.
+//
+// Well-known names (the targets of zero-arg constructors like
+// `ModuleSource::prelude()`) live in `LazyLock<Arc<str>>` statics so they
+// can be constructed without an interner reference. The interner adopts
+// these statics on construction, ensuring that
+// `interner.core("prelude") == ModuleSource::prelude()` (ptr-equal).
+
+/// Sentinel `Arc<str>` for `ModuleSource::default()` placeholders.
+/// Distinct identity from any real interned core name (no real module
+/// has empty content).
+static PLACEHOLDER_NAME: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from(""));
+
+static CORE_PRELUDE: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("prelude"));
+static CORE_BUILTIN: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("builtin"));
+static CORE_INTERNAL: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("internal"));
+static CORE_ALLOCATOR: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("allocator"));
+static CORE_CLI: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("cli"));
+static CORE_PRELUDE_STRING: LazyLock<Arc<str>> =
+    LazyLock::new(|| Arc::<str>::from("prelude/string.wado"));
+static CORE_PRELUDE_ARRAY: LazyLock<Arc<str>> =
+    LazyLock::new(|| Arc::<str>::from("prelude/array.wado"));
+static CORE_PRELUDE_FORMAT: LazyLock<Arc<str>> =
+    LazyLock::new(|| Arc::<str>::from("prelude/format.wado"));
+static CORE_PRELUDE_INT128: LazyLock<Arc<str>> =
+    LazyLock::new(|| Arc::<str>::from("prelude/int128.wado"));
+static CORE_PRELUDE_PRIMITIVE: LazyLock<Arc<str>> =
+    LazyLock::new(|| Arc::<str>::from("prelude/primitive.wado"));
+static CORE_PRELUDE_TYPES: LazyLock<Arc<str>> =
+    LazyLock::new(|| Arc::<str>::from("prelude/types.wado"));
+static CORE_PRELUDE_TRAITS: LazyLock<Arc<str>> =
+    LazyLock::new(|| Arc::<str>::from("prelude/traits.wado"));
+static CORE_PRELUDE_RANGE: LazyLock<Arc<str>> =
+    LazyLock::new(|| Arc::<str>::from("prelude/range"));
+static CORE_SERDE: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("serde"));
+
+// Well-known WASI interface names embedded in the compiler.
+static WASI_CLI: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("cli"));
+static WASI_CLOCKS: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("clocks"));
+static WASI_FILESYSTEM: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("filesystem"));
+static WASI_HTTP: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("http"));
+
+// Synthetic entry-point filenames used by from_path / loader.
+static ENTRY_FILENAME_ENTRY: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("<entry>"));
+static ENTRY_FILENAME_STDIN: LazyLock<Arc<str>> = LazyLock::new(|| Arc::<str>::from("<stdin>"));
+static ENTRY_FILENAME_UNINITIALIZED: LazyLock<Arc<str>> =
+    LazyLock::new(|| Arc::<str>::from("<uninitialized>"));
+
+fn well_known_arcs() -> [Arc<str>; 22] {
+    [
+        PLACEHOLDER_NAME.clone(),
+        CORE_PRELUDE.clone(),
+        CORE_BUILTIN.clone(),
+        CORE_INTERNAL.clone(),
+        CORE_ALLOCATOR.clone(),
+        CORE_CLI.clone(),
+        CORE_PRELUDE_STRING.clone(),
+        CORE_PRELUDE_ARRAY.clone(),
+        CORE_PRELUDE_FORMAT.clone(),
+        CORE_PRELUDE_INT128.clone(),
+        CORE_PRELUDE_PRIMITIVE.clone(),
+        CORE_PRELUDE_TYPES.clone(),
+        CORE_PRELUDE_TRAITS.clone(),
+        CORE_PRELUDE_RANGE.clone(),
+        CORE_SERDE.clone(),
+        WASI_CLI.clone(),
+        WASI_CLOCKS.clone(),
+        WASI_FILESYSTEM.clone(),
+        WASI_HTTP.clone(),
+        ENTRY_FILENAME_ENTRY.clone(),
+        ENTRY_FILENAME_STDIN.clone(),
+        ENTRY_FILENAME_UNINITIALIZED.clone(),
+    ]
+}
+
+/// Interned string used for `ModuleSource` payloads.
+///
+/// Eq compares by pointer identity first (fast path: O(1) when both
+/// values went through the same interner or share a well-known
+/// `LazyLock<Arc<str>>` static), then falls back to byte comparison so
+/// values produced via the `from_string_uncanonicalized` escape hatch
+/// (e.g., during synthesis where no interner is reachable) still
+/// behave correctly.
+///
+/// Hash uses the byte content so a non-canonical `InternedStr` and a
+/// canonical one with the same content collide at the same bucket and
+/// `Eq` then reports them equal — required for `IndexMap` correctness.
+#[derive(Debug, Clone)]
+pub struct InternedStr(Arc<str>);
+
+impl InternedStr {
+    /// Build from a raw `Arc<str>`. Restricted to this crate so external
+    /// callers cannot bypass the interner.
+    pub(crate) fn from_arc(arc: Arc<str>) -> Self {
+        Self(arc)
+    }
+
+    /// Build from a `String` without going through a
+    /// `ModuleSourceInterner`. The resulting value has an identity
+    /// unique to this call — `Arc::ptr_eq` against a canonical interned
+    /// value with the same content returns false, but [`PartialEq`]
+    /// falls back to byte comparison so equality still holds. Hash uses
+    /// byte content so map lookups remain consistent with canonicalized
+    /// counterparts.
+    ///
+    /// Use at boundaries where an interner is not reachable: the
+    /// `From<SourceError>` impl in the loader, deep synthesis sites
+    /// that run after annotate, integration tests that build expected
+    /// `ModuleSource` values directly.
+    pub fn from_string_uncanonicalized(s: String) -> Self {
+        Self(Arc::from(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn as_arc(&self) -> &Arc<str> {
+        &self.0
+    }
+}
+
+impl Deref for InternedStr {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for InternedStr {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl PartialEq for InternedStr {
+    fn eq(&self, other: &Self) -> bool {
+        // Fast path: same Arc => equal (always true for canonicalized
+        // values produced by a single `ModuleSourceInterner` and for
+        // well-known statics).
+        if Arc::ptr_eq(&self.0, &other.0) {
+            return true;
+        }
+        // Slow path: bytes match. Required because the
+        // `from_string_uncanonicalized` escape hatch produces values
+        // whose pointer identity differs from canonical values with the
+        // same content.
+        &*self.0 == &*other.0
+    }
+}
+impl Eq for InternedStr {}
+
+impl Hash for InternedStr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Hash by byte content so canonicalized and uncanonicalized
+        // values with the same content land at the same bucket.
+        (&*self.0).hash(state);
+    }
+}
+
+impl fmt::Display for InternedStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl PartialEq<str> for InternedStr {
+    fn eq(&self, other: &str) -> bool {
+        &*self.0 == other
+    }
+}
+
+impl PartialEq<&str> for InternedStr {
+    fn eq(&self, other: &&str) -> bool {
+        &*self.0 == *other
+    }
+}
+
+/// Interner for `ModuleSource` payloads. Owns the canonical `Arc<str>`
+/// for each interned content; clones are cheap (refcount bump).
+///
+/// `ModuleSourceInterner::new()` adopts every well-known static
+/// (`PLACEHOLDER_NAME`, `CORE_PRELUDE`, ...), so calls like
+/// `interner.core("prelude")` return the same `Arc` as the static — and
+/// therefore the same `InternedStr` as `ModuleSource::prelude()`.
+pub struct ModuleSourceInterner {
+    strings: HashSet<Arc<str>>,
+}
+
+impl ModuleSourceInterner {
+    pub fn new() -> Self {
+        let mut strings = HashSet::new();
+        for arc in well_known_arcs() {
+            strings.insert(arc);
+        }
+        Self { strings }
+    }
+
+    pub fn intern(&mut self, s: &str) -> InternedStr {
+        if let Some(existing) = self.strings.get(s) {
+            return InternedStr::from_arc(existing.clone());
+        }
+        let arc: Arc<str> = Arc::from(s);
+        self.strings.insert(arc.clone());
+        InternedStr::from_arc(arc)
+    }
+
+    pub fn core(&mut self, name: &str) -> ModuleSource {
+        ModuleSource::Core {
+            name: self.intern(name),
+        }
+    }
+    pub fn wasi(&mut self, interface: &str) -> ModuleSource {
+        ModuleSource::Wasi {
+            interface: self.intern(interface),
+        }
+    }
+    pub fn local(&mut self, path: &str) -> ModuleSource {
+        ModuleSource::Local {
+            path: self.intern(path),
+        }
+    }
+    pub fn remote(&mut self, url: &str) -> ModuleSource {
+        ModuleSource::Remote {
+            url: self.intern(url),
+        }
+    }
+    pub fn redirected(&mut self, uri: &str) -> ModuleSource {
+        ModuleSource::Redirected {
+            uri: self.intern(uri),
+        }
+    }
+    pub fn wasm(&mut self, path: &str, kind: WasmAssetKind) -> ModuleSource {
+        ModuleSource::Wasm {
+            path: self.intern(path),
+            kind,
+        }
+    }
+    pub fn entry_point(&mut self, filename: &str) -> ModuleSource {
+        ModuleSource::EntryPoint {
+            filename: self.intern(filename),
+        }
+    }
+
+    /// Convert from the legacy `&[String]` module path representation.
+    pub fn from_path(&mut self, segments: &[String]) -> ModuleSource {
+        match segments {
+            // Legacy: empty path represents entry module
+            [] => ModuleSource::EntryPoint {
+                filename: InternedStr::from_arc(ENTRY_FILENAME_ENTRY.clone()),
+            },
+            [first] if first.starts_with("./") || first.starts_with("../") => self.local(first),
+            [first, rest @ ..] if first == "core" => self.core(&rest.join("/")),
+            [first, rest @ ..] if first == "wasi" => self.wasi(&rest.join("/")),
+            segments => self.local(&segments.join("/")),
+        }
+    }
+}
+
+impl Default for ModuleSourceInterner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Format of a wasm asset imported via `use ... with { type: "..." }`.
 ///
@@ -87,27 +361,27 @@ pub enum ModuleSource {
     /// Core library module (e.g., `core:prelude`, `core:cli`, `core:internal`, `core:builtin`)
     Core {
         /// Module name within core (e.g., "prelude", "cli", "internal", "builtin")
-        name: String,
+        name: InternedStr,
     },
     /// WASI module (e.g., `wasi:cli`, `wasi:io`)
     Wasi {
         /// Interface name (e.g., "cli", "io", "filesystem")
-        interface: String,
+        interface: InternedStr,
     },
     /// Local module relative to project root
     Local {
         /// Relative path (e.g., "./geometry.wado", "./utils/helper.wado")
-        path: String,
+        path: InternedStr,
     },
     /// Remote module loaded via HTTP/HTTPS
     Remote {
         /// Full URL (e.g., "<https://example.com/lib.wado>")
-        url: String,
+        url: InternedStr,
     },
     /// Entry point module (the main file being compiled)
     EntryPoint {
         /// Filename of the entry point (e.g., "hello.wado", "<stdin>", "<entry>")
-        filename: String,
+        filename: InternedStr,
     },
     /// Module loaded through a Kiln invocation redirect.
     ///
@@ -123,7 +397,7 @@ pub enum ModuleSource {
     /// [`crate::kiln::InvocationIndex`]; never written by user source.
     Redirected {
         /// Absolute URI (typically `file:///abs/path/to/file.wado`).
-        uri: String,
+        uri: InternedStr,
     },
     /// Wasm asset imported via `use ... from "<path>" with { type: "wat"|"wasm" }`.
     ///
@@ -141,7 +415,7 @@ pub enum ModuleSource {
         /// Canonical path identifier (used as the unique module key and
         /// as the namespace component of the synthesized
         /// `#[canonical("wasm:<path>", "<export>")]` attributes).
-        path: String,
+        path: InternedStr,
         /// `wat` or `wasm` source format.
         kind: WasmAssetKind,
     },
@@ -198,142 +472,177 @@ impl Default for ModuleSource {
     /// Placeholder value — replaced by the link phase with the real module source.
     fn default() -> Self {
         Self::Core {
-            name: String::new(),
+            name: InternedStr::from_arc(PLACEHOLDER_NAME.clone()),
         }
     }
 }
 
 impl ModuleSource {
-    /// Create a core module source.
-    #[must_use]
-    pub fn core(name: impl Into<String>) -> Self {
-        Self::Core { name: name.into() }
-    }
-
-    /// Create a WASI module source.
-    #[must_use]
-    pub fn wasi(interface: impl Into<String>) -> Self {
-        Self::Wasi {
-            interface: interface.into(),
-        }
-    }
-
-    /// Create a local module source.
-    #[must_use]
-    pub fn local(path: impl Into<String>) -> Self {
-        Self::Local { path: path.into() }
-    }
-
-    /// Create a remote module source.
-    #[must_use]
-    pub fn remote(url: impl Into<String>) -> Self {
-        Self::Remote { url: url.into() }
-    }
-
     /// `core:prelude` — the prelude module.
     #[must_use]
     pub fn prelude() -> Self {
-        Self::core("prelude")
+        Self::Core {
+            name: InternedStr::from_arc(CORE_PRELUDE.clone()),
+        }
     }
 
     /// `core:prelude/string.wado` — the String type.
     #[must_use]
     pub fn string() -> Self {
-        Self::core("prelude/string.wado")
+        Self::Core {
+            name: InternedStr::from_arc(CORE_PRELUDE_STRING.clone()),
+        }
     }
 
     /// `core:prelude/array.wado` — the Array type.
     #[must_use]
     pub fn array() -> Self {
-        Self::core("prelude/array.wado")
+        Self::Core {
+            name: InternedStr::from_arc(CORE_PRELUDE_ARRAY.clone()),
+        }
     }
 
     /// `core:prelude/format.wado` — format trait helpers.
     #[must_use]
     pub fn format() -> Self {
-        Self::core("prelude/format.wado")
+        Self::Core {
+            name: InternedStr::from_arc(CORE_PRELUDE_FORMAT.clone()),
+        }
     }
 
     /// `core:prelude/int128.wado` — 128-bit integer types.
     #[must_use]
     pub fn int128() -> Self {
-        Self::core("prelude/int128.wado")
+        Self::Core {
+            name: InternedStr::from_arc(CORE_PRELUDE_INT128.clone()),
+        }
     }
 
     /// `core:prelude/primitive.wado` — primitive type methods.
     #[must_use]
     pub fn primitive() -> Self {
-        Self::core("prelude/primitive.wado")
+        Self::Core {
+            name: InternedStr::from_arc(CORE_PRELUDE_PRIMITIVE.clone()),
+        }
     }
 
     /// `core:prelude/types.wado` — core type definitions.
     #[must_use]
     pub fn types() -> Self {
-        Self::core("prelude/types.wado")
+        Self::Core {
+            name: InternedStr::from_arc(CORE_PRELUDE_TYPES.clone()),
+        }
     }
 
     /// `core:prelude/traits.wado` — builtin trait definitions.
     #[must_use]
     pub fn traits() -> Self {
-        Self::core("prelude/traits.wado")
+        Self::Core {
+            name: InternedStr::from_arc(CORE_PRELUDE_TRAITS.clone()),
+        }
+    }
+
+    /// `core:prelude/range` — range types.
+    #[must_use]
+    pub fn range() -> Self {
+        Self::Core {
+            name: InternedStr::from_arc(CORE_PRELUDE_RANGE.clone()),
+        }
     }
 
     /// `core:internal` — compiler internal functions.
     #[must_use]
     pub fn internal() -> Self {
-        Self::core("internal")
+        Self::Core {
+            name: InternedStr::from_arc(CORE_INTERNAL.clone()),
+        }
     }
 
     /// `core:allocator` — linear memory allocator (compiled into "mem" Wasm module).
     #[must_use]
     pub fn allocator() -> Self {
-        Self::core("allocator")
+        Self::Core {
+            name: InternedStr::from_arc(CORE_ALLOCATOR.clone()),
+        }
     }
 
     /// `core:builtin` — builtin wasm instruction mappings.
     #[must_use]
     pub fn builtin() -> Self {
-        Self::core("builtin")
+        Self::Core {
+            name: InternedStr::from_arc(CORE_BUILTIN.clone()),
+        }
     }
 
     /// `core:cli` — CLI output functions.
     #[must_use]
     pub fn cli() -> Self {
-        Self::core("cli")
-    }
-
-    /// Create an entry point module source with a filename.
-    #[must_use]
-    pub fn entry_point_with_filename(filename: impl Into<String>) -> Self {
-        Self::EntryPoint {
-            filename: filename.into(),
+        Self::Core {
+            name: InternedStr::from_arc(CORE_CLI.clone()),
         }
     }
 
-    /// Convert from a legacy `Vec<String>` module path.
-    ///
-    /// This enables gradual migration from the old representation.
+    /// `core:serde` — serde framework.
     #[must_use]
-    pub fn from_path(path: &[String]) -> Self {
-        match path {
-            // Legacy: empty path represents entry module
-            // TODO: Remove this case by changing resolve_all_modules to return IndexMap<ModuleSource, _>
-            [] => Self::entry_point_with_filename("<entry>"),
-            [first] if first.starts_with("./") || first.starts_with("../") => Self::Local {
-                path: first.clone(),
-            },
-            [first, rest @ ..] if first == "core" => Self::Core {
-                name: rest.join("/"),
-            },
-            [first, rest @ ..] if first == "wasi" => Self::Wasi {
-                interface: rest.join("/"),
-            },
-            segments => {
-                // Treat as local path
-                Self::Local {
-                    path: segments.join("/"),
-                }
-            }
+    pub fn serde() -> Self {
+        Self::Core {
+            name: InternedStr::from_arc(CORE_SERDE.clone()),
+        }
+    }
+
+    /// `wasi:cli` — CLI interface root.
+    #[must_use]
+    pub fn wasi_cli() -> Self {
+        Self::Wasi {
+            interface: InternedStr::from_arc(WASI_CLI.clone()),
+        }
+    }
+
+    /// `wasi:clocks` — clocks interface root.
+    #[must_use]
+    pub fn wasi_clocks() -> Self {
+        Self::Wasi {
+            interface: InternedStr::from_arc(WASI_CLOCKS.clone()),
+        }
+    }
+
+    /// `wasi:filesystem` — filesystem interface root.
+    #[must_use]
+    pub fn wasi_filesystem() -> Self {
+        Self::Wasi {
+            interface: InternedStr::from_arc(WASI_FILESYSTEM.clone()),
+        }
+    }
+
+    /// `wasi:http` — http interface root.
+    #[must_use]
+    pub fn wasi_http() -> Self {
+        Self::Wasi {
+            interface: InternedStr::from_arc(WASI_HTTP.clone()),
+        }
+    }
+
+    /// Synthetic `<entry>` placeholder used by `from_path(&[])`.
+    #[must_use]
+    pub fn entry_point_synthetic() -> Self {
+        Self::EntryPoint {
+            filename: InternedStr::from_arc(ENTRY_FILENAME_ENTRY.clone()),
+        }
+    }
+
+    /// `<uninitialized>` sentinel for resolver bootstrap.
+    #[must_use]
+    pub fn entry_point_uninitialized() -> Self {
+        Self::EntryPoint {
+            filename: InternedStr::from_arc(ENTRY_FILENAME_UNINITIALIZED.clone()),
+        }
+    }
+
+    /// `<stdin>` placeholder.
+    #[must_use]
+    pub fn entry_point_stdin() -> Self {
+        Self::EntryPoint {
+            filename: InternedStr::from_arc(ENTRY_FILENAME_STDIN.clone()),
         }
     }
 
@@ -343,22 +652,13 @@ impl ModuleSource {
     #[must_use]
     pub fn to_path(&self) -> Vec<String> {
         match self {
-            Self::Core { name } => vec!["core".to_string(), name.clone()],
-            Self::Wasi { interface } => vec!["wasi".to_string(), interface.clone()],
-            Self::Local { path } => vec![path.clone()],
-            Self::Remote { url } => vec![url.clone()],
-            Self::EntryPoint { filename } => vec![filename.clone()],
-            Self::Redirected { uri } => vec![uri.clone()],
-            Self::Wasm { path, .. } => vec![path.clone()],
-        }
-    }
-
-    /// Construct a wasm-asset module source.
-    #[must_use]
-    pub fn wasm(path: impl Into<String>, kind: WasmAssetKind) -> Self {
-        Self::Wasm {
-            path: path.into(),
-            kind,
+            Self::Core { name } => vec!["core".to_string(), name.to_string()],
+            Self::Wasi { interface } => vec!["wasi".to_string(), interface.to_string()],
+            Self::Local { path } => vec![path.to_string()],
+            Self::Remote { url } => vec![url.to_string()],
+            Self::EntryPoint { filename } => vec![filename.to_string()],
+            Self::Redirected { uri } => vec![uri.to_string()],
+            Self::Wasm { path, .. } => vec![path.to_string()],
         }
     }
 
@@ -494,7 +794,7 @@ impl ModuleSource {
                 if filename.starts_with('<') {
                     String::new() // synthetic names like <stdin>, <entry>
                 } else {
-                    filename.clone()
+                    filename.to_string()
                 }
             }
             other => other.to_string(),
@@ -565,9 +865,13 @@ impl FreeFunctionName {
 
     /// Create a `FreeFunctionName` from a module path and name.
     /// This is a convenience method for code that still uses `Vec<String>` paths.
-    pub fn from_path_and_name(module_path: &[String], name: &str) -> Self {
+    pub fn from_path_and_name(
+        interner: &mut ModuleSourceInterner,
+        module_path: &[String],
+        name: &str,
+    ) -> Self {
         Self {
-            module_source: ModuleSource::from_path(module_path),
+            module_source: interner.from_path(module_path),
             name: name.to_string(),
             is_monomorphized: false,
             base_name: None,
@@ -576,10 +880,14 @@ impl FreeFunctionName {
 
     /// Create a `FreeFunctionName` from string literal slices.
     /// Convenience method for when you have &[&str] instead of &[String].
-    pub fn from_strs(module_path: &[&str], name: &str) -> Self {
+    pub fn from_strs(
+        interner: &mut ModuleSourceInterner,
+        module_path: &[&str],
+        name: &str,
+    ) -> Self {
         let path: Vec<String> = module_path.iter().map(|s| (*s).to_string()).collect();
         Self {
-            module_source: ModuleSource::from_path(&path),
+            module_source: interner.from_path(&path),
             name: name.to_string(),
             is_monomorphized: false,
             base_name: None,
@@ -1063,9 +1371,13 @@ impl StructName {
     /// Create a `StructName` from a module path and name.
     /// This is a convenience method for code that still uses `Vec<String>` paths.
     #[must_use]
-    pub fn from_path_and_name(module_path: &[String], name: &str) -> Self {
+    pub fn from_path_and_name(
+        interner: &mut ModuleSourceInterner,
+        module_path: &[String],
+        name: &str,
+    ) -> Self {
         Self {
-            module_source: ModuleSource::from_path(module_path),
+            module_source: interner.from_path(module_path),
             name: name.to_string(),
         }
     }
@@ -1073,10 +1385,14 @@ impl StructName {
     /// Create a `StructName` from string slices.
     /// This is a convenience method for tests and initialization.
     #[must_use]
-    pub fn from_strs(module_path: &[&str], name: &str) -> Self {
+    pub fn from_strs(
+        interner: &mut ModuleSourceInterner,
+        module_path: &[&str],
+        name: &str,
+    ) -> Self {
         let path: Vec<String> = module_path.iter().map(|&s| s.to_string()).collect();
         Self {
-            module_source: ModuleSource::from_path(&path),
+            module_source: interner.from_path(&path),
             name: name.to_string(),
         }
     }
@@ -1093,8 +1409,11 @@ impl fmt::Display for StructName {
 /// Format: `core/internal/{name}`
 ///
 /// Example: `core/internal/log_stdout`
-pub fn build_core_internal_name(name: &str) -> FreeFunctionName {
-    FreeFunctionName::from_strs(&["core", "internal"], name)
+pub fn build_core_internal_name(
+    interner: &mut ModuleSourceInterner,
+    name: &str,
+) -> FreeFunctionName {
+    FreeFunctionName::from_strs(interner, &["core", "internal"], name)
 }
 
 /// Validate that a module path is a valid URI reference.
@@ -1218,8 +1537,12 @@ pub fn resolve_module_path(base: &str, relative: &str) -> String {
 ///
 /// # Returns
 /// The resolved `ModuleSource`.
-pub fn resolve_import(from_module: &ModuleSource, import_source: &str) -> ModuleSource {
-    resolve_import_with_entry(from_module, import_source, None)
+pub fn resolve_import(
+    interner: &mut ModuleSourceInterner,
+    from_module: &ModuleSource,
+    import_source: &str,
+) -> ModuleSource {
+    resolve_import_with_entry(interner, from_module, import_source, None)
 }
 
 /// Resolve an import source, consulting a Kiln [`crate::kiln::InvocationIndex`]
@@ -1234,6 +1557,7 @@ pub fn resolve_import(from_module: &ModuleSource, import_source: &str) -> Module
 /// available — typically the CLI and LSP compile entry points, after the
 /// Kiln pipeline has populated the index.
 pub fn resolve_import_with_invocations(
+    interner: &mut ModuleSourceInterner,
     from_module: &ModuleSource,
     import_source: &str,
     entry_module: Option<&ModuleSource>,
@@ -1247,34 +1571,27 @@ pub fn resolve_import_with_invocations(
             _ => "",
         };
         if let Some(entry_uri) = invocations.redirect(decl_file, import_source) {
-            return ModuleSource::Redirected {
-                uri: entry_uri.to_string(),
-            };
+            return interner.redirected(&entry_uri);
         }
     }
-    resolve_import_with_entry(from_module, import_source, entry_module)
+    resolve_import_with_entry(interner, from_module, import_source, entry_module)
 }
 
 pub fn resolve_import_with_entry(
+    interner: &mut ModuleSourceInterner,
     from_module: &ModuleSource,
     import_source: &str,
     entry_module: Option<&ModuleSource>,
 ) -> ModuleSource {
     // Handle special prefixes
     if let Some(name) = import_source.strip_prefix("core:") {
-        return ModuleSource::Core {
-            name: name.to_string(),
-        };
+        return interner.core(name);
     }
     if let Some(interface) = import_source.strip_prefix("wasi:") {
-        return ModuleSource::Wasi {
-            interface: interface.to_string(),
-        };
+        return interner.wasi(interface);
     }
     if import_source.starts_with("https://") || import_source.starts_with("http://") {
-        return ModuleSource::Remote {
-            url: import_source.to_string(),
-        };
+        return interner.remote(import_source);
     }
 
     // Handle relative imports from local modules
@@ -1294,14 +1611,12 @@ pub fn resolve_import_with_entry(
                 return entry.clone();
             }
         }
-        return ModuleSource::Local { path: resolved };
+        return interner.local(&resolved);
     }
 
     // Fallback: normalize and return as Local path
     // This handles EntryPoint imports and bare imports
-    ModuleSource::Local {
-        path: normalize_module_path(import_source),
-    }
+    interner.local(&normalize_module_path(import_source))
 }
 
 /// Get the canonical name for an entry point file.
@@ -1590,10 +1905,9 @@ mod tests {
 
     #[test]
     fn test_method_name_to_string_simple() {
+        let mut interner = ModuleSourceInterner::new();
         let method = MethodName::new(
-            ModuleSource::Local {
-                path: "./geometry.wado".to_string(),
-            },
+            interner.local("./geometry.wado"),
             "Point".to_string(),
             None,
             "sum".to_string(),
@@ -1603,10 +1917,9 @@ mod tests {
 
     #[test]
     fn test_method_name_to_string_with_trait() {
+        let mut interner = ModuleSourceInterner::new();
         let method = MethodName::new(
-            ModuleSource::Local {
-                path: "./geometry.wado".to_string(),
-            },
+            interner.local("./geometry.wado"),
             "Point".to_string(),
             Some("Display".to_string()),
             "fmt".to_string(),
@@ -1616,7 +1929,9 @@ mod tests {
 
     #[test]
     fn test_free_function_name_to_string() {
+        let mut interner = ModuleSourceInterner::new();
         let func = FreeFunctionName::from_path_and_name(
+            &mut interner,
             &["core".to_string(), "cli".to_string()],
             "println",
         );
@@ -1625,40 +1940,62 @@ mod tests {
 
     #[test]
     fn test_free_function_name_from_strs() {
-        let func = FreeFunctionName::from_strs(&["core", "internal"], "log_stdout");
+        let mut interner = ModuleSourceInterner::new();
+        let func = FreeFunctionName::from_strs(&mut interner, &["core", "internal"], "log_stdout");
         assert_eq!(func.to_string(), "core/internal/log_stdout");
     }
 
     #[test]
     fn test_free_function_name_empty_path() {
-        let func = FreeFunctionName::from_strs(&[], "main");
+        let mut interner = ModuleSourceInterner::new();
+        let func = FreeFunctionName::from_strs(&mut interner, &[], "main");
         assert_eq!(func.to_string(), "main");
     }
 
     #[test]
     fn test_struct_name_to_string() {
-        let struct_name = StructName::from_path_and_name(&["./geometry.wado".to_string()], "Point");
+        let mut interner = ModuleSourceInterner::new();
+        let struct_name = StructName::from_path_and_name(
+            &mut interner,
+            &["./geometry.wado".to_string()],
+            "Point",
+        );
         assert_eq!(struct_name.to_string(), "./geometry.wado/Point");
     }
 
     #[test]
     fn test_struct_name_from_strs() {
-        let struct_name = StructName::from_strs(&["core", "internal"], "SomeType");
+        let mut interner = ModuleSourceInterner::new();
+        let struct_name = StructName::from_strs(&mut interner, &["core", "internal"], "SomeType");
         assert_eq!(struct_name.to_string(), "core:internal/SomeType");
     }
 
     #[test]
     fn test_struct_name_empty_path() {
-        let struct_name = StructName::from_path_and_name(&[], "Point");
+        let mut interner = ModuleSourceInterner::new();
+        let struct_name = StructName::from_path_and_name(&mut interner, &[], "Point");
         assert_eq!(struct_name.to_string(), "<entry>/Point");
     }
 
     #[test]
     fn test_struct_name_hash_eq() {
         use crate::hashmap::IndexSet;
-        let s1 = StructName::from_path_and_name(&["./geometry.wado".to_string()], "Point");
-        let s2 = StructName::from_path_and_name(&["./geometry.wado".to_string()], "Point");
-        let s3 = StructName::from_path_and_name(&["./other.wado".to_string()], "Point");
+        let mut interner = ModuleSourceInterner::new();
+        let s1 = StructName::from_path_and_name(
+            &mut interner,
+            &["./geometry.wado".to_string()],
+            "Point",
+        );
+        let s2 = StructName::from_path_and_name(
+            &mut interner,
+            &["./geometry.wado".to_string()],
+            "Point",
+        );
+        let s3 = StructName::from_path_and_name(
+            &mut interner,
+            &["./other.wado".to_string()],
+            "Point",
+        );
 
         let mut set = IndexSet::default();
         set.insert(s1);
@@ -1668,7 +2005,8 @@ mod tests {
 
     #[test]
     fn test_build_core_internal_name() {
-        let name = build_core_internal_name("log_stdout");
+        let mut interner = ModuleSourceInterner::new();
+        let name = build_core_internal_name(&mut interner, "log_stdout");
         assert_eq!(name.to_string(), "core/internal/log_stdout");
         assert_eq!(name.module_source, ModuleSource::internal());
         assert_eq!(name.name, "log_stdout");
@@ -1819,73 +2157,77 @@ mod tests {
 
     #[test]
     fn test_module_source_from_path_core() {
-        let source = ModuleSource::from_path(&["core".to_string(), "prelude".to_string()]);
-        assert!(matches!(source, ModuleSource::Core { name } if name == "prelude"));
+        let mut interner = ModuleSourceInterner::new();
+        let source = interner.from_path(&["core".to_string(), "prelude".to_string()]);
+        assert!(matches!(source, ModuleSource::Core { ref name } if name == "prelude"));
 
-        let source = ModuleSource::from_path(&["core".to_string(), "cli".to_string()]);
-        assert!(matches!(source, ModuleSource::Core { name } if name == "cli"));
+        let source = interner.from_path(&["core".to_string(), "cli".to_string()]);
+        assert!(matches!(source, ModuleSource::Core { ref name } if name == "cli"));
 
-        let source = ModuleSource::from_path(&["core".to_string(), "internal".to_string()]);
+        let source = interner.from_path(&["core".to_string(), "internal".to_string()]);
         assert!(source.is_core_internal());
     }
 
     #[test]
     fn test_module_source_from_path_wasi() {
-        let source = ModuleSource::from_path(&["wasi".to_string(), "cli".to_string()]);
-        assert!(matches!(source, ModuleSource::Wasi { interface } if interface == "cli"));
+        let mut interner = ModuleSourceInterner::new();
+        let source = interner.from_path(&["wasi".to_string(), "cli".to_string()]);
+        assert!(matches!(source, ModuleSource::Wasi { ref interface } if interface == "cli"));
 
-        let source = ModuleSource::from_path(&["wasi".to_string(), "io".to_string()]);
+        let source = interner.from_path(&["wasi".to_string(), "io".to_string()]);
         assert!(source.is_wasi());
     }
 
     #[test]
     fn test_module_source_from_path_local() {
-        let source = ModuleSource::from_path(&["./geometry.wado".to_string()]);
-        assert!(matches!(source, ModuleSource::Local { path } if path == "./geometry.wado"));
+        let mut interner = ModuleSourceInterner::new();
+        let source = interner.from_path(&["./geometry.wado".to_string()]);
+        assert!(matches!(source, ModuleSource::Local { ref path } if path == "./geometry.wado"));
 
-        let source = ModuleSource::from_path(&["../lib.wado".to_string()]);
+        let source = interner.from_path(&["../lib.wado".to_string()]);
         assert!(source.is_local());
     }
 
     #[test]
     fn test_module_source_from_path_entry_point() {
         // Legacy: empty path represents entry module
-        let source = ModuleSource::from_path(&[]);
+        let mut interner = ModuleSourceInterner::new();
+        let source = interner.from_path(&[]);
         assert!(source.is_entry_point());
     }
 
     #[test]
     fn test_module_source_to_path() {
+        let mut interner = ModuleSourceInterner::new();
         let source = ModuleSource::prelude();
         assert_eq!(source.to_path(), vec!["core", "prelude"]);
 
-        let source = ModuleSource::wasi("cli");
+        let source = interner.wasi("cli");
         assert_eq!(source.to_path(), vec!["wasi", "cli"]);
 
-        let source = ModuleSource::local("./geometry.wado");
+        let source = interner.local("./geometry.wado");
         assert_eq!(source.to_path(), vec!["./geometry.wado"]);
 
-        let source = ModuleSource::entry_point_with_filename("test.wado");
+        let source = interner.entry_point("test.wado");
         assert_eq!(source.to_path(), vec!["test.wado"]);
     }
 
     #[test]
     fn test_module_source_display() {
+        let mut interner = ModuleSourceInterner::new();
         assert_eq!(ModuleSource::prelude().to_string(), "core:prelude");
         assert_eq!(ModuleSource::cli().to_string(), "core:cli");
-        assert_eq!(ModuleSource::wasi("cli").to_string(), "wasi:cli");
+        assert_eq!(interner.wasi("cli").to_string(), "wasi:cli");
         assert_eq!(
-            ModuleSource::local("./geometry.wado").to_string(),
+            interner.local("./geometry.wado").to_string(),
             "./geometry.wado"
         );
-        assert_eq!(
-            ModuleSource::entry_point_with_filename("hello.wado").to_string(),
-            "hello.wado"
-        );
+        assert_eq!(interner.entry_point("hello.wado").to_string(), "hello.wado");
     }
 
     #[test]
     fn test_module_source_helpers() {
+        let mut interner = ModuleSourceInterner::new();
         let core = ModuleSource::internal();
         assert!(core.is_core());
         assert!(core.is_core_internal());
@@ -1898,31 +2240,32 @@ mod tests {
         let prelude = ModuleSource::prelude();
         assert!(prelude.is_core_prelude());
 
-        let wasi = ModuleSource::wasi("cli");
+        let wasi = interner.wasi("cli");
         assert!(wasi.is_wasi());
         assert!(!wasi.is_core());
 
-        let local = ModuleSource::local("./file.wado");
+        let local = interner.local("./file.wado");
         assert!(local.is_local());
         assert!(!local.is_core());
     }
 
     #[test]
     fn test_module_source_qualify_name() {
+        let mut interner = ModuleSourceInterner::new();
         assert_eq!(
             ModuleSource::prelude().qualify_name("Option"),
             "core:prelude//Option"
         );
         assert_eq!(
-            ModuleSource::local("./geometry.wado").qualify_name("Point"),
+            interner.local("./geometry.wado").qualify_name("Point"),
             "./geometry.wado//Point"
         );
         assert_eq!(
-            ModuleSource::wasi("cli").qualify_name("Stdout"),
+            interner.wasi("cli").qualify_name("Stdout"),
             "wasi:cli//Stdout"
         );
         assert_eq!(
-            ModuleSource::entry_point_with_filename("main.wado").qualify_name("Foo"),
+            interner.entry_point("main.wado").qualify_name("Foo"),
             "main.wado//Foo"
         );
     }
@@ -1936,8 +2279,9 @@ mod tests {
             vec!["./geometry.wado".to_string()],
         ];
 
+        let mut interner = ModuleSourceInterner::new();
         for path in paths {
-            let source = ModuleSource::from_path(&path);
+            let source = interner.from_path(&path);
             assert_eq!(source.to_path(), path, "Roundtrip failed for {path:?}");
         }
     }

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -2427,32 +2427,42 @@ fn remove_dead_global_sets_expr(expr: &mut TirExpr, used: &IndexSet<(String, Str
 mod tests {
     use super::*;
 
-    fn free_fn(name: &str) -> FunctionId {
-        let mut interner = crate::name::ModuleSourceInterner::new();
-        FunctionId::Free(FreeFunctionName::from_strs(&mut interner, &["test"], name))
+    fn free_fn(interner: &mut crate::name::ModuleSourceInterner, name: &str) -> FunctionId {
+        FunctionId::Free(FreeFunctionName::from_strs(interner, &["test"], name))
     }
 
     #[test]
     fn test_empty_reachable_set() {
+        let mut interner = crate::name::ModuleSourceInterner::new();
         let call_graph = IndexMap::default();
-        let entry = free_fn("run");
+        let entry = free_fn(&mut interner, "run");
         let reachable = compute_reachable(&call_graph, &entry);
-        assert!(reachable.contains(&free_fn("run")));
+        assert!(reachable.contains(&free_fn(&mut interner, "run")));
         assert_eq!(reachable.len(), 1);
     }
 
     #[test]
     fn test_transitive_reachability() {
+        let mut interner = crate::name::ModuleSourceInterner::new();
         let mut call_graph = IndexMap::default();
-        call_graph.insert(free_fn("run"), IndexSet::from_iter([free_fn("foo")]));
-        call_graph.insert(free_fn("foo"), IndexSet::from_iter([free_fn("bar")]));
-        call_graph.insert(free_fn("bar"), IndexSet::default());
-        call_graph.insert(free_fn("unused"), IndexSet::from_iter([free_fn("bar")]));
+        call_graph.insert(
+            free_fn(&mut interner, "run"),
+            IndexSet::from_iter([free_fn(&mut interner, "foo")]),
+        );
+        call_graph.insert(
+            free_fn(&mut interner, "foo"),
+            IndexSet::from_iter([free_fn(&mut interner, "bar")]),
+        );
+        call_graph.insert(free_fn(&mut interner, "bar"), IndexSet::default());
+        call_graph.insert(
+            free_fn(&mut interner, "unused"),
+            IndexSet::from_iter([free_fn(&mut interner, "bar")]),
+        );
 
-        let reachable = compute_reachable(&call_graph, &free_fn("run"));
-        assert!(reachable.contains(&free_fn("run")));
-        assert!(reachable.contains(&free_fn("foo")));
-        assert!(reachable.contains(&free_fn("bar")));
-        assert!(!reachable.contains(&free_fn("unused")));
+        let reachable = compute_reachable(&call_graph, &free_fn(&mut interner, "run"));
+        assert!(reachable.contains(&free_fn(&mut interner, "run")));
+        assert!(reachable.contains(&free_fn(&mut interner, "foo")));
+        assert!(reachable.contains(&free_fn(&mut interner, "bar")));
+        assert!(!reachable.contains(&free_fn(&mut interner, "unused")));
     }
 }

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -2428,7 +2428,8 @@ mod tests {
     use super::*;
 
     fn free_fn(name: &str) -> FunctionId {
-        FunctionId::Free(FreeFunctionName::from_strs(&["test"], name))
+        let mut interner = crate::name::ModuleSourceInterner::new();
+        FunctionId::Free(FreeFunctionName::from_strs(&mut interner, &["test"], name))
     }
 
     #[test]

--- a/wado-compiler/src/package.rs
+++ b/wado-compiler/src/package.rs
@@ -77,6 +77,14 @@ pub struct Package {
         crate::synthesis::effect_dispatch::InstantiationKey,
         crate::synthesis::effect_dispatch::DispatchPlan,
     >,
+
+    /// `ModuleSource` interner shared with the resolver. Synthesis
+    /// passes (`cm_binding`, `effect_dispatch`) borrow this when they
+    /// need to construct fresh `ModuleSource` values for synthesised
+    /// items. Dropped at the `Package → FlatPackage` boundary —
+    /// downstream phases (link, monomorphize, lower, optimize, codegen)
+    /// only consume existing `ModuleSource` values.
+    pub interner: std::rc::Rc<std::cell::RefCell<crate::name::ModuleSourceInterner>>,
 }
 
 impl Package {
@@ -90,6 +98,7 @@ impl Package {
         wasi_registry: &'static WasiRegistry,
         world_registry: &'static WorldRegistry,
         builtin_registry: BuiltinRegistry,
+        interner: std::rc::Rc<std::cell::RefCell<crate::name::ModuleSourceInterner>>,
     ) -> Self {
         Self {
             entry_module_source,
@@ -100,6 +109,7 @@ impl Package {
             wasi_registry,
             world_registry,
             builtin_registry,
+            interner,
             // Usage analysis fields default to empty/false
             used_wasi_functions: IndexSet::default(),
             // Codegen options

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -189,6 +189,11 @@ pub struct Resolver<'a, H: CompilerHost> {
     /// by `Rc` so per-module Resolver instances can read the single
     /// compilation-unit-wide redirect map cheaply.
     pub(super) invocations: Rc<crate::kiln::InvocationIndex>,
+    /// `ModuleSource` interner shared with the loader and downstream
+    /// phases. Wrapped in `Rc<RefCell<>>` so per-module resolver
+    /// instances can `borrow_mut()` it from `&self` contexts (e.g.
+    /// `record_use_specifier_references`).
+    pub(super) interner: Rc<RefCell<crate::name::ModuleSourceInterner>>,
 }
 
 impl<'a, H: CompilerHost> Resolver<'a, H> {
@@ -225,8 +230,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             imported_functions: IndexSet::default(),
             namespace_imports: IndexMap::default(),
             logger,
-            current_module_source: ModuleSource::entry_point_with_filename("<uninitialized>"),
-            entry_module_source: ModuleSource::entry_point_with_filename("<uninitialized>"),
+            current_module_source: ModuleSource::entry_point_uninitialized(),
+            entry_module_source: ModuleSource::entry_point_uninitialized(),
             current_module_items: &[],
             effect_sources: IndexMap::default(),
             current_effect_params: IndexSet::default(),
@@ -256,6 +261,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             local_symbols: Rc::new(RefCell::new(IndexMap::default())),
             default_scope_module: None,
             invocations: Rc::new(crate::kiln::InvocationIndex::new()),
+            interner: Rc::new(RefCell::new(crate::name::ModuleSourceInterner::new())),
         }
     }
 
@@ -583,6 +589,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
     /// For `use { Stdout } from "core:cli"`, maps "Stdout" → resolved("core:cli").
     /// For local effect declarations, maps name → current module source.
     fn build_effect_sources(
+        interner: &mut crate::name::ModuleSourceInterner,
         module: &Module,
         module_source: &ModuleSource,
         invocations: &crate::kiln::InvocationIndex,
@@ -592,6 +599,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             match item {
                 Item::Use(use_decl) => {
                     let source = name::resolve_import_with_invocations(
+                        interner,
                         module_source,
                         &use_decl.source,
                         None,
@@ -700,6 +708,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         for item in &module.items {
             let Item::Use(use_decl) = item else { continue };
             let source = name::resolve_import_with_invocations(
+                &mut self.interner.borrow_mut(),
                 &self.current_module_source,
                 &use_decl.source,
                 Some(&self.entry_module_source),
@@ -735,7 +744,12 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         // Clear trait lookup caches (current_module_items changed)
         self.indexing_trait_cache.clear();
         // Build effect source map from imports
-        self.effect_sources = Self::build_effect_sources(module, &module_source, &self.invocations);
+        self.effect_sources = Self::build_effect_sources(
+            &mut self.interner.borrow_mut(),
+            module,
+            &module_source,
+            &self.invocations,
+        );
 
         // Record use→def edges for names that appear inside `use { ... }` specifiers.
         // These power LSP jump-to-definition when the cursor is on an imported
@@ -769,6 +783,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         for item in &module.items {
             if let Item::Use(use_decl) = item {
                 let source_module_source = name::resolve_import_with_invocations(
+                    &mut self.interner.borrow_mut(),
                     &module_source,
                     &use_decl.source,
                     None,

--- a/wado-compiler/src/resolver/call.rs
+++ b/wado-compiler/src/resolver/call.rs
@@ -801,7 +801,11 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     // This covers Stdout::write(), etc.
                     else {
                         (
-                            Some(CalleeRef::local_namespace(prefix, suffix)),
+                            Some(CalleeRef::local_namespace(
+                                &mut self.interner.borrow_mut(),
+                                prefix,
+                                suffix,
+                            )),
                             ident.name.clone(),
                         )
                     }
@@ -860,7 +864,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 if let Expr::Ident(ident) = &field_access.expr {
                     (
                         Some(CalleeRef::local_namespace(
-                            ident.name.clone(),
+                            &mut self.interner.borrow_mut(),
+                            &ident.name,
                             field_access.field.clone(),
                         )),
                         format!("{}.{}", ident.name, field_access.field),

--- a/wado-compiler/src/resolver/call.rs
+++ b/wado-compiler/src/resolver/call.rs
@@ -1037,6 +1037,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     || (IndexMap::default(), IndexMap::default()),
                     |m| {
                         Self::build_imported_type_sources(
+                            &mut self.interner.borrow_mut(),
                             m,
                             callee_module,
                             Some(&self.entry_module_source),
@@ -1166,7 +1167,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         let base_type = self.resolve_wasi_type_scoped(&aliased, wasi_package);
                         let newtype_id = self.type_table.borrow_mut().make_newtype(
                             named.name.clone(),
-                            ModuleSource::wasi("clocks"),
+                            ModuleSource::wasi_clocks(),
                             base_type,
                         );
                         // Cache the newtype for future lookups
@@ -1190,7 +1191,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                     None
                                 }
                             })
-                            .unwrap_or_else(|| ModuleSource::wasi("filesystem"));
+                            .unwrap_or_else(|| ModuleSource::wasi_filesystem());
                         self.type_table
                             .borrow_mut()
                             .make_resource(named.name.clone(), module_source)
@@ -1215,7 +1216,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                     .find_map(|(ms, map)| {
                                         map.contains_key(&named.name).then(|| ms.clone())
                                     })
-                                    .unwrap_or_else(|| ModuleSource::wasi("cli"));
+                                    .unwrap_or_else(|| ModuleSource::wasi_cli());
                                 self.type_table
                                     .borrow_mut()
                                     .make_enum(named.name.clone(), module_source)
@@ -1230,7 +1231,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                     .find_map(|(ms, map)| {
                                         map.contains_key(&named.name).then(|| ms.clone())
                                     })
-                                    .unwrap_or_else(|| ModuleSource::wasi("clocks"));
+                                    .unwrap_or_else(|| ModuleSource::wasi_clocks());
                                 self.type_table
                                     .borrow_mut()
                                     .make_struct(named.name.clone(), module_source)
@@ -1254,7 +1255,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                     None
                                 }
                             })
-                            .unwrap_or_else(|| ModuleSource::wasi("cli"));
+                            .unwrap_or_else(|| ModuleSource::wasi_cli());
                         self.type_table
                             .borrow_mut()
                             .make_enum(named.name.clone(), module_source)
@@ -1274,7 +1275,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                     None
                                 }
                             })
-                            .unwrap_or_else(|| ModuleSource::wasi("clocks"));
+                            .unwrap_or_else(|| ModuleSource::wasi_clocks());
                         self.type_table
                             .borrow_mut()
                             .make_struct(named.name.clone(), module_source)
@@ -1488,6 +1489,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         let (imported_type_sources, import_original_names) =
                             if let Some(module) = callee_module {
                                 Self::build_imported_type_sources(
+                                    &mut self.interner.borrow_mut(),
                                     module,
                                     &src,
                                     Some(&self.entry_module_source),

--- a/wado-compiler/src/resolver/call.rs
+++ b/wado-compiler/src/resolver/call.rs
@@ -1196,7 +1196,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                     None
                                 }
                             })
-                            .unwrap_or_else(|| ModuleSource::wasi_filesystem());
+                            .unwrap_or_else(ModuleSource::wasi_filesystem);
                         self.type_table
                             .borrow_mut()
                             .make_resource(named.name.clone(), module_source)
@@ -1221,7 +1221,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                     .find_map(|(ms, map)| {
                                         map.contains_key(&named.name).then(|| ms.clone())
                                     })
-                                    .unwrap_or_else(|| ModuleSource::wasi_cli());
+                                    .unwrap_or_else(ModuleSource::wasi_cli);
                                 self.type_table
                                     .borrow_mut()
                                     .make_enum(named.name.clone(), module_source)
@@ -1236,7 +1236,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                     .find_map(|(ms, map)| {
                                         map.contains_key(&named.name).then(|| ms.clone())
                                     })
-                                    .unwrap_or_else(|| ModuleSource::wasi_clocks());
+                                    .unwrap_or_else(ModuleSource::wasi_clocks);
                                 self.type_table
                                     .borrow_mut()
                                     .make_struct(named.name.clone(), module_source)
@@ -1260,7 +1260,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                     None
                                 }
                             })
-                            .unwrap_or_else(|| ModuleSource::wasi_cli());
+                            .unwrap_or_else(ModuleSource::wasi_cli);
                         self.type_table
                             .borrow_mut()
                             .make_enum(named.name.clone(), module_source)
@@ -1280,7 +1280,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                                     None
                                 }
                             })
-                            .unwrap_or_else(|| ModuleSource::wasi_clocks());
+                            .unwrap_or_else(ModuleSource::wasi_clocks);
                         self.type_table
                             .borrow_mut()
                             .make_struct(named.name.clone(), module_source)

--- a/wado-compiler/src/resolver/callee.rs
+++ b/wado-compiler/src/resolver/callee.rs
@@ -54,10 +54,17 @@ impl CalleeRef {
     /// A callee reached through a namespace-qualified call `Prefix::name`
     /// where `Prefix` is a module path (e.g. `Stdout::write`). The `prefix`
     /// is treated as a `ModuleSource::Local` path for codegen routing.
+    ///
+    /// The constructed `ModuleSource::Local` is uncanonicalized — its
+    /// `Arc<str>` does not go through the resolver's interner. This is
+    /// safe because the resulting `Local { path }` only flows into a
+    /// `FunctionRef` for codegen routing; it is never used as an
+    /// `IndexMap` key against a canonicalized counterpart, and `Eq`
+    /// falls back to byte comparison when pointer identity differs.
     pub fn local_namespace(prefix: impl Into<String>, name: impl Into<String>) -> Self {
         Self::new(
             ModuleSource::Local {
-                path: prefix.into(),
+                path: crate::name::InternedStr::from_string_uncanonicalized(prefix.into()),
             },
             name,
         )

--- a/wado-compiler/src/resolver/callee.rs
+++ b/wado-compiler/src/resolver/callee.rs
@@ -52,22 +52,16 @@ impl CalleeRef {
     }
 
     /// A callee reached through a namespace-qualified call `Prefix::name`
-    /// where `Prefix` is a module path (e.g. `Stdout::write`). The `prefix`
-    /// is treated as a `ModuleSource::Local` path for codegen routing.
-    ///
-    /// The constructed `ModuleSource::Local` is uncanonicalized — its
-    /// `Arc<str>` does not go through the resolver's interner. This is
-    /// safe because the resulting `Local { path }` only flows into a
-    /// `FunctionRef` for codegen routing; it is never used as an
-    /// `IndexMap` key against a canonicalized counterpart, and `Eq`
-    /// falls back to byte comparison when pointer identity differs.
-    pub fn local_namespace(prefix: impl Into<String>, name: impl Into<String>) -> Self {
-        Self::new(
-            ModuleSource::Local {
-                path: crate::name::InternedStr::from_string_uncanonicalized(prefix.into()),
-            },
-            name,
-        )
+    /// where `Prefix` is a module path (e.g. `Stdout::write`). The
+    /// `prefix` is interned through the resolver's
+    /// [`crate::name::ModuleSourceInterner`] and wrapped in a
+    /// `ModuleSource::Local`.
+    pub fn local_namespace(
+        interner: &mut crate::name::ModuleSourceInterner,
+        prefix: &str,
+        name: impl Into<String>,
+    ) -> Self {
+        Self::new(interner.local(prefix), name)
     }
 }
 

--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -3453,7 +3453,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     .borrow()
                     .range_exclusive_module_source
                     .clone()
-                    .unwrap_or_else(|| ModuleSource::core("prelude/range"));
+                    .unwrap_or_else(|| ModuleSource::range());
                 let fields = vec![
                     TirStructField {
                         name: "start".to_string(),
@@ -3474,7 +3474,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     .borrow()
                     .range_inclusive_module_source
                     .clone()
-                    .unwrap_or_else(|| ModuleSource::core("prelude/range"));
+                    .unwrap_or_else(|| ModuleSource::range());
                 let fields = vec![
                     TirStructField {
                         name: "start".to_string(),

--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -3453,7 +3453,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     .borrow()
                     .range_exclusive_module_source
                     .clone()
-                    .unwrap_or_else(|| ModuleSource::range());
+                    .unwrap_or_else(ModuleSource::range);
                 let fields = vec![
                     TirStructField {
                         name: "start".to_string(),
@@ -3474,7 +3474,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     .borrow()
                     .range_inclusive_module_source
                     .clone()
-                    .unwrap_or_else(|| ModuleSource::range());
+                    .unwrap_or_else(ModuleSource::range);
                 let fields = vec![
                     TirStructField {
                         name: "start".to_string(),

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -578,6 +578,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 .get(module_source)
                 .map(|m| {
                     Self::build_imported_type_sources(
+                        &mut self.interner.borrow_mut(),
                         m,
                         module_source,
                         Some(&self.entry_module_source),

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -80,6 +80,10 @@ pub(crate) struct AnnotateState {
     /// Kiln invocation redirects consulted by `resolve_import` call sites
     /// when walking `use` declarations. Populated from [`crate::loader::LoadResult`].
     pub(crate) invocations: Rc<crate::kiln::InvocationIndex>,
+    /// `ModuleSource` interner shared across phases. `Rc<RefCell<>>` so
+    /// `&self` resolver methods can `borrow_mut()` it when constructing
+    /// new module sources during name resolution.
+    pub(crate) interner: Rc<RefCell<crate::name::ModuleSourceInterner>>,
 }
 
 impl<'a, H: CompilerHost> Resolver<'a, H> {
@@ -95,9 +99,16 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         logger: &'a Logger<'a, H>,
         included_files: &'a IndexMap<[String; 2], Vec<u8>>,
         invocations: crate::kiln::InvocationIndex,
+        interner: Rc<RefCell<crate::name::ModuleSourceInterner>>,
     ) -> Result<IndexMap<ModuleSource, TirModule>, Bail> {
-        let state =
-            Self::annotate_modules(symbols, modules, &entry_module_source, logger, invocations)?;
+        let state = Self::annotate_modules(
+            symbols,
+            modules,
+            &entry_module_source,
+            logger,
+            invocations,
+            interner,
+        )?;
         Self::lower_tir_from_state(
             &state,
             symbols,
@@ -118,6 +129,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         entry_module_source: &ModuleSource,
         logger: &'a Logger<'a, H>,
         invocations: crate::kiln::InvocationIndex,
+        interner: Rc<RefCell<crate::name::ModuleSourceInterner>>,
     ) -> Result<AnnotateState, Bail> {
         let invocations = Rc::new(invocations);
         // Create a shared type table wrapped in Rc<RefCell<>> for cross-module sharing
@@ -271,6 +283,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         // tables (`all_*`) via [`TypeLookup`] — no per-module flat-map cloning.
         for (module_source, module) in modules {
             let (imported_type_sources, import_original_names) = Self::build_imported_type_sources(
+                &mut interner.borrow_mut(),
                 module,
                 module_source,
                 Some(entry_module_source),
@@ -680,6 +693,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             references: Rc::new(RefCell::new(IndexMap::default())),
             local_symbols: Rc::new(RefCell::new(IndexMap::default())),
             invocations,
+            interner,
         })
     }
 
@@ -705,6 +719,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
 
             // Build imported type sources and module-specific flat maps for this module
             let (imported_type_sources, import_original_names) = Self::build_imported_type_sources(
+                &mut state.interner.borrow_mut(),
                 module,
                 module_source,
                 Some(&entry_module_source),
@@ -781,6 +796,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             crate::ast::UseItem::Namespace { name } => {
                                 // Namespace import: all symbols from source module are available
                                 let source = crate::name::resolve_import_with_invocations(
+                                    &mut state.interner.borrow_mut(),
                                     module_source,
                                     &use_decl.source,
                                     Some(&entry_module_source),
@@ -822,7 +838,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 imported_functions,
                 namespace_imports,
                 logger,
-                current_module_source: ModuleSource::entry_point_with_filename("<uninitialized>"), // Set in resolve_module
+                current_module_source: ModuleSource::entry_point_uninitialized(), // Set in resolve_module
                 entry_module_source: entry_module_source.clone(),
                 current_module_items: &[], // Set in resolve_module
                 effect_sources: IndexMap::default(), // Populated per-module in resolve_module
@@ -853,6 +869,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 local_symbols: Rc::clone(&state.local_symbols),
                 default_scope_module: None,
                 invocations: Rc::clone(&state.invocations),
+                interner: Rc::clone(&state.interner),
             };
             // known_type_names_cache is pre-computed globally; no per-module rebuild needed
 
@@ -964,6 +981,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
     /// Returns `(local_name -> module_source, local_name -> original_name)`.
     /// The `original_name` is different from `local_name` when `use { Foo as Bar }` is used.
     pub(super) fn build_imported_type_sources(
+        interner: &mut crate::name::ModuleSourceInterner,
         module: &Module,
         from_module: &ModuleSource,
         entry_module: Option<&ModuleSource>,
@@ -974,6 +992,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         for item in &module.items {
             if let Item::Use(use_decl) = item {
                 let source = name::resolve_import_with_invocations(
+                    interner,
                     from_module,
                     &use_decl.source,
                     entry_module,
@@ -1014,6 +1033,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             .get(module_source)
             .map(|module| {
                 Self::build_imported_type_sources(
+                    &mut self.interner.borrow_mut(),
                     module,
                     module_source,
                     Some(&self.entry_module_source),

--- a/wado-compiler/src/resolver/trait_env.rs
+++ b/wado-compiler/src/resolver/trait_env.rs
@@ -675,15 +675,10 @@ mod tests {
 
     fn make_type_decl_index(local_names: &[&str]) -> IndexMap<String, ModuleSource> {
         let mut m = IndexMap::default();
+        let mut interner = crate::name::ModuleSourceInterner::new();
+        let entry = interner.entry_point("test.wado");
         for &name in local_names {
-            m.insert(
-                name.to_string(),
-                ModuleSource::EntryPoint {
-                    filename: crate::name::InternedStr::from_string_uncanonicalized(
-                        "test.wado".to_string(),
-                    ),
-                },
-            );
+            m.insert(name.to_string(), entry.clone());
         }
         m
     }
@@ -707,37 +702,32 @@ mod tests {
 
     #[test]
     fn test_is_user_local_entry_point() {
-        assert!(is_user_local(&ModuleSource::EntryPoint {
-            filename: crate::name::InternedStr::from_string_uncanonicalized("main.wado".to_string())
-        }));
+        let mut interner = crate::name::ModuleSourceInterner::new();
+        assert!(is_user_local(&interner.entry_point("main.wado")));
     }
 
     #[test]
     fn test_is_user_local_local_path() {
-        assert!(is_user_local(&ModuleSource::Local {
-            path: crate::name::InternedStr::from_string_uncanonicalized("./lib.wado".to_string())
-        }));
+        let mut interner = crate::name::ModuleSourceInterner::new();
+        assert!(is_user_local(&interner.local("./lib.wado")));
     }
 
     #[test]
     fn test_is_user_local_core_is_foreign() {
-        assert!(!is_user_local(&ModuleSource::Core {
-            name: crate::name::InternedStr::from_string_uncanonicalized("prelude".to_string())
-        }));
+        assert!(!is_user_local(&ModuleSource::prelude()));
     }
 
     #[test]
     fn test_is_user_local_wasi_is_foreign() {
-        assert!(!is_user_local(&ModuleSource::Wasi {
-            interface: crate::name::InternedStr::from_string_uncanonicalized("cli".to_string())
-        }));
+        assert!(!is_user_local(&ModuleSource::wasi_cli()));
     }
 
     #[test]
     fn test_is_user_local_remote_is_foreign() {
-        assert!(!is_user_local(&ModuleSource::Remote {
-            url: crate::name::InternedStr::from_string_uncanonicalized("https://example.com/lib.wado".to_string())
-        }));
+        let mut interner = crate::name::ModuleSourceInterner::new();
+        assert!(!is_user_local(
+            &interner.remote("https://example.com/lib.wado")
+        ));
     }
 
     // --- classify_position ---

--- a/wado-compiler/src/resolver/trait_env.rs
+++ b/wado-compiler/src/resolver/trait_env.rs
@@ -679,7 +679,9 @@ mod tests {
             m.insert(
                 name.to_string(),
                 ModuleSource::EntryPoint {
-                    filename: "test.wado".to_string(),
+                    filename: crate::name::InternedStr::from_string_uncanonicalized(
+                        "test.wado".to_string(),
+                    ),
                 },
             );
         }
@@ -706,35 +708,35 @@ mod tests {
     #[test]
     fn test_is_user_local_entry_point() {
         assert!(is_user_local(&ModuleSource::EntryPoint {
-            filename: "main.wado".to_string()
+            filename: crate::name::InternedStr::from_string_uncanonicalized("main.wado".to_string())
         }));
     }
 
     #[test]
     fn test_is_user_local_local_path() {
         assert!(is_user_local(&ModuleSource::Local {
-            path: "./lib.wado".to_string()
+            path: crate::name::InternedStr::from_string_uncanonicalized("./lib.wado".to_string())
         }));
     }
 
     #[test]
     fn test_is_user_local_core_is_foreign() {
         assert!(!is_user_local(&ModuleSource::Core {
-            name: "prelude".to_string()
+            name: crate::name::InternedStr::from_string_uncanonicalized("prelude".to_string())
         }));
     }
 
     #[test]
     fn test_is_user_local_wasi_is_foreign() {
         assert!(!is_user_local(&ModuleSource::Wasi {
-            interface: "cli".to_string()
+            interface: crate::name::InternedStr::from_string_uncanonicalized("cli".to_string())
         }));
     }
 
     #[test]
     fn test_is_user_local_remote_is_foreign() {
         assert!(!is_user_local(&ModuleSource::Remote {
-            url: "https://example.com/lib.wado".to_string()
+            url: crate::name::InternedStr::from_string_uncanonicalized("https://example.com/lib.wado".to_string())
         }));
     }
 

--- a/wado-compiler/src/symbol.rs
+++ b/wado-compiler/src/symbol.rs
@@ -527,7 +527,8 @@ mod tests {
     fn test_struct_aliases() {
         let mut table = SymbolTable::new();
 
-        let geometry = ModuleSource::local("./geometry.wado");
+        let mut interner = crate::name::ModuleSourceInterner::new();
+        let geometry = interner.local("./geometry.wado");
 
         let key = table.define(
             &geometry,
@@ -552,7 +553,8 @@ mod tests {
     fn test_struct_aliases_same_name() {
         let mut table = SymbolTable::new();
 
-        let geometry = ModuleSource::local("./geometry.wado");
+        let mut interner = crate::name::ModuleSourceInterner::new();
+        let geometry = interner.local("./geometry.wado");
 
         let key = table.define(
             &geometry,

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -60,6 +60,12 @@ pub struct LiftContext<'a> {
     /// identity of synthesised types (e.g. `wasi:http/types`,
     /// `core:kiln/types.wado`) so they match the resolver's registered
     /// `StructName`s ptr-eq.
+    ///
+    /// Re-entrancy: the lift call chain may `borrow_mut()` this cell;
+    /// callers must not hold a `RefMut` to the same cell across calls
+    /// into [`synthesize_lift_with_context`] or its helpers. The lift
+    /// path itself only borrows transiently inside
+    /// [`module_source_for_cm_interface`].
     pub interner: &'a RefCell<crate::name::ModuleSourceInterner>,
 }
 

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -545,8 +545,7 @@ fn try_lift_wasi_struct(
     // `wir_build::types::register_struct` registered.
     let struct_type_id = {
         let mut tt = ctx.type_table.borrow_mut();
-        let module_source =
-            module_source_for_cm_interface(&mut ctx.interner.borrow_mut(), source);
+        let module_source = module_source_for_cm_interface(&mut ctx.interner.borrow_mut(), source);
         tt.make_struct(named.name.clone(), module_source)
     };
 

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -9855,13 +9855,10 @@ mod tests {
     #[test]
     fn param_needs_lifting_enum() {
         let mut tt = TypeTable::new();
+        let mut interner = crate::name::ModuleSourceInterner::new();
         let e = tt.intern(crate::tir::ResolvedType::Enum {
             name: "Color".to_string(),
-            module_source: ModuleSource::EntryPoint {
-                filename: crate::name::InternedStr::from_string_uncanonicalized(
-                    "<test>".to_string(),
-                ),
-            },
+            module_source: interner.entry_point("<test>"),
         });
         assert!(!param_needs_lifting(e, &tt));
     }

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -211,9 +211,15 @@ fn wasi_interface_suffix(source_interface: &str) -> String {
 /// matching the `StructName`s under which the WIR types pass registered
 /// them (see `wir_build::types::register_struct`).
 fn module_source_for_cm_interface(source_interface: &str) -> ModuleSource {
+    // CM-binding synthesis runs after annotate; the loader's interner
+    // is not threaded through these synthesis passes. The values
+    // produced here flow into `StructName` keys whose `Eq` falls back
+    // to byte comparison when pointer identity differs.
     if source_interface.starts_with("wasi:") {
         return ModuleSource::Wasi {
-            interface: wasi_interface_suffix(source_interface),
+            interface: crate::name::InternedStr::from_string_uncanonicalized(
+                wasi_interface_suffix(source_interface),
+            ),
         };
     }
     if let Some(rest) = source_interface.strip_prefix("core:") {
@@ -223,7 +229,9 @@ fn module_source_for_cm_interface(source_interface: &str) -> ModuleSource {
         } else {
             format!("{without_version}.wado")
         };
-        return ModuleSource::Core { name };
+        return ModuleSource::Core {
+            name: crate::name::InternedStr::from_string_uncanonicalized(name),
+        };
     }
     ModuleSource::default()
 }
@@ -6341,7 +6349,11 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                     &func_info.interface_name,
                     &func_info.package,
                 )
-                .unwrap_or_else(|| ModuleSource::wasi(&func_info.package));
+                .unwrap_or_else(|| ModuleSource::Wasi {
+                    interface: crate::name::InternedStr::from_string_uncanonicalized(
+                        func_info.package.clone(),
+                    ),
+                });
                 let adapter = synthesize_adapter(
                     &func_info,
                     project.wasi_registry,
@@ -9835,7 +9847,7 @@ mod tests {
         let mut tt = TypeTable::new();
         let r = tt.intern(crate::tir::ResolvedType::Resource {
             name: "Request".to_string(),
-            module_source: ModuleSource::wasi("http"),
+            module_source: ModuleSource::wasi_http(),
         });
         assert!(!param_needs_lifting(r, &tt));
     }
@@ -9846,7 +9858,9 @@ mod tests {
         let e = tt.intern(crate::tir::ResolvedType::Enum {
             name: "Color".to_string(),
             module_source: ModuleSource::EntryPoint {
-                filename: "<test>".to_string(),
+                filename: crate::name::InternedStr::from_string_uncanonicalized(
+                    "<test>".to_string(),
+                ),
             },
         });
         assert!(!param_needs_lifting(e, &tt));
@@ -9860,7 +9874,7 @@ mod tests {
         let mut tt = TypeTable::new();
         let opt = tt.intern(crate::tir::ResolvedType::GenericInstance {
             name: "Option".to_string(),
-            module_source: ModuleSource::core("types"),
+            module_source: ModuleSource::types(),
             type_args: vec![TypeTable::I32],
         });
         assert!(param_needs_lifting(opt, &tt));

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -55,6 +55,12 @@ pub struct LiftContext<'a> {
     /// `wasi:http/ErrorCode` — or, across schemes,
     /// `wasi:http/types::Response` vs. `core:kiln/types::Response`.
     pub cm_package: &'a str,
+    /// `ModuleSource` interner shared with the package; used by
+    /// `module_source_for_cm_interface` to canonicalise the module
+    /// identity of synthesised types (e.g. `wasi:http/types`,
+    /// `core:kiln/types.wado`) so they match the resolver's registered
+    /// `StructName`s ptr-eq.
+    pub interner: &'a RefCell<crate::name::ModuleSourceInterner>,
 }
 
 /// Convert a WASI AST `Type` to a `TypeId` in the type table.
@@ -210,17 +216,12 @@ fn wasi_interface_suffix(source_interface: &str) -> String {
 /// registering its types. Keeps the lift path's fabricated `TypeId`s
 /// matching the `StructName`s under which the WIR types pass registered
 /// them (see `wir_build::types::register_struct`).
-fn module_source_for_cm_interface(source_interface: &str) -> ModuleSource {
-    // CM-binding synthesis runs after annotate; the loader's interner
-    // is not threaded through these synthesis passes. The values
-    // produced here flow into `StructName` keys whose `Eq` falls back
-    // to byte comparison when pointer identity differs.
+fn module_source_for_cm_interface(
+    interner: &mut crate::name::ModuleSourceInterner,
+    source_interface: &str,
+) -> ModuleSource {
     if source_interface.starts_with("wasi:") {
-        return ModuleSource::Wasi {
-            interface: crate::name::InternedStr::from_string_uncanonicalized(
-                wasi_interface_suffix(source_interface),
-            ),
-        };
+        return interner.wasi(&wasi_interface_suffix(source_interface));
     }
     if let Some(rest) = source_interface.strip_prefix("core:") {
         let without_version = rest.split('@').next().unwrap_or(rest);
@@ -229,9 +230,7 @@ fn module_source_for_cm_interface(source_interface: &str) -> ModuleSource {
         } else {
             format!("{without_version}.wado")
         };
-        return ModuleSource::Core {
-            name: crate::name::InternedStr::from_string_uncanonicalized(name),
-        };
+        return interner.core(&name);
     }
     ModuleSource::default()
 }
@@ -546,7 +545,9 @@ fn try_lift_wasi_struct(
     // `wir_build::types::register_struct` registered.
     let struct_type_id = {
         let mut tt = ctx.type_table.borrow_mut();
-        tt.make_struct(named.name.clone(), module_source_for_cm_interface(source))
+        let module_source =
+            module_source_for_cm_interface(&mut ctx.interner.borrow_mut(), source);
+        tt.make_struct(named.name.clone(), module_source)
     };
 
     // Lift each field — Wado field names come directly from this interface's
@@ -2542,6 +2543,7 @@ fn synthesize_adapter(
     func_info: &WasiFunctionInfo,
     wasi_registry: &crate::component_model::WasiRegistry,
     type_table: &RefCell<TypeTable>,
+    interner: &RefCell<crate::name::ModuleSourceInterner>,
     owner_module: &ModuleSource,
 ) -> Rc<RefCell<TirFunction>> {
     let name = binding_func_name(&func_info.interface_name, &func_info.method_name);
@@ -3473,6 +3475,7 @@ fn synthesize_adapter(
             wasi_registry,
             type_table,
             cm_package: &func_info.package,
+            interner,
         };
         let lifted = synthesize_lift_with_context(
             &resolved,
@@ -3529,6 +3532,7 @@ fn synthesize_adapter(
                 wasi_registry,
                 type_table,
                 cm_package: &func_info.package,
+                interner,
             };
             let lifted = synthesize_lift_flat_result(
                 &resolved,
@@ -4964,6 +4968,7 @@ fn synthesize_result_export_binding(
     world_params: &[(String, Type)],
     wasi_registry: &WasiRegistry,
     cm_package: &str,
+    interner: &RefCell<crate::name::ModuleSourceInterner>,
 ) -> Rc<RefCell<TirFunction>> {
     let binding_name = export_binding_func_name(export_name);
     let mut body_stmts: Vec<TirStmt> = Vec::new();
@@ -4976,6 +4981,7 @@ fn synthesize_result_export_binding(
         wasi_registry,
         type_table,
         cm_package,
+        interner,
     };
 
     // Build adapter params and call args
@@ -5512,6 +5518,7 @@ fn synthesize_general_export_binding(
     world_params: &[(String, Type)],
     wasi_registry: &WasiRegistry,
     cm_package: &str,
+    interner: &RefCell<crate::name::ModuleSourceInterner>,
 ) -> Rc<RefCell<TirFunction>> {
     let binding_name = export_binding_func_name(export_name);
     let mut body_stmts: Vec<TirStmt> = Vec::new();
@@ -5524,6 +5531,7 @@ fn synthesize_general_export_binding(
         wasi_registry,
         type_table,
         cm_package,
+        interner,
     };
 
     // Build adapter params and call args
@@ -5741,6 +5749,7 @@ fn synthesize_async_export_binding(
     world_params: &[(String, Type)],
     wasi_registry: &WasiRegistry,
     cm_package: &str,
+    interner: &RefCell<crate::name::ModuleSourceInterner>,
 ) -> Rc<RefCell<TirFunction>> {
     let binding_name = export_binding_func_name(export_name);
     let mut body_stmts: Vec<TirStmt> = Vec::new();
@@ -5781,6 +5790,7 @@ fn synthesize_async_export_binding(
             wasi_registry,
             type_table,
             cm_package,
+            interner,
         };
         for (i, (_name, param_ty)) in world_params.iter().enumerate() {
             let user_type_id = user_func_ref
@@ -5886,6 +5896,7 @@ fn expand_task_returns_in_func(
     type_table: &Rc<RefCell<TypeTable>>,
     wasi_registry: &WasiRegistry,
     cm_package: &str,
+    interner: &RefCell<crate::name::ModuleSourceInterner>,
 ) {
     let mut func = user_func.borrow_mut();
     let mut next_local = func.local_count;
@@ -5903,6 +5914,7 @@ fn expand_task_returns_in_func(
         type_table,
         wasi_registry,
         cm_package,
+        interner,
     );
     func.body = Some(body);
     func.local_count = next_local;
@@ -5965,6 +5977,7 @@ fn expand_task_return_in_block(
     type_table: &Rc<RefCell<TypeTable>>,
     wasi_registry: &WasiRegistry,
     cm_package: &str,
+    interner: &RefCell<crate::name::ModuleSourceInterner>,
 ) {
     let stmts = std::mem::take(&mut blk.stmts);
     let mut new_stmts: Vec<TirStmt> = Vec::with_capacity(stmts.len());
@@ -5982,6 +5995,7 @@ fn expand_task_return_in_block(
                     type_table,
                     wasi_registry,
                     cm_package,
+                    interner,
                 );
                 new_stmts.extend(expanded);
             }
@@ -5995,6 +6009,7 @@ fn expand_task_return_in_block(
                 type_table,
                 wasi_registry,
                 cm_package,
+                interner,
             );
             new_stmts.push(stmt);
         }
@@ -6011,6 +6026,7 @@ fn expand_task_return_in_stmt(
     type_table: &Rc<RefCell<TypeTable>>,
     wasi_registry: &WasiRegistry,
     cm_package: &str,
+    interner: &RefCell<crate::name::ModuleSourceInterner>,
 ) {
     match &mut stmt.kind {
         TirStmtKind::If {
@@ -6027,6 +6043,7 @@ fn expand_task_return_in_stmt(
                 type_table,
                 wasi_registry,
                 cm_package,
+                interner,
             );
             if let Some(blk) = else_block {
                 expand_task_return_in_block(
@@ -6038,6 +6055,7 @@ fn expand_task_return_in_stmt(
                     type_table,
                     wasi_registry,
                     cm_package,
+                    interner,
                 );
             }
         }
@@ -6051,6 +6069,7 @@ fn expand_task_return_in_stmt(
                 type_table,
                 wasi_registry,
                 cm_package,
+                interner,
             );
         }
         TirStmtKind::IfLet {
@@ -6067,6 +6086,7 @@ fn expand_task_return_in_stmt(
                 type_table,
                 wasi_registry,
                 cm_package,
+                interner,
             );
             if let Some(blk) = else_block {
                 expand_task_return_in_block(
@@ -6078,6 +6098,7 @@ fn expand_task_return_in_stmt(
                     type_table,
                     wasi_registry,
                     cm_package,
+                    interner,
                 );
             }
         }
@@ -6101,11 +6122,13 @@ fn generate_inline_task_return(
     type_table: &Rc<RefCell<TypeTable>>,
     wasi_registry: &WasiRegistry,
     cm_package: &str,
+    interner: &RefCell<crate::name::ModuleSourceInterner>,
 ) -> Vec<TirStmt> {
     let lift_ctx = LiftContext {
         wasi_registry,
         type_table,
         cm_package,
+        interner,
     };
     let mut stmts: Vec<TirStmt> = Vec::new();
     let value_type_id = value.type_id;
@@ -6349,15 +6372,12 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                     &func_info.interface_name,
                     &func_info.package,
                 )
-                .unwrap_or_else(|| ModuleSource::Wasi {
-                    interface: crate::name::InternedStr::from_string_uncanonicalized(
-                        func_info.package.clone(),
-                    ),
-                });
+                .unwrap_or_else(|| project.interner.borrow_mut().wasi(&func_info.package));
                 let adapter = synthesize_adapter(
                     &func_info,
                     project.wasi_registry,
                     &entry_type_table,
+                    &project.interner,
                     &owner_module,
                 );
                 adapters.insert(qualified_name.clone(), adapter.clone());
@@ -6503,6 +6523,7 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                                 &entry_type_table,
                                 project.wasi_registry,
                                 &binding_cm_package,
+                                &project.interner,
                             );
                         }
                         synthesize_async_export_binding(
@@ -6514,6 +6535,7 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                             &export.params,
                             project.wasi_registry,
                             &binding_cm_package,
+                            &project.interner,
                         )
                     } else {
                         // Check the user function's actual return type (signature-driven)
@@ -6547,6 +6569,7 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                                 &export.params,
                                 project.wasi_registry,
                                 &binding_cm_package,
+                                &project.interner,
                             )
                         } else {
                             // Non-Result return: check if we can use the simple void adapter
@@ -6579,6 +6602,7 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                                     &export.params,
                                     project.wasi_registry,
                                     &binding_cm_package,
+                                    &project.interner,
                                 )
                             }
                         }
@@ -6756,6 +6780,7 @@ fn synthesize_record_stream_reads(project: &mut Package) {
             elem_align,
             wasi_registry,
             &type_table,
+            &project.interner,
         );
         new_functions.push(Rc::new(RefCell::new(func)));
     }
@@ -6881,6 +6906,7 @@ fn synthesize_stream_read_func(
     elem_align: i32,
     wasi_registry: &crate::component_model::WasiRegistry,
     type_table: &RefCell<TypeTable>,
+    interner: &RefCell<crate::name::ModuleSourceInterner>,
 ) -> TirFunction {
     use crate::synthesis::common::{
         assign, binary, break_stmt, builtin_call, cm_raw_call, expr_stmt, i32_const, if_stmt,
@@ -7086,6 +7112,7 @@ fn synthesize_stream_read_func(
         wasi_registry,
         type_table,
         cm_package: "filesystem",
+        interner,
     };
     let ast_type = crate::ast::Type::Named(crate::ast::NamedType {
         id: crate::ast::AstId::fresh(),

--- a/wado-compiler/src/synthesis/effect_dispatch.rs
+++ b/wado-compiler/src/synthesis/effect_dispatch.rs
@@ -750,7 +750,11 @@ fn build_dispatch_wrapper_function(
         let effect_call = TirExpr::new(
             TirExprKind::Call {
                 func: FunctionRef {
-                    module_source: ModuleSource::local(base_name.to_string()),
+                    module_source: ModuleSource::Local {
+                        path: crate::name::InternedStr::from_string_uncanonicalized(
+                            base_name.to_string(),
+                        ),
+                    },
                     name: op_name.clone(),
                     monomorph_info: None,
                     method_info: None,
@@ -2577,7 +2581,9 @@ fn rewrite_calls_in_expr(expr: &mut TirExpr, ctx: &RewriteCtx<'_>) {
                     )
                 })
             } else if let ModuleSource::Local { path } = &func.module_source
-                && let Some(wrapper) = ctx.user_to_wrapper.get(&(path.clone(), func.name.clone()))
+                && let Some(wrapper) = ctx
+                    .user_to_wrapper
+                    .get(&(path.to_string(), func.name.clone()))
             {
                 Some(wrapper_call(
                     wrapper.clone(),

--- a/wado-compiler/src/synthesis/effect_dispatch.rs
+++ b/wado-compiler/src/synthesis/effect_dispatch.rs
@@ -454,6 +454,7 @@ fn synthesize_dispatch_wrappers(
     let effect_module = effect_module.clone();
     let base_name = base_name.clone();
     let is_resource = meta.is_resource;
+    let interner = project.interner.clone();
     let entry_module = project
         .tir_modules
         .get_mut(entry_source)
@@ -471,6 +472,7 @@ fn synthesize_dispatch_wrappers(
             plan,
             is_resource,
             &type_table,
+            &interner,
         );
         entry_module.add_function(wrapper);
     }
@@ -486,6 +488,7 @@ fn build_dispatch_wrapper_function(
     plan: &DispatchPlan,
     is_resource: bool,
     type_table: &std::rc::Rc<std::cell::RefCell<TypeTable>>,
+    interner: &std::cell::RefCell<crate::name::ModuleSourceInterner>,
 ) -> TirFunction {
     let span = synth_span();
     let op_name = &op.name;
@@ -750,11 +753,7 @@ fn build_dispatch_wrapper_function(
         let effect_call = TirExpr::new(
             TirExprKind::Call {
                 func: FunctionRef {
-                    module_source: ModuleSource::Local {
-                        path: crate::name::InternedStr::from_string_uncanonicalized(
-                            base_name.to_string(),
-                        ),
-                    },
+                    module_source: interner.borrow_mut().local(base_name),
                     name: op_name.clone(),
                     monomorph_info: None,
                     method_info: None,

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -488,7 +488,7 @@ fn generate_struct_serialize(
 ) -> Option<TirFunction> {
     let struct_def = find_struct(module, &req.target_type_name)?;
     let span = synth_span();
-    let serde_module = ModuleSource::core("serde");
+    let serde_module = ModuleSource::serde();
 
     let mut tt = module.type_table.borrow_mut();
 
@@ -713,7 +713,7 @@ fn generate_struct_deserialize(
     let struct_def = find_struct(module, &req.target_type_name)?;
     let span = synth_span();
     let module_source = module.module_source.clone();
-    let serde_module = ModuleSource::core("serde");
+    let serde_module = ModuleSource::serde();
 
     let mut tt = module.type_table.borrow_mut();
 
@@ -1457,7 +1457,7 @@ fn generate_enum_serialize(
 ) -> Option<TirFunction> {
     let enum_def = find_enum(module, &req.target_type_name)?;
     let span = synth_span();
-    let serde_module = ModuleSource::core("serde");
+    let serde_module = ModuleSource::serde();
 
     let mut tt = module.type_table.borrow_mut();
 
@@ -1606,7 +1606,7 @@ fn generate_enum_deserialize(
 ) -> Option<TirFunction> {
     let enum_def = find_enum(module, &req.target_type_name)?;
     let span = synth_span();
-    let serde_module = ModuleSource::core("serde");
+    let serde_module = ModuleSource::serde();
 
     let mut tt = module.type_table.borrow_mut();
 
@@ -1982,7 +1982,7 @@ fn generate_variant_serialize(
 ) -> Option<TirFunction> {
     let variant_def = find_variant(module, &req.target_type_name)?;
     let span = synth_span();
-    let serde_module = ModuleSource::core("serde");
+    let serde_module = ModuleSource::serde();
 
     let mut tt = module.type_table.borrow_mut();
 
@@ -2267,7 +2267,7 @@ fn generate_variant_deserialize(
 ) -> Option<TirFunction> {
     let variant_def = find_variant(module, &req.target_type_name)?;
     let span = synth_span();
-    let serde_module = ModuleSource::core("serde");
+    let serde_module = ModuleSource::serde();
 
     let mut tt = module.type_table.borrow_mut();
 
@@ -2844,7 +2844,7 @@ fn generate_flags_serialize(
 ) -> Option<TirFunction> {
     let flags_def = find_flags(module, &req.target_type_name)?;
     let span = synth_span();
-    let serde_module = ModuleSource::core("serde");
+    let serde_module = ModuleSource::serde();
 
     let mut tt = module.type_table.borrow_mut();
 
@@ -3077,7 +3077,7 @@ fn generate_flags_deserialize(
 ) -> Option<TirFunction> {
     let flags_def = find_flags(module, &req.target_type_name)?;
     let span = synth_span();
-    let serde_module = ModuleSource::core("serde");
+    let serde_module = ModuleSource::serde();
 
     let mut tt = module.type_table.borrow_mut();
 

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1034,7 +1034,7 @@ impl TypeTable {
         let module_source = self
             .tuple_module_source
             .clone()
-            .unwrap_or_else(|| ModuleSource::core("prelude"));
+            .unwrap_or_else(|| ModuleSource::prelude());
         self.intern(ResolvedType::GenericInstance {
             name: Self::TUPLE_TYPE_NAME.to_string(),
             module_source,

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1034,7 +1034,7 @@ impl TypeTable {
         let module_source = self
             .tuple_module_source
             .clone()
-            .unwrap_or_else(|| ModuleSource::prelude());
+            .unwrap_or_else(ModuleSource::prelude);
         self.intern(ResolvedType::GenericInstance {
             name: Self::TUPLE_TYPE_NAME.to_string(),
             module_source,

--- a/wado-compiler/tests/annotate.rs
+++ b/wado-compiler/tests/annotate.rs
@@ -25,7 +25,7 @@ export fn run() {
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
 
     let entry = ModuleSource::EntryPoint {
-        filename: "entry.wado".to_string(),
+        filename: wado_compiler::name::InternedStr::from_string_uncanonicalized("entry.wado".to_string()),
     };
 
     let point_symbol = annotated
@@ -63,7 +63,7 @@ fn annotate_resolves_position_to_ast_id() {
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
 
     let entry = ModuleSource::EntryPoint {
-        filename: "entry.wado".to_string(),
+        filename: wado_compiler::name::InternedStr::from_string_uncanonicalized("entry.wado".to_string()),
     };
 
     // Column 12 is inside "run" on line 1.

--- a/wado-compiler/tests/annotate.rs
+++ b/wado-compiler/tests/annotate.rs
@@ -5,8 +5,8 @@
 mod common;
 
 use common::InMemoryHost;
-use wado_compiler::symbol::{SymbolKey, SymbolKind};
 use wado_compiler::annotate;
+use wado_compiler::symbol::{SymbolKey, SymbolKind};
 
 fn block_on<F: std::future::Future>(future: F) -> F::Output {
     tokio::runtime::Runtime::new().unwrap().block_on(future)

--- a/wado-compiler/tests/annotate.rs
+++ b/wado-compiler/tests/annotate.rs
@@ -6,7 +6,7 @@ mod common;
 
 use common::InMemoryHost;
 use wado_compiler::symbol::{SymbolKey, SymbolKind};
-use wado_compiler::{ModuleSource, annotate};
+use wado_compiler::annotate;
 
 fn block_on<F: std::future::Future>(future: F) -> F::Output {
     tokio::runtime::Runtime::new().unwrap().block_on(future)
@@ -24,9 +24,7 @@ export fn run() {
     let host = InMemoryHost::new();
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
 
-    let entry = ModuleSource::EntryPoint {
-        filename: wado_compiler::name::InternedStr::from_string_uncanonicalized("entry.wado".to_string()),
-    };
+    let entry = annotated.interner.borrow_mut().entry_point("entry.wado");
 
     let point_symbol = annotated
         .symbols
@@ -62,9 +60,7 @@ fn annotate_resolves_position_to_ast_id() {
     let host = InMemoryHost::new();
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
 
-    let entry = ModuleSource::EntryPoint {
-        filename: wado_compiler::name::InternedStr::from_string_uncanonicalized("entry.wado".to_string()),
-    };
+    let entry = annotated.interner.borrow_mut().entry_point("entry.wado");
 
     // Column 12 is inside "run" on line 1.
     let id = annotated

--- a/wado-compiler/tests/kiln_loader_redirect.rs
+++ b/wado-compiler/tests/kiln_loader_redirect.rs
@@ -90,7 +90,9 @@ pub fn greet() {}
     };
 
     let redirected = ModuleSource::Redirected {
-        uri: "build/kiln/test-invocation/sample.wado".to_string(),
+        uri: wado_compiler::name::InternedStr::from_string_uncanonicalized(
+            "build/kiln/test-invocation/sample.wado".to_string(),
+        ),
     };
     assert!(
         annotated.modules.contains_key(&redirected),
@@ -114,7 +116,9 @@ export fn run() {}
     ))
     .unwrap();
     let entry_ms = ModuleSource::EntryPoint {
-        filename: "entry.wado".to_string(),
+        filename: wado_compiler::name::InternedStr::from_string_uncanonicalized(
+            "entry.wado".to_string(),
+        ),
     };
     assert!(annotated.modules.contains_key(&entry_ms));
 }

--- a/wado-compiler/tests/kiln_loader_redirect.rs
+++ b/wado-compiler/tests/kiln_loader_redirect.rs
@@ -8,8 +8,7 @@ use std::sync::Mutex;
 
 use indexmap::IndexMap;
 use wado_compiler::{
-    CompilerHost, Diagnostic, ModuleSource, SourceError, annotate_with_invocations,
-    kiln::InvocationIndex,
+    CompilerHost, Diagnostic, SourceError, annotate_with_invocations, kiln::InvocationIndex,
 };
 
 struct MapHost {
@@ -89,11 +88,10 @@ pub fn greet() {}
         );
     };
 
-    let redirected = ModuleSource::Redirected {
-        uri: wado_compiler::name::InternedStr::from_string_uncanonicalized(
-            "build/kiln/test-invocation/sample.wado".to_string(),
-        ),
-    };
+    let redirected = annotated
+        .interner
+        .borrow_mut()
+        .redirected("build/kiln/test-invocation/sample.wado");
     assert!(
         annotated.modules.contains_key(&redirected),
         "loader should have loaded the generated entry module, got: {:?}",
@@ -115,10 +113,6 @@ export fn run() {}
         idx,
     ))
     .unwrap();
-    let entry_ms = ModuleSource::EntryPoint {
-        filename: wado_compiler::name::InternedStr::from_string_uncanonicalized(
-            "entry.wado".to_string(),
-        ),
-    };
+    let entry_ms = annotated.interner.borrow_mut().entry_point("entry.wado");
     assert!(annotated.modules.contains_key(&entry_ms));
 }

--- a/wado-compiler/tests/kiln_options.rs
+++ b/wado-compiler/tests/kiln_options.rs
@@ -13,12 +13,8 @@ fn block_on<F: std::future::Future>(future: F) -> F::Output {
     tokio::runtime::Runtime::new().unwrap().block_on(future)
 }
 
-fn entry() -> ModuleSource {
-    ModuleSource::EntryPoint {
-        filename: wado_compiler::name::InternedStr::from_string_uncanonicalized(
-            "entry.wado".to_string(),
-        ),
-    }
+fn entry(annotated: &wado_compiler::Annotated) -> ModuleSource {
+    annotated.interner.borrow_mut().entry_point("entry.wado")
 }
 
 #[test]
@@ -34,7 +30,7 @@ pub fn generate() {}
 ";
     let host = InMemoryHost::new();
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
-    let desc = extract_options_descriptor(&annotated, &entry()).unwrap();
+    let desc = extract_options_descriptor(&annotated, &entry(&annotated)).unwrap();
     assert_eq!(desc.fields.len(), 3);
 
     assert_eq!(desc.fields[0].name, "highlight");
@@ -61,7 +57,7 @@ pub fn generate() {}
 ";
     let host = InMemoryHost::new();
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
-    let desc = extract_options_descriptor(&annotated, &entry()).unwrap();
+    let desc = extract_options_descriptor(&annotated, &entry(&annotated)).unwrap();
     assert_eq!(desc.fields.len(), 1);
     match &desc.fields[0].ty {
         OptionsType::Option(inner) => assert!(matches!(inner.as_ref(), OptionsType::String)),
@@ -86,7 +82,7 @@ pub fn generate() {}
 ";
     let host = InMemoryHost::new();
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
-    let desc = extract_options_descriptor(&annotated, &entry()).unwrap();
+    let desc = extract_options_descriptor(&annotated, &entry(&annotated)).unwrap();
     assert_eq!(desc.fields.len(), 1);
     match &desc.fields[0].ty {
         OptionsType::Enum { name, variants } => {
@@ -117,7 +113,7 @@ pub fn generate() {}
 ";
     let host = InMemoryHost::new();
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
-    let desc = extract_options_descriptor(&annotated, &entry()).unwrap();
+    let desc = extract_options_descriptor(&annotated, &entry(&annotated)).unwrap();
     assert_eq!(desc.fields.len(), 1);
     let OptionsType::Struct { name, descriptor } = &desc.fields[0].ty else {
         panic!("expected nested Struct field");
@@ -141,7 +137,7 @@ pub fn generate() {}
 ";
     let host = InMemoryHost::new();
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
-    let err = extract_options_descriptor(&annotated, &entry()).unwrap_err();
+    let err = extract_options_descriptor(&annotated, &entry(&annotated)).unwrap_err();
     assert!(
         err.iter()
             .any(|d| d.message.contains("does not declare `pub struct Options`"))
@@ -157,7 +153,7 @@ pub struct Options {
 ";
     let host = InMemoryHost::new();
     let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
-    let err = extract_options_descriptor(&annotated, &entry()).unwrap_err();
+    let err = extract_options_descriptor(&annotated, &entry(&annotated)).unwrap_err();
     assert!(
         err.iter()
             .any(|d| d.message.contains("does not declare `generate` function"))

--- a/wado-compiler/tests/kiln_options.rs
+++ b/wado-compiler/tests/kiln_options.rs
@@ -15,7 +15,9 @@ fn block_on<F: std::future::Future>(future: F) -> F::Output {
 
 fn entry() -> ModuleSource {
     ModuleSource::EntryPoint {
-        filename: "entry.wado".to_string(),
+        filename: wado_compiler::name::InternedStr::from_string_uncanonicalized(
+            "entry.wado".to_string(),
+        ),
     }
 }
 

--- a/wado-lsp/src/definition.rs
+++ b/wado-lsp/src/definition.rs
@@ -94,8 +94,12 @@ fn file_path_definition(
 ) -> Option<DefinitionResult> {
     let ast_module = annotated.modules.get(module)?;
     let path = find_file_path_at_cursor(ast_module, line, col)?;
-    let target_module =
-        resolve_import_with_entry(module, &path, Some(&annotated.entry_module_source));
+    let target_module = resolve_import_with_entry(
+        &mut annotated.interner.borrow_mut(),
+        module,
+        &path,
+        Some(&annotated.entry_module_source),
+    );
     let target_uri = module_uri(annotated, &target_module, request_uri)?;
     Some(DefinitionResult {
         uri: target_uri,

--- a/wado-lsp/src/location.rs
+++ b/wado-lsp/src/location.rs
@@ -43,16 +43,16 @@ pub(crate) fn module_uri(
         ModuleSource::Local { path } => Some(resolve_local_uri(path, request_uri)),
         ModuleSource::Core { name } => Some(format!("core:{name}")),
         ModuleSource::Wasi { interface } => Some(format!("wasi:{interface}")),
-        ModuleSource::Remote { url } => Some(url.clone()),
+        ModuleSource::Remote { url } => Some(url.to_string()),
         // Kiln-redirected modules already carry a fully-qualified URI;
         // hand it to the LSP client unchanged.
-        ModuleSource::Redirected { uri } => Some(uri.clone()),
+        ModuleSource::Redirected { uri } => Some(uri.to_string()),
         // Wasm assets (`.wat`/`.wasm` imported via `with { type: ... }`)
         // expose their canonical path; opening these in the editor isn't
         // useful (binary `.wasm`) and stdlib `.wat` paths can't be served
         // until `workspace/textDocumentContent` lands. Emit the path so
         // CLI consumers can still see the reference site.
-        ModuleSource::Wasm { path, .. } => Some(path.clone()),
+        ModuleSource::Wasm { path, .. } => Some(path.to_string()),
     }
 }
 


### PR DESCRIPTION
## Summary

`ModuleSource` payloads are now `Arc<str>` canonicalised through a
`ModuleSourceInterner`, with `Eq` / `Hash` implemented as plain
`Arc::ptr_eq` / pointer hash. Cloning a `ModuleSource` is a refcount
bump, comparing two of them is one pointer compare, and hashing is
one pointer load — vs. the previous `String`-payload path which was
`O(n)` for all three. Monomorphisation, the loader's import resolution,
and the resolver's per-module setup all benefited measurably from
this in profiling, and the same identity is what the synthesis +
lower passes need to keep `IndexMap<(ModuleSource, _)>` lookups
correct without falling back to byte equality.

## Mechanism

- `name::InternedStr` is a newtype around `Arc<str>` with a private
  constructor (`InternedStr::from_arc`, `pub(crate)`) so non-canonical
  values cannot be built outside this crate.
- `name::ModuleSourceInterner` holds the canonical pool and adopts 22
  well-known `LazyLock<Arc<str>>` statics on construction
  (`prelude`, `cli`, `serde`, `wasi:cli`, …, `<entry>`,
  `<uninitialized>`). Calls like `interner.core("prelude")` and
  `ModuleSource::prelude()` therefore share the same `Arc`.
- The loader owns the live interner. `LoadResult.interner` is wrapped
  in `Rc<RefCell<>>` and threaded into `Annotated`, the resolver,
  `Package`, and `FlatPackage`. The interner is dropped at the
  `FlatPackage → WirPackage` boundary so codegen never sees it,
  preserving the existing pipeline-by-type-change discipline.
- `Package` and `FlatPackage` carry the interner so synthesis
  (`cm_binding::generate_adapters`,
  `effect_dispatch::synthesize_*`) and `lower::cm_intrinsics` can
  canonicalise fresh `ModuleSource` values they emit during lifting
  / wrapper synthesis.
- `LoadError::ModuleNotFound` switched from `{ module_source }` to
  `{ path: String }` so `From<SourceError>` can construct it without
  reaching for an interner. Display / `Diagnostic::from` use the path
  string directly; behaviour is unchanged.
- The stdlib AST cache is rekeyed by `String` (the `core:` / `wasi:`
  display form) instead of `ModuleSource`; the cache outlives any
  single loader's interner, so a content-addressed key is correct
  without requiring a process-wide pool.
- All escape hatches removed. There is no
  `from_string_uncanonicalized`; the only way to obtain an
  `InternedStr` is through a `ModuleSourceInterner` or one of the
  well-known statics.

## Verified by

`time mise run on-task-done`:
- `cargo test`: every workspace test green (lib 439, e2e 5690,
  integration suites all passing).
- `wado test` aggregate: 190 modules compiled, 1657 tests passed, 0
  failed, 5 expected `#![TODO]`.
- `mise run update-golden-fixtures` /
  `update-golden-format-fixtures` regenerated cleanly without diff
  noise.
- `mise run doc-stdlib` regenerated stdlib docs without diff
  noise.

## Test plan

- [x] `cargo test --workspace --all-targets`
- [x] `cargo test -p wado-compiler --test e2e`
- [x] `wado test` over the full project (`mise run test-wado`)
- [x] Golden fixture regen (`mise run update-golden-fixtures`)
- [x] Format fixture regen (`mise run update-golden-format-fixtures`)
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo fmt --all`

https://claude.ai/code/session_01YDaquBngkvKsg35Nbx3SHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDaquBngkvKsg35Nbx3SHQ)_