### PR TITLE
kiln: relocate per-invocation cache to <output_dir>/<primary>.kiln.json

### DIFF
--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -11,7 +11,7 @@ Each pipeline is wired up by hand in `mise.toml`, runs out-of-band, and produces
 
 This WEP introduces **Kiln** (**K**eyed **I**DL **L**owering **N**otation), a first-class mechanism for **schema-driven code generation** — the Wado equivalent of Java annotation processors (APT/KSP), Roslyn source generators, Swift macros, or Dart's `build_runner`, narrowed to a single use case: **IDL → Wado source**. The name joins Wado's existing element-themed tools (Tide for WebIDL, Gale for grammars) as the "fire" in which raw schemas are fired into Wado source, and the expansion captures the four defining properties of the design:
 
-- **K**eyed — every invocation is content-addressed by a cache key covering schemas, options, and the generator's own source hash (see "Caching and `metadata.json`").
+- **K**eyed — every invocation is content-addressed by a cache key covering schemas, options, and the generator's own source hash (see "Caching and the `<primary>.kiln.json` cache file").
 - **I**DL — the sole accepted input shape is an interface description language; Kiln is deliberately narrower than a general build system.
 - **L**owering — Kiln lowers high-level schema files into plain Wado source that the ordinary compiler pipeline then handles with no further specialization.
 - **N**otation — the user-facing surface is a declarative notation (`use ... from "<schema>" with { generator: { ... } }`), not an imperative build script.
@@ -23,7 +23,7 @@ In scope:
 - Users register code generators in `wado.toml` or inline at a `use` site.
 - Generators read schema files (`.proto`, `.graphql`, `.g4`, `.wit`, `.json`, custom IDLs, …) and emit `.wado` source files.
 - Generators are ordinary Wado packages compiled to `wasm32-wasip3` Component Model components by `wado-compiler` and executed by the host via a new `CompilerHost::run_generator` capability. The native host (`wado-cli`) uses wasmtime; `wasm32`-bundled clients either forward to a Wasm runtime available to them or fall back to the consume-only mode described in "Transitional consume-only mode".
-- All Kiln cache state lives under `build/kiln/`: per-invocation cache metadata (`metadata.json`) under `build/kiln/<synthesized-id>/`, compiled generator components under `build/kiln/generators/`, and extracted descriptors (e.g. `OptionsDescriptor`) under `build/kiln/metadata/`. Generated `.wado` source defaults to the same `build/kiln/<synthesized-id>/` directory but may be redirected per-invocation via `output_dir` to a committable location such as `src/generated/`. `build/kiln/` itself is intended to be `.gitignore`d; cache state is rebuilt on demand and is never required for compilation correctness. See "Caching and `metadata.json`" and "Transitional consume-only mode" for the two workflows.
+- Shared Kiln caches live under `build/kiln/`: compiled generator components under `build/kiln/generators/` and extracted descriptors (e.g. `OptionsDescriptor`) under `build/kiln/metadata/`. `build/kiln/` itself is intended to be `.gitignore`d; cache state is rebuilt on demand and is never required for compilation correctness. Per-invocation cache state — the cache key + output hashes — lives next to the outputs as `<output_dir>/<primary>.kiln.json`, so the committed-source workflow can commit the cache file alongside the generated `.wado` and a fresh checkout hits the cache. Generated `.wado` source defaults to `build/kiln/<synthesized-id>/` but may be redirected per-invocation via `output_dir` to a committable location such as `src/generated/`. See "Caching and the `<primary>.kiln.json` cache file" and "Transitional consume-only mode" for the two workflows.
 - Invocation is automatic: the compiler runs the relevant generators during `wado compile`, with content-addressed caching so unchanged inputs skip the generator.
 
 Out of scope:
@@ -40,7 +40,7 @@ Languages with a serious IDL story have landed on one of four designs: in-compil
 ### What Wado already has that we build on
 
 - **`CompilerHost` abstraction** ([`wep-2026-01-16-source-provider-abstraction.md`](./wep-2026-01-16-source-provider-abstraction.md)) — `wado-compiler` is itself I/O-free. All source reads go through a trait implemented by `wado-cli`. Kiln reuses this boundary: generators never touch the filesystem directly; they call a host-provided `read-file` import that the compiler forwards to `CompilerHost`.
-- **`wado.toml` + `wado.lock`** ([`wep-2026-02-14-package-manifest.md`](./wep-2026-02-14-package-manifest.md)) — package manifest and lock file. We add a new `[build-dependencies]` section for build-only generator packages. `wado.lock` itself is dependency-pin-only; per-invocation cache state lives outside the lockfile (see "Caching and `metadata.json`").
+- **`wado.toml` + `wado.lock`** ([`wep-2026-02-14-package-manifest.md`](./wep-2026-02-14-package-manifest.md)) — package manifest and lock file. We add a new `[build-dependencies]` section for build-only generator packages. `wado.lock` itself is dependency-pin-only; per-invocation cache state lives outside the lockfile (see "Caching and the `<primary>.kiln.json` cache file").
 - **Wado → WIT mapping** ([`wep-2026-01-29-wit-wado-mapping.md`](./wep-2026-01-29-wit-wado-mapping.md)) — the longer-term mechanism for translating Wado types into WIT. Kiln relies on it only at its eventual evolution point (per-generator `Options` WIT records, see "Options schema"); the v1 path extracts the `Options` shape directly from the generator's Wado IR.
 - **`#![generated]` module attribute** — already parsed by the compiler. Kiln extends it with named arguments; see "Generated file header".
 
@@ -246,7 +246,7 @@ Responsibility split:
 | ----------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------ |
 | Parse `[build-dependencies]` in `wado.toml`                                   | `wado-manifest`               | Already `wasm32-unknown-unknown`-ready.                      |
 | Read and write `[[build-dependency]]` in `wado.lock`                          | `wado-manifest`               | Pure parsing + serialization.                                |
-| Read and write per-invocation `metadata.json` under `build/kiln/<id>/`        | `wado-cli`                    | JSON; gitignored cache state, never the lockfile.            |
+| Read and write per-invocation `<primary>.kiln.json` next to outputs           | `wado-cli`                    | JSON; committable when `output_dir` is tracked.              |
 | Collect inline `with` clauses, deduplicate, build the DAG, topologically sort | `wado-compiler`               | Pure logic.                                                  |
 | Compile each generator's Wado source to a `wasm32-wasip3` component           | `wado-compiler`               | Ordinary codegen path.                                       |
 | Compute cache keys                                                            | `wado-compiler`               | Pure logic.                                                  |
@@ -263,14 +263,14 @@ In principle, any host that can run `wado-compiler` as Wasm can also run a gener
 Consume-only semantics:
 
 - `run_generator` returns `Unsupported`.
-- For each invocation the compiler still recomputes the cache key and compares it against `metadata.json` and `<output-dir>`:
+- For each invocation the compiler still recomputes the cache key and compares it against `<output_dir>/<primary>.kiln.json` and `<output_dir>`:
   - Cache hit: the generated `.wado` files are loaded through the ordinary `load_source` path; compilation proceeds as if the user had authored those files by hand.
   - Cache miss or hash mismatch: the compiler emits a `warning` diagnostic (`stale kiln cache: <invocation>; re-run 'wado compile' natively to refresh`) and treats the invocation's entry module as present-but-unresolved. `use` statements targeting its symbols surface as ordinary resolution errors; the rest of the compilation unit still proceeds.
-- No writes occur: neither `metadata.json` nor `<output-dir>` is modified in consume-only mode.
+- No writes occur: neither `<primary>.kiln.json` nor `<output_dir>` is modified in consume-only mode.
 
 Consume-only is a compatibility bridge, not part of the steady-state design. Once a web host gains CM + WASI p3 support, the same `CompilerHost` implementation can route `run_generator` through that host's runtime and consume-only never kicks in. Nothing user-visible changes at that point.
 
-Because `wado-lsp` running in web editors depends on this mode, projects that want a full web LSP experience set `output_dir` to a tracked path (e.g. `src/generated/`) and commit the generated `.wado` source. `metadata.json` itself remains gitignored under `build/kiln/`; consume-only mode reads it locally if present and falls back to "no cache, trust on-disk source" otherwise.
+Because `wado-lsp` running in web editors depends on this mode, projects that want a full web LSP experience set `output_dir` to a tracked path (e.g. `src/generated/`) and commit the generated `.wado` source together with the `<primary>.kiln.json` cache file that lives next to it; consume-only mode reads the committed cache file when available and falls back to "no cache, trust on-disk source" otherwise.
 
 ### Anatomy of a generator module
 
@@ -324,29 +324,30 @@ A generator that emits zero entries, two entries, or a supplementary module with
 
 ### `build/kiln/` directory layout
 
-All Kiln cache state lives under a single `build/kiln/` directory rooted at the consuming project. The layout is fixed by the compiler.
+`build/kiln/` holds shared, content-addressed caches (compiled generator components and extracted descriptors). Per-invocation cache state lives next to the generated outputs in `output_dir`, not under `build/kiln/`.
 
 ```
 build/kiln/
 ├── generators/                 # compiled generator components
 │   └── <stable-id>.wasm
-├── metadata/                   # extracted metadata per generator module
-│   └── <stable-id>.descriptor  # serialized OptionsDescriptor, etc.
-└── <synthesized-id>/           # one directory per invocation
-    ├── metadata.json           # per-invocation cache state (key + outputs)
-    ├── <entry>.wado            # generated source (when output_dir defaults here)
-    └── <supplementary>.wado
+└── metadata/                   # extracted metadata per generator module
+    └── <stable-id>.descriptor  # serialized OptionsDescriptor, etc.
+
+<output_dir>/                   # default: build/kiln/<synthesized-id>
+├── <primary>.kiln.json         # per-invocation cache state (key + outputs)
+├── <entry>.wado                # generated source
+└── <supplementary>.wado
 ```
 
-- `generators/<stable-id>.wasm` — the `wasm32-wasip3` Component Model component that the compiler produced from a generator package's Wado source. `<stable-id>` is content-addressed: for `GeneratorModule::LocalPath`, the normalized path plus source tree hash; for `GeneratorModule::Spec`, the resolved `namespace:name@version` plus source-distribution hash. The compiled `.wasm` is not part of the cache key for an invocation (see "Caching and `metadata.json`") — it is a cache of the generator compilation itself, keyed independently.
-- `metadata/<stable-id>.descriptor` — deserializable cache of per-generator-module metadata the compiler extracts when it first loads a generator, currently the typed `OptionsDescriptor`. Regenerated whenever the corresponding `.wasm` is regenerated. (Distinct from per-invocation `metadata.json`.)
-- `<synthesized-id>/metadata.json` — per-invocation cache state: the cache-key inputs from the previous run plus the path and content hash of every output it produced. Read by the compiler to decide whether to rerun the generator and to detect hand-edits of generated files. Always lives under `build/kiln/` regardless of where `output_dir` points the generated `.wado`. See "Caching and `metadata.json`" for the schema.
-- `<synthesized-id>/<entry>.wado` (and supplementary modules) — generated `.wado` source for the invocation. This is the default location; `output_dir` redirects it to any project-relative path such as `src/generated/`. Files carry the `#![generated(...)]` header (see "Generated file header") and are managed by the compiler.
+- `build/kiln/generators/<stable-id>.wasm` — the `wasm32-wasip3` Component Model component that the compiler produced from a generator package's Wado source. `<stable-id>` is content-addressed: for `GeneratorModule::LocalPath`, the normalized path plus source tree hash; for `GeneratorModule::Spec`, the resolved `namespace:name@version` plus source-distribution hash. The compiled `.wasm` is not part of the cache key for an invocation (see "Caching and the `<primary>.kiln.json` cache file") — it is a cache of the generator compilation itself, keyed independently.
+- `build/kiln/metadata/<stable-id>.descriptor` — deserializable cache of per-generator-module metadata the compiler extracts when it first loads a generator, currently the typed `OptionsDescriptor`. Regenerated whenever the corresponding `.wasm` is regenerated. (Distinct from per-invocation `<primary>.kiln.json`.)
+- `<output_dir>/<primary>.kiln.json` — per-invocation cache state: the cache-key inputs from the previous run plus the path and content hash of every output it produced. Read by the compiler to decide whether to rerun the generator and to detect hand-edits of generated files. The basename is the `file_name` of `Invocation::from` (the primary input). Living next to its outputs lets the committed-source workflow keep the cache state under git, so a fresh checkout (or CI) hits the cache and skips the generator on the first compile. See "Caching and the `<primary>.kiln.json` cache file" for the schema.
+- `<output_dir>/<entry>.wado` (and supplementary modules) — generated `.wado` source for the invocation. The default `output_dir` is `build/kiln/<synthesized-id>/`; `output_dir` redirects it to any project-relative path such as `src/generated/`. Files carry the `#![generated(...)]` header (see "Generated file header") and are managed by the compiler.
 
 Two recommended workflows:
 
-- **Ephemeral** (default): leave `output_dir` at its default. Generated `.wado` lives under `build/kiln/<synthesized-id>/` alongside `metadata.json`, the whole `build/kiln/` is `.gitignore`d, and a clean checkout regenerates everything on first compile.
-- **Committed source**: set `output_dir` to a tracked path such as `src/generated/<feature>/`. The generated `.wado` is committed and shows up in PR review and IDE navigation; only `build/kiln/` (including `metadata.json`) stays gitignored. CI uses `wado check` (see "The `wado check` command") to enforce that the committed source still matches what the generator would produce now.
+- **Ephemeral** (default): leave `output_dir` at its default. Generated `.wado` and the `<primary>.kiln.json` cache file live under `build/kiln/<synthesized-id>/`; the whole `build/kiln/` is `.gitignore`d, and a clean checkout regenerates everything on first compile.
+- **Committed source**: set `output_dir` to a tracked path such as `src/generated/<feature>/`. The generated `.wado` and the `<primary>.kiln.json` cache file are both committed; PR review sees the source and a fresh checkout (or CI) hits the cache. `build/kiln/` itself stays gitignored — only the per-invocation cache file relocates with `output_dir`. CI uses `wado check` (see "The `wado check` command") to enforce that the committed source still matches what the generator would produce now.
 
 Both workflows use the same code path; the only difference is whether the user commits `output_dir`'s contents.
 
@@ -413,7 +414,7 @@ Field semantics:
 - LSP navigation:
   - **Go to definition** on an imported symbol jumps to the generated `.wado` that defines it — ordinarily the entry module, but a symbol re-exported through the entry resolves to its true definition file as usual.
   - **Go to schema** on the `from` literal jumps to the primary IDL; on an entry in `inputs` it jumps to that supplementary IDL.
-- The compiler synthesizes an internal `Invocation { module, from, inputs, output_dir, options }` from each clause. The synthesized id used in the default `output_dir` and as the `metadata.json` directory name is the `kiln-<16-hex>` SHA-256 prefix of `(module, from, inputs, options)`. `decl_file` is intentionally not folded in, so two files that emit the exact same invocation tuple share a single cache entry.
+- The compiler synthesizes an internal `Invocation { module, from, inputs, output_dir, options }` from each clause. The synthesized id used in the default `output_dir` is the `kiln-<16-hex>` SHA-256 prefix of `(module, from, inputs, options)`. `decl_file` is intentionally not folded in, so two files that emit the exact same invocation tuple share a single cache entry.
 
 De-duplication:
 
@@ -430,10 +431,10 @@ Kiln sits between parsing and name resolution in the pipeline described by [`wep
 3. Build the generator dependency graph: an edge from invocation A to invocation B exists if any of A's inputs (primary or supplementary), or any `read-file` target recorded on a previous run of A, lies inside B's `output_dir`. Topologically sort. Cycles are a compile error.
 4. For each invocation in topological order:
    a. Compute the cache key.
-   b. Read `build/kiln/<synthesized-id>/metadata.json` if it exists. If the recorded cache key matches the freshly computed one and every output file listed in metadata exists on disk, the invocation is up-to-date — but the on-disk hash is also compared to the metadata's recorded hash; a mismatch surfaces a `Code::KilnGeneratedModified` warning and compilation continues against the on-disk content (the user's hand-edit is honored). On a clean cache hit, continue to the next invocation.
+   b. Read `<output_dir>/<primary>.kiln.json` if it exists, where `<primary>` is the basename of `Invocation::from`. If the recorded cache key matches the freshly computed one and every output file listed in metadata exists on disk, the invocation is up-to-date — but the on-disk hash is also compared to the metadata's recorded hash; a mismatch surfaces a `Code::KilnGeneratedModified` warning and compilation continues against the on-disk content (the user's hand-edit is honored). On a clean cache hit, continue to the next invocation.
    c. Otherwise, compile the generator module to a `wasm32-wasip3` component if not already cached. This step reuses `wado-compiler`'s ordinary codegen pipeline.
    d. Build a `GeneratorRequest` (primary + inputs + options) and call `CompilerHost::run_generator` (see "Host-delegated execution" for its contract). Each `read-file` the host relays back is appended to the invocation's dependency list for future cache-key computation. On `Ok(response)` continue with 4(e). On `Err(Unsupported)` the consume-only path in "Transitional consume-only mode" runs instead: 4(e) is skipped, a stale-cache warning is emitted if the on-disk outputs do not match the cache key, and compilation continues against whatever is in `<output_dir>`. On any other `Err(...)` the invocation fails with a hard compile error reported against its declaration.
-   e. Persist each `output-file` to `<output_dir>/<path>`, stamping the `#![generated(...)]` header. If a previous file at the same path differed from the new content (e.g. the schema or generator changed since the user last touched it), surface a `Code::KilnGeneratedRegenerated` warning naming the file. Delete any existing `#![generated]` file in `output_dir` that was not produced by this run. Write the new cache state to `build/kiln/<synthesized-id>/metadata.json`.
+   e. Persist each `output-file` to `<output_dir>/<path>`, stamping the `#![generated(...)]` header. If a previous file at the same path differed from the new content (e.g. the schema or generator changed since the user last touched it), surface a `Code::KilnGeneratedRegenerated` warning naming the file. Delete any existing `#![generated]` file in `output_dir` that was not produced by this run. Write the new cache state to `<output_dir>/<primary>.kiln.json`.
 5. Resolve every `use` statement. A `use { ... } from "<schema>" with { ... }` binds to its invocation's entry module; bare `use { ... } from "<schema>"` against a non-`.wado` schema is the `Code::KilnMissingWith` error unless another clause in the same file already registered an invocation for that `from`. All other `use` statements resolve normally.
 
 Generated files go through the same parser and resolver as user-authored Wado, so a generator emitting syntactically invalid Wado fails with a normal parse error against the on-disk file.
@@ -456,7 +457,7 @@ The mechanism is a name-resolution hook: at `use` time, the compiler checks whet
 
 Two pieces of compiler-internal state drive the redirect:
 
-- `wado_compiler::kiln::InvocationIndex` — the lookup table. Entries are keyed by `(decl_file, from_path_normalized)` and point at the generated entry module's URI. Every entry is local to one declaring file: invocations are always declared inline, so the redirect only fires for `use` clauses inside the same file as the `with` clause. An unrelated file that happens to `use` the same `.g4` path with no `with` clause receives the `Code::KilnMissingWith` error rather than being silently hijacked. The index is built once per compilation unit from the inline invocation set, after the pipeline has populated `build/kiln/…`. For consume-only mode (no pipeline run), the index is built from the recorded `metadata.json` entry's `outputs[i].entry == true` path — that path lives on disk already or the cache check has failed.
+- `wado_compiler::kiln::InvocationIndex` — the lookup table. Entries are keyed by `(decl_file, from_path_normalized)` and point at the generated entry module's URI. Every entry is local to one declaring file: invocations are always declared inline, so the redirect only fires for `use` clauses inside the same file as the `with` clause. An unrelated file that happens to `use` the same `.g4` path with no `with` clause receives the `Code::KilnMissingWith` error rather than being silently hijacked. The index is built once per compilation unit from the inline invocation set, after the pipeline has populated each invocation's `output_dir`. For consume-only mode (no pipeline run), the index is built from the recorded `<primary>.kiln.json` entry's `outputs[i].entry == true` path — that path lives on disk already or the cache check has failed.
 - `ModuleSource::Redirected { uri }` — the compiler's `ModuleSource` variant that carries the redirect through the rest of the pipeline. The `uri` is opaque to every phase after the loader: resolver, analyzer, TIR / WIR, and monomorphizer all treat it as an identity token.
 
 `InvocationIndex::redirect(decl_file, from)` performs a single lookup keyed by `(decl_file, from)`. There is no project-wide fallback (no `DeclScope::Any`); a manifest section that could implicitly redirect imports across the project does not exist by design.
@@ -500,7 +501,7 @@ the flow is:
 - The referenced schema file (`from`) does not exist on disk. The generator's `host::read-file` call fails; the pipeline surfaces this as a compile error at the inline `use ... with { ... }` declaration site.
 - The generator runs but emits invalid Wado. The generated file is parsed by the ordinary frontend, so the user sees a normal parse / type error pointing at the on-disk file. Spans into the generated file carry the same `file` field the loader saw, so the LSP can open them.
 - The redirect fires but imported symbols are not `pub` in the resolved entry module. This is a regular `use` resolution error, not a Kiln-specific one.
-- Consume-only mode (no Kiln runtime available): the invocation index is built from the per-invocation `metadata.json`'s last recorded `outputs[i].entry == true` path. If the file still exists with the recorded hash, compilation proceeds silently; otherwise a `Code::KilnStaleCache` warning is emitted and the existing on-disk content is used as-is. See §"Transitional consume-only mode".
+- Consume-only mode (no Kiln runtime available): the invocation index is built from the per-invocation `<primary>.kiln.json`'s last recorded `outputs[i].entry == true` path. If the file still exists with the recorded hash, compilation proceeds silently; otherwise a `Code::KilnStaleCache` warning is emitted and the existing on-disk content is used as-is. See §"Transitional consume-only mode".
 - Two `use ... with` clauses in the _same_ file disagree on `(module, inputs, options, output_dir)` for the same `from`: duplicate-generator error listing both declarations. Two clauses in _different_ files coexist as independent invocations, scoped to their respective files.
 - A bare `use { ... } from "./schema.<ext>"` against a non-`.wado` source in a file that has no matching `with` clause: `Code::KilnMissingWith`, pointing at the bare `use` and suggesting the `with { generator: { module: ... } }` form.
 
@@ -522,7 +523,7 @@ The compiler prefixes every generated file with a `#![generated(...)]` attribute
 
 The attribute lets `wado format` and linters skip the file, lets the LSP offer "go to schema" independently of any `with` clause, flags the file as derived for human readers, and gates stale-output garbage collection inside `output-dir`.
 
-### Caching and `metadata.json`
+### Caching and the `<primary>.kiln.json` cache file
 
 Each invocation's cache key is the SHA-256 of a canonical concatenation of:
 
@@ -534,9 +535,9 @@ Each invocation's cache key is the SHA-256 of a canonical concatenation of:
 
 The compiled generator `.wasm` is not part of the cache key: its content is determined by the generator source and the compiler version, both already captured elsewhere. Hashing the `.wasm` would force every generator to re-run on a compiler upgrade for no added safety.
 
-The cache state is recorded **per invocation** in a JSON file at `build/kiln/<synthesized-id>/metadata.json`, never in `wado.lock`. The lockfile is dependency-pin-only (`[[package]]`, `[[build-dependency]]`); generator-cache state lives outside it because the cache state is purely a local rebuild aid: bytes that would be regenerated identically on demand do not belong in version control.
+The cache state is recorded **per invocation** in a JSON file at `<output_dir>/<primary>.kiln.json`, where `<primary>` is the basename of `Invocation::from`. It is never in `wado.lock`: the lockfile is dependency-pin-only (`[[package]]`, `[[build-dependency]]`); per-invocation cache state lives outside it. When `output_dir` defaults to `build/kiln/<synthesized-id>/`, the cache file lives there and is gitignored along with the rest of `build/kiln/`. When `output_dir` is committed (e.g. `src/generated/<feature>/`), the cache file is committed alongside the generated `.wado` so a fresh checkout (or CI) hits the cache and skips the generator.
 
-`metadata.json` schema (snake_case, Rust-struct-shaped):
+`<primary>.kiln.json` schema (snake_case, Rust-struct-shaped):
 
 ```json
 {
@@ -562,25 +563,25 @@ The cache state is recorded **per invocation** in a JSON file at `build/kiln/<sy
 Notes:
 
 - `outputs[].path` is project-root-relative (the same shape `output_dir` uses), so committed-source workflows record paths like `src/generated/...`.
-- `outputs[].hash` is recorded **only** in `metadata.json`. The lockfile never carries it. Because `metadata.json` is gitignored, recomputing the hash on every regeneration produces no version-control churn.
-- `metadata.json` is treated as a private, regenerable cache: deleting it or losing the entire `build/kiln/` tree is not an error. The next compile rebuilds from scratch.
+- `outputs[].hash` is recorded **only** in `<primary>.kiln.json`. The lockfile never carries it.
+- `<primary>.kiln.json` is treated as a regenerable cache: deleting it (or losing the entire `build/kiln/` tree, or the entire `output_dir` for committed-source) is not an error. The next compile rebuilds from scratch. Committed-source projects do commit the cache file because it lets a fresh checkout hit the cache; under the default `output_dir`, the file lives under gitignored `build/kiln/`.
 
 Cache check at compile time:
 
 | Situation                                                | Behavior                                                                                                                                                   |
 | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `metadata.json` missing                                  | Cache miss. Run generator, write outputs and `metadata.json`.                                                                                              |
+| `<primary>.kiln.json` missing                            | Cache miss. Run generator, write outputs and `<primary>.kiln.json`.                                                                                        |
 | Cache key matches and on-disk hash matches metadata      | Cache hit. Skip generator.                                                                                                                                 |
 | Cache key matches but on-disk hash differs from metadata | Cache hit (the file was hand-edited). Surface `Code::KilnGeneratedModified` warning, use the on-disk content as-is — the edit is honored.                  |
 | Cache key differs                                        | Cache miss. Run generator. If the new output bytes differ from any pre-existing file, surface `Code::KilnGeneratedRegenerated` warning before overwriting. |
 
 Hand-edits are deliberately accommodated: temporarily tweaking a generated file to debug a downstream issue should not require fighting the build system. The warning makes the divergence visible without breaking the loop.
 
-In consume-only mode (see "Transitional consume-only mode"), the compiler reads `metadata.json` to obtain the entry path and applies the same cache check. A mismatch produces a `warning` diagnostic, not an error; compilation proceeds against whatever is on disk and `metadata.json` is not rewritten.
+In consume-only mode (see "Transitional consume-only mode"), the compiler reads `<output_dir>/<primary>.kiln.json` to obtain the entry path and applies the same cache check. A mismatch produces a `warning` diagnostic, not an error; compilation proceeds against whatever is on disk and the cache file is not rewritten.
 
 ### The `wado check` command
 
-`wado check` is the CI-facing companion to `wado compile`. It runs the same pipeline up to (but not including) Wasm code generation, force-regenerates every Kiln invocation regardless of `metadata.json`, byte-compares each fresh output against the on-disk file, and treats every Kiln warning as an error.
+`wado check` is the CI-facing companion to `wado compile`. It runs the same pipeline up to (but not including) Wasm code generation, force-regenerates every Kiln invocation regardless of any `<primary>.kiln.json`, byte-compares each fresh output against the on-disk file, and treats every Kiln warning as an error.
 
 ```sh
 wado check               # CI default: warnings-as-errors, codegen skipped
@@ -593,7 +594,7 @@ Behavior:
 - All non-codegen compiler phases (parse → analyze → annotate → lower_tir → optimize) run normally. Type errors, missing imports, etc. surface exactly as they would under `wado compile`.
 - For each Kiln invocation: load `<output_dir>/<path>` from disk (if present), run the generator, compare bytes. A difference produces `Code::KilnGeneratedStaleOnDisk`, which `--warn` shows as a warning and the default mode promotes to an error.
 - Wasm emission is skipped, so `wado check` is meaningfully faster than `wado compile`.
-- `metadata.json` is **not** consulted: `wado check` answers "would running the generator now produce what is committed?", which is independent of any local cache state. The check therefore works identically on a fresh CI clone (where `build/kiln/` is empty) and on a developer machine.
+- The `<primary>.kiln.json` cache file is **not** consulted: `wado check` answers "would running the generator now produce what is committed?", which is independent of any cache state. The check therefore works identically on a fresh CI clone and on a developer machine.
 
 The same cache-coherence verification runs implicitly during `wado compile` as well, but with warnings reported as warnings — `wado check` differs only in promoting them to errors and skipping codegen.
 
@@ -816,7 +817,7 @@ The following are deliberately unresolved here; they will be decided during impl
 ## Consequences
 
 - Users gain a first-class way to consume any schema language that has (or can acquire) a Wado generator package. Operationally close to Swift macros: sandboxed, deterministic, cacheable, automatic.
-- `wado.toml` grows a `[build-dependencies]` section and a new `[package].generator` well-known-world field (joining `command`, `service`, `lib`); `wado.lock` grows `[[build-dependency]]` only. Per-invocation cache state (`metadata.json`) lives under `build/kiln/<id>/` outside version control. All `wado.toml` / `wado.lock` changes land in `wado-manifest`, which is already `wasm32-unknown-unknown`-ready; `metadata.json` I/O lives in `wado-cli` because reading and writing the file is host-side work.
+- `wado.toml` grows a `[build-dependencies]` section and a new `[package].generator` well-known-world field (joining `command`, `service`, `lib`); `wado.lock` grows `[[build-dependency]]` only. Per-invocation cache state lives next to the outputs as `<output_dir>/<primary>.kiln.json` — gitignored under the default `output_dir`, committed alongside generated `.wado` when `output_dir` is tracked. All `wado.toml` / `wado.lock` changes land in `wado-manifest`, which is already `wasm32-unknown-unknown`-ready; the cache-file I/O lives in `wado-cli` because reading and writing the file is host-side work.
 - `wado-compiler` gains a phase between parsing and name resolution that plans generator invocations, compiles generator modules to components, hands them to `CompilerHost::run_generator`, and materializes the returned output. The core compiler remains I/O-free and runtime-free; wasmtime is never linked into it, and `cargo check -p wado-compiler --target wasm32-unknown-unknown` continues to pass.
 - `CompilerHost` grows one method (`run_generator`). `CliCompilerHost` (in `wado-cli`) implements it via wasmtime; hosts that cannot run generators today return `Unsupported` and the compiler degrades to consume-only mode. `CompilerHost` serves generator-relayed `read-file` calls on top of user-source reads.
 - `SourceMap` and the diagnostic renderer extend to spans in generator-read files; existing user diagnostics are unaffected.

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "invocation": "kiln-6fd58782d32cfb10",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/ANTLRv4Lexer.g4",
+    "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"
+  },
+  "inputs": [
+    {
+      "path": "grammars/ANTLRv4Parser.g4",
+      "hash": "c7d102d894988bb73d7e12cc3f5e29ad1843069a0178273e371dfbfb83fe77c7"
+    }
+  ],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4/antlrv4.wado",
+      "hash": "9db5215520896ec5d90eda7dc2166deeaced5f1dbd6b792b72362245042cccd9",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-a6ec2b8f2ddde283",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Declarations_1.g4",
+    "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_1/t.wado",
+      "hash": "421b6f9abc7555c3adcdf9cf5c00228b7428a363994c1c414bf1fb8af9a0bb20",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-61c5e70fcdb6da1f",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Declarations_10.g4",
+    "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_10/t.wado",
+      "hash": "bf390d9ea441a9cad963c49a319aca2b83180236f310c9b645698b9cc444d192",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-699ecb3a8f815e27",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Declarations_2.g4",
+    "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_2/t.wado",
+      "hash": "8c31022ac945cb12912ed16d42179b5812fb861d9cec91e0b94c06a463a43575",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-262e54587e9044c3",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Declarations_3.g4",
+    "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_3/t.wado",
+      "hash": "0f03a9794b5dd1f70121c91d335c0d71528b0b3df85e70f04d9e90df4a7d65a7",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-a998eaa06c653a5b",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Declarations_4.g4",
+    "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_4/t.wado",
+      "hash": "86f37aa59131ec6d8c06e1e927ed2c89c737584de832c850eac5e5924fd55e08",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-fc22b0fc36d36630",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Declarations_5.g4",
+    "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_5/t.wado",
+      "hash": "d041d023399841c27ba981e7aa0bb5efb109a5dadcb25a60995ff261c268453b",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-2852af861801de26",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Declarations_6.g4",
+    "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_6/t.wado",
+      "hash": "a78ceb80b11ce98ab55fc8a9c6dc5ad1a7fbc24edde88ff8890e28dbf7191694",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-320d631a0baf5c0b",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Declarations_7.g4",
+    "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_7/t.wado",
+      "hash": "f3575a1c7dac955b66e26be249e50e93533ad7d1b42d0d2019145a836561b643",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-3bd4c5ea00e5572f",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Declarations_8.g4",
+    "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_8/t.wado",
+      "hash": "13d3c9d90b1d0713e50bd63136d38db557ddcb12fe38673f9197cbc69c84f50d",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-49d484703a919155",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Declarations_9.g4",
+    "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_9/t.wado",
+      "hash": "4d07ab212e33b7dc6b75ef40afdc513240be4b788e95a2ae60a2d7133250d1d9",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-713ef5230fbaf9f1",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
+    "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/t.wado",
+      "hash": "cc33e07380a5cc7d01b3fac13a4cf991a0eeb234639cf1586b78bd1eb8adbedf",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-558b311b80c4da10",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
+    "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/t.wado",
+      "hash": "359323bfea6646fefad6d3d93d534cc09b1ceb76be29c05d7ee794f6ba00b155",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-c369756dc031bf12",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
+    "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/t.wado",
+      "hash": "cbd57c724d871ee71dddecaff2574f598ba7c5b9d346f5dc09ce1cf175fb82da",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-abed1c70b5e6c53f",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Expressions_1.g4",
+    "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_1/t.wado",
+      "hash": "4628f50bafcbe4503fccd804618f5b186e2f2e909aafc19baaca1c55fdc73fde",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-a1b502206053bf7a",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Expressions_2.g4",
+    "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_2/t.wado",
+      "hash": "19215edfab0e6cc21d253c036ddcf317befaa3c7ce862095dae3d99ef4f88cce",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-68045ae831d55159",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Expressions_3.g4",
+    "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_3/t.wado",
+      "hash": "d1c190b86a02ff58b1c086d402af0e0ea18a3f5269ed64556c4c868a8d54ff4f",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-678c469712c8fc23",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Expressions_4.g4",
+    "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_4/t.wado",
+      "hash": "e37a9aa0ad70bd9c6a53caa99509b889b94e7e3ec5426a868d4c0696880a0efa",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-16bc5e2c231c2ba8",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Expressions_5.g4",
+    "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_5/t.wado",
+      "hash": "46247952959e737209989bcc5c53caf0f71364189f780ad8aff324c105233924",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-c116bb1cfe62a2a8",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Expressions_6.g4",
+    "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_6/t.wado",
+      "hash": "f548efdbbac9ad50cdab3a767ebc1bf08482bb016b78e2c8498fd60add2561ac",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-0484794f535b91f2",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Expressions_7.g4",
+    "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_7/t.wado",
+      "hash": "52a8811d1b0622fc9cc8e98e4d9eb2f3defd25f260bbaf716c50027adec14906",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-fe2840241e9172a0",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/JavaExpressions_1.g4",
+    "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado",
+      "hash": "98305412b01919bca4f5eb899916aa44c6868dba09058ccfaf9e696c979e528c",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-235cd53ca8f4663a",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/JavaExpressions_10.g4",
+    "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado",
+      "hash": "68d9b6c27d847e4771135248acd974db31ce50bff285cfe889cc26a648f450c7",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-ed84013859c673b1",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/JavaExpressions_11.g4",
+    "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado",
+      "hash": "1e8b00dc444b89ce62fb87be904766b943df87c31e0d5bf9b4ab3ca2805d9d80",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-739357c31b4c8ca4",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/JavaExpressions_12.g4",
+    "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado",
+      "hash": "ff0b92a2adf6d4962da21b60c7a3a96082e05edd3beacc64445dface882f6405",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-70a21a8410fad983",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/JavaExpressions_2.g4",
+    "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado",
+      "hash": "44c5ca07830ba4289a599f3987425df07375d170a3729a9eb831e4abed8d50b9",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-99bcc333174e8ead",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/JavaExpressions_5.g4",
+    "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado",
+      "hash": "9a4a8cf5d4b369d6905a37ba8da165f15d10b5abec21063c0ed5e43955261dcc",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-2f290cf17eba13e0",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/JavaExpressions_6.g4",
+    "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado",
+      "hash": "54a7b1b0ce2a4ba144875a9e60dd4023c75bcc05026416739f40c5e7c6cefe80",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-bd943cd5ec077b75",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/JavaExpressions_7.g4",
+    "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado",
+      "hash": "4d31fff2c3838095a70c866eb909959a23eb8b56ebcefbdc6bcf510b7e285b9f",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-6ad535192ef3e12f",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/JavaExpressions_8.g4",
+    "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado",
+      "hash": "2333b430ca0aded43b030c294da446c43331d2044bcdec5fc7ccb10769bfba99",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-43dcc5eba0df7ec4",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/JavaExpressions_9.g4",
+    "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado",
+      "hash": "f3826ece80cbbb152e15bc00178dd51a69bc9c3128ee29e6709db0d5a19d3742",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-112c4a21992a04ed",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
+    "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/t.wado",
+      "hash": "c2c66a3fb6adb58dc15a9d55f120ad14fe6d48dd1622264dea848f688191572e",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-459d0b754845c21f",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
+    "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/t.wado",
+      "hash": "f882701656ccac1409bcf318abda9ab361d12d22eb85cd55d6f13c979f77710c",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-1181507cda20d45b",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
+    "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/t.wado",
+      "hash": "7d77992bad68e87747a6317d448348d0bbd76e9c370406b73103380052676454",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-4b506a26b7b7c7b1",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
+    "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/t.wado",
+      "hash": "24b052ed07c37e8f8f282f500ba2d5997b47eb7afb13820989d20458761b051d",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-34e6293e9d4c3e83",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
+    "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/t.wado",
+      "hash": "2bbf30b26eebf3f89c2fd7334355ce46b5231a170777a2de28a2ac96f0209c2c",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-b2467e37954af95c",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
+    "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/t.wado",
+      "hash": "0ad079d5bfb84881656a7cbadb4696ffa627a0b35e8f321abc3259e7400f118a",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-be8254158e713214",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/MultipleActions_1.g4",
+    "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/t.wado",
+      "hash": "ee250433de1efa305c6d88dc31d8ce4be7bc24cefb71bbee56e545f769a2b0a8",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-4fc8261d73da648f",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/MultipleActions_2.g4",
+    "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/t.wado",
+      "hash": "1bb8c8744d8e48aaa7c75c9ff2f11cd4ae19283382d49fb93ade6164ab8926d3",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-93334f393b16d8e0",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/MultipleActions_3.g4",
+    "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/t.wado",
+      "hash": "17cb886d9191c631923b1f5170d8f3903f1a5a69239cf2ac1cdd3d4068835d73",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-e522638eb5f62a2f",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
+    "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/t.wado",
+      "hash": "49e1e2ea2ed040c4b0d0988da64ab52601ccc1638ee07de4057b3e26656bc2c0",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-709c12dbc0d22c0c",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
+    "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/t.wado",
+      "hash": "2a3471bb5270d3d6899ef76a3f906e6b3aadc69fac2b14c0c5ec1cc4ecfecd23",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-1f6f1364b2571756",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
+    "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/t.wado",
+      "hash": "d8b01ba9c586990067f08290b285fa99603d59060cbdd5b29b8a8bc868f6f772",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-960ef5ffa9d45556",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/SemPred.g4",
+    "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/SemPred/t.wado",
+      "hash": "6f13b0e7a14c51a5cb6c574e7b8acaa91970e5b03052b5fb6fb534a0e1500a45",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-a26551c8d0a65a59",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/SemPredFailOption.g4",
+    "hash": "baacd97f45a8e197f2d9363c57506eebffd7f8862b34984e659ed317ac48a7d5"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/t.wado",
+      "hash": "f58e4935615d44185fa57cdabe8e110ee76ab4fba86cc4d83cea086982cc3617",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-5d3495c986bff9bd",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Simple_1.g4",
+    "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Simple_1/t.wado",
+      "hash": "a9a77b56695d2cfb24d0d4f6e773a6ff28fee80ed1e80173bddee908dab40900",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-33ccce79b79bf5e2",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Simple_2.g4",
+    "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Simple_2/t.wado",
+      "hash": "5ede54c4be454f238a68204604c41e296fb78a29d7ff7e36e663e21703187260",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-6dcbc071fc2f601e",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/Simple_3.g4",
+    "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/Simple_3/t.wado",
+      "hash": "0ee1493dc2f469b7c4bf00353696a1fb3d7ba15034d8f0cdd0a806c1487c3c9c",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-741313c066ff2cd5",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
+    "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/t.wado",
+      "hash": "b907524ae0222d44ed745d4c2a45f958ae9e983cf48ec40af0ba904340c13a0b",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-381677e2c28357d8",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
+    "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/t.wado",
+      "hash": "38627a0e9e10463262911817628b2a9718eecdad5b17a6e1bebf37b62e35103d",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-4d665f3c7d50cbb6",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
+    "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/t.wado",
+      "hash": "1bef3b04340915607153b1f11e3c28f591830b9d6d02b01a5d97d4bc147971d0",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-18d85335cd7b6ba7",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
+    "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/t.wado",
+      "hash": "ebaf59c1e6ebd046980ee940d1e708e004235a10b31f99012d125fb5eb1ed994",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-6c0e1c831530f504",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
+    "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/t.wado",
+      "hash": "7d4fb34a51f419ca5d38fe8fab1314a078d640d7ba685c5c3787b3739379b259",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-d5dda292b3d95344",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
+    "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/t.wado",
+      "hash": "8d4f5e33bc76d4d3c6337a74a9c3e5fb2ce866b08d096c6026e72c483d09f0f9",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-bc586f7b630f85cb",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
+    "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/t.wado",
+      "hash": "425c0e43e5c2b56203d4c568942832b82a069736c44cc5da4ce4ef3a49a17ea5",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-b8fe4abc43e4380d",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
+    "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/t.wado",
+      "hash": "6a4cac988872d8a3706de32995182370733a8e0fc08b61bd938879a2f3b8e9ae",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-ddd4f8db5f21632f",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
+    "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/t.wado",
+      "hash": "c225233c430296f2bd57096a9fb5952be42ec436027121be950ecdf17a68dc94",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-1a2ad3adca9a2a07",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExpr_1.g4",
+    "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/t.wado",
+      "hash": "5732f291bf4756411c82f6e442ebf68bf660e1c492fe157e83da482bbee97926",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-eed4df03ca7a51f5",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExpr_2.g4",
+    "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/t.wado",
+      "hash": "fe6b915954e0049484056c06c6ea94a0511164a428734e8ce55fff0d4c10bf52",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-bfcc2ec63de46569",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExpr_3.g4",
+    "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/t.wado",
+      "hash": "cd1c9f4c23622327ac19ab5b363014888bf2aa2ccc30321c4d7b17d4e5c956ce",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-20cd1bcceb40fb33",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExpr_4.g4",
+    "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/t.wado",
+      "hash": "deb2723d49350b523868fc2656badfd91fdd702db364be6e44af918879ee75ff",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-cfe1fc1849a20141",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExpr_5.g4",
+    "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/t.wado",
+      "hash": "72c54ec90d23623236cda91771085cf70599aa6bf449836876f8e920c5ba079a",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-88482992acd5509f",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExpr_6.g4",
+    "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/t.wado",
+      "hash": "baf1e65123597fbaaa2ec0ab8040fc55db307c2b758fbc81d875fb3132c1cdfe",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-78bbab6b273081fa",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExpr_7.g4",
+    "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/t.wado",
+      "hash": "baf561815c0117e5de1709095b0445752fa2331fe96d045fa0afd1990cb34bea",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-03918ec747b14ad6",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExpr_8.g4",
+    "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/t.wado",
+      "hash": "4524620b7d0c056e37258787477627ee4fad07e55f55b83b88bc270e291b0993",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-a66253165de20181",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/TernaryExpr_9.g4",
+    "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/t.wado",
+      "hash": "2bf8f212f4a871ceec0bbe8ee075b3d1398f25fe056d80394c9e87b4d63524b4",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-1d1b100d63f04166",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/ParserExec/BuildParseTree_TRUE.g4",
+    "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/t.wado",
+      "hash": "a9599cfb5bb30a7cf26866b309be103c9b6dc677639c6f235ef19c055f10662d",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-94c0b5df15a69680",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/ParserExec/PredictionIssue334.g4",
+    "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/ParserExec/PredictionIssue334/t.wado",
+      "hash": "2a20c892682d87802c7dcab28d638cc72957f7c64d52f903e82326fb993842b2",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-3ebf8faf7a4261df",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/ParserExec/PredictionMode_LL.g4",
+    "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/t.wado",
+      "hash": "7b436897158f552cb5b42188d7bd966dc036391c22fbb9beaf5aa22927d36dba",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-3c84aa606fbeb863",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_1.g4",
+    "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/t.wado",
+      "hash": "02a2a851e69e58456302e71d60a5ff3897020ad50bc4cdf28bf45f731961eb3d",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-7f162199fbfa5a4d",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
+    "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/t.wado",
+      "hash": "6f09c3c7a58e0038082b63b6fb32b73f48a6ed23f6938686946dbb3b6acddc73",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/calculator/calculator.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-7fbe69e34c931e16",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/calculator.g4",
+    "hash": "67431dad6dcc459fea7d4c448fb04944de2c4cf61ecd75d546aeccd93b4564d7"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/calculator/calculator.wado",
+      "hash": "327fb4e092e1448338d319bd7ea054355c611aa37e4591fe4b59d31885c9fbff",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-66c270910e5642be",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/ci_rule_override.g4",
+    "hash": "6efdfe55ecb215bf526900a32a11c664a57c9e14d61c6a67758f870adc73d09b"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/ci_rule_override/ci_rule_override.wado",
+      "hash": "eeebcce8913eaa66b0850046d1a270b163c68737ab9eb10503a3320a3fca9b29",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-b9bfa38391d7f122",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/ci_sql.g4",
+    "hash": "41b72934417dd2f6fa0359722ce53ca05cd10cccde08fd9f3d0d58018f2137fe"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/ci_sql/ci_sql.wado",
+      "hash": "7930dec3596536ba2f54f63cc720510233b3abb7ab43e9be2e3a8221b91e463e",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "invocation": "kiln-fa4a5fa8cced30ae",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/css3Lexer.g4",
+    "hash": "4733198f782344f0d3dbd2456ee9f6db955f53c688d14334fb403985551c963c"
+  },
+  "inputs": [
+    {
+      "path": "grammars/css3Parser.g4",
+      "hash": "9955e24289a4f929667721f5f9afb56a3f5edc0ac9f26aaabb61e1efcdf92a08"
+    }
+  ],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/css3/css3.wado",
+      "hash": "323449f7eb52fffb431c868fa58508d63bdddde1db10d584baafcb22293c3ff4",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "invocation": "kiln-c6b3fd168a1b47a8",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/HTMLLexer.g4",
+    "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"
+  },
+  "inputs": [
+    {
+      "path": "grammars/HTMLParser.g4",
+      "hash": "5e00a8bb809a85b98b3a5d0dd733762e1033a634c084a25a038b7c3f4112caf9"
+    }
+  ],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/html/html.wado",
+      "hash": "5815a60d983fdce81fac0e1194e44fae7ad29aba6ffafa8311eee8cf6571c793",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json/JSON.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-deb9206518cd2a6f",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/JSON.g4",
+    "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/json/json.wado",
+      "hash": "4e03c9415ba90edadb182e853d0661a4c7e2b259c56518d941e13db10dfeda66",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-deb9206518cd2a6f",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/JSON.g4",
+    "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "221a81964a4e4212ce2e828643b07faa05ae8ecd824158743f342b88120c56f5",
+  "outputs": [
+    {
+      "path": "tests/generated/json_highlight/json.wado",
+      "hash": "60dee7a012c1f869410be1f224186fb1d8bcd7c360c3f0358c0fe91ffc1e1955",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-6e9e12ac993603d7",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/label_gaps.g4",
+    "hash": "8e2049cd7baf82750b8e242018ffdc1f8e684226f8e27fe8068ad7838d6da425"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/label_gaps/label_gaps.wado",
+      "hash": "32b27042da2dbd1be281d41775ec8cd35ebf94390d0fe0d31f7863287a337845",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-c1bc56a77b40e824",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/lexer_command_gaps.g4",
+    "hash": "253a32f9908895a3ffaa23ac8e32eaa12f43998f25d7d2b73637ddf11a3cb3c9"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/lexer_command_gaps/lexer_command_gaps.wado",
+      "hash": "5584ac71813b60c6e2ab6b2b17fdcd0ea033b215a52391b8575faec1b411e822",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-934b67223a7d4708",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/mode_gaps.g4",
+    "hash": "2129310ea345f84328b61531ce102c6306fda62ef4fa71d7c64d1dc4bb9f1d14"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/mode_gaps/mode_gaps.wado",
+      "hash": "1318c4b4e4da897e4ff341c19f3b1edc39bb5f3cef2c317e0d3b8a35dd466f88",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-a7aa34c1db2fca6a",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/non_greedy_gaps.g4",
+    "hash": "b7ebb6e1d962ee295bf43cc5a13f167cbd270ef3d9e15a052d2eb060eefb012c"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/non_greedy_gaps/non_greedy_gaps.wado",
+      "hash": "ad949727a8cdb82600b7f6b6220c845d3fcd07c620d1db6c9776920dea9a8fed",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-8eb28e22b79ba2bd",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/parser_gaps.g4",
+    "hash": "8262a9d7c10805db35e063564eaea6deb43e8de540af19d0969551d042b6d03a"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/parser_gaps/parser_gaps.wado",
+      "hash": "fb26c43cceb5be38f6b6f959fac80ebb0e6e872b714c91cdb42553228b7dc72b",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-b23078c163edb700",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/recursive_lexer.g4",
+    "hash": "3bba2a980c91c247bfa081040a71e8349ebd29cec177d15cf69feb75f40e705f"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/recursive_lexer/recursive_lexer.wado",
+      "hash": "8b56e8dcb105452b6196137e8a29ea4e82169045649ada8ca283e87b075e462c",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-7382226003c5d9e1",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/right_assoc_gaps.g4",
+    "hash": "7632fce865fe8aa2c3c460beea14a27a0a020b9ccb2312fb59a2c980f12f639a"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/right_assoc_gaps/right_assoc_gaps.wado",
+      "hash": "d53161e2efe8f44a82af00de79e4a64671033a827a320fb5c0c0b9155835510d",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "invocation": "kiln-28566ce8c3b8a5b1",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/RustLexer.g4",
+    "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"
+  },
+  "inputs": [
+    {
+      "path": "grammars/RustParser.g4",
+      "hash": "f04a6035ee067e5f25830c9022654ef67826309529f68f6f2987b72033822f2e"
+    }
+  ],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/rust/rust.wado",
+      "hash": "033fb1c18fd3dbeb7c7d56f6308732153384332a4361ce109745a7fb2bca602e",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-1847ef51d5668bfd",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/sexpression.g4",
+    "hash": "74549e6167e186b754886880a5d473ad3361bee8440368f99e1b233e2c1c7bdb"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/sexpression/sexpression.wado",
+      "hash": "18f981e32bcfaeae77c739aeef79642d72c5828ec3b9178795c7514ab2758163",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-880d9db12a6d7521",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/SQLite.g4",
+    "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/sqlite/sqlite.wado",
+      "hash": "a5baffeaa7bcda3a710019c75e8a69a38b6c3902d97808a287a7f5c879d09fed",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-880d9db12a6d7521",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/SQLite.g4",
+    "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "221a81964a4e4212ce2e828643b07faa05ae8ecd824158743f342b88120c56f5",
+  "outputs": [
+    {
+      "path": "tests/generated/sqlite_highlight/sqlite.wado",
+      "hash": "05cabe3ca535e268dc3a3b6877220a86e10b83ef21ec3c8258449906b31c2b42",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "invocation": "kiln-b6f068637d3275ff",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/TypeScriptLexer.g4",
+    "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"
+  },
+  "inputs": [
+    {
+      "path": "grammars/TypeScriptParser.g4",
+      "hash": "517c04e534f4d045437e1f54ded9f30883b2d576b6d99c80ed537e94e4fd8f42"
+    }
+  ],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/typescript/type_script.wado",
+      "hash": "b2f36c6303482de8cf003bbba42d324d799f1618e33565b2c6eb8ccfde806ae6",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-f37fa830f2a0df13",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/unicode_props.g4",
+    "hash": "7559b99d20b67597cdc99b2e9e0eaeea1ad4b0931d40859c1dbb600e20d1c5c0"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/unicode_props/unicode_props.wado",
+      "hash": "7d8509ec4790168541823a5e767b24ee19bad7640c3aa4acc32fc4be636b736c",
+      "entry": true
+    }
+  ]
+}

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -14,12 +14,12 @@
 //!    file — see [`execute`].
 //! 3. Convert an [`InvocationRun`] into a [`crate::kiln_metadata::Metadata`]
 //!    record for persistence (`build_metadata`), check a recorded
-//!    `metadata.json` for freshness against the current filesystem +
+//!    `<primary>.kiln.json` for freshness against the current filesystem +
 //!    sources (`cache_matches`), and delete orphaned `#![generated]`
 //!    files left over from an earlier run (`reconcile_outputs`).
 //!
 //! Per-invocation cache state lives at
-//! `<manifest_root>/build/kiln/<invocation_id>/metadata.json` (see
+//! `<manifest_root>/<output_dir>/<primary>.kiln.json` (see
 //! [`crate::kiln_metadata`]). `wado.lock` is dependency-pin-only since
 //! WEP M9 — it does not contain any generator-cache rows.
 
@@ -316,11 +316,11 @@ pub async fn execute_with_mode<H: CompilerHost>(
 }
 
 /// Convert an [`InvocationRun`] into a [`Metadata`] record ready to be
-/// written to `build/kiln/<invocation_id>/metadata.json`.
+/// written to `<output_dir>/<primary>.kiln.json`.
 ///
 /// `invocation_name` is the synthesized id derived from `(decl_file,
-/// from)` for inline clauses, used both as the directory name and as
-/// the metadata's own `invocation` field. `options_hash` is the hex
+/// from)` for inline clauses; it is recorded in the metadata's own
+/// `invocation` field for diagnostics. `options_hash` is the hex
 /// SHA-256 of the canonical options encoding — produced by
 /// [`wado_compiler::kiln::hash_options_canonical`] so it stays stable
 /// across the M3 provisional encoder and the M4 lifted-form encoder.
@@ -431,8 +431,8 @@ pub enum CacheCheck {
     Miss,
 }
 
-/// Check whether a recorded `metadata.json` is still valid for the given
-/// invocation.
+/// Check whether a recorded `<primary>.kiln.json` is still valid for the
+/// given invocation.
 ///
 /// Re-hashes the primary + declared inputs via `host.load_source`, then
 /// re-hashes every `reads` entry the same way, then re-hashes every output
@@ -795,7 +795,7 @@ pub enum PipelineError {
         path: PathBuf,
         source: std::io::Error,
     },
-    /// Writing per-invocation `metadata.json` failed.
+    /// Writing per-invocation `<primary>.kiln.json` failed.
     MetadataSave {
         invocation: String,
         source: kiln_metadata::MetadataError,
@@ -876,7 +876,11 @@ where
     for invocation in &planned.plan.order {
         let invocation_name = invocation_id(invocation);
 
-        let existing = match kiln_metadata::load(manifest_root, &invocation_name) {
+        let existing = match kiln_metadata::load(
+            manifest_root,
+            invocation.output_dir.as_str(),
+            invocation.from.as_str(),
+        ) {
             Ok(m) => m,
             Err(source) => {
                 emit_metadata_load_warning(host, &invocation_name, &source);
@@ -965,7 +969,12 @@ where
                     .insert(&decl_file, invocation.from.as_str(), &uri);
             }
             if executed
-                && let Err(source) = kiln_metadata::save(manifest_root, &invocation_name, &metadata)
+                && let Err(source) = kiln_metadata::save(
+                    manifest_root,
+                    invocation.output_dir.as_str(),
+                    invocation.from.as_str(),
+                    &metadata,
+                )
             {
                 return Err(PipelineError::MetadataSave {
                     invocation: invocation_name.clone(),
@@ -1011,12 +1020,12 @@ pub struct CheckOutcome {
 }
 
 /// Run the Kiln pipeline in `wado check` mode: re-run every invocation
-/// from scratch (ignoring `metadata.json`), byte-compare each output
-/// against the on-disk file, and surface
+/// from scratch (ignoring `<primary>.kiln.json`), byte-compare each
+/// output against the on-disk file, and surface
 /// [`Code::KilnGeneratedStaleOnDisk`] diagnostics for mismatches.
 ///
 /// Does not write generator outputs to disk and does not touch
-/// `metadata.json`. Suitable for CI: a clean checkout of a
+/// `<primary>.kiln.json`. Suitable for CI: a clean checkout of a
 /// committed-source project should produce zero divergence.
 pub async fn check_pipeline<H, P>(
     manifest: &Manifest,
@@ -1265,7 +1274,7 @@ fn emit_metadata_load_warning<H: CompilerHost>(
         severity: Severity::Warning,
         code: Code::Log,
         message: format!(
-            "kiln[{invocation}]: failed to read metadata.json ({source}); \
+            "kiln[{invocation}]: failed to read cache file ({source}); \
              treating as cache miss and re-running generator",
         ),
         span: None,

--- a/wado-cli/src/kiln_metadata.rs
+++ b/wado-cli/src/kiln_metadata.rs
@@ -1,26 +1,31 @@
-//! Per-invocation Kiln cache state, stored at
-//! `<manifest_root>/build/kiln/<invocation_id>/metadata.json`.
+//! Per-invocation Kiln cache state, stored next to the generated outputs
+//! at `<manifest_root>/<output_dir>/<primary_basename>.kiln.json`.
 //!
 //! See [WEP: Kiln](../../docs/wep-2026-04-12-kiln.md), section
-//! "Caching and `metadata.json`", for the design.
+//! "Caching and the `<primary>.kiln.json` cache file", for the design.
 //!
-//! Always lives under `build/kiln/` regardless of where `output_dir`
-//! points the generated `.wado` source — keeps cache state gitignored
-//! even for committed-source workflows. Deleting the file (or the whole
-//! `build/kiln/` tree) is not an error: the next compile rebuilds from
-//! scratch.
+//! The location is derived deterministically from `Invocation::output_dir`
+//! and the basename of `Invocation::from` (the primary input file). For
+//! invocations that opt into a committed `output_dir` (e.g.
+//! `tests/generated/sqlite`), this means the cache state can be committed
+//! alongside the generated `.wado` so a fresh checkout hits the cache and
+//! skips the generator. For default invocations (`output_dir` under
+//! `build/kiln/<synthetic_id>`), the file lives in that gitignored tree
+//! and behaves like before. Deleting the file is not an error: the next
+//! compile rebuilds from scratch.
 
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-/// Schema version of the `metadata.json` file. Bumped only on
+/// Schema version of the `<primary>.kiln.json` file. Bumped only on
 /// incompatible changes; older files are silently ignored (treated as a
 /// cache miss) when the version differs.
 pub const METADATA_VERSION: u32 = 1;
 
-const METADATA_FILE: &str = "metadata.json";
-const KILN_DIR: &str = "build/kiln";
+/// Suffix appended to the primary input's basename to form the metadata
+/// filename. Lives in `<manifest_root>/<output_dir>/`.
+const METADATA_SUFFIX: &str = ".kiln.json";
 
 /// Per-invocation cache state recorded between Kiln runs.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -51,12 +56,22 @@ pub struct OutputEntry {
 }
 
 /// Path to the metadata file for an invocation.
+///
+/// `output_dir` is the relative `Invocation::output_dir` (e.g.
+/// `tests/generated/sqlite` or `build/kiln/<synthetic_id>`). `primary`
+/// is `Invocation::from` — the metadata's basename uses
+/// `Path::file_name(primary)` so two invocations sharing one
+/// `output_dir` collide only if they share both primary basename and
+/// options, which would already make them the same invocation under
+/// [`crate::kiln_driver::invocation_id`].
 #[must_use]
-pub fn metadata_path(manifest_root: &Path, invocation_id: &str) -> PathBuf {
+pub fn metadata_path(manifest_root: &Path, output_dir: &str, primary: &str) -> PathBuf {
+    let basename = Path::new(primary)
+        .file_name()
+        .map_or_else(|| primary.to_string(), |s| s.to_string_lossy().into_owned());
     manifest_root
-        .join(KILN_DIR)
-        .join(invocation_id)
-        .join(METADATA_FILE)
+        .join(output_dir)
+        .join(format!("{basename}{METADATA_SUFFIX}"))
 }
 
 /// Read the metadata file for an invocation, if present.
@@ -68,8 +83,12 @@ pub fn metadata_path(manifest_root: &Path, invocation_id: &str) -> PathBuf {
 /// schema bumps do not require any manual intervention from the user.
 ///
 /// Returns `Err` only on real I/O failure or syntactically broken JSON.
-pub fn load(manifest_root: &Path, invocation_id: &str) -> Result<Option<Metadata>, MetadataError> {
-    let path = metadata_path(manifest_root, invocation_id);
+pub fn load(
+    manifest_root: &Path,
+    output_dir: &str,
+    primary: &str,
+) -> Result<Option<Metadata>, MetadataError> {
+    let path = metadata_path(manifest_root, output_dir, primary);
     let content = match std::fs::read_to_string(&path) {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -90,13 +109,14 @@ pub fn load(manifest_root: &Path, invocation_id: &str) -> Result<Option<Metadata
     Ok(Some(metadata))
 }
 
-/// Write metadata.json, creating the parent directory if needed.
+/// Write the metadata file, creating the parent directory if needed.
 pub fn save(
     manifest_root: &Path,
-    invocation_id: &str,
+    output_dir: &str,
+    primary: &str,
     metadata: &Metadata,
 ) -> Result<(), MetadataError> {
-    let path = metadata_path(manifest_root, invocation_id);
+    let path = metadata_path(manifest_root, output_dir, primary);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|source| MetadataError::Io {
             path: parent.to_path_buf(),
@@ -176,49 +196,67 @@ mod tests {
         }
     }
 
+    const OUTPUT_DIR: &str = "tests/generated/x";
+    const PRIMARY: &str = "schemas/x.proto";
+
     #[test]
     fn roundtrip_save_load() {
         let tmp = tempfile::tempdir().unwrap();
         let m = sample();
-        save(tmp.path(), &m.invocation, &m).unwrap();
-        let loaded = load(tmp.path(), &m.invocation).unwrap().unwrap();
+        save(tmp.path(), OUTPUT_DIR, PRIMARY, &m).unwrap();
+        let loaded = load(tmp.path(), OUTPUT_DIR, PRIMARY).unwrap().unwrap();
         assert_eq!(loaded, m);
     }
 
     #[test]
     fn missing_file_is_cache_miss() {
         let tmp = tempfile::tempdir().unwrap();
-        let result = load(tmp.path(), "kiln-nope").unwrap();
+        let result = load(tmp.path(), OUTPUT_DIR, PRIMARY).unwrap();
         assert!(result.is_none());
     }
 
     #[test]
     fn version_mismatch_is_cache_miss() {
         let tmp = tempfile::tempdir().unwrap();
-        let m = sample();
-        let path = metadata_path(tmp.path(), &m.invocation);
+        let mut bumped = sample();
+        let path = metadata_path(tmp.path(), OUTPUT_DIR, PRIMARY);
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         // Write with an unsupported version.
-        let mut bumped = m.clone();
         bumped.version = u32::MAX;
         let json = serde_json::to_string(&bumped).unwrap();
         std::fs::write(&path, json).unwrap();
-        assert!(load(tmp.path(), &m.invocation).unwrap().is_none());
+        assert!(load(tmp.path(), OUTPUT_DIR, PRIMARY).unwrap().is_none());
     }
 
     #[test]
     fn parse_error_propagates() {
         let tmp = tempfile::tempdir().unwrap();
-        let path = metadata_path(tmp.path(), "kiln-broken");
+        let path = metadata_path(tmp.path(), OUTPUT_DIR, PRIMARY);
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(&path, "{ not json").unwrap();
-        let err = load(tmp.path(), "kiln-broken").unwrap_err();
+        let err = load(tmp.path(), OUTPUT_DIR, PRIMARY).unwrap_err();
         assert!(matches!(err, MetadataError::Parse { .. }), "{err}");
     }
 
     #[test]
-    fn metadata_path_layout() {
-        let p = metadata_path(Path::new("/proj"), "kiln-abc");
-        assert_eq!(p, PathBuf::from("/proj/build/kiln/kiln-abc/metadata.json"));
+    fn metadata_path_uses_primary_basename_in_output_dir() {
+        let p = metadata_path(
+            Path::new("/proj"),
+            "tests/generated/sqlite",
+            "tests/grammars/SQLite.g4",
+        );
+        assert_eq!(
+            p,
+            PathBuf::from("/proj/tests/generated/sqlite/SQLite.g4.kiln.json")
+        );
+    }
+
+    #[test]
+    fn metadata_path_handles_bare_primary_filename() {
+        let p = metadata_path(Path::new("/proj"), "build/kiln/synth-id", "schema.proto");
+        assert_eq!(
+            p,
+            PathBuf::from("/proj/build/kiln/synth-id/schema.proto.kiln.json")
+        );
     }
 }

--- a/wado-cli/tests/kiln_pipeline.rs
+++ b/wado-cli/tests/kiln_pipeline.rs
@@ -200,12 +200,15 @@ fn end_to_end_two_generators_execute_cache_and_reuse() {
     assert!(tmp.path().join("build/kiln/kiln-alpha/alpha.wado").exists());
     assert!(tmp.path().join("build/kiln/kiln-beta/beta.wado").exists());
 
-    let alpha_meta = kiln_metadata::load(tmp.path(), "kiln-alpha")
+    let alpha = alpha_inv();
+    let beta = beta_inv();
+    let alpha_meta =
+        kiln_metadata::load(tmp.path(), alpha.output_dir.as_str(), alpha.from.as_str())
+            .unwrap()
+            .expect("kiln-alpha metadata should be written after run");
+    let beta_meta = kiln_metadata::load(tmp.path(), beta.output_dir.as_str(), beta.from.as_str())
         .unwrap()
-        .expect("kiln-alpha metadata.json should be written after run");
-    let beta_meta = kiln_metadata::load(tmp.path(), "kiln-beta")
-        .unwrap()
-        .expect("kiln-beta metadata.json should be written after run");
+        .expect("kiln-beta metadata should be written after run");
     assert_eq!(alpha_meta.invocation, "kiln-alpha");
     assert_eq!(beta_meta.invocation, "kiln-beta");
 
@@ -270,13 +273,15 @@ fn each_invocation_writes_its_own_metadata_file() {
         ],
     );
     let provider = StubProvider::new(b"component-bytes".to_vec());
-    run(&m, tmp.path(), &host, &provider, vec![z_inv, a_inv, m_inv]);
+    let invs = vec![z_inv, a_inv, m_inv];
+    run(&m, tmp.path(), &host, &provider, invs.clone());
 
-    for id in ["kiln-zebra", "kiln-alpha", "kiln-mango"] {
-        let m = kiln_metadata::load(tmp.path(), id)
+    for inv in &invs {
+        let id = inv.decl_site.synthetic_id.as_str();
+        let meta = kiln_metadata::load(tmp.path(), inv.output_dir.as_str(), inv.from.as_str())
             .unwrap()
-            .unwrap_or_else(|| panic!("missing metadata.json for {id}"));
-        assert_eq!(m.invocation, id);
+            .unwrap_or_else(|| panic!("missing metadata for {id}"));
+        assert_eq!(meta.invocation, id);
     }
     assert!(
         !tmp.path().join("wado.lock").exists(),

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -142,8 +142,9 @@ pub enum Code {
     /// the required `with { generator: { ... } }` clause.
     KilnMissingWith,
     /// A generated `.wado` file on disk has been modified after generation
-    /// (cache key matches metadata.json but on-disk content does not). The
-    /// edit is honored — compilation proceeds against the on-disk content.
+    /// (cache key matches the per-invocation `<primary>.kiln.json` cache file
+    /// but on-disk content does not). The edit is honored — compilation
+    /// proceeds against the on-disk content.
     KilnGeneratedModified,
     /// On a cache miss, the generator produced bytes that differ from the
     /// pre-existing file at the same path. The new bytes overwrite the old.

--- a/wado-manifest/src/lockfile.rs
+++ b/wado-manifest/src/lockfile.rs
@@ -7,10 +7,11 @@ use serde::Deserialize;
 ///
 /// As of WEP M9, `wado.lock` is dependency-pin-only: it contains
 /// `[[package]]` and `[[build-dependency]]` entries but no Kiln
-/// generator-cache state. Per-invocation cache state lives in
-/// `build/kiln/<id>/metadata.json`. Older lockfiles that contain
-/// `[[generator-cache]]` sections still parse cleanly — the unknown
-/// table is ignored — but newly written lockfiles never emit it.
+/// generator-cache state. Per-invocation cache state lives next to the
+/// generated outputs as `<output_dir>/<primary>.kiln.json`. Older
+/// lockfiles that contain `[[generator-cache]]` sections still parse
+/// cleanly — the unknown table is ignored — but newly written lockfiles
+/// never emit it.
 #[derive(Debug, Clone)]
 pub struct LockFile {
     /// Lock file format version.
@@ -86,7 +87,7 @@ impl FromStr for LockFile {
 
         // `[[generator-cache]]` sections from older lockfiles are tolerated
         // but ignored — the new design (WEP M9) records that state in
-        // `build/kiln/<id>/metadata.json`.
+        // `<output_dir>/<primary>.kiln.json`.
 
         Ok(LockFile {
             version,


### PR DESCRIPTION
## Summary

- Move Kiln per-invocation cache state from `build/kiln/<id>/metadata.json` (gitignored) to `<output_dir>/<primary>.kiln.json` (committable when `output_dir` is tracked). Previously a fresh CI clone always missed the cache and re-ran every generator. With the file living next to the outputs, committed-source workflows can commit the cache file alongside the generated `.wado` and a clean checkout hits the cache on the first compile.
- Commit 91 cache files for `package-gale/tests/generated/**` so CI's `test-gale-o2` job (and `o1`/`o3`) gains the cache on first run.
- Update `wado-cli/src/kiln_metadata.rs` API: `metadata_path(manifest_root, output_dir, primary)`. Update `kiln_driver.rs` callers, integration test, and WEP-2026-04-12 to match the new layout. Behavior under default `output_dir` (`build/kiln/<synthesized-id>`) is unchanged — the file lives there and stays gitignored as before.

## Performance

Local `wado test -O2 package-gale`:

| | 1st run (cold) | 2nd run (warm) |
|---|---:|---:|
| **Total** | **672.84s** | **350.44s** (−48%) |
| `driver_css3_test` | 40.55s | 7.72s |
| `driver_rust_test` | 40.84s | 10.17s |
| `driver_typescript_test` | 41.78s | 9.27s |
| `driver_sqlite_create_table_test` | 35.77s | 6.98s |
| `driver_sqlite_highlight_test` | 36.65s | 8.04s |
| `driver_sqlite_minimal_test` | 35.56s | 6.84s |
| stage_b/* (each) | ~3.5s | ~750ms |

Test results unchanged: 229/229 compile, 1020/1020 test pass, 13 TODO pending (same set).

## Cache key (unchanged)

The cache key is still SHA-256 over `(MAGIC, world version, generator identity, generator source hash, primary path+hash, inputs[], prior reads[], options canonical)`. Only the file *location* changed; the hash composition, the `Code::KilnGeneratedModified` / `Code::KilnGeneratedRegenerated` semantics, and `wado check`'s force-regen byte-compare gate are all preserved.

## DX impact for Gale developers

- Editing a `.g4` test grammar regenerates that invocation's `.wado` + `.kiln.json` together — exactly like today's flow regenerates the `.wado` alone.
- Editing Gale source (e.g. `parser_gen.wado`) invalidates `generator_source_hash` and forces all 91 invocations to re-run. The diff grows by 91 small (one-hash-line) JSON entries; the `.wado` regeneration churn was already happening.
- Forgetting to commit a `.kiln.json` is non-fatal: `cache_matches` falls through with a `HitButModified` warning and uses the on-disk `.wado` as-is. `wado check` does **not** consult `<primary>.kiln.json`, so the CI freshness gate is unchanged.

## Test plan

- [x] `cargo test -p wado-cli --lib kiln_metadata` (6/6 pass — new layout test added)
- [x] `cargo test -p wado-cli --test kiln_pipeline` (6/6 pass)
- [x] `cargo test -p wado-cli --lib kiln` (30/30 pass)
- [x] `cargo clippy -p wado-cli --all-features --all-targets` (clean)
- [x] `cargo run -p wado-cli -- test -O2 package-gale` warmup run (672.84s, 1020/1020 pass)
- [x] `cargo run -p wado-cli -- test -O2 package-gale` cached run (350.44s, 1020/1020 pass)
- [ ] Watch the next CI run for `test-gale-o2` to confirm the speedup carries to the runner.

https://claude.ai/code/session_01VwxD1Z7AkssPkrHADJfzBx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwxD1Z7AkssPkrHADJfzBx)_